### PR TITLE
Readme edit

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This repository contains the Dafny formalization of Cedar and infrastructure for
 
 To build the Dafny formalization and proofs:
 
-* Install Dafny version 4.0 and Z3 version 4.12.1, following the instructions [here](https://github.com/dafny-lang/dafny/wiki/INSTALL#building-and-developing-from-source-code). Ensure that Z3 is on your path.
+* Install Dafny 4, following the instructions [here](https://github.com/dafny-lang/dafny/wiki/INSTALL). Our proofs expect Z3 version 4.12.1, so if you have another copy of Z3 installed locally, you may need to adjust your PATH.
 * `cd cedar-dafny && make`
 
 To build the DRT framework:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Updated build instructions for Dafny. Users don't need to manually install Z3 unless they're downloading the binary or building from source (both of which are covered in Dafny's install instructions). The note about version Z3 version 4.12.1 is important because our proofs don't currently build with older versions like 4.8.5.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
