### PR TITLE
Find dependency in sibling of repository as README states

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          path: ./cedar-spec
       - name: Download Dafny
         shell: bash
         run: wget https://github.com/dafny-lang/dafny/releases/download/v4.0.0/dafny-4.0.0-x64-ubuntu-20.04.zip
@@ -29,11 +31,11 @@ jobs:
         shell: bash
         run: ln -s $(pwd)/dafny/z3/bin/z3-4.12.1 $(pwd)/dafny/z3/bin/z3
       - name: verify dafny
-        working-directory: ./cedar-dafny
-        run: export PATH=$PATH:$(pwd)/../dafny/z3/bin && make verify
+        working-directory: ./cedar-spec/cedar-dafny
+        run: export PATH=$PATH:$(pwd)/../../dafny/z3/bin && make verify
       - name: test dafny
-        working-directory: ./cedar-dafny
-        run: export PATH=$PATH:$(pwd)/../dafny/z3/bin && make test
+        working-directory: ./cedar-spec/cedar-dafny
+        run: export PATH=$PATH:$(pwd)/../../dafny/z3/bin && make test
       - name: Get Java 17
         uses: actions/setup-java@v3
         with:
@@ -41,14 +43,14 @@ jobs:
           java-version: '17'
           cache: 'gradle'
       - name: build dafny def engine
-        working-directory: ./cedar-dafny
+        working-directory: ./cedar-spec/cedar-dafny
         run: |
-             export PATH=$PATH:$(pwd)/../dafny/z3/bin && 
+             export PATH=$PATH:$(pwd)/../../dafny/z3/bin && 
              export JAVA_HOME="/opt/hostedtoolcache/Java_Corretto_jdk/17.0.7.7.1/x64" && 
              export LD_LIBRARY_PATH=${LD_LIBRARY_PATH+$LD_LIBRARY_PATH:}$JAVA_HOME/lib/server && 
              make compile-difftest
       - name: Build cedar-dafny-java-wrapper
-        working-directory: ./cedar-dafny-java-wrapper
+        working-directory: ./cedar-spec/cedar-dafny-java-wrapper
         shell: bash
         run: ./gradlew build dumpClasspath
       - name: Checkout cedar
@@ -61,7 +63,7 @@ jobs:
       - name: rustup
         run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
       - name: cargo test
-        working-directory: ./cedar-drt
+        working-directory: ./cedar-spec/cedar-drt
         shell: bash
         run: |
              export JAVA_HOME="/opt/hostedtoolcache/Java_Corretto_jdk/17.0.7.7.1/x64" &&
@@ -82,6 +84,8 @@ jobs:
     steps:
       - name: Checkout cedar-spec
         uses: actions/checkout@v3
+        with:
+          path: ./cedar-spec
       - name: Checkout cedar
         uses: actions/checkout@v3
         with:
@@ -92,11 +96,11 @@ jobs:
       - name: rustup
         run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
       - name: cargo fmt
-        working-directory: ./cedar-drt
+        working-directory: ./cedar-spec/cedar-drt
         run: cargo fmt --all --check
       - name: cargo rustc
-        working-directory: ./cedar-drt
+        working-directory: ./cedar-spec/cedar-drt
         run: RUSTFLAGS="-D warnings -F unsafe-code" cargo build --verbose
       - name: cargo rustc
-        working-directory: ./cedar-drt/fuzz
+        working-directory: ./cedar-spec/cedar-drt/fuzz
         run: RUSTFLAGS="--cfg=fuzzing -D warnings -F unsafe-code" cargo build --verbose

--- a/cedar-drt/Cargo.toml
+++ b/cedar-drt/Cargo.toml
@@ -10,10 +10,10 @@ highway = "0.8.1"
 env_logger = "0.9.0"
 log = "0.4"
 libfuzzer-sys = "0.4"
-cedar-policy = { path = "../cedar/cedar-policy", version = "2.0.0", features = ["integration_testing"] }
-cedar-policy-core = { path = "../cedar/cedar-policy-core", version = "2.0.0" }
-cedar-policy-validator = { path = "../cedar/cedar-policy-validator", version = "2.0.0" }
-cedar-policy-formatter = { path = "../cedar/cedar-policy-formatter", version = "2.0.0" }
+cedar-policy = { path = "../../cedar/cedar-policy", version = "2.0.0", features = ["integration_testing"] }
+cedar-policy-core = { path = "../../cedar/cedar-policy-core", version = "2.0.0" }
+cedar-policy-validator = { path = "../../cedar/cedar-policy-validator", version = "2.0.0" }
+cedar-policy-formatter = { path = "../../cedar/cedar-policy-formatter", version = "2.0.0" }
 jni = { version = "0.19.0", features = ["invocation"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/cedar-drt/fuzz/Cargo.toml
+++ b/cedar-drt/fuzz/Cargo.toml
@@ -15,9 +15,9 @@ libfuzzer-sys = "0.4"
 serde = { version = "1.0", feature = ["derive"] }
 serde_json = "1.0"
 cedar-drt = { version = "2.0.0", path = ".." }
-cedar-policy-core = { path = "../../cedar/cedar-policy-core", version = "2.0.0" }
-cedar-policy-validator = { path = "../../cedar/cedar-policy-validator", version = "2.0.0" }
-cedar-policy-formatter = { path = "../../cedar/cedar-policy-formatter", version = "2.0.0" }
+cedar-policy-core = { path = "../../../cedar/cedar-policy-core", version = "2.0.0" }
+cedar-policy-validator = { path = "../../../cedar/cedar-policy-validator", version = "2.0.0" }
+cedar-policy-formatter = { path = "../../../cedar/cedar-policy-formatter", version = "2.0.0" }
 smol_str = { version = "0.2", features = ["serde"] }
 regex = "1"
 rayon = { version = "1.5", optional = true }


### PR DESCRIPTION
I noticed a discrepancy between the README and what actualy needs to be done for a build to go through.

It would be easier to change the README to instead say to clone `cedar` into the root of this repository, but then that would require some annoying symlinking to have a local build of `cedar-spec` and `cedar-java` at the same time.

Hopefully the actions work.
