### PR TITLE
cleanup in cedar-dafny Makefile

### DIFF
--- a/cedar-dafny/Makefile
+++ b/cedar-dafny/Makefile
@@ -10,7 +10,6 @@
 all:
 
 clean:
-# REVIEW: Should we delete the directories created by `dotnet tool restore` too?
 	rm -rf build
 
 export DOTNET_CLI_TELEMETRY_OPTOUT := 1
@@ -20,8 +19,6 @@ export DOTNET_SYSTEM_GLOBALIZATION_INVARIANT := 1
 # Make `dotnet` install Dafny into the current directory instead of the user's
 # home directory to keep things self-contained. The files that get created are
 # `.dotnet`, `.local/share/NuGet`, and `.nuget`.
-#
-# REVIEW: Is this what we want? Should we even use a subdirectory of `build`?
 export DOTNET_CLI_HOME := $(PWD)
 
 uname_S := $(shell sh -c 'uname -s 2>/dev/null || echo not')
@@ -32,17 +29,15 @@ DOTNET = dotnet
 restore-dafny:
 	dotnet tool restore
 
+# If GEN_STATS is set to 1, compilation will generate statistics in a `TestResults` directory.
 GEN_STATS ?= 0
 ifeq ($(GEN_STATS), 1)
 clean-test-results:
 	rm -rf TestResults/*.csv TestResults/*.trx
 DAFNY_ARGS = /dafnyVerify:1 /compile:0 /warnShadowing /warningsAsErrors /vcsLoad:1 /definiteAssignment:3 /verificationLogger:csv
-REPORTS_DIR="./build/reports"
-STATS_CMD = mkdir -p $(REPORTS_DIR); ./build-tools/bin/tabulate.sh TestResults > $(REPORTS_DIR)/resourceStats.csv
 else
 clean-test-results:
 DAFNY_ARGS = /compile:0 /warnShadowing /warningsAsErrors /vcsLoad:1 /definiteAssignment:3
-STATS_CMD = :
 endif
 
 SOURCEDIR := .
@@ -63,9 +58,6 @@ $(SOURCES): restore-dafny clean-test-results
 
 verify: $(SOURCES)
 
-generate-stats: verify
-	$(STATS_CMD)
-
 TEST_SOURCES := $(shell find $(TEST_SOURCEDIR) -name '*.dfy' | grep -v flycheck)
 DAFNY_TEST_ARGS := /compile:4 /runAllTests:1 /noVerify
 
@@ -74,23 +66,12 @@ $(TEST_SOURCES): restore-dafny
 
 test: $(TEST_SOURCES)
 
-# Notes:
-#
-# - The actual path of the output directory consists of the `/out` path plus
-#   `-java`. Dafny also generates a jar at the `/out` path plus `.jar`. We set
-#   the `DIFFTEST_*` variables below accordingly.
-#
-# - We copy the Java source files to
-#   $(PACKAGE_BUILD_ROOT)/private/gradle/generated/java/main as a hack to make
-#   Bemol detect them so it doesn't report errors on references to them from
-#   CedarDafnyJavaWrapper. That's one of a few source directories that
-#   Bemol automatically checks for. The cleaner solution would be to set Bemol's
-#   `src-dirs` configuration property, but that can only be done in a user-level
-#   configuration file (which is invasive), not by a file in CedarDafny.
+# The actual path of the output directory consists of the `/out` path plus
+# `-java`. Dafny also generates a jar at the `/out` path plus `.jar`. We set
+# the `DIFFTEST_*` variables below accordingly.
 DIFFTEST_COMPILE_OUT := $(PACKAGE_BUILD_ROOT)/private/compile-difftest
 DIFFTEST_JAVA_DIR := $(DIFFTEST_COMPILE_OUT)-java
 DIFFTEST_JAR_FROM_DAFNY := $(DIFFTEST_COMPILE_OUT).jar
-BEMOL_GENERATED_JAVA_SRC_DIR := $(PACKAGE_BUILD_ROOT)/private/gradle/generated/java/main
 DIFFTEST_JAR_EXPORTED := $(PACKAGE_BUILD_ROOT)/lib/CedarDafny-difftest.jar
 compile-difftest: restore-dafny
 	mkdir -p $(PACKAGE_BUILD_ROOT)/private
@@ -100,10 +81,7 @@ compile-difftest: restore-dafny
 	mkdir -p $(PACKAGE_BUILD_ROOT)/lib
 	cp $(DIFFTEST_JAR_FROM_DAFNY) $(DIFFTEST_JAR_EXPORTED)
 	cp $(DIFFTEST_JAVA_DIR)/DafnyRuntime.jar $(PACKAGE_BUILD_ROOT)/lib
-	mkdir -p $(BEMOL_GENERATED_JAVA_SRC_DIR)
-	rsync -rt --del --delete-excluded --include='*/' --include='*.java' --exclude='*' \
-		$(DIFFTEST_JAVA_DIR)/ $(BEMOL_GENERATED_JAVA_SRC_DIR)/
 
-all: generate-stats test compile-difftest
+all: test compile-difftest
 
 .PHONY: $(SOURCES) $(TEST_SOURCES) verify compile-difftest all test


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Minor cleanup in the cedar-dafny Makefile. The important part of the cleanup is removing a reference to the `tabulate.sh` script, which is no longer in the repo. I ran the `./build.sh` script in the toplevel directory, and everything appears to work as expected.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
