### PR TITLE
adding back the 'verify' target

### DIFF
--- a/cedar-dafny/Makefile
+++ b/cedar-dafny/Makefile
@@ -82,6 +82,6 @@ compile-difftest: restore-dafny
 	cp $(DIFFTEST_JAR_FROM_DAFNY) $(DIFFTEST_JAR_EXPORTED)
 	cp $(DIFFTEST_JAVA_DIR)/DafnyRuntime.jar $(PACKAGE_BUILD_ROOT)/lib
 
-all: test compile-difftest
+all: verify test compile-difftest
 
 .PHONY: $(SOURCES) $(TEST_SOURCES) verify compile-difftest all test


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Made a mistake in #25 -- I didn't realize that I had deleted the most important target (`verify`) from the `all` target.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
