### PR TITLE
Refactoring in type soundness proof

### DIFF
--- a/cedar-dafny/def/ext/parser.dfy
+++ b/cedar-dafny/def/ext/parser.dfy
@@ -78,10 +78,10 @@ module def.ext.utils.parser {
       case _ => 16*HexPowerOf(n-1)
     }
   }
+
   lemma HexPowerMonotonic(n1: nat, n2: nat)
     ensures n1 < n2 ==> HexPowerOf(n1) < HexPowerOf(n2)
-  {
-  }
+  {}
 
   function HexStrToNat(s: string): (res: nat)
     requires |s| > 0 && forall i | 0 <= i < |s| :: IsHexDigit(s[i])

--- a/cedar-dafny/def/wildcard.dfy
+++ b/cedar-dafny/def/wildcard.dfy
@@ -101,13 +101,13 @@ module def.engine.wildcard {
   method wildcardMatchIdxMem(text: string, pattern: Pattern, i: nat, j: nat, cache: array2<std.Option<bool>>) returns(r: bool)
     requires i <= |text| && j <= |pattern|;
     requires cache.Length0 == |text| + 1 && cache.Length1 == |pattern| + 1;
-    requires forall p: nat, q: nat ::  p < cache.Length0 &&  q < cache.Length1 && cache[p, q].Some? ==> cache[p, q].value == wildcardMatchIdx(text, pattern, p, q);
+    requires forall p: nat, q: nat | p < cache.Length0 &&  q < cache.Length1 && cache[p, q].Some? :: cache[p, q].value == wildcardMatchIdx(text, pattern, p, q);
     modifies cache;
     decreases |text| - i;
     decreases |pattern| - j;
     ensures r == wildcardMatchIdx(text, pattern, i, j);
     ensures cache[i, j] == Some(wildcardMatchIdx(text, pattern, i, j));
-    ensures forall p: nat, q: nat ::  p < cache.Length0 &&  q < cache.Length1 && cache[p, q].Some? ==> cache[p, q].value == wildcardMatchIdx(text, pattern, p, q);
+    ensures forall p: nat, q: nat | p < cache.Length0 &&  q < cache.Length1 && cache[p, q].Some? :: cache[p, q].value == wildcardMatchIdx(text, pattern, p, q);
   {
     if cache[i, j].Some? {
       r := cache[i, j].value;

--- a/cedar-dafny/thm/slicing.dfy
+++ b/cedar-dafny/thm/slicing.dfy
@@ -26,17 +26,17 @@ module slicing {
     slice.policies.Keys <= store.policies.Keys &&
     (forall pid |
        pid in slice.policies.Keys ::
-         slice.policies[pid] == store.policies[pid])
+       slice.policies[pid] == store.policies[pid])
   }
 
   ghost predicate isSoundSliceForRequest(request: Request, slice: Store, store: Store) {
     isSliceOfPolicyStore(slice.policies, store.policies) &&
     (forall pid |
        (pid in store.policies.policies.Keys && pid !in slice.policies.policies.Keys) ::
-         !Authorizer(request, store).satisfied(pid)) &&
+       !Authorizer(request, store).satisfied(pid)) &&
     (forall pid |
        pid in slice.policies.policies.Keys ::
-         Authorizer(request, slice).satisfied(pid) == Authorizer(request, store).satisfied(pid))
+       Authorizer(request, slice).satisfied(pid) == Authorizer(request, store).satisfied(pid))
   }
 
   lemma AuthorizationIsCorrectForSoundSlicing(request: Request, slice: Store, store: Store)

--- a/cedar-dafny/thm/slicing.dfy
+++ b/cedar-dafny/thm/slicing.dfy
@@ -24,18 +24,18 @@ module slicing {
 
   ghost predicate isSliceOfPolicyStore(slice: PolicyStore, store: PolicyStore) {
     slice.policies.Keys <= store.policies.Keys &&
-    (forall pid ::
-       pid in slice.policies.Keys ==>
+    (forall pid |
+       pid in slice.policies.Keys ::
          slice.policies[pid] == store.policies[pid])
   }
 
   ghost predicate isSoundSliceForRequest(request: Request, slice: Store, store: Store) {
     isSliceOfPolicyStore(slice.policies, store.policies) &&
-    (forall pid ::
-       (pid in store.policies.policies.Keys && pid !in slice.policies.policies.Keys) ==>
+    (forall pid |
+       (pid in store.policies.policies.Keys && pid !in slice.policies.policies.Keys) ::
          !Authorizer(request, store).satisfied(pid)) &&
-    (forall pid ::
-       pid in slice.policies.policies.Keys ==>
+    (forall pid |
+       pid in slice.policies.policies.Keys ::
          Authorizer(request, slice).satisfied(pid) == Authorizer(request, store).satisfied(pid))
   }
 

--- a/cedar-dafny/validation/strict.dfy
+++ b/cedar-dafny/validation/strict.dfy
@@ -119,7 +119,7 @@ module validation.strict {
               var _ :- inferStrictSeq(args,effs);
               // require literal arguments for string parsing functions, which have a "check" field
               if (name in extFunTypes && extFunTypes[name].check.Some?) ==>
-                forall i | 0 <= i < |args| :: args[i].PrimitiveLit?
+                   forall i | 0 <= i < |args| :: args[i].PrimitiveLit?
               then Result.Ok((ty,effs0))
               else Result.Err(NonLitExtConstructor)
           }
@@ -143,7 +143,7 @@ module validation.strict {
         case (Set(ty1), Set(ty2)) => unify(ty1, ty2)
         case (Record(rty1), Record(rty2)) =>
           if rty1.Keys == rty2.Keys &&
-            forall k | k in rty1.Keys :: unify(rty1[k].ty,rty2[k].ty).Ok? && rty1[k].isRequired == rty2[k].isRequired
+             forall k | k in rty1.Keys :: unify(rty1[k].ty,rty2[k].ty).Ok? && rty1[k].isRequired == rty2[k].isRequired
           then Result.Ok(())
           else Result.Err(TypesMustMatch)
         case _ =>

--- a/cedar-dafny/validation/thm/base.dfy
+++ b/cedar-dafny/validation/thm/base.dfy
@@ -122,9 +122,9 @@ module validation.thm.base {
         forall v1 | v1 in s :: InstanceOfType(v1,ty1)
       case (Record(r),Record(rt)) =>
         // if an attribute is present, then it has the expected type
-        (forall k :: k in rt && k in r ==> InstanceOfType(r[k],rt[k].ty)) &&
+        (forall k | k in rt && k in r :: InstanceOfType(r[k],rt[k].ty)) &&
         // required attributes are present
-        (forall k :: k in rt && rt[k].isRequired ==> k in r)
+        (forall k | k in rt && rt[k].isRequired :: k in r)
       case (Extension(Decimal(_)),_) => ty == Type.Extension(Name.fromStr("decimal"))
       case (Extension(IPAddr(_)),_) => ty == Type.Extension(Name.fromStr("ipaddr"))
       case _ => false

--- a/cedar-dafny/validation/thm/model.dfy
+++ b/cedar-dafny/validation/thm/model.dfy
@@ -48,7 +48,7 @@ module validation.thm.model {
 
   lemma InterpretRecordLemmaOk(es: seq<(Attr,Expr)>, r: Request, s: EntityStore)
     requires Evaluator(r,s).interpretRecord(es).Ok?
-    ensures forall i | 0 <= i < |es| :: es[i].0 in Evaluator(r,s).interpretRecord(es).value.Keys && Evaluator(r,s).interpret(es[i].1).Ok?
+    ensures forall i :: 0 <= i < |es| ==> es[i].0 in Evaluator(r,s).interpretRecord(es).value.Keys && Evaluator(r,s).interpret(es[i].1).Ok?
     ensures forall k | k in Evaluator(r,s).interpretRecord(es).value.Keys :: KeyExists(k,es) && Evaluator(r,s).interpret(LastOfKey(k,es)) == base.Ok(Evaluator(r,s).interpretRecord(es).value[k])
   {}
 
@@ -882,9 +882,9 @@ module validation.thm.model {
 
   lemma RecordSafe(r: Request, s: EntityStore, es: seq<(Attr,Expr)>, rt: RecordType)
     // every entry has some type
-    requires forall ae | ae in es :: ExistsSafeType(r,s,ae.1)
+    requires forall ae :: ae in es ==> ExistsSafeType(r,s,ae.1)
     // and the last instance of every required key is safe at the correct type.
-    requires forall k | k in rt :: KeyExists(k,es) && IsSafe(r,s,LastOfKey(k,es),rt[k].ty)
+    requires forall k :: k in rt ==> KeyExists(k,es) && IsSafe(r,s,LastOfKey(k,es),rt[k].ty)
     ensures IsSafe(r,s,Expr.Record(es),Type.Record(rt))
   {
     reveal IsSafe();

--- a/cedar-dafny/validation/thm/model.dfy
+++ b/cedar-dafny/validation/thm/model.dfy
@@ -22,6 +22,7 @@ include "base.dfy"
 module validation.thm.model {
   import opened def
   import opened def.core
+  import opened def.engine
   import opened types
   import opened subtyping
   import opened base
@@ -38,7 +39,7 @@ module validation.thm.model {
     exists i :: 0 <= i < |es| && es[i].0 == k
   }
 
-  ghost function {:opaque true} LastOfKey<K,V>(k: K, es: seq<(K,V)>): (res: V)
+  opaque ghost function LastOfKey<K,V>(k: K, es: seq<(K,V)>): (res: V)
     requires KeyExists(k,es)
     ensures exists i :: 0 <= i < |es| && es[i].0 == k && es[i].1 == res && (forall j :: i < j < |es| ==> es[j].0 != k)
   {
@@ -64,1222 +65,1008 @@ module validation.thm.model {
     ensures Evaluator(r,s).interpretSet(es).Err? ==> exists i :: 0 <= i < |es| && Evaluator(r,s).interpret(es[i]).Err? && Evaluator(r,s).interpret(es[i]).error == Evaluator(r,s).interpretSet(es).error && (forall j :: 0 <= j < i ==> Evaluator(r,s).interpret(es[j]).Ok?);
   {}
 
-  // An implementation of the SemanticModel trait is a model of Cedar.
-  // It consists of two main predicates: InstanceOfType and IsSafe, as well as
-  // compatability lemmata about the predicates.
-  //
-  // IsSafe(r, s, e, t) says that when evaluated with Request `q` and EntityStore `s`,
-  // evaluating Expr `e` will result in a Value of type `t`.
-  //
-  // The compatability lemmata are obtained by taking the Cedar typing rules, and
-  // replacing the typing relation with the expression safety relation.
-  // For example, in Cedar, when e: Bool and e': False, then e && e': False.
-  // This is mirrored by the required lemma `AndRShortSafe`, shown below.
-  //
-  //  lemma AndRShortSafe(r: Request, s: EntityStore, e: Expr, e': Expr)
-  //    requires IsSafe(r,s,e,Type.Bool(AnyBool))
-  //    requires IsSafe(r,s,e',Type.Bool(False))
-  //    ensures IsSafe(r,s,And(e,e'),Type.Bool(False))
-  //
-  // Every Cedar typing rule has a related compatability lemma. The upshot of this
-  // is that we can prove, by induction on the typing relation e: t, that
-  // model.IsSafe(_,_,e,t), for any model: SemanticModel.
+  // ----- Semantic model of Cedar ----- //
 
-  // The SemanticModel construction can also be thought of as a way of axiomatizing
+  // The semantic model construction can be thought of as a way of axiomatizing
   // the behavior of the evaluator that's necessary to prove soundness. When we
   // prove soundness, hiding these properties behind the axiomatic interface
   // of a trait improves the performance of the Dafny verifier significantly.
-  trait SemanticModel {
-    ghost predicate IsSafe(r: Request, s: EntityStore, e: Expr, t: Type)
 
-    // stronger version of `IsSafe` that disallows errors
-    ghost predicate IsSafeStrong(r: Request, s: EntityStore, e: Expr, t: Type)
-
-    // useful shorthands
-    ghost predicate IsTrue (r: Request, s: EntityStore, e: Expr) {
-      IsSafe(r,s,e,Type.Bool(True))
-    }
-    ghost predicate IsFalse (r: Request, s: EntityStore, e: Expr) {
-      IsSafe(r,s,e,Type.Bool(False))
-    }
-    ghost predicate GetAttrSafe (r: Request, s: EntityStore, e: Expr, k: Attr) {
-      IsTrue(r,s,HasAttr(e,k))
-    }
-    ghost predicate IsTrueStrong (r: Request, s: EntityStore, e: Expr) {
-      IsSafeStrong(r,s,e,Type.Bool(True))
-    }
-    ghost predicate IsFalseStrong (r: Request, s: EntityStore, e: Expr) {
-      IsSafeStrong(r,s,e,Type.Bool(False))
-    }
-
-    lemma IsTrueStrongImpliesIsTrue(r: Request, s: EntityStore, e: Expr)
-      requires IsTrueStrong(r,s,e)
-      ensures IsTrue(r,s,e)
-
-    lemma IsTrueImpliesIsTrueStrong(r: Request, s: EntityStore, e: Expr, t: Type)
-      requires IsSafeStrong(r,s,e,t)
-      requires IsTrue(r,s,e)
-      ensures IsTrueStrong(r,s,e)
-
-    lemma NotTrueImpliesFalse(r: Request, s: EntityStore, e: Expr, bt: BoolType)
-      requires IsSafe(r,s,e,Type.Bool(bt))
-      requires !IsTrue(r,s,e)
-      ensures IsFalse(r,s,e)
-
-    lemma FalseImpliesNotTrueStrong(r: Request, s: EntityStore, e: Expr)
-      requires IsFalse(r,s,e)
-      ensures !IsTrueStrong(r,s,e)
-
-    ghost predicate SemanticSubty(t1: Type, t2: Type) {
-      forall v :: InstanceOfType(v,t1) ==> InstanceOfType(v,t2)
-    }
-
-    ghost predicate SemanticUB(t1: Type, t2: Type, ub: Type) {
-      SemanticSubty(t1,ub) && SemanticSubty(t2,ub)
-    }
-
-    lemma SubtyCompat(t1: Type, t2: Type)
-      requires subty(t1,t2)
-      ensures SemanticSubty(t1,t2)
-
-    lemma SemSubtyTransportVal(t: Type, t': Type, v: Value)
-      requires SemanticSubty(t,t')
-      requires InstanceOfType(v,t)
-      ensures InstanceOfType(v,t')
-    {}
-
-    lemma SemSubtyTransport(r: Request, s: EntityStore, e: Expr, t: Type, t': Type)
-      requires SemanticSubty(t,t')
-      requires IsSafe(r,s,e,t)
-      ensures IsSafe(r,s,e,t')
-
-    lemma PrincipalIsSafe(r: Request, s: EntityStore, t: Type)
-      requires InstanceOfType(Value.EntityUID(r.principal),t)
-      ensures IsSafe(r,s,Var(Principal),t)
-
-    lemma ActionIsSafe(r: Request, s: EntityStore, t: Type)
-      requires InstanceOfType(Value.EntityUID(r.action),t)
-      ensures IsSafe(r,s,Var(Action),t)
-
-    lemma ResourceIsSafe(r: Request, s: EntityStore, t: Type)
-      requires InstanceOfType(Value.EntityUID(r.resource),t)
-      ensures IsSafe(r,s,Var(Resource),t)
-
-    lemma ContextIsSafe(r: Request, s: EntityStore, t: Type)
-      requires InstanceOfType(Value.Record(r.context),t)
-      ensures IsSafe(r,s,Var(Context),t)
-
-    lemma PrimSafeLift(r: Request, s: EntityStore, p: Primitive, t: Type)
-      requires InstanceOfType(Value.Primitive(p),t)
-      ensures IsSafe(r,s,Expr.PrimitiveLit(p),t)
-
-    lemma PrimSafeAtInferredType(p: Primitive)
-      ensures InstanceOfType(Value.Primitive(p),typeOfPrim(p))
-
-    lemma EqIsSafe(r: Request, s: EntityStore, e: Expr, e': Expr, t: Type, t': Type)
-      requires IsSafe(r,s,e,t)
-      requires IsSafe(r,s,e',t')
-      ensures IsSafe(r,s,BinaryApp(BinaryOp.Eq,e,e'),Type.Bool(AnyBool))
-
-    lemma EqFalseIsSafe(r: Request, s: EntityStore, e: Expr, e': Expr, lub: EntityLUB, lub': EntityLUB)
-      requires IsSafe(r,s,e,Type.Entity(lub))
-      requires IsSafe(r,s,e',Type.Entity(lub'))
-      requires lub.disjoint(lub')
-      ensures IsFalse(r,s,BinaryApp(BinaryOp.Eq,e,e'))
-
-    lemma EqEntitySameSafe(r: Request, s: EntityStore, E: EntityUID)
-      ensures IsTrue(r,s,Expr.BinaryApp(BinaryOp.Eq,PrimitiveLit(Primitive.EntityUID(E)),PrimitiveLit(Primitive.EntityUID(E))))
-
-    lemma EqEntityDiffSafe(r: Request, s: EntityStore, E: EntityUID, E': EntityUID)
-      requires E != E'
-      ensures IsFalse(r,s,Expr.BinaryApp(BinaryOp.Eq,PrimitiveLit(Primitive.EntityUID(E)),PrimitiveLit(Primitive.EntityUID(E'))))
-
-    lemma AndLShortSafe(r: Request, s: EntityStore, e: Expr, e': Expr)
-      requires IsFalse(r,s,e)
-      ensures IsFalse(r,s,And(e,e'))
-
-    lemma AndRShortSafe(r: Request, s: EntityStore, e: Expr, e': Expr)
-      requires IsSafe(r,s,e,Type.Bool(AnyBool))
-      requires IsFalse(r,s,e')
-      ensures IsFalse(r,s,And(e,e'))
-
-    lemma AndLRetSafe(r: Request, s: EntityStore, e: Expr, e': Expr, t: Type)
-      requires IsSafe(r,s,e,t)
-      requires IsTrue(r,s,e')
-      requires SemanticSubty(t,Type.Bool(AnyBool))
-      ensures IsSafe(r,s,And(e,e'),t)
-
-    lemma AndSafe(r: Request, s: EntityStore, e: Expr, e': Expr)
-      requires IsSafe(r,s,e,Type.Bool(AnyBool))
-      requires IsSafe(r,s,e',Type.Bool(AnyBool))
-      ensures IsSafe(r,s,And(e,e'),Type.Bool(AnyBool))
-
-    lemma AndTrueStrong(r: Request, s: EntityStore, e1: Expr, e2: Expr)
-      requires IsTrue(r,s,e1)
-      requires IsTrueStrong(r,s,And(e1,e2))
-      ensures IsTrueStrong(r,s,e2)
-
-    lemma AndError(r: Request, s: EntityStore, e1: Expr, e2: Expr, t: Type, tnew: Type)
-      requires IsSafe(r,s,e1,t)
-      requires !IsSafeStrong(r,s,e1,t)
-      ensures IsSafe(r,s,And(e1,e2),tnew)
-      ensures !IsSafeStrong(r,s,And(e1,e2),tnew)
-
-    lemma OrLShortSafe(r: Request, s: EntityStore, e: Expr, e': Expr)
-      requires IsTrue(r,s,e)
-      ensures IsTrue(r,s,Or(e,e'))
-
-    lemma OrRShortSafe(r: Request, s: EntityStore, e: Expr, e': Expr)
-      requires IsSafe(r,s,e,Type.Bool(AnyBool))
-      requires IsTrue(r,s,e')
-      ensures IsTrue(r,s,Or(e,e'))
-
-    lemma OrLRetSafe(r: Request, s: EntityStore, e: Expr, e': Expr, t: Type)
-      requires IsSafe(r,s,e,t)
-      requires IsFalse(r,s,e')
-      requires SemanticSubty(t,Type.Bool(AnyBool))
-      ensures IsSafe(r,s,Or(e,e'),t)
-
-    lemma OrRRetSafe(r: Request, s: EntityStore, e: Expr, e': Expr, t: Type)
-      requires IsFalse(r,s,e)
-      requires IsSafe(r,s,e',t)
-      requires SemanticSubty(t,Type.Bool(AnyBool))
-      ensures IsSafe(r,s,Or(e,e'),t)
-
-    lemma OrSafe(r: Request, s: EntityStore, e: Expr, e': Expr)
-      requires IsSafe(r,s,e,Type.Bool(AnyBool))
-      requires IsSafe(r,s,e',Type.Bool(AnyBool))
-      ensures IsSafe(r,s,Or(e,e'),Type.Bool(AnyBool))
-
-    lemma OrTrueStrong(r: Request, s: EntityStore, e1: Expr, e2: Expr)
-      requires IsTrueStrong(r,s,Or(e1,e2))
-      ensures IsTrueStrong(r,s,e1) || IsTrueStrong(r,s,e2)
-
-    lemma NotTrueSafe(r: Request, s: EntityStore, e: Expr)
-      requires IsTrue(r,s,e)
-      ensures IsFalse(r,s,UnaryApp(Not,e))
-
-    lemma NotFalseSafe(r: Request, s: EntityStore, e: Expr)
-      requires IsFalse(r,s,e)
-      ensures IsTrue(r,s,UnaryApp(Not,e))
-
-    lemma NotSafe(r: Request, s: EntityStore, e: Expr)
-      requires IsSafe(r,s,e,Type.Bool(AnyBool))
-      ensures IsSafe(r,s,UnaryApp(Not,e),Type.Bool(AnyBool))
-
-    lemma NegSafe(r: Request, s: EntityStore, e: Expr)
-      requires IsSafe(r,s,e,Type.Int)
-      ensures IsSafe(r,s,UnaryApp(Neg,e),Type.Int)
-
-    lemma MulBySafe(r: Request, s: EntityStore, e: Expr, i: int)
-      requires IsSafe(r,s,e,Type.Int)
-      ensures IsSafe(r,s,UnaryApp(MulBy(i),e),Type.Int)
-
-    lemma IteTrueSafe(r: Request, s: EntityStore, e: Expr, e1: Expr, e2: Expr, t: Type)
-      requires IsTrue(r,s,e)
-      requires IsSafe(r,s,e1,t)
-      ensures IsSafe(r,s,If(e,e1,e2),t)
-
-    lemma IteFalseSafe(r: Request, s: EntityStore, e: Expr, e1: Expr, e2: Expr, t: Type)
-      requires IsFalse(r,s,e)
-      requires IsSafe(r,s,e2,t)
-      ensures IsSafe(r,s,If(e,e1,e2),t)
-
-    lemma IteTrueStrongTrue(r: Request, s: EntityStore, e1: Expr, e2: Expr, e3: Expr)
-      requires IsTrue(r,s,e1)
-      requires IsTrueStrong(r,s,If(e1,e2,e3))
-      ensures IsTrueStrong(r,s,e2)
-
-    lemma IteTrueStrongFalse(r: Request, s: EntityStore, e1: Expr, e2: Expr, e3: Expr)
-      requires IsFalse(r,s,e1)
-      requires IsTrueStrong(r,s,If(e1,e2,e3))
-      ensures IsTrueStrong(r,s,e3)
-
-    lemma IteError(r: Request, s: EntityStore, e1: Expr, e2: Expr, e3: Expr, t: Type, tnew: Type)
-      requires IsSafe(r,s,e1,t)
-      requires !IsSafeStrong(r,s,e1,t)
-      ensures IsSafe(r,s,If(e1,e2,e3),tnew)
-      ensures !IsSafeStrong(r,s,If(e1,e2,e3),tnew)
-
-    lemma ContainsSetSafe(r: Request, s: EntityStore, e: Expr, e': Expr, t1: Type, t2: Type)
-      requires IsSafe(r,s,e,Type.Set(t1))
-      requires IsSafe(r,s,e',t2)
-      ensures IsSafe(r,s,BinaryApp(Contains,e,e'),Type.Bool(AnyBool))
-
-    lemma LikeSafe(r: Request, s: EntityStore, e: Expr, p: Pattern)
-      requires IsSafe(r,s,e,Type.String)
-      ensures IsSafe(r,s,UnaryApp(Like(p),e),Type.Bool(AnyBool))
-
-    lemma SetConstrSafe(r: Request, s: EntityStore, es: seq<Expr>, t: Type)
-      requires forall i :: 0 <= i < |es| ==> IsSafe(r,s,es[i],t)
-      ensures IsSafe(r,s,Expr.Set(es),Type.Set(t))
-
-    lemma ContainsAnyAllSafe(r: Request, s: EntityStore, op: BinaryOp, e1: Expr, e2: Expr, t1: Type, t2: Type)
-      requires op == ContainsAll || op == ContainsAny
-      requires IsSafe(r,s,e1,Type.Set(t1))
-      requires IsSafe(r,s,e2,Type.Set(t2))
-      ensures IsSafe(r,s,BinaryApp(op,e1,e2), Type.Bool(AnyBool))
-
-    lemma IneqSafe(r: Request, s: EntityStore, op: BinaryOp, e1: Expr, e2: Expr)
-      requires op == Less || op == BinaryOp.LessEq
-      requires IsSafe(r,s,e1,Type.Int)
-      requires IsSafe(r,s,e2,Type.Int)
-      ensures IsSafe(r,s,BinaryApp(op,e1,e2),Type.Bool(AnyBool))
-
-    lemma ArithSafe(r: Request, s: EntityStore, op: BinaryOp, e1: Expr, e2: Expr)
-      requires op == Add || op == Sub
-      requires IsSafe(r,s,e1,Type.Int)
-      requires IsSafe(r,s,e2,Type.Int)
-      ensures IsSafe(r,s,BinaryApp(op,e1,e2),Type.Int)
-
-    lemma CallSafe(r: Request, s: EntityStore, name: base.Name, args: seq<Expr>)
-      requires name in extFunTypes
-      requires |args| == |extFunTypes[name].args|
-      requires forall i | 0 <= i < |args| :: IsSafe(r,s,args[i],extFunTypes[name].args[i])
-      ensures IsSafe(r,s,Call(name,args),extFunTypes[name].ret)
-
-    lemma RecordSafe(r: Request, s: EntityStore, es: seq<(Attr,Expr)>, rt: RecordType)
-      //every entry has some type
-      requires forall ae :: ae in es ==> exists t :: IsSafe(r,s,ae.1,t)
-      //and the last instance of every required key is safe at the correct type.
-      requires forall k :: k in rt ==> KeyExists(k,es) && IsSafe(r,s,LastOfKey(k,es),rt[k].ty)
-      ensures IsSafe(r,s,Expr.Record(es),Type.Record(rt))
-
-    lemma ObjectProjSafeRequired(r: Request, s: EntityStore, e: Expr, t: Type, l: Attr, t': AttrType)
-      requires IsSafe(r,s,e,t)
-      requires SemanticSubty(t,Type.Record(map[l := t']))
-      requires t'.isRequired
-      ensures IsSafe(r,s,GetAttr(e,l),t'.ty)
-
-    lemma ObjectProjSafeGetAttrSafe(r: Request, s: EntityStore, e: Expr, t: Type, l: Attr, t': AttrType)
-      requires IsSafe(r,s,e,t)
-      requires SemanticSubty(t,Type.Record(map[l := t']))
-      requires GetAttrSafe(r,s,e,l)
-      ensures IsSafe(r,s,GetAttr(e,l),t'.ty)
-
-    ghost predicate ExistingEntityInLub(s: EntityStore, ev: EntityUID, lub: EntityLUB) {
-      InstanceOfType(Value.Primitive(Primitive.EntityUID(ev)),Type.Entity(lub)) && ev in s.entities
-    }
-
-    ghost predicate EntityProjStoreCondition(s: EntityStore, l: Attr, lub: EntityLUB, t': Type, isRequired: bool) {
-      forall ev: EntityUID | ExistingEntityInLub(s, ev, lub) ::
-        (isRequired ==> l in s.entities[ev].attrs) &&
-        (l in s.entities[ev].attrs ==> InstanceOfType(s.entities[ev].attrs[l],t'))
-    }
-
-    lemma EntityProjSafe(r: Request, s: EntityStore, e: Expr, l: Attr, lub: EntityLUB, t': Type, isRequired: bool)
-      requires IsSafe(r,s,e,Type.Entity(lub))
-      requires EntityProjStoreCondition(s, l, lub, t', isRequired)
-      requires isRequired || GetAttrSafe(r,s,e,l)
-      ensures IsSafe(r,s,GetAttr(e,l),t')
-
-    lemma RecordHasRequiredTrueSafe(r: Request, s: EntityStore, e: Expr, l: Attr, t: AttrType)
-      requires IsSafe(r,s,e,Type.Record(map[l := t]))
-      requires t.isRequired
-      ensures IsTrue(r,s,HasAttr(e,l))
-
-    lemma RecordHasOpenRecSafe(r: Request, s: EntityStore, e: Expr, l: Attr)
-      requires IsSafe(r,s,e,Type.Record(map[]))
-      ensures IsSafe(r,s,HasAttr(e,l),Type.Bool(AnyBool))
-
-    lemma EntityHasImpossibleFalseSafe(r: Request, s: EntityStore, e: Expr, l: Attr, lub: EntityLUB)
-      requires IsSafe(r,s,e,Type.Entity(lub))
-      requires forall ev: EntityUID | ExistingEntityInLub(s, ev, lub) ::
-                 l !in s.entities[ev].attrs
-      ensures IsFalse(r,s,HasAttr(e,l))
-
-    lemma EntityHasOpenSafe(r: Request, s: EntityStore, e: Expr, l: Attr)
-      requires IsSafe(r,s,e,Type.Entity(AnyEntity))
-      ensures IsSafe(r,s,HasAttr(e,l),Type.Bool(AnyBool))
-
-    lemma InSingleSafe(r: Request, s: EntityStore, e1: Expr, e2: Expr)
-      requires IsSafe(r,s,e1,Type.Entity(AnyEntity))
-      requires IsSafe(r,s,e2,Type.Entity(AnyEntity))
-      ensures IsSafe(r,s,BinaryApp(BinaryOp.In,e1,e2),Type.Bool(AnyBool))
-
-    // Duplicate Evaluator.EntityInEntity here so that SemanticModel and
-    // soundness.dfy don't have to depend on engine.dfy.
-    ghost predicate EntityInEntity(s: EntityStore, u1: EntityUID, u2: EntityUID) {
-      u1 == u2 || (s.getEntityAttrs(u1).Ok? && s.entityIn(u1, u2))
-    }
-
-    lemma InSingleFalseLiterals(r: Request, s: EntityStore, u1: EntityUID, u2: EntityUID)
-      requires !EntityInEntity(s,u1,u2)
-      ensures IsFalse(r,s,BinaryApp(BinaryOp.In,PrimitiveLit(Primitive.EntityUID(u1)),PrimitiveLit(Primitive.EntityUID(u2))))
-
-    lemma InSingleFalseEntityTypeAndLiteral(r: Request, s: EntityStore, e1: Expr, et1: EntityType, u2: EntityUID)
-      requires IsSafe(r,s,e1,Type.Entity(EntityLUB({et1})))
-      requires forall u1: EntityUID | u1.ty == et1 :: !EntityInEntity(s,u1,u2)
-      ensures IsFalse(r,s,BinaryApp(BinaryOp.In,e1,PrimitiveLit(Primitive.EntityUID(u2))))
-
-    lemma InSingleFalseTypes(r: Request, s: EntityStore, e1: Expr, e2: Expr, t1: Type, t2: Type)
-      requires subty(t1,Type.Entity(AnyEntity))
-      requires subty(t2,Type.Entity(AnyEntity))
-      requires IsSafe(r,s,e1,t1)
-      requires IsSafe(r,s,e2,t2)
-      requires forall u1, u2: EntityUID |
-        InstanceOfType(Value.EntityUID(u1), t1) && InstanceOfType(Value.EntityUID(u2), t2) ::
-        !EntityInEntity(s,u1,u2)
-      ensures IsFalse(r,s,BinaryApp(BinaryOp.In,e1,e2))
-
-    lemma InSetSafe(r: Request, s: EntityStore, e1: Expr, e2: Expr)
-      requires IsSafe(r,s,e1,Type.Entity(AnyEntity))
-      requires IsSafe(r,s,e2,Type.Set(Type.Entity(AnyEntity)))
-      ensures IsSafe(r,s,BinaryApp(BinaryOp.In,e1,e2),Type.Bool(AnyBool))
-
-    lemma InSetFalseIfAllFalse(r: Request, s: EntityStore, e1: Expr, e2s: seq<Expr>)
-      requires IsSafe(r,s,e1,Type.Entity(AnyEntity))
-      requires forall i | 0 <= i < |e2s| ::
-                 IsSafe(r,s,e2s[i],Type.Entity(AnyEntity)) &&
-                 IsFalse(r,s,BinaryApp(BinaryOp.In,e1,e2s[i]))
-      ensures IsFalse(r,s,BinaryApp(BinaryOp.In,e1,Expr.Set(e2s)))
-
-    lemma InSetFalseTypes(r: Request, s: EntityStore, e1: Expr, e2: Expr, t1: Type, t2: Type)
-      requires subty(t1,Type.Entity(AnyEntity))
-      requires subty(t2,Type.Entity(AnyEntity))
-      requires IsSafe(r,s,e1,t1)
-      requires IsSafe(r,s,e2,Type.Set(t2))
-      requires forall u1, u2: EntityUID |
-        InstanceOfType(Value.EntityUID(u1), t1) && InstanceOfType(Value.EntityUID(u2), t2) ::
-        !EntityInEntity(s,u1,u2)
-      ensures IsFalse(r,s,BinaryApp(BinaryOp.In,e1,e2))
+  ghost predicate IsTrue (r: Request, s: EntityStore, e: Expr) {
+    IsSafe(r,s,e,Type.Bool(True))
   }
 
-  // The particular model we're interested in is the EvaluatorModel, where a term
-  // is safe if it evaluates to a safe value or an error that is out-of-scope for
-  // the validator.
-  import opened def.engine
-  class EvaluatorModel extends SemanticModel {
-    ghost constructor(){}
+  ghost predicate IsFalse (r: Request, s: EntityStore, e: Expr) {
+    IsSafe(r,s,e,Type.Bool(False))
+  }
 
-    // An expression is safe if it evaluates to a value of the expected type
-    // or produces an error of type EntityDoesNotExist or ExtensionError.
-    //
-    // The validator cannot protect against errors where an entity literal is
-    // not defined in the entity store or extension errors, but it can protect
-    // against all other types of errors, namely: AttrDoesNotExist, TypeError,
-    // ArityMismatchError, NoSuchFunctionError
-    ghost predicate IsSafe(r: Request, s: EntityStore, e: Expr, t: Type) {
-      Evaluate(e,r,s) == base.Err(base.EntityDoesNotExist) ||
-      Evaluate(e,r,s) == base.Err(base.ExtensionError) ||
-      (Evaluate(e,r,s).Ok? && InstanceOfType(Evaluate(e,r,s).value,t))
+  ghost predicate GetAttrSafe (r: Request, s: EntityStore, e: Expr, k: Attr) {
+    IsTrue(r,s,HasAttr(e,k))
+  }
+
+  ghost predicate IsTrueStrong (r: Request, s: EntityStore, e: Expr) {
+    IsSafeStrong(r,s,e,Type.Bool(True))
+  }
+
+  ghost predicate IsFalseStrong (r: Request, s: EntityStore, e: Expr) {
+    IsSafeStrong(r,s,e,Type.Bool(False))
+  }
+
+  ghost predicate SemanticSubty(t1: Type, t2: Type) {
+    forall v :: InstanceOfType(v,t1) ==> InstanceOfType(v,t2)
+  }
+
+  ghost predicate SemanticUB(t1: Type, t2: Type, ub: Type) {
+    SemanticSubty(t1,ub) && SemanticSubty(t2,ub)
+  }
+
+  lemma SemSubtyTransportVal(t: Type, t': Type, v: Value)
+    requires SemanticSubty(t,t')
+    requires InstanceOfType(v,t)
+    ensures InstanceOfType(v,t')
+  {}
+
+  ghost predicate ExistingEntityInLub(s: EntityStore, ev: EntityUID, lub: EntityLUB) {
+    InstanceOfType(Value.Primitive(Primitive.EntityUID(ev)),Type.Entity(lub)) && ev in s.entities
+  }
+
+  ghost predicate EntityProjStoreCondition(s: EntityStore, l: Attr, lub: EntityLUB, t': Type, isRequired: bool) {
+    forall ev: EntityUID | ExistingEntityInLub(s, ev, lub) ::
+      (isRequired ==> l in s.entities[ev].attrs) &&
+      (l in s.entities[ev].attrs ==> InstanceOfType(s.entities[ev].attrs[l],t'))
+  }
+
+  // Duplicate Evaluator.EntityInEntity here so that SemanticModel and
+  // soundness.dfy don't have to depend on engine.dfy.
+  ghost predicate EntityInEntity(s: EntityStore, u1: EntityUID, u2: EntityUID) {
+    u1 == u2 || (s.getEntityAttrs(u1).Ok? && s.entityIn(u1, u2))
+  }
+
+  // An expression is safe if it evaluates to a value of the expected type
+  // or produces an error of type EntityDoesNotExist or ExtensionError.
+  //
+  // The validator cannot protect against errors where an entity literal is
+  // not defined in the entity store or extension errors, but it can protect
+  // against all other types of errors, namely: AttrDoesNotExist, TypeError,
+  // ArityMismatchError, NoSuchFunctionError
+  opaque ghost predicate IsSafe(r: Request, s: EntityStore, e: Expr, t: Type) {
+    Evaluate(e,r,s) == base.Err(base.EntityDoesNotExist) ||
+    Evaluate(e,r,s) == base.Err(base.ExtensionError) ||
+    (Evaluate(e,r,s).Ok? && InstanceOfType(Evaluate(e,r,s).value,t))
+  }
+
+  opaque ghost predicate IsSafeStrong (r: Request, s: EntityStore, e: Expr, t: Type) {
+    IsSafe(r,s,e,t) && Evaluate(e,r,s).Ok?
+  }
+
+  lemma IsTrueStrongImpliesIsTrue(r: Request, s: EntityStore, e: Expr)
+    requires IsTrueStrong(r,s,e)
+    ensures IsTrue(r,s,e)
+  {
+    reveal IsSafeStrong();
+  }
+
+  lemma IsTrueImpliesIsTrueStrong(r: Request, s: EntityStore, e: Expr, t: Type)
+    requires IsSafeStrong(r,s,e,t)
+    requires IsTrue(r,s,e)
+    ensures IsTrueStrong(r,s,e)
+  {
+    reveal IsSafeStrong();
+  }
+
+  lemma NotTrueImpliesFalse(r: Request, s: EntityStore, e: Expr, bt: BoolType)
+    requires IsSafe(r,s,e,Type.Bool(bt))
+    requires !IsTrue(r,s,e)
+    ensures IsFalse(r,s,e)
+  {
+    reveal IsSafe();
+  }
+
+  lemma NotSafeImpliesNotSafeStrong(r: Request, s: EntityStore, e: Expr, t: Type)
+    requires !IsSafe(r,s,e,t)
+    ensures !IsSafeStrong(r,s,e,t)
+  {
+    reveal IsSafeStrong();
+    reveal IsSafe();
+  }
+
+  lemma FalseImpliesNotTrueStrong(r: Request, s: EntityStore, e: Expr)
+    requires IsFalse(r,s,e)
+    ensures !IsTrueStrong(r,s,e)
+  {
+    reveal IsSafeStrong();
+    reveal IsSafe();
+  }
+
+  lemma SubtyCompat(t: Type, t': Type)
+    requires subty(t,t')
+    ensures SemanticSubty(t,t')
+  {
+    assert subty(t,t');
+    assert SemanticSubty(t,t') by {
+      forall v: Value | InstanceOfType(v,t)
+        ensures InstanceOfType(v,t')
+      {
+        SubtyCompatPointwise(t,t',v);
+      }
     }
+  }
 
-    ghost predicate IsSafeStrong (r: Request, s: EntityStore, e: Expr, t: Type) {
-      IsSafe(r,s,e,t) && Evaluate(e,r,s).Ok?
-    }
-
-    lemma IsTrueStrongImpliesIsTrue(r: Request, s: EntityStore, e: Expr)
-      requires IsTrueStrong(r,s,e)
-      ensures IsTrue(r,s,e)
-    {}
-
-    lemma IsTrueImpliesIsTrueStrong(r: Request, s: EntityStore, e: Expr, t: Type)
-      requires IsSafeStrong(r,s,e,t)
-      requires IsTrue(r,s,e)
-      ensures IsTrueStrong(r,s,e)
-    {}
-
-    lemma NotTrueImpliesFalse(r: Request, s: EntityStore, e: Expr, bt: BoolType)
-      requires IsSafe(r,s,e,Type.Bool(bt))
-      requires !IsTrue(r,s,e)
-      ensures IsFalse(r,s,e)
-    {}
-
-    lemma NotSafeImpliesNotSafeStrong(r: Request, s: EntityStore, e: Expr, t: Type)
-      requires !IsSafe(r,s,e,t)
-      ensures !IsSafeStrong(r,s,e,t)
-    {}
-
-    lemma FalseImpliesNotTrueStrong(r: Request, s: EntityStore, e: Expr)
-      requires IsFalse(r,s,e)
-      ensures !IsTrueStrong(r,s,e)
-    {}
-
-    lemma SubtyCompat(t: Type, t': Type)
-      requires subty(t,t')
-      ensures SemanticSubty(t,t')
-    {
-      assert subty(t,t');
-      assert SemanticSubty(t,t') by {
-        forall v: Value | InstanceOfType(v,t)
-          ensures InstanceOfType(v,t')
-        {
-          SubtyCompatPointwise(t,t',v);
+  lemma SubtyCompatMatchPointwise(t: Type, t': Type, v: Value)
+    requires subty(t,t')
+    requires InstanceOfType(v,t)
+    ensures InstanceOfType(v,t')
+    decreases t
+  {
+    match (t,t',v) {
+      case (Never,_,_) =>
+      case (String,String,_) =>
+      case (Int,Int,_) =>
+      case (Bool(b1),Bool(b2),_) =>
+      case (Set(t1),Set(t2),Set(s)) =>
+        assert forall v' | v' in s :: InstanceOfType(v',t2) by {
+          forall v': Value | v' in s
+            ensures InstanceOfType(v',t2)
+          {
+            assert InstanceOfType(v',t1);
+            SubtyCompatMatchPointwise(t1,t2,v');
+          }
         }
-      }
-    }
-
-    lemma SubtyCompatMatchPointwise(t: Type, t': Type, v: Value)
-      requires subty(t,t')
-      requires InstanceOfType(v,t)
-      ensures InstanceOfType(v,t')
-      decreases t
-    {
-      match (t,t',v) {
-        case (Never,_,_) =>
-        case (String,String,_) =>
-        case (Int,Int,_) =>
-        case (Bool(b1),Bool(b2),_) =>
-        case (Set(t1),Set(t2),Set(s)) =>
-          assert forall v' | v' in s :: InstanceOfType(v',t2) by {
-            forall v': Value | v' in s
-              ensures InstanceOfType(v',t2)
-            {
-              assert InstanceOfType(v',t1);
-              SubtyCompatMatchPointwise(t1,t2,v');
-            }
+      case (Record(rt1),Record(rt2),Record(rv)) =>
+        assert forall k | k in rt2 && k in rv :: InstanceOfType(rv[k],rt2[k].ty) by {
+          forall k: Attr | k in rt2 && k in rv
+            ensures InstanceOfType(rv[k],rt2[k].ty)
+          {
+            assert InstanceOfType(rv[k],rt1[k].ty);
+            assert subtyAttrType(rt1[k],rt2[k]);
+            SubtyCompatMatchPointwise(rt1[k].ty,rt2[k].ty,rv[k]);
           }
-        case (Record(rt1),Record(rt2),Record(rv)) =>
-          assert forall k | k in rt2 && k in rv :: InstanceOfType(rv[k],rt2[k].ty) by {
-            forall k: Attr | k in rt2 && k in rv
-              ensures InstanceOfType(rv[k],rt2[k].ty)
-            {
-              assert InstanceOfType(rv[k],rt1[k].ty);
-              assert subtyAttrType(rt1[k],rt2[k]);
-              SubtyCompatMatchPointwise(rt1[k].ty,rt2[k].ty,rv[k]);
-            }
-          }
-          assert forall k | k in rt2 && rt2[k].isRequired :: k in rv by {
-            forall k | k in rt2 && rt2[k].isRequired
-              ensures k in rv
-            {
-              assert subtyAttrType(rt1[k],rt2[k]);
-            }
-          }
-        case (Entity(e1),Entity(e2),_) =>
-        case (Extension(e1),Extension(e2),_) =>
-      }
-    }
-
-    lemma SubtyCompatPointwise(t: Type, t': Type, v: Value)
-      requires subty(t,t')
-      requires InstanceOfType(v,t)
-      ensures InstanceOfType(v,t')
-    {
-      SubtyCompatMatchPointwise(t,t',v);
-    }
-
-    lemma SemSubtyTransport(r: Request, s: EntityStore, e: Expr, t: Type, t': Type)
-      requires SemanticSubty(t,t')
-      requires IsSafe(r,s,e,t)
-      ensures IsSafe(r,s,e,t')
-    {
-      if (exists v :: Evaluate(e,r,s) == base.Ok(v) && InstanceOfType(v,t)) {
-        var v :| Evaluate(e,r,s) == base.Ok(v) && InstanceOfType(v,t);
-        assert InstanceOfType(v,t') by {
-          SemSubtyTransportVal(t,t',v);
         }
+        assert forall k | k in rt2 && rt2[k].isRequired :: k in rv by {
+          forall k | k in rt2 && rt2[k].isRequired
+            ensures k in rv
+          {
+            assert subtyAttrType(rt1[k],rt2[k]);
+          }
+        }
+      case (Entity(e1),Entity(e2),_) =>
+      case (Extension(e1),Extension(e2),_) =>
+    }
+  }
+
+  lemma SubtyCompatPointwise(t: Type, t': Type, v: Value)
+    requires subty(t,t')
+    requires InstanceOfType(v,t)
+    ensures InstanceOfType(v,t')
+  {
+    SubtyCompatMatchPointwise(t,t',v);
+  }
+
+  lemma SemSubtyTransport(r: Request, s: EntityStore, e: Expr, t: Type, t': Type)
+    requires SemanticSubty(t,t')
+    requires IsSafe(r,s,e,t)
+    ensures IsSafe(r,s,e,t')
+  {
+    reveal IsSafe();
+    if (exists v :: Evaluate(e,r,s) == base.Ok(v) && InstanceOfType(v,t)) {
+      var v :| Evaluate(e,r,s) == base.Ok(v) && InstanceOfType(v,t);
+      assert InstanceOfType(v,t') by {
+        SemSubtyTransportVal(t,t',v);
       }
     }
+  }
 
-    lemma PrincipalIsSafe(r: Request, s: EntityStore, t: Type)
-      requires InstanceOfType(Value.EntityUID(r.principal),t)
-      ensures IsSafe(r,s,Var(Principal),t)
-    {}
+  lemma PrincipalIsSafe(r: Request, s: EntityStore, t: Type)
+    requires InstanceOfType(Value.EntityUID(r.principal),t)
+    ensures IsSafe(r,s,Var(Principal),t)
+  {
+    reveal IsSafe();
+  }
 
-    lemma ActionIsSafe(r: Request, s: EntityStore, t: Type)
-      requires InstanceOfType(Value.EntityUID(r.action),t)
-      ensures IsSafe(r,s,Var(Action),t)
-    {}
+  lemma ActionIsSafe(r: Request, s: EntityStore, t: Type)
+    requires InstanceOfType(Value.EntityUID(r.action),t)
+    ensures IsSafe(r,s,Var(Action),t)
+  {
+    reveal IsSafe();
+  }
 
-    lemma ResourceIsSafe(r: Request, s: EntityStore, t: Type)
-      requires InstanceOfType(Value.EntityUID(r.resource),t)
-      ensures IsSafe(r,s,Var(Resource),t)
-    {}
+  lemma ResourceIsSafe(r: Request, s: EntityStore, t: Type)
+    requires InstanceOfType(Value.EntityUID(r.resource),t)
+    ensures IsSafe(r,s,Var(Resource),t)
+  {
+    reveal IsSafe();
+  }
 
-    lemma ContextIsSafe(r: Request, s: EntityStore, t: Type)
-      requires InstanceOfType(Value.Record(r.context),t)
-      ensures IsSafe(r,s,Var(Context),t)
-    {}
+  lemma ContextIsSafe(r: Request, s: EntityStore, t: Type)
+    requires InstanceOfType(Value.Record(r.context),t)
+    ensures IsSafe(r,s,Var(Context),t)
+  {
+    reveal IsSafe();
+  }
 
-    lemma PrimSafeLift(r: Request, s: EntityStore, p: Primitive, t: Type)
-      requires InstanceOfType(Value.Primitive(p),t)
-      ensures IsSafe(r,s,Expr.PrimitiveLit(p),t)
-    {}
+  lemma PrimSafeLift(r: Request, s: EntityStore, p: Primitive, t: Type)
+    requires InstanceOfType(Value.Primitive(p),t)
+    ensures IsSafe(r,s,Expr.PrimitiveLit(p),t)
+  {
+    reveal IsSafe();
+  }
 
-    lemma PrimSafeAtInferredType(p: Primitive)
-      ensures InstanceOfType(Value.Primitive(p),typeOfPrim(p))
-    {}
+  lemma PrimSafeAtInferredType(p: Primitive)
+    ensures InstanceOfType(Value.Primitive(p),typeOfPrim(p))
+  {}
 
-    lemma EqIsSafe(r: Request, s: EntityStore, e: Expr, e': Expr, t: Type, t': Type)
-      requires IsSafe(r,s,e,t)
-      requires IsSafe(r,s,e',t')
-      ensures IsSafe(r,s,BinaryApp(BinaryOp.Eq,e,e'),Type.Bool(AnyBool))
-    {}
+  lemma EqIsSafe(r: Request, s: EntityStore, e: Expr, e': Expr, t: Type, t': Type)
+    requires IsSafe(r,s,e,t)
+    requires IsSafe(r,s,e',t')
+    ensures IsSafe(r,s,BinaryApp(BinaryOp.Eq,e,e'),Type.Bool(AnyBool))
+  {
+    reveal IsSafe();
+  }
 
-    lemma EqFalseIsSafe(r: Request, s: EntityStore, e: Expr, e': Expr, lub: EntityLUB, lub': EntityLUB)
-      requires IsSafe(r,s,e,Type.Entity(lub))
-      requires IsSafe(r,s,e',Type.Entity(lub'))
-      requires lub.disjoint(lub')
-      ensures IsFalse(r,s,BinaryApp(BinaryOp.Eq,e,e'))
-    {}
+  lemma EqFalseIsSafe(r: Request, s: EntityStore, e: Expr, e': Expr, lub: EntityLUB, lub': EntityLUB)
+    requires IsSafe(r,s,e,Type.Entity(lub))
+    requires IsSafe(r,s,e',Type.Entity(lub'))
+    requires lub.disjoint(lub')
+    ensures IsFalse(r,s,BinaryApp(BinaryOp.Eq,e,e'))
+  {
+    reveal IsSafe();
+  }
 
-    lemma EqEntitySameSafe(r: Request, s: EntityStore, E: EntityUID)
-      ensures IsTrue(r,s,Expr.BinaryApp(BinaryOp.Eq,PrimitiveLit(Primitive.EntityUID(E)),PrimitiveLit(Primitive.EntityUID(E))))
-    {
-      var e := Expr.BinaryApp(BinaryOp.Eq,PrimitiveLit(Primitive.EntityUID(E)),PrimitiveLit(Primitive.EntityUID(E)));
-      assert Evaluator(r,s).interpret(e) == base.Ok(Value.Primitive(Primitive.Bool(true)));
+  lemma EqEntitySameSafe(r: Request, s: EntityStore, E: EntityUID)
+    ensures IsTrue(r,s,Expr.BinaryApp(BinaryOp.Eq,PrimitiveLit(Primitive.EntityUID(E)),PrimitiveLit(Primitive.EntityUID(E))))
+  {
+    reveal IsSafe();
+    var e := Expr.BinaryApp(BinaryOp.Eq,PrimitiveLit(Primitive.EntityUID(E)),PrimitiveLit(Primitive.EntityUID(E)));
+    assert Evaluator(r,s).interpret(e) == base.Ok(Value.Primitive(Primitive.Bool(true)));
+  }
+
+  lemma EqEntityDiffSafe(r: Request, s: EntityStore, E: EntityUID, E': EntityUID)
+    requires E != E'
+    ensures IsFalse(r,s,Expr.BinaryApp(BinaryOp.Eq,PrimitiveLit(Primitive.EntityUID(E)),PrimitiveLit(Primitive.EntityUID(E'))))
+  {
+    reveal IsSafe();
+    var e := Expr.BinaryApp(BinaryOp.Eq,PrimitiveLit(Primitive.EntityUID(E)),PrimitiveLit(Primitive.EntityUID(E')));
+    assert Evaluator(r,s).interpret(e) == base.Ok(Value.Primitive(Primitive.Bool(false)));
+  }
+
+  lemma AndLShortSafe(r: Request, s: EntityStore, e: Expr, e': Expr)
+    requires IsFalse(r,s,e)
+    ensures IsFalse(r,s,And(e,e'))
+  {
+    reveal IsSafe();
+    if Evaluate(e,r,s).Ok? {
+      assert Evaluate(e,r,s) == base.Ok(Value.Primitive(Primitive.Bool(false)));
+      assert Evaluator(r,s).interpretShortcircuit(And(e,e'),e,e',false) == base.Ok(Value.Primitive(Primitive.Bool(false)));
+      assert Evaluate(And(e,e'),r,s) == base.Ok(Value.Primitive(Primitive.Bool(false)));
+    } else {
+      assert Evaluator(r,s).interpretShortcircuit(And(e,e'),e,e',false) == Evaluate(e,r,s);
+      assert Evaluate(And(e,e'),r,s) == Evaluate(e,r,s);
     }
+  }
 
-    lemma EqEntityDiffSafe(r: Request, s: EntityStore, E: EntityUID, E': EntityUID)
-      requires E != E'
-      ensures IsFalse(r,s,Expr.BinaryApp(BinaryOp.Eq,PrimitiveLit(Primitive.EntityUID(E)),PrimitiveLit(Primitive.EntityUID(E'))))
-    {
-      var e := Expr.BinaryApp(BinaryOp.Eq,PrimitiveLit(Primitive.EntityUID(E)),PrimitiveLit(Primitive.EntityUID(E')));
-      assert Evaluator(r,s).interpret(e) == base.Ok(Value.Primitive(Primitive.Bool(false)));
-    }
-
-    lemma AndLShortSafe(r: Request, s: EntityStore, e: Expr, e': Expr)
-      requires IsFalse(r,s,e)
-      ensures IsFalse(r,s,And(e,e'))
-    {
-      if Evaluate(e,r,s).Ok? {
-        assert Evaluate(e,r,s) == base.Ok(Value.Primitive(Primitive.Bool(false)));
-        assert Evaluator(r,s).interpretShortcircuit(And(e,e'),e,e',false) == base.Ok(Value.Primitive(Primitive.Bool(false)));
-        assert Evaluate(And(e,e'),r,s) == base.Ok(Value.Primitive(Primitive.Bool(false)));
-      } else {
+  lemma AndRShortSafe(r: Request, s: EntityStore, e: Expr, e': Expr)
+    requires IsSafe(r,s,e,Type.Bool(AnyBool))
+    requires IsFalse(r,s,e')
+    ensures IsFalse(r,s,And(e,e'))
+  {
+    reveal IsSafe();
+    if Evaluate(e,r,s).Ok? && Evaluate(e',r,s).Ok? {
+      assert Evaluate(e',r,s) == base.Ok(Value.Primitive(Primitive.Bool(false)));
+      assert Evaluator(r,s).interpretShortcircuit(And(e,e'),e,e',false) == base.Ok(Value.Primitive(Primitive.Bool(false)));
+      assert Evaluate(And(e,e'),r,s) == base.Ok(Value.Primitive(Primitive.Bool(false)));
+    } else {
+      if Evaluate(e,r,s).Err? {
         assert Evaluator(r,s).interpretShortcircuit(And(e,e'),e,e',false) == Evaluate(e,r,s);
         assert Evaluate(And(e,e'),r,s) == Evaluate(e,r,s);
-      }
-    }
-
-    lemma AndRShortSafe(r: Request, s: EntityStore, e: Expr, e': Expr)
-      requires IsSafe(r,s,e,Type.Bool(AnyBool))
-      requires IsFalse(r,s,e')
-      ensures IsFalse(r,s,And(e,e'))
-    {
-      if Evaluate(e,r,s).Ok? && Evaluate(e',r,s).Ok? {
-        assert Evaluate(e',r,s) == base.Ok(Value.Primitive(Primitive.Bool(false)));
-        assert Evaluator(r,s).interpretShortcircuit(And(e,e'),e,e',false) == base.Ok(Value.Primitive(Primitive.Bool(false)));
-        assert Evaluate(And(e,e'),r,s) == base.Ok(Value.Primitive(Primitive.Bool(false)));
       } else {
-        if Evaluate(e,r,s).Err? {
-          assert Evaluator(r,s).interpretShortcircuit(And(e,e'),e,e',false) == Evaluate(e,r,s);
-          assert Evaluate(And(e,e'),r,s) == Evaluate(e,r,s);
+        assert Evaluate(e',r,s).Err?;
+        var b :| Evaluate(e,r,s) == base.Ok(Value.Primitive(Primitive.Bool(b)));
+        if b {
+          assert Evaluator(r,s).interpretShortcircuit(And(e,e'),e,e',false) == Evaluate(e',r,s);
+          assert Evaluate(And(e,e'),r,s) == Evaluate(e',r,s);
         } else {
-          assert Evaluate(e',r,s).Err?;
-          var b :| Evaluate(e,r,s) == base.Ok(Value.Primitive(Primitive.Bool(b)));
-          if b {
-            assert Evaluator(r,s).interpretShortcircuit(And(e,e'),e,e',false) == Evaluate(e',r,s);
-            assert Evaluate(And(e,e'),r,s) == Evaluate(e',r,s);
-          } else {
-            assert Evaluator(r,s).interpretShortcircuit(And(e,e'),e,e',false) == base.Ok(Value.Primitive(Primitive.Bool(false)));
-            assert Evaluate(And(e,e'),r,s) == base.Ok(Value.Primitive(Primitive.Bool(false)));
-          }
+          assert Evaluator(r,s).interpretShortcircuit(And(e,e'),e,e',false) == base.Ok(Value.Primitive(Primitive.Bool(false)));
+          assert Evaluate(And(e,e'),r,s) == base.Ok(Value.Primitive(Primitive.Bool(false)));
         }
       }
     }
+  }
 
-    lemma AndLRetSafe(r: Request, s: EntityStore, e: Expr, e': Expr, t: Type)
-      requires IsSafe(r,s,e,t)
-      requires IsTrue(r,s,e')
-      requires SemanticSubty(t,Type.Bool(AnyBool))
-      ensures IsSafe(r,s,And(e,e'),t)
-    {
-      if Evaluate(e,r,s).Ok? && Evaluate(e',r,s).Ok? {
-        assert Evaluate(e',r,s) == base.Ok(Value.Primitive(Primitive.Bool(true)));
-        var v :| Evaluate(e,r,s) == base.Ok(v) && InstanceOfType(v,t);
-        assert InstanceOfType(v,Type.Bool(AnyBool)) by {
-          SemSubtyTransportVal(t,Type.Bool(AnyBool),v);
-        }
-        var b :| v == Value.Primitive(Primitive.Bool(b));
-        assert Evaluator(r,s).interpretShortcircuit(And(e,e'),e,e',false) == base.Ok(Value.Primitive(Primitive.Bool(b)));
-        assert Evaluate(And(e,e'),r,s) == base.Ok(Value.Primitive(Primitive.Bool(b)));
+  lemma AndLRetSafe(r: Request, s: EntityStore, e: Expr, e': Expr, t: Type)
+    requires IsSafe(r,s,e,t)
+    requires IsTrue(r,s,e')
+    requires SemanticSubty(t,Type.Bool(AnyBool))
+    ensures IsSafe(r,s,And(e,e'),t)
+  {
+    reveal IsSafe();
+    if Evaluate(e,r,s).Ok? && Evaluate(e',r,s).Ok? {
+      assert Evaluate(e',r,s) == base.Ok(Value.Primitive(Primitive.Bool(true)));
+      var v :| Evaluate(e,r,s) == base.Ok(v) && InstanceOfType(v,t);
+      assert InstanceOfType(v,Type.Bool(AnyBool)) by {
+        SemSubtyTransportVal(t,Type.Bool(AnyBool),v);
+      }
+      var b :| v == Value.Primitive(Primitive.Bool(b));
+      assert Evaluator(r,s).interpretShortcircuit(And(e,e'),e,e',false) == base.Ok(Value.Primitive(Primitive.Bool(b)));
+      assert Evaluate(And(e,e'),r,s) == base.Ok(Value.Primitive(Primitive.Bool(b)));
+    } else {
+      if Evaluate(e,r,s).Err? {
+        assert Evaluator(r,s).interpretShortcircuit(And(e,e'),e,e',false) == Evaluate(e,r,s);
+        assert Evaluate(And(e,e'),r,s) == Evaluate(e,r,s);
       } else {
-        if Evaluate(e,r,s).Err? {
-          assert Evaluator(r,s).interpretShortcircuit(And(e,e'),e,e',false) == Evaluate(e,r,s);
-          assert Evaluate(And(e,e'),r,s) == Evaluate(e,r,s);
+        assert Evaluate(e',r,s).Err?;
+        var b :| Evaluate(e,r,s) == base.Ok(Value.Primitive(Primitive.Bool(b)));
+        if b {
+          assert Evaluator(r,s).interpretShortcircuit(And(e,e'),e,e',false) == Evaluate(e',r,s);
+          assert Evaluate(And(e,e'),r,s) == Evaluate(e',r,s);
         } else {
-          assert Evaluate(e',r,s).Err?;
-          var b :| Evaluate(e,r,s) == base.Ok(Value.Primitive(Primitive.Bool(b)));
-          if b {
-            assert Evaluator(r,s).interpretShortcircuit(And(e,e'),e,e',false) == Evaluate(e',r,s);
-            assert Evaluate(And(e,e'),r,s) == Evaluate(e',r,s);
-          } else {
-            assert Evaluator(r,s).interpretShortcircuit(And(e,e'),e,e',false) == base.Ok(Value.Primitive(Primitive.Bool(false)));
-            assert Evaluate(And(e,e'),r,s) == base.Ok(Value.Primitive(Primitive.Bool(false)));
-          }
+          assert Evaluator(r,s).interpretShortcircuit(And(e,e'),e,e',false) == base.Ok(Value.Primitive(Primitive.Bool(false)));
+          assert Evaluate(And(e,e'),r,s) == base.Ok(Value.Primitive(Primitive.Bool(false)));
         }
       }
     }
+  }
 
-    lemma AndSafe(r: Request, s: EntityStore, e: Expr, e': Expr)
-      requires IsSafe(r,s,e,Type.Bool(AnyBool))
-      requires IsSafe(r,s,e',Type.Bool(AnyBool))
-      ensures IsSafe(r,s,And(e,e'),Type.Bool(AnyBool))
-    {
-      if Evaluate(e,r,s).Ok? && Evaluate(e',r,s).Ok? {
-        assert Evaluator(r,s).interpretShortcircuit(And(e,e'),e,e',false).Ok?;
-        assert Evaluate(And(e,e'),r,s).Ok?;
+  lemma AndSafe(r: Request, s: EntityStore, e: Expr, e': Expr)
+    requires IsSafe(r,s,e,Type.Bool(AnyBool))
+    requires IsSafe(r,s,e',Type.Bool(AnyBool))
+    ensures IsSafe(r,s,And(e,e'),Type.Bool(AnyBool))
+  {
+    reveal IsSafe();
+    if Evaluate(e,r,s).Ok? && Evaluate(e',r,s).Ok? {
+      assert Evaluator(r,s).interpretShortcircuit(And(e,e'),e,e',false).Ok?;
+      assert Evaluate(And(e,e'),r,s).Ok?;
+    } else {
+      if Evaluate(e,r,s).Err? {
+        assert Evaluator(r,s).interpretShortcircuit(And(e,e'),e,e',false) == Evaluate(e,r,s);
+        assert Evaluate(And(e,e'),r,s) == Evaluate(e,r,s);
       } else {
-        if Evaluate(e,r,s).Err? {
-          assert Evaluator(r,s).interpretShortcircuit(And(e,e'),e,e',false) == Evaluate(e,r,s);
-          assert Evaluate(And(e,e'),r,s) == Evaluate(e,r,s);
+        assert Evaluate(e',r,s).Err?;
+        var b :| Evaluate(e,r,s) == base.Ok(Value.Primitive(Primitive.Bool(b)));
+        if b {
+          assert Evaluator(r,s).interpretShortcircuit(And(e,e'),e,e',false) == Evaluate(e',r,s);
+          assert Evaluate(And(e,e'),r,s) == Evaluate(e',r,s);
         } else {
-          assert Evaluate(e',r,s).Err?;
-          var b :| Evaluate(e,r,s) == base.Ok(Value.Primitive(Primitive.Bool(b)));
-          if b {
-            assert Evaluator(r,s).interpretShortcircuit(And(e,e'),e,e',false) == Evaluate(e',r,s);
-            assert Evaluate(And(e,e'),r,s) == Evaluate(e',r,s);
-          } else {
-            assert Evaluator(r,s).interpretShortcircuit(And(e,e'),e,e',false) == base.Ok(Value.Primitive(Primitive.Bool(false)));
-            assert Evaluate(And(e,e'),r,s) == base.Ok(Value.Primitive(Primitive.Bool(false)));
-          }
+          assert Evaluator(r,s).interpretShortcircuit(And(e,e'),e,e',false) == base.Ok(Value.Primitive(Primitive.Bool(false)));
+          assert Evaluate(And(e,e'),r,s) == base.Ok(Value.Primitive(Primitive.Bool(false)));
         }
       }
     }
+  }
 
-    lemma AndTrueStrong(r: Request, s: EntityStore, e1: Expr, e2: Expr)
-      requires IsTrue(r,s,e1)
-      requires IsTrueStrong(r,s,And(e1,e2))
-      ensures IsTrueStrong(r,s,e2)
-    {
-      assert Evaluator(r,s).interpretShortcircuit(And(e1,e2),e1,e2,false) == base.Ok(Value.Bool(true));
+  lemma AndTrueStrong(r: Request, s: EntityStore, e1: Expr, e2: Expr)
+    requires IsTrue(r,s,e1)
+    requires IsTrueStrong(r,s,And(e1,e2))
+    ensures IsTrueStrong(r,s,e2)
+  {
+    reveal IsSafeStrong();
+    reveal IsSafe();
+    assert Evaluator(r,s).interpretShortcircuit(And(e1,e2),e1,e2,false) == base.Ok(Value.Bool(true));
+  }
+
+  lemma AndError(r: Request, s: EntityStore, e1: Expr, e2: Expr, t: Type, tnew: Type)
+    requires IsSafe(r,s,e1,t)
+    requires !IsSafeStrong(r,s,e1,t)
+    ensures IsSafe(r,s,And(e1,e2),tnew)
+    ensures !IsSafeStrong(r,s,And(e1,e2),tnew)
+  {
+    reveal IsSafeStrong();
+    reveal IsSafe();
+    assert Evaluator(r,s).interpretShortcircuit(And(e1,e2),e1,e2,false).Err?;
+  }
+
+  lemma OrLShortSafe(r: Request, s: EntityStore, e: Expr, e': Expr)
+    requires IsTrue(r,s,e)
+    ensures IsTrue(r,s,Or(e,e'))
+  {
+    reveal IsSafe();
+    if Evaluate(e,r,s).Ok? {
+      assert Evaluate(e,r,s) == base.Ok(Value.Primitive(Primitive.Bool(true)));
+      assert Evaluator(r,s).interpretShortcircuit(Or(e,e'),e,e',true) == base.Ok(Value.Primitive(Primitive.Bool(true)));
+      assert Evaluate(Or(e,e'),r,s) == base.Ok(Value.Primitive(Primitive.Bool(true)));
+    } else {
+      assert Evaluator(r,s).interpretShortcircuit(Or(e,e'),e,e',true) == Evaluate(e,r,s);
+      assert Evaluate(Or(e,e'),r,s) == Evaluate(e,r,s);
     }
+  }
 
-    lemma AndError(r: Request, s: EntityStore, e1: Expr, e2: Expr, t: Type, tnew: Type)
-      requires IsSafe(r,s,e1,t)
-      requires !IsSafeStrong(r,s,e1,t)
-      ensures IsSafe(r,s,And(e1,e2),tnew)
-      ensures !IsSafeStrong(r,s,And(e1,e2),tnew)
-    {
-      assert Evaluator(r,s).interpretShortcircuit(And(e1,e2),e1,e2,false).Err?;
-    }
-
-    lemma OrLShortSafe(r: Request, s: EntityStore, e: Expr, e': Expr)
-      requires IsTrue(r,s,e)
-      ensures IsTrue(r,s,Or(e,e'))
-    {
-      if Evaluate(e,r,s).Ok? {
-        assert Evaluate(e,r,s) == base.Ok(Value.Primitive(Primitive.Bool(true)));
-        assert Evaluator(r,s).interpretShortcircuit(Or(e,e'),e,e',true) == base.Ok(Value.Primitive(Primitive.Bool(true)));
-        assert Evaluate(Or(e,e'),r,s) == base.Ok(Value.Primitive(Primitive.Bool(true)));
-      } else {
+  lemma OrRShortSafe(r: Request, s: EntityStore, e: Expr, e': Expr)
+    requires IsSafe(r,s,e,Type.Bool(AnyBool))
+    requires IsTrue(r,s,e')
+    ensures IsTrue(r,s,Or(e,e'))
+  {
+    reveal IsSafe();
+    if Evaluate(e,r,s).Ok? && Evaluate(e',r,s).Ok? {
+      assert Evaluate(e',r,s) == base.Ok(Value.Primitive(Primitive.Bool(true)));
+      assert Evaluator(r,s).interpretShortcircuit(Or(e,e'),e,e',true) == base.Ok(Value.Primitive(Primitive.Bool(true)));
+      assert Evaluate(Or(e,e'),r,s) == base.Ok(Value.Primitive(Primitive.Bool(true)));
+    } else {
+      if Evaluate(e,r,s).Err? {
         assert Evaluator(r,s).interpretShortcircuit(Or(e,e'),e,e',true) == Evaluate(e,r,s);
         assert Evaluate(Or(e,e'),r,s) == Evaluate(e,r,s);
-      }
-    }
-
-    lemma OrRShortSafe(r: Request, s: EntityStore, e: Expr, e': Expr)
-      requires IsSafe(r,s,e,Type.Bool(AnyBool))
-      requires IsTrue(r,s,e')
-      ensures IsTrue(r,s,Or(e,e'))
-    {
-      if Evaluate(e,r,s).Ok? && Evaluate(e',r,s).Ok? {
-        assert Evaluate(e',r,s) == base.Ok(Value.Primitive(Primitive.Bool(true)));
-        assert Evaluator(r,s).interpretShortcircuit(Or(e,e'),e,e',true) == base.Ok(Value.Primitive(Primitive.Bool(true)));
-        assert Evaluate(Or(e,e'),r,s) == base.Ok(Value.Primitive(Primitive.Bool(true)));
       } else {
-        if Evaluate(e,r,s).Err? {
-          assert Evaluator(r,s).interpretShortcircuit(Or(e,e'),e,e',true) == Evaluate(e,r,s);
-          assert Evaluate(Or(e,e'),r,s) == Evaluate(e,r,s);
+        assert Evaluate(e',r,s).Err?;
+        var b :| Evaluate(e,r,s) == base.Ok(Value.Primitive(Primitive.Bool(b)));
+        if b {
+          assert Evaluator(r,s).interpretShortcircuit(Or(e,e'),e,e',true) == base.Ok(Value.Primitive(Primitive.Bool(true)));
+          assert Evaluate(Or(e,e'),r,s) == base.Ok(Value.Primitive(Primitive.Bool(true)));
         } else {
-          assert Evaluate(e',r,s).Err?;
-          var b :| Evaluate(e,r,s) == base.Ok(Value.Primitive(Primitive.Bool(b)));
-          if b {
-            assert Evaluator(r,s).interpretShortcircuit(Or(e,e'),e,e',true) == base.Ok(Value.Primitive(Primitive.Bool(true)));
-            assert Evaluate(Or(e,e'),r,s) == base.Ok(Value.Primitive(Primitive.Bool(true)));
-          } else {
-            assert Evaluator(r,s).interpretShortcircuit(Or(e,e'),e,e',true) == Evaluate(e',r,s);
-            assert Evaluate(Or(e,e'),r,s) == Evaluate(e',r,s);
-          }
+          assert Evaluator(r,s).interpretShortcircuit(Or(e,e'),e,e',true) == Evaluate(e',r,s);
+          assert Evaluate(Or(e,e'),r,s) == Evaluate(e',r,s);
         }
       }
     }
+  }
 
-    lemma OrLRetSafe(r: Request, s: EntityStore, e: Expr, e': Expr, t: Type)
-      requires IsSafe(r,s,e,t)
-      requires IsFalse(r,s,e')
-      requires SemanticSubty(t,Type.Bool(AnyBool))
-      ensures IsSafe(r,s,Or(e,e'),t)
-    {
-      if Evaluate(e,r,s).Ok? && Evaluate(e',r,s).Ok? {
-        assert Evaluate(e',r,s) == base.Ok(Value.Primitive(Primitive.Bool(false)));
-        var v :| Evaluate(e,r,s) == base.Ok(v) && InstanceOfType(v,t);
-        assert InstanceOfType(v,Type.Bool(AnyBool)) by {
-          SemSubtyTransportVal(t,Type.Bool(AnyBool),v);
-        }
-        var b :| v == Value.Primitive(Primitive.Bool(b));
-        assert Evaluator(r,s).interpretShortcircuit(Or(e,e'),e,e',true) == base.Ok(Value.Primitive(Primitive.Bool(b)));
-        assert Evaluate(Or(e,e'),r,s) == base.Ok(Value.Primitive(Primitive.Bool(b)));
-        assert IsSafe(r,s,e,Type.Bool(AnyBool)) by {
-          SemSubtyTransport(r,s,e,t,Type.Bool(AnyBool));
-        }
+  lemma OrLRetSafe(r: Request, s: EntityStore, e: Expr, e': Expr, t: Type)
+    requires IsSafe(r,s,e,t)
+    requires IsFalse(r,s,e')
+    requires SemanticSubty(t,Type.Bool(AnyBool))
+    ensures IsSafe(r,s,Or(e,e'),t)
+  {
+    reveal IsSafe();
+    if Evaluate(e,r,s).Ok? && Evaluate(e',r,s).Ok? {
+      assert Evaluate(e',r,s) == base.Ok(Value.Primitive(Primitive.Bool(false)));
+      var v :| Evaluate(e,r,s) == base.Ok(v) && InstanceOfType(v,t);
+      assert InstanceOfType(v,Type.Bool(AnyBool)) by {
+        SemSubtyTransportVal(t,Type.Bool(AnyBool),v);
+      }
+      var b :| v == Value.Primitive(Primitive.Bool(b));
+      assert Evaluator(r,s).interpretShortcircuit(Or(e,e'),e,e',true) == base.Ok(Value.Primitive(Primitive.Bool(b)));
+      assert Evaluate(Or(e,e'),r,s) == base.Ok(Value.Primitive(Primitive.Bool(b)));
+      assert IsSafe(r,s,e,Type.Bool(AnyBool)) by {
+        SemSubtyTransport(r,s,e,t,Type.Bool(AnyBool));
+      }
+    } else {
+      if Evaluate(e,r,s).Err? {
+        assert Evaluator(r,s).interpretShortcircuit(Or(e,e'),e,e',true) == Evaluate(e,r,s);
+        assert Evaluate(Or(e,e'),r,s) == Evaluate(e,r,s);
       } else {
-        if Evaluate(e,r,s).Err? {
-          assert Evaluator(r,s).interpretShortcircuit(Or(e,e'),e,e',true) == Evaluate(e,r,s);
-          assert Evaluate(Or(e,e'),r,s) == Evaluate(e,r,s);
+        assert Evaluate(e',r,s).Err?;
+        var b :| Evaluate(e,r,s) == base.Ok(Value.Primitive(Primitive.Bool(b)));
+        if b {
+          assert Evaluator(r,s).interpretShortcircuit(Or(e,e'),e,e',true) == base.Ok(Value.Primitive(Primitive.Bool(true)));
+          assert Evaluate(Or(e,e'),r,s) == base.Ok(Value.Primitive(Primitive.Bool(true)));
         } else {
-          assert Evaluate(e',r,s).Err?;
-          var b :| Evaluate(e,r,s) == base.Ok(Value.Primitive(Primitive.Bool(b)));
-          if b {
-            assert Evaluator(r,s).interpretShortcircuit(Or(e,e'),e,e',true) == base.Ok(Value.Primitive(Primitive.Bool(true)));
-            assert Evaluate(Or(e,e'),r,s) == base.Ok(Value.Primitive(Primitive.Bool(true)));
-          } else {
-            assert Evaluator(r,s).interpretShortcircuit(Or(e,e'),e,e',true) == Evaluate(e',r,s);
-            assert Evaluate(Or(e,e'),r,s) == Evaluate(e',r,s);
-          }
+          assert Evaluator(r,s).interpretShortcircuit(Or(e,e'),e,e',true) == Evaluate(e',r,s);
+          assert Evaluate(Or(e,e'),r,s) == Evaluate(e',r,s);
         }
       }
     }
+  }
 
-    lemma OrRRetSafe(r: Request, s: EntityStore, e: Expr, e': Expr, t: Type)
-      requires IsFalse(r,s,e)
-      requires IsSafe(r,s,e',t)
-      requires SemanticSubty(t,Type.Bool(AnyBool))
-      ensures IsSafe(r,s,Or(e,e'),t)
-    {
-      if Evaluate(e,r,s).Ok? && Evaluate(e',r,s).Ok? {
-        assert Evaluate(e,r,s) == base.Ok(Value.Primitive(Primitive.Bool(false)));
-        var v :| Evaluate(e',r,s) == base.Ok(v) && InstanceOfType(v,t);
-        assert InstanceOfType(v,Type.Bool(AnyBool)) by {
-          SemSubtyTransportVal(t,Type.Bool(AnyBool),v);
-        }
-        var b :| v == Value.Primitive(Primitive.Bool(b));
-        assert Evaluator(r,s).interpretShortcircuit(Or(e,e'),e,e',true) == base.Ok(Value.Primitive(Primitive.Bool(b)));
-        assert Evaluate(Or(e,e'),r,s) == base.Ok(Value.Primitive(Primitive.Bool(b)));
-        assert IsSafe(r,s,e',Type.Bool(AnyBool)) by {
-          SemSubtyTransport(r,s,e',t,Type.Bool(AnyBool));
-        }
+  lemma OrRRetSafe(r: Request, s: EntityStore, e: Expr, e': Expr, t: Type)
+    requires IsFalse(r,s,e)
+    requires IsSafe(r,s,e',t)
+    requires SemanticSubty(t,Type.Bool(AnyBool))
+    ensures IsSafe(r,s,Or(e,e'),t)
+  {
+    reveal IsSafe();
+    if Evaluate(e,r,s).Ok? && Evaluate(e',r,s).Ok? {
+      assert Evaluate(e,r,s) == base.Ok(Value.Primitive(Primitive.Bool(false)));
+      var v :| Evaluate(e',r,s) == base.Ok(v) && InstanceOfType(v,t);
+      assert InstanceOfType(v,Type.Bool(AnyBool)) by {
+        SemSubtyTransportVal(t,Type.Bool(AnyBool),v);
+      }
+      var b :| v == Value.Primitive(Primitive.Bool(b));
+      assert Evaluator(r,s).interpretShortcircuit(Or(e,e'),e,e',true) == base.Ok(Value.Primitive(Primitive.Bool(b)));
+      assert Evaluate(Or(e,e'),r,s) == base.Ok(Value.Primitive(Primitive.Bool(b)));
+      assert IsSafe(r,s,e',Type.Bool(AnyBool)) by {
+        SemSubtyTransport(r,s,e',t,Type.Bool(AnyBool));
+      }
+    } else {
+      if Evaluate(e,r,s).Err? {
+        assert Evaluator(r,s).interpretShortcircuit(Or(e,e'),e,e',true) == Evaluate(e,r,s);
+        assert Evaluate(Or(e,e'),r,s) == Evaluate(e,r,s);
       } else {
-        if Evaluate(e,r,s).Err? {
-          assert Evaluator(r,s).interpretShortcircuit(Or(e,e'),e,e',true) == Evaluate(e,r,s);
-          assert Evaluate(Or(e,e'),r,s) == Evaluate(e,r,s);
+        assert Evaluate(e',r,s).Err?;
+        var b :| Evaluate(e,r,s) == base.Ok(Value.Primitive(Primitive.Bool(b)));
+        if b {
+          assert Evaluator(r,s).interpretShortcircuit(Or(e,e'),e,e',true) == base.Ok(Value.Primitive(Primitive.Bool(true)));
+          assert Evaluate(Or(e,e'),r,s) == base.Ok(Value.Primitive(Primitive.Bool(true)));
         } else {
-          assert Evaluate(e',r,s).Err?;
-          var b :| Evaluate(e,r,s) == base.Ok(Value.Primitive(Primitive.Bool(b)));
-          if b {
-            assert Evaluator(r,s).interpretShortcircuit(Or(e,e'),e,e',true) == base.Ok(Value.Primitive(Primitive.Bool(true)));
-            assert Evaluate(Or(e,e'),r,s) == base.Ok(Value.Primitive(Primitive.Bool(true)));
-          } else {
-            assert Evaluator(r,s).interpretShortcircuit(Or(e,e'),e,e',true) == Evaluate(e',r,s);
-            assert Evaluate(Or(e,e'),r,s) == Evaluate(e',r,s);
-          }
+          assert Evaluator(r,s).interpretShortcircuit(Or(e,e'),e,e',true) == Evaluate(e',r,s);
+          assert Evaluate(Or(e,e'),r,s) == Evaluate(e',r,s);
         }
       }
     }
+  }
 
-    lemma OrSafe(r: Request, s: EntityStore, e: Expr, e': Expr)
-      requires IsSafe(r,s,e,Type.Bool(AnyBool))
-      requires IsSafe(r,s,e',Type.Bool(AnyBool))
-      ensures IsSafe(r,s,Or(e,e'),Type.Bool(AnyBool))
-    {
-      if Evaluate(e,r,s).Ok? && Evaluate(e',r,s).Ok? {
-        assert Evaluator(r,s).interpretShortcircuit(Or(e,e'),e,e',true).Ok?;
-        assert Evaluate(Or(e,e'),r,s).Ok?;
+  lemma OrSafe(r: Request, s: EntityStore, e: Expr, e': Expr)
+    requires IsSafe(r,s,e,Type.Bool(AnyBool))
+    requires IsSafe(r,s,e',Type.Bool(AnyBool))
+    ensures IsSafe(r,s,Or(e,e'),Type.Bool(AnyBool))
+  {
+    reveal IsSafe();
+    if Evaluate(e,r,s).Ok? && Evaluate(e',r,s).Ok? {
+      assert Evaluator(r,s).interpretShortcircuit(Or(e,e'),e,e',true).Ok?;
+      assert Evaluate(Or(e,e'),r,s).Ok?;
+    } else {
+      if Evaluate(e,r,s).Err? {
+        assert Evaluator(r,s).interpretShortcircuit(Or(e,e'),e,e',true) == Evaluate(e,r,s);
+        assert Evaluate(Or(e,e'),r,s) == Evaluate(e,r,s);
       } else {
-        if Evaluate(e,r,s).Err? {
-          assert Evaluator(r,s).interpretShortcircuit(Or(e,e'),e,e',true) == Evaluate(e,r,s);
-          assert Evaluate(Or(e,e'),r,s) == Evaluate(e,r,s);
+        assert Evaluate(e',r,s).Err?;
+        var b :| Evaluate(e,r,s) == base.Ok(Value.Primitive(Primitive.Bool(b)));
+        if b {
+          assert Evaluator(r,s).interpretShortcircuit(Or(e,e'),e,e',true) == base.Ok(Value.Primitive(Primitive.Bool(true)));
+          assert Evaluate(Or(e,e'),r,s) == base.Ok(Value.Primitive(Primitive.Bool(true)));
         } else {
-          assert Evaluate(e',r,s).Err?;
-          var b :| Evaluate(e,r,s) == base.Ok(Value.Primitive(Primitive.Bool(b)));
-          if b {
-            assert Evaluator(r,s).interpretShortcircuit(Or(e,e'),e,e',true) == base.Ok(Value.Primitive(Primitive.Bool(true)));
-            assert Evaluate(Or(e,e'),r,s) == base.Ok(Value.Primitive(Primitive.Bool(true)));
-          } else {
-            assert Evaluator(r,s).interpretShortcircuit(Or(e,e'),e,e',true) == Evaluate(e',r,s);
-            assert Evaluate(Or(e,e'),r,s) == Evaluate(e',r,s);
-          }
+          assert Evaluator(r,s).interpretShortcircuit(Or(e,e'),e,e',true) == Evaluate(e',r,s);
+          assert Evaluate(Or(e,e'),r,s) == Evaluate(e',r,s);
         }
       }
     }
+  }
 
-    lemma OrTrueStrong(r: Request, s: EntityStore, e1: Expr, e2: Expr)
-      requires IsTrueStrong(r,s,Or(e1,e2))
-      ensures IsTrueStrong(r,s,e1) || IsTrueStrong(r,s,e2)
-    {
-      assert Evaluator(r,s).interpretShortcircuit(Or(e1,e2),e1,e2,true) == base.Ok(Value.Bool(true));
-    }
+  lemma OrTrueStrong(r: Request, s: EntityStore, e1: Expr, e2: Expr)
+    requires IsTrueStrong(r,s,Or(e1,e2))
+    ensures IsTrueStrong(r,s,e1) || IsTrueStrong(r,s,e2)
+  {
+    reveal IsSafeStrong();
+    reveal IsSafe();
+    assert Evaluator(r,s).interpretShortcircuit(Or(e1,e2),e1,e2,true) == base.Ok(Value.Bool(true));
+  }
 
-    lemma NotTrueSafe(r: Request, s: EntityStore, e: Expr)
-      requires IsTrue(r,s,e)
-      ensures IsFalse(r,s,UnaryApp(Not,e))
-    {}
+  lemma NotTrueSafe(r: Request, s: EntityStore, e: Expr)
+    requires IsTrue(r,s,e)
+    ensures IsFalse(r,s,UnaryApp(Not,e))
+  {
+    reveal IsSafe();
+  }
 
-    lemma NotFalseSafe(r: Request, s: EntityStore, e: Expr)
-      requires IsFalse(r,s,e)
-      ensures IsTrue(r,s,UnaryApp(Not,e))
-    {}
+  lemma NotFalseSafe(r: Request, s: EntityStore, e: Expr)
+    requires IsFalse(r,s,e)
+    ensures IsTrue(r,s,UnaryApp(Not,e))
+  {
+    reveal IsSafe();
+  }
 
-    lemma NotSafe(r: Request, s: EntityStore, e: Expr)
-      requires IsSafe(r,s,e,Type.Bool(AnyBool))
-      ensures IsSafe(r,s,UnaryApp(Not,e),Type.Bool(AnyBool))
-    {}
+  lemma NotSafe(r: Request, s: EntityStore, e: Expr)
+    requires IsSafe(r,s,e,Type.Bool(AnyBool))
+    ensures IsSafe(r,s,UnaryApp(Not,e),Type.Bool(AnyBool))
+  {
+    reveal IsSafe();
+  }
 
-    lemma NegSafe(r: Request, s: EntityStore, e: Expr)
-      requires IsSafe(r,s,e,Type.Int)
-      ensures IsSafe(r,s,UnaryApp(Neg,e),Type.Int)
-    {}
+  lemma NegSafe(r: Request, s: EntityStore, e: Expr)
+    requires IsSafe(r,s,e,Type.Int)
+    ensures IsSafe(r,s,UnaryApp(Neg,e),Type.Int)
+  {
+    reveal IsSafe();
+  }
 
-    lemma MulBySafe(r: Request, s: EntityStore, e: Expr, i: int)
-      requires IsSafe(r,s,e,Type.Int)
-      ensures IsSafe(r,s,UnaryApp(MulBy(i),e),Type.Int)
-    {}
+  lemma MulBySafe(r: Request, s: EntityStore, e: Expr, i: int)
+    requires IsSafe(r,s,e,Type.Int)
+    ensures IsSafe(r,s,UnaryApp(MulBy(i),e),Type.Int)
+  {
+    reveal IsSafe();
+  }
 
-    lemma IteTrueSafe(r: Request, s: EntityStore, e: Expr, e1: Expr, e2: Expr, t: Type)
-      requires IsTrue(r,s,e)
-      requires IsSafe(r,s,e1,t)
-      ensures IsSafe(r,s,If(e,e1,e2),t)
-    {}
+  lemma IteTrueSafe(r: Request, s: EntityStore, e: Expr, e1: Expr, e2: Expr, t: Type)
+    requires IsTrue(r,s,e)
+    requires IsSafe(r,s,e1,t)
+    ensures IsSafe(r,s,If(e,e1,e2),t)
+  {
+    reveal IsSafe();
+  }
 
-    lemma IteFalseSafe(r: Request, s: EntityStore, e: Expr, e1: Expr, e2: Expr, t: Type)
-      requires IsFalse(r,s,e)
-      requires IsSafe(r,s,e2,t)
-      ensures IsSafe(r,s,If(e,e1,e2),t)
-    {}
+  lemma IteFalseSafe(r: Request, s: EntityStore, e: Expr, e1: Expr, e2: Expr, t: Type)
+    requires IsFalse(r,s,e)
+    requires IsSafe(r,s,e2,t)
+    ensures IsSafe(r,s,If(e,e1,e2),t)
+  {
+    reveal IsSafe();
+  }
 
-    lemma IteTrueStrongTrue(r: Request, s: EntityStore, e1: Expr, e2: Expr, e3: Expr)
-      requires IsTrue(r,s,e1)
-      requires IsTrueStrong(r,s,If(e1,e2,e3))
-      ensures IsTrueStrong(r,s,e2)
-    {}
+  lemma IteTrueStrongTrue(r: Request, s: EntityStore, e1: Expr, e2: Expr, e3: Expr)
+    requires IsTrue(r,s,e1)
+    requires IsTrueStrong(r,s,If(e1,e2,e3))
+    ensures IsTrueStrong(r,s,e2)
+  {
+    reveal IsSafeStrong();
+    reveal IsSafe();
+  }
 
-    lemma IteTrueStrongFalse(r: Request, s: EntityStore, e1: Expr, e2: Expr, e3: Expr)
-      requires IsFalse(r,s,e1)
-      requires IsTrueStrong(r,s,If(e1,e2,e3))
-      ensures IsTrueStrong(r,s,e3)
-    {}
+  lemma IteTrueStrongFalse(r: Request, s: EntityStore, e1: Expr, e2: Expr, e3: Expr)
+    requires IsFalse(r,s,e1)
+    requires IsTrueStrong(r,s,If(e1,e2,e3))
+    ensures IsTrueStrong(r,s,e3)
+  {
+    reveal IsSafeStrong();
+    reveal IsSafe();
+  }
 
-    lemma IteError(r: Request, s: EntityStore, e1: Expr, e2: Expr, e3: Expr, t: Type, tnew: Type)
-      requires IsSafe(r,s,e1,t)
-      requires !IsSafeStrong(r,s,e1,t)
-      ensures IsSafe(r,s,If(e1,e2,e3),tnew)
-      ensures !IsSafeStrong(r,s,If(e1,e2,e3),tnew)
-    {}
+  lemma IteError(r: Request, s: EntityStore, e1: Expr, e2: Expr, e3: Expr, t: Type, tnew: Type)
+    requires IsSafe(r,s,e1,t)
+    requires !IsSafeStrong(r,s,e1,t)
+    ensures IsSafe(r,s,If(e1,e2,e3),tnew)
+    ensures !IsSafeStrong(r,s,If(e1,e2,e3),tnew)
+  {
+    reveal IsSafeStrong();
+    reveal IsSafe();
+  }
 
-    lemma ContainsSetSafe(r: Request, s: EntityStore, e: Expr, e': Expr, t1: Type, t2: Type)
-      requires IsSafe(r,s,e,Type.Set(t1))
-      requires IsSafe(r,s,e',t2)
-      ensures IsSafe(r,s,BinaryApp(Contains,e,e'),Type.Bool(AnyBool))
-    {}
+  lemma ContainsSetSafe(r: Request, s: EntityStore, e: Expr, e': Expr, t1: Type, t2: Type)
+    requires IsSafe(r,s,e,Type.Set(t1))
+    requires IsSafe(r,s,e',t2)
+    ensures IsSafe(r,s,BinaryApp(Contains,e,e'),Type.Bool(AnyBool))
+  {
+    reveal IsSafe();
+  }
 
-    lemma LikeSafe(r: Request, s: EntityStore, e: Expr, p: Pattern)
-      requires IsSafe(r,s,e,Type.String)
-      ensures IsSafe(r,s,UnaryApp(Like(p),e),Type.Bool(AnyBool))
-    {}
+  lemma LikeSafe(r: Request, s: EntityStore, e: Expr, p: Pattern)
+    requires IsSafe(r,s,e,Type.String)
+    ensures IsSafe(r,s,UnaryApp(Like(p),e),Type.Bool(AnyBool))
+  {
+    reveal IsSafe();
+  }
 
-    lemma SetConstrSafe(r: Request, s: EntityStore, es: seq<Expr>, t: Type)
-      requires forall i :: 0 <= i < |es| ==> IsSafe(r,s,es[i],t)
-      ensures IsSafe(r,s,Expr.Set(es),Type.Set(t))
-    {
-      InterpretSetLemma(es,r,s);
-      if(forall i :: 0 <= i < |es| ==> exists v :: Evaluate(es[i],r,s) == base.Ok(v) && InstanceOfType(v,t)){
-        assert forall e :: e in es ==> Evaluate(e,r,s).Ok?;
-        assert Evaluate(Expr.Set(es),r,s).Ok?;
-        var vs :| Evaluator(r,s).interpretSet(es) == base.Ok(vs);
-        assert InstanceOfType(Value.Set(vs),Type.Set(t)) by {
-          forall v | v in vs ensures InstanceOfType(v,t) {}
-        }
+  lemma SetConstrSafe(r: Request, s: EntityStore, es: seq<Expr>, t: Type)
+    requires forall i :: 0 <= i < |es| ==> IsSafe(r,s,es[i],t)
+    ensures IsSafe(r,s,Expr.Set(es),Type.Set(t))
+  {
+    reveal IsSafe();
+    InterpretSetLemma(es,r,s);
+    if(forall i :: 0 <= i < |es| ==> exists v :: Evaluate(es[i],r,s) == base.Ok(v) && InstanceOfType(v,t)){
+      assert forall e :: e in es ==> Evaluate(e,r,s).Ok?;
+      assert Evaluate(Expr.Set(es),r,s).Ok?;
+      var vs :| Evaluator(r,s).interpretSet(es) == base.Ok(vs);
+      assert InstanceOfType(Value.Set(vs),Type.Set(t)) by {
+        forall v | v in vs ensures InstanceOfType(v,t) {}
       }
     }
+  }
 
-    lemma ContainsAnyAllSafe(r: Request, s: EntityStore, op: BinaryOp, e1: Expr, e2: Expr, t1: Type, t2: Type)
-      requires op == ContainsAll || op == ContainsAny
-      requires IsSafe(r,s,e1,Type.Set(t1))
-      requires IsSafe(r,s,e2,Type.Set(t2))
-      ensures IsSafe(r,s,BinaryApp(op,e1,e2), Type.Bool(AnyBool))
-    {}
+  lemma ContainsAnyAllSafe(r: Request, s: EntityStore, op: BinaryOp, e1: Expr, e2: Expr, t1: Type, t2: Type)
+    requires op == ContainsAll || op == ContainsAny
+    requires IsSafe(r,s,e1,Type.Set(t1))
+    requires IsSafe(r,s,e2,Type.Set(t2))
+    ensures IsSafe(r,s,BinaryApp(op,e1,e2), Type.Bool(AnyBool))
+  {
+    reveal IsSafe();
+  }
 
-    lemma IneqSafe(r: Request, s: EntityStore, op: BinaryOp, e1: Expr, e2: Expr)
-      requires op == Less || op == BinaryOp.LessEq
-      requires IsSafe(r,s,e1,Type.Int)
-      requires IsSafe(r,s,e2,Type.Int)
-      ensures IsSafe(r,s,BinaryApp(op,e1,e2),Type.Bool(AnyBool))
-    {}
+  lemma IneqSafe(r: Request, s: EntityStore, op: BinaryOp, e1: Expr, e2: Expr)
+    requires op == Less || op == BinaryOp.LessEq
+    requires IsSafe(r,s,e1,Type.Int)
+    requires IsSafe(r,s,e2,Type.Int)
+    ensures IsSafe(r,s,BinaryApp(op,e1,e2),Type.Bool(AnyBool))
+  {
+    reveal IsSafe();
+  }
 
-    lemma ArithSafe(r: Request, s: EntityStore, op: BinaryOp, e1: Expr, e2: Expr)
-      requires op == Add || op == Sub
-      requires IsSafe(r,s,e1,Type.Int)
-      requires IsSafe(r,s,e2,Type.Int)
-      ensures IsSafe(r,s,BinaryApp(op,e1,e2),Type.Int)
-    {}
+  lemma ArithSafe(r: Request, s: EntityStore, op: BinaryOp, e1: Expr, e2: Expr)
+    requires op == Add || op == Sub
+    requires IsSafe(r,s,e1,Type.Int)
+    requires IsSafe(r,s,e2,Type.Int)
+    ensures IsSafe(r,s,BinaryApp(op,e1,e2),Type.Int)
+  {
+    reveal IsSafe();
+  }
 
-    // We prove that every extension function is safe with respect to the
-    // ExtFunType assigned to it by the validator. In particular, we show that
-    // the argument types of the ExtFunType match the argument type checks
-    // actually performed by the function at runtime, the return value has the
-    // correct type on success, and the function doesn't raise any error other
-    // than ExtensionError.
-    //
-    // Writing one lemma per extension function would be a lot of boilerplate.
-    // Instead, we put them in groups that have the same ExtFunType.
+  // We prove that every extension function is safe with respect to the
+  // ExtFunType assigned to it by the validator. In particular, we show that
+  // the argument types of the ExtFunType match the argument type checks
+  // actually performed by the function at runtime, the return value has the
+  // correct type on success, and the function doesn't raise any error other
+  // than ExtensionError.
+  //
+  // Writing one lemma per extension function would be a lot of boilerplate.
+  // Instead, we put them in groups that have the same ExtFunType.
 
-    ghost predicate ExtensionFunSafeRequires(name: base.Name, args: seq<Value>)
-      requires name in extFunTypes
-    {
-      var eft := extFunTypes[name];
-      |args| == |eft.args| &&
-      forall i | 0 <= i < |args| :: InstanceOfType(args[i], eft.args[i])
-    }
+  ghost predicate ExtensionFunSafeRequires(name: base.Name, args: seq<Value>)
+    requires name in extFunTypes
+  {
+    var eft := extFunTypes[name];
+    |args| == |eft.args| &&
+    forall i | 0 <= i < |args| :: InstanceOfType(args[i], eft.args[i])
+  }
 
-    ghost predicate ExtensionFunSafeEnsures(name: base.Name, args: seq<Value>)
-      requires name in extFunTypes
-    {
-      var eft := extFunTypes[name];
-      var res := extFuns[name].fun(args);
-      res == base.Err(base.ExtensionError) || (res.Ok? && InstanceOfType(res.value, eft.ret))
-    }
+  ghost predicate ExtensionFunSafeEnsures(name: base.Name, args: seq<Value>)
+    requires name in extFunTypes
+  {
+    var eft := extFunTypes[name];
+    var res := extFuns[name].fun(args);
+    res == base.Err(base.ExtensionError) || (res.Ok? && InstanceOfType(res.value, eft.ret))
+  }
 
-    ghost predicate IsDecimalConstructorName(name: base.Name) {
-      name == base.Name.fromStr("decimal")
-    }
+  ghost predicate IsDecimalConstructorName(name: base.Name) {
+    name == base.Name.fromStr("decimal")
+  }
 
-    lemma DecimalConstructorSafe(name: base.Name, args: seq<Value>)
-      requires IsDecimalConstructorName(name)
-      requires ExtensionFunSafeRequires(name, args)
-      ensures ExtensionFunSafeEnsures(name, args)
-    {}
+  lemma DecimalConstructorSafe(name: base.Name, args: seq<Value>)
+    requires IsDecimalConstructorName(name)
+    requires ExtensionFunSafeRequires(name, args)
+    ensures ExtensionFunSafeEnsures(name, args)
+  {}
 
-    ghost predicate IsDecimalComparisonName(name: base.Name) {
-      name == base.Name.fromStr("lessThan") ||
-      name == base.Name.fromStr("lessThanOrEqual") ||
-      name == base.Name.fromStr("greaterThan") ||
-      name == base.Name.fromStr("greaterThanOrEqual")
-    }
+  ghost predicate IsDecimalComparisonName(name: base.Name) {
+    name == base.Name.fromStr("lessThan") ||
+    name == base.Name.fromStr("lessThanOrEqual") ||
+    name == base.Name.fromStr("greaterThan") ||
+    name == base.Name.fromStr("greaterThanOrEqual")
+  }
 
-    lemma DecimalComparisonSafe(name: base.Name, args: seq<Value>)
-      requires IsDecimalComparisonName(name)
-      requires ExtensionFunSafeRequires(name, args)
-      ensures ExtensionFunSafeEnsures(name, args)
-    {}
+  lemma DecimalComparisonSafe(name: base.Name, args: seq<Value>)
+    requires IsDecimalComparisonName(name)
+    requires ExtensionFunSafeRequires(name, args)
+    ensures ExtensionFunSafeEnsures(name, args)
+  {}
 
-    ghost predicate IsIpConstructorName(name: base.Name) {
-      name == base.Name.fromStr("ip")
-    }
+  ghost predicate IsIpConstructorName(name: base.Name) {
+    name == base.Name.fromStr("ip")
+  }
 
-    lemma IpConstructorSafe(name: base.Name, args: seq<Value>)
-      requires IsIpConstructorName(name)
-      requires ExtensionFunSafeRequires(name, args)
-      ensures ExtensionFunSafeEnsures(name, args)
-    {}
+  lemma IpConstructorSafe(name: base.Name, args: seq<Value>)
+    requires IsIpConstructorName(name)
+    requires ExtensionFunSafeRequires(name, args)
+    ensures ExtensionFunSafeEnsures(name, args)
+  {}
 
-    ghost predicate IsIpUnaryName(name: base.Name) {
-      name == base.Name.fromStr("isIpv4") ||
-      name == base.Name.fromStr("isIpv6") ||
-      name == base.Name.fromStr("isLoopback") ||
-      name == base.Name.fromStr("isMulticast")
-    }
+  ghost predicate IsIpUnaryName(name: base.Name) {
+    name == base.Name.fromStr("isIpv4") ||
+    name == base.Name.fromStr("isIpv6") ||
+    name == base.Name.fromStr("isLoopback") ||
+    name == base.Name.fromStr("isMulticast")
+  }
 
-    lemma IpUnarySafe(name: base.Name, args: seq<Value>)
-      requires IsIpUnaryName(name)
-      requires ExtensionFunSafeRequires(name, args)
-      ensures ExtensionFunSafeEnsures(name, args)
-    {
-      assert |args| == 1 && args[0].Extension? && args[0].ex.IPAddr?;
-    }
+  lemma IpUnarySafe(name: base.Name, args: seq<Value>)
+    requires IsIpUnaryName(name)
+    requires ExtensionFunSafeRequires(name, args)
+    ensures ExtensionFunSafeEnsures(name, args)
+  {
+    assert |args| == 1 && args[0].Extension? && args[0].ex.IPAddr?;
+  }
 
-    ghost predicate IsIpBinaryName(name: base.Name) {
-      name == base.Name.fromStr("isInRange")
-    }
+  ghost predicate IsIpBinaryName(name: base.Name) {
+    name == base.Name.fromStr("isInRange")
+  }
 
-    lemma IpBinarySafe(name: base.Name, args: seq<Value>)
-      requires IsIpBinaryName(name)
-      requires ExtensionFunSafeRequires(name, args)
-      ensures ExtensionFunSafeEnsures(name, args)
-    {}
+  lemma IpBinarySafe(name: base.Name, args: seq<Value>)
+    requires IsIpBinaryName(name)
+    requires ExtensionFunSafeRequires(name, args)
+    ensures ExtensionFunSafeEnsures(name, args)
+  {}
 
-    lemma InterpretListEnsures(eval: Evaluator, es: seq<Expr>)
-      ensures eval.interpretList(es).Ok? ==> (|eval.interpretList(es).value| == |es| &&
-                                              forall i | 0 <= i < |es| :: eval.interpret(es[i]) == base.Ok(eval.interpretList(es).value[i]))
-      ensures (forall e :: e in es ==> eval.interpret(e).Ok?) ==> eval.interpretList(es).Ok?
-      ensures (exists i :: 0 <= i < |es| && eval.interpret(es[i]).Err?) ==> eval.interpretList(es).Err?
-      ensures eval.interpretList(es).Err? <==> exists i :: 0 <= i < |es| && eval.interpret(es[i]).Err? && (forall j :: 0 <= j < i ==> eval.interpret(es[j]).Ok?)
-      ensures eval.interpretList(es).Err? ==> exists i :: 0 <= i < |es| && eval.interpret(es[i]).Err? && eval.interpret(es[i]).error == eval.interpretList(es).error && (forall j :: 0 <= j < i ==> eval.interpret(es[j]).Ok?)
-    {}
+  lemma InterpretListEnsures(eval: Evaluator, es: seq<Expr>)
+    ensures eval.interpretList(es).Ok? ==> (|eval.interpretList(es).value| == |es| &&
+                                            forall i | 0 <= i < |es| :: eval.interpret(es[i]) == base.Ok(eval.interpretList(es).value[i]))
+    ensures (forall e :: e in es ==> eval.interpret(e).Ok?) ==> eval.interpretList(es).Ok?
+    ensures (exists i :: 0 <= i < |es| && eval.interpret(es[i]).Err?) ==> eval.interpretList(es).Err?
+    ensures eval.interpretList(es).Err? <==> exists i :: 0 <= i < |es| && eval.interpret(es[i]).Err? && (forall j :: 0 <= j < i ==> eval.interpret(es[j]).Ok?)
+    ensures eval.interpretList(es).Err? ==> exists i :: 0 <= i < |es| && eval.interpret(es[i]).Err? && eval.interpret(es[i]).error == eval.interpretList(es).error && (forall j :: 0 <= j < i ==> eval.interpret(es[j]).Ok?)
+  {}
 
-    lemma CallSafe(r: Request, s: EntityStore, name: base.Name, args: seq<Expr>)
-      requires name in extFunTypes
-      requires |args| == |extFunTypes[name].args|
-      requires forall i | 0 <= i < |args| :: IsSafe(r,s,args[i],extFunTypes[name].args[i])
-      ensures IsSafe(r,s,Call(name,args),extFunTypes[name].ret)
-    {
-      var eft := extFunTypes[name];
-      if (forall i | 0 <= i < |args| :: Evaluate(args[i],r,s).Ok?) {
-        assert forall e <- args :: Evaluate(e,r,s).Ok?;
+  lemma CallSafe(r: Request, s: EntityStore, name: base.Name, args: seq<Expr>)
+    requires name in extFunTypes
+    requires |args| == |extFunTypes[name].args|
+    requires forall i | 0 <= i < |args| :: IsSafe(r,s,args[i],extFunTypes[name].args[i])
+    ensures IsSafe(r,s,Call(name,args),extFunTypes[name].ret)
+  {
+    reveal IsSafe();
+    var eft := extFunTypes[name];
+    if (forall i | 0 <= i < |args| :: Evaluate(args[i],r,s).Ok?) {
+      assert forall e <- args :: Evaluate(e,r,s).Ok?;
 
-        InterpretListEnsures(Evaluator(r, s), args);
-        var argVals := Evaluator(r, s).interpretList(args).value;
+      InterpretListEnsures(Evaluator(r, s), args);
+      var argVals := Evaluator(r, s).interpretList(args).value;
 
-        var res := Evaluator(r, s).applyExtFun(name, argVals);
-        assert Evaluate(Call(name,args),r,s) == res;
-        assert forall i | 0 <= i < |args| :: InstanceOfType(argVals[i], eft.args[i]);
-        var isSafe := (res == base.Err(base.ExtensionError) || (res.Ok? && InstanceOfType(res.value, eft.ret)));
-        if IsDecimalConstructorName(name) {
-          DecimalConstructorSafe(name, argVals);
-          assert isSafe;
-        } else if IsDecimalComparisonName(name) {
-          DecimalComparisonSafe(name, argVals);
-          assert isSafe;
-        } else if IsIpConstructorName(name) {
-          IpConstructorSafe(name, argVals);
-          assert isSafe;
-        } else if IsIpUnaryName(name) {
-          IpUnarySafe(name, argVals);
-          assert isSafe;
-        } else if IsIpBinaryName(name) {
-          IpBinarySafe(name, argVals);
-          assert isSafe;
-        }
-      } else {
-        InterpretListEnsures(Evaluator(r, s), args);
+      var res := Evaluator(r, s).applyExtFun(name, argVals);
+      assert Evaluate(Call(name,args),r,s) == res;
+      assert forall i | 0 <= i < |args| :: InstanceOfType(argVals[i], eft.args[i]);
+      var isSafe := (res == base.Err(base.ExtensionError) || (res.Ok? && InstanceOfType(res.value, eft.ret)));
+      if IsDecimalConstructorName(name) {
+        DecimalConstructorSafe(name, argVals);
+        assert isSafe;
+      } else if IsDecimalComparisonName(name) {
+        DecimalComparisonSafe(name, argVals);
+        assert isSafe;
+      } else if IsIpConstructorName(name) {
+        IpConstructorSafe(name, argVals);
+        assert isSafe;
+      } else if IsIpUnaryName(name) {
+        IpUnarySafe(name, argVals);
+        assert isSafe;
+      } else if IsIpBinaryName(name) {
+        IpBinarySafe(name, argVals);
+        assert isSafe;
       }
+    } else {
+      InterpretListEnsures(Evaluator(r, s), args);
     }
+  }
 
-    lemma RecordSafe(r: Request, s: EntityStore, es: seq<(Attr,Expr)>, rt: RecordType)
-      // every entry has some type
-      requires forall ae :: ae in es ==> exists t :: IsSafe(r,s,ae.1,t)
-      // and the last instance of every required key is safe at the correct type.
-      requires forall k :: k in rt ==> KeyExists(k,es) && IsSafe(r,s,LastOfKey(k,es),rt[k].ty)
-      ensures IsSafe(r,s,Expr.Record(es),Type.Record(rt))
-    {
-      if Evaluator(r,s).interpretRecord(es).Ok? {
-        InterpretRecordLemmaOk(es,r,s);
-      } else {
-        InterpretRecordLemmaErr(es,r,s);
-      }
+  ghost predicate ExistsSafeType(r: Request, s: EntityStore, e: Expr) {
+    exists t :: IsSafe(r,s,e,t)
+  }
+
+  lemma RecordSafe(r: Request, s: EntityStore, es: seq<(Attr,Expr)>, rt: RecordType)
+    // every entry has some type
+    requires forall ae | ae in es :: ExistsSafeType(r,s,ae.1)
+    // and the last instance of every required key is safe at the correct type.
+    requires forall k | k in rt :: KeyExists(k,es) && IsSafe(r,s,LastOfKey(k,es),rt[k].ty)
+    ensures IsSafe(r,s,Expr.Record(es),Type.Record(rt))
+  {
+    reveal IsSafe();
+    if Evaluator(r,s).interpretRecord(es).Ok? {
+      InterpretRecordLemmaOk(es,r,s);
+    } else {
+      InterpretRecordLemmaErr(es,r,s);
     }
+  }
 
-    lemma ObjectProjSafeRequired(r: Request, s: EntityStore, e: Expr, t: Type, l: Attr, t': AttrType)
-      requires IsSafe(r,s,e,t)
-      requires t'.isRequired
-      requires SemanticSubty(t,Type.Record(map[l := t']))
-      ensures IsSafe(r,s,GetAttr(e,l),t'.ty)
-    {}
+  lemma ObjectProjSafeRequired(r: Request, s: EntityStore, e: Expr, t: Type, l: Attr, t': AttrType)
+    requires IsSafe(r,s,e,t)
+    requires t'.isRequired
+    requires SemanticSubty(t,Type.Record(map[l := t']))
+    ensures IsSafe(r,s,GetAttr(e,l),t'.ty)
+  {
+    reveal IsSafe();
+  }
 
-    lemma ObjectProjSafeGetAttrSafe(r: Request, s: EntityStore, e: Expr, t: Type, l: Attr, t': AttrType)
-      requires IsSafe(r,s,e,t)
-      requires SemanticSubty(t,Type.Record(map[l := t']))
-      requires GetAttrSafe(r,s,e,l)
-      ensures IsSafe(r,s,GetAttr(e,l),t'.ty)
-    {}
+  lemma ObjectProjSafeGetAttrSafe(r: Request, s: EntityStore, e: Expr, t: Type, l: Attr, t': AttrType)
+    requires IsSafe(r,s,e,t)
+    requires SemanticSubty(t,Type.Record(map[l := t']))
+    requires GetAttrSafe(r,s,e,l)
+    ensures IsSafe(r,s,GetAttr(e,l),t'.ty)
+  {
+    reveal IsSafe();
+  }
 
-    lemma EntityProjSafe(r: Request, s: EntityStore, e: Expr, l: Attr, lub: EntityLUB, t': Type, isRequired: bool)
-      requires IsSafe(r,s,e,Type.Entity(lub))
-      requires EntityProjStoreCondition(s, l, lub, t', isRequired)
-      requires isRequired || GetAttrSafe(r,s,e,l)
-      ensures IsSafe(r,s,GetAttr(e,l),t')
-    {}
+  lemma EntityProjSafe(r: Request, s: EntityStore, e: Expr, l: Attr, lub: EntityLUB, t': Type, isRequired: bool)
+    requires IsSafe(r,s,e,Type.Entity(lub))
+    requires EntityProjStoreCondition(s, l, lub, t', isRequired)
+    requires isRequired || GetAttrSafe(r,s,e,l)
+    ensures IsSafe(r,s,GetAttr(e,l),t')
+  {
+    reveal IsSafe();
+  }
 
-    lemma RecordHasRequiredTrueSafe(r: Request, s: EntityStore, e: Expr, l: Attr, t: AttrType)
-      requires IsSafe(r,s,e,Type.Record(map[l := t]))
-      requires t.isRequired
-      ensures IsTrue(r,s,HasAttr(e,l))
-    {}
+  lemma RecordHasRequiredTrueSafe(r: Request, s: EntityStore, e: Expr, l: Attr, t: AttrType)
+    requires IsSafe(r,s,e,Type.Record(map[l := t]))
+    requires t.isRequired
+    ensures IsTrue(r,s,HasAttr(e,l))
+  {
+    reveal IsSafe();
+  }
 
-    lemma RecordHasOpenRecSafe(r: Request, s: EntityStore, e: Expr, l: Attr)
-      requires IsSafe(r,s,e,Type.Record(map[]))
-      ensures IsSafe(r,s,HasAttr(e,l),Type.Bool(AnyBool))
-    {}
+  lemma RecordHasOpenRecSafe(r: Request, s: EntityStore, e: Expr, l: Attr)
+    requires IsSafe(r,s,e,Type.Record(map[]))
+    ensures IsSafe(r,s,HasAttr(e,l),Type.Bool(AnyBool))
+  {
+    reveal IsSafe();
+  }
 
-    lemma EntityHasImpossibleFalseSafe(r: Request, s: EntityStore, e: Expr, l: Attr, lub: EntityLUB)
-      requires IsSafe(r,s,e,Type.Entity(lub))
-      requires forall ev: EntityUID | ExistingEntityInLub(s, ev, lub) ::
-                 l !in s.entities[ev].attrs
-      ensures IsFalse(r,s,HasAttr(e,l))
-    {}
+  lemma EntityHasImpossibleFalseSafe(r: Request, s: EntityStore, e: Expr, l: Attr, lub: EntityLUB)
+    requires IsSafe(r,s,e,Type.Entity(lub))
+    requires forall ev: EntityUID | ExistingEntityInLub(s, ev, lub) ::
+                l !in s.entities[ev].attrs
+    ensures IsFalse(r,s,HasAttr(e,l))
+  {
+    reveal IsSafe();
+  }
 
-    lemma EntityHasOpenSafe(r: Request, s: EntityStore, e: Expr, l: Attr)
-      requires IsSafe(r,s,e,Type.Entity(AnyEntity))
-      ensures IsSafe(r,s,HasAttr(e,l),Type.Bool(AnyBool))
-    {}
+  lemma EntityHasOpenSafe(r: Request, s: EntityStore, e: Expr, l: Attr)
+    requires IsSafe(r,s,e,Type.Entity(AnyEntity))
+    ensures IsSafe(r,s,HasAttr(e,l),Type.Bool(AnyBool))
+  {
+    reveal IsSafe();
+  }
 
-    lemma InSingleSafe(r: Request, s: EntityStore, e1: Expr, e2: Expr)
-      requires IsSafe(r,s,e1,Type.Entity(AnyEntity))
-      requires IsSafe(r,s,e2,Type.Entity(AnyEntity))
-      ensures IsSafe(r,s,BinaryApp(BinaryOp.In,e1,e2),Type.Bool(AnyBool))
-    {}
+  lemma InSingleSafe(r: Request, s: EntityStore, e1: Expr, e2: Expr)
+    requires IsSafe(r,s,e1,Type.Entity(AnyEntity))
+    requires IsSafe(r,s,e2,Type.Entity(AnyEntity))
+    ensures IsSafe(r,s,BinaryApp(BinaryOp.In,e1,e2),Type.Bool(AnyBool))
+  {
+    reveal IsSafe();
+  }
 
-    lemma EntityInEntityMatchesEngine(r: Request, s: EntityStore, u1: EntityUID, u2: EntityUID)
-      ensures EntityInEntity(s,u1,u2) == Evaluator(r,s).entityInEntity(u1,u2)
-    {}
+  lemma EntityInEntityMatchesEngine(r: Request, s: EntityStore, u1: EntityUID, u2: EntityUID)
+    ensures EntityInEntity(s,u1,u2) == Evaluator(r,s).entityInEntity(u1,u2)
+  {}
 
-    lemma InSingleFalseLiterals(r: Request, s: EntityStore, u1: EntityUID, u2: EntityUID)
-      requires !EntityInEntity(s,u1,u2)
-      ensures IsFalse(r,s,BinaryApp(BinaryOp.In,PrimitiveLit(Primitive.EntityUID(u1)),PrimitiveLit(Primitive.EntityUID(u2))))
-    {
-      var evaluator := Evaluator(r,s);
-      calc == {
-        evaluator.interpret(BinaryApp(BinaryOp.In,PrimitiveLit(Primitive.EntityUID(u1)),PrimitiveLit(Primitive.EntityUID(u2))));
-        evaluator.applyBinaryOp(BinaryOp.In,Value.EntityUID(u1),Value.EntityUID(u2));
-        base.Ok(Value.Bool(evaluator.entityInEntity(u1, u2)));
-      }
+  lemma InSingleFalseLiterals(r: Request, s: EntityStore, u1: EntityUID, u2: EntityUID)
+    requires !EntityInEntity(s,u1,u2)
+    ensures IsFalse(r,s,BinaryApp(BinaryOp.In,PrimitiveLit(Primitive.EntityUID(u1)),PrimitiveLit(Primitive.EntityUID(u2))))
+  {
+    reveal IsSafe();
+    var evaluator := Evaluator(r,s);
+    calc == {
+      evaluator.interpret(BinaryApp(BinaryOp.In,PrimitiveLit(Primitive.EntityUID(u1)),PrimitiveLit(Primitive.EntityUID(u2))));
+      evaluator.applyBinaryOp(BinaryOp.In,Value.EntityUID(u1),Value.EntityUID(u2));
+      base.Ok(Value.Bool(evaluator.entityInEntity(u1, u2)));
     }
+  }
 
-    lemma InSingleFalseEntityTypeAndLiteral(r: Request, s: EntityStore, e1: Expr, et1: EntityType, u2: EntityUID)
-      requires IsSafe(r,s,e1,Type.Entity(EntityLUB({et1})))
-      requires forall u1: EntityUID | u1.ty == et1 :: !EntityInEntity(s,u1,u2)
-      ensures IsFalse(r,s,BinaryApp(BinaryOp.In,e1,PrimitiveLit(Primitive.EntityUID(u2))))
-    {
-      var evaluator := Evaluator(r,s);
-      var r1 := evaluator.interpret(e1);
-      if r1.Ok? {
-        var u1 :- assert Value.asEntity(r1.value);
-        assert u1.ty == et1;
-        assert !EntityInEntity(s,u1,u2);
-        assert evaluator.interpret(BinaryApp(BinaryOp.In,e1,PrimitiveLit(Primitive.EntityUID(u2)))) == base.Ok(Value.FALSE);
-      }
+  lemma InSingleFalseEntityTypeAndLiteral(r: Request, s: EntityStore, e1: Expr, et1: EntityType, u2: EntityUID)
+    requires IsSafe(r,s,e1,Type.Entity(EntityLUB({et1})))
+    requires forall u1: EntityUID | u1.ty == et1 :: !EntityInEntity(s,u1,u2)
+    ensures IsFalse(r,s,BinaryApp(BinaryOp.In,e1,PrimitiveLit(Primitive.EntityUID(u2))))
+  {
+    reveal IsSafe();
+    var evaluator := Evaluator(r,s);
+    var r1 := evaluator.interpret(e1);
+    if r1.Ok? {
+      var u1 :- assert Value.asEntity(r1.value);
+      assert u1.ty == et1;
+      assert !EntityInEntity(s,u1,u2);
+      assert evaluator.interpret(BinaryApp(BinaryOp.In,e1,PrimitiveLit(Primitive.EntityUID(u2)))) == base.Ok(Value.FALSE);
     }
+  }
 
-    lemma InSingleFalseTypes(r: Request, s: EntityStore, e1: Expr, e2: Expr, t1: Type, t2: Type)
-      requires subty(t1,Type.Entity(AnyEntity))
-      requires subty(t2,Type.Entity(AnyEntity))
-      requires IsSafe(r,s,e1,t1)
-      requires IsSafe(r,s,e2,t2)
-      requires forall u1, u2: EntityUID |
-                 InstanceOfType(Value.EntityUID(u1), t1) && InstanceOfType(Value.EntityUID(u2), t2) ::
-                 !EntityInEntity(s,u1,u2)
-      ensures IsFalse(r,s,BinaryApp(BinaryOp.In,e1,e2))
-    {
-      var evaluator := Evaluator(r,s);
-      if evaluator.interpret(BinaryApp(BinaryOp.In,e1,e2)).Ok? {
-        var u1 := Value.asEntity(evaluator.interpret(e1).value).value;
-        var u2 := Value.asEntity(evaluator.interpret(e2).value).value;
-        assert !EntityInEntity(s,u1,u2);
-      }
+  lemma InSingleFalseTypes(r: Request, s: EntityStore, e1: Expr, e2: Expr, t1: Type, t2: Type)
+    requires subty(t1,Type.Entity(AnyEntity))
+    requires subty(t2,Type.Entity(AnyEntity))
+    requires IsSafe(r,s,e1,t1)
+    requires IsSafe(r,s,e2,t2)
+    requires forall u1, u2: EntityUID |
+      InstanceOfType(Value.EntityUID(u1), t1) && InstanceOfType(Value.EntityUID(u2), t2) ::
+      !EntityInEntity(s,u1,u2)
+    ensures IsFalse(r,s,BinaryApp(BinaryOp.In,e1,e2))
+  {
+    var evaluator := Evaluator(r,s);
+    var r1 := evaluator.interpret(e1);
+    var r2 := evaluator.interpret(e2);
+    var res := evaluator.interpret(BinaryApp(BinaryOp.In,e1,e2));
+
+    reveal IsSafe();
+    if r1.Err? {
+      assert res == r1;
+    } else if r2.Err? {
+      assert res == r2;
+    } else {
+      assert r1.value.Primitive? && r1.value.primitive.EntityUID?;
+      assert r2.value.Primitive? && r2.value.primitive.EntityUID?;
+      var u1 := r1.value.primitive.uid;
+      var u2 := r2.value.primitive.uid;
+      assert !EntityInEntity(s,u1,u2);
+      assert res.value == Value.FALSE;
     }
+  }
 
-    lemma InSetSafe(r: Request, s: EntityStore, e1: Expr, e2: Expr)
-      requires IsSafe(r,s,e1,Type.Entity(AnyEntity))
-      requires IsSafe(r,s,e2,Type.Set(Type.Entity(AnyEntity)))
-      ensures IsSafe(r,s,BinaryApp(BinaryOp.In,e1,e2),Type.Bool(AnyBool))
-    {}
+  lemma InSetSafe(r: Request, s: EntityStore, e1: Expr, e2: Expr)
+    requires IsSafe(r,s,e1,Type.Entity(AnyEntity))
+    requires IsSafe(r,s,e2,Type.Set(Type.Entity(AnyEntity)))
+    ensures IsSafe(r,s,BinaryApp(BinaryOp.In,e1,e2),Type.Bool(AnyBool))
+  {
+    reveal IsSafe();
+  }
 
-    lemma InSetFalseIfAllFalse(r: Request, s: EntityStore, e1: Expr, e2s: seq<Expr>)
-      requires IsSafe(r,s,e1,Type.Entity(AnyEntity))
-      requires forall i | 0 <= i < |e2s| ::
-                 IsSafe(r,s,e2s[i],Type.Entity(AnyEntity)) &&
-                 IsFalse(r,s,BinaryApp(BinaryOp.In,e1,e2s[i]))
-      ensures IsFalse(r,s,BinaryApp(BinaryOp.In,e1,Expr.Set(e2s)))
-    {
-      InterpretSetLemma(e2s,r,s);
-      var evaluator := Evaluator(r,s);
-      var res := evaluator.interpret(BinaryApp(BinaryOp.In,e1,Expr.Set(e2s)));
-      var r1 := evaluator.interpret(e1);
-      var r2 := evaluator.interpret(Expr.Set(e2s));
-    }
+  lemma InSetFalseIfAllFalse(r: Request, s: EntityStore, e1: Expr, e2s: seq<Expr>)
+    requires IsSafe(r,s,e1,Type.Entity(AnyEntity))
+    requires forall i | 0 <= i < |e2s| ::
+                IsSafe(r,s,e2s[i],Type.Entity(AnyEntity)) &&
+                IsFalse(r,s,BinaryApp(BinaryOp.In,e1,e2s[i]))
+    ensures IsFalse(r,s,BinaryApp(BinaryOp.In,e1,Expr.Set(e2s)))
+  {
+    reveal IsSafe();
+    InterpretSetLemma(e2s,r,s);
+    var evaluator := Evaluator(r,s);
+    var res := evaluator.interpret(BinaryApp(BinaryOp.In,e1,Expr.Set(e2s)));
+    var r1 := evaluator.interpret(e1);
+    var r2 := evaluator.interpret(Expr.Set(e2s));
+  }
 
-    lemma InSetFalseTypes(r: Request, s: EntityStore, e1: Expr, e2: Expr, t1: Type, t2: Type)
-      requires subty(t1,Type.Entity(AnyEntity))
-      requires subty(t2,Type.Entity(AnyEntity))
-      requires IsSafe(r,s,e1,t1)
-      requires IsSafe(r,s,e2,Type.Set(t2))
-      requires forall u1, u2: EntityUID |
-                 InstanceOfType(Value.EntityUID(u1), t1) && InstanceOfType(Value.EntityUID(u2), t2) ::
-                 !EntityInEntity(s,u1,u2)
-      ensures IsFalse(r,s,BinaryApp(BinaryOp.In,e1,e2))
-    {
-      var evaluator := Evaluator(r,s);
-      var r1 := evaluator.interpret(e1);
-      var r2 := evaluator.interpret(e2);
-      if r1.Ok? && r2.Ok? {
-        var u1 := Value.asEntity(r1.value).value;
-        var s2 := Value.asSet(r2.value).value;
-        assert forall us2 <- s2 :: InstanceOfType(us2,t2);
-        var us2 :- assert evaluator.checkEntitySet(s2);
-        assert forall u2 <- us2 :: !EntityInEntity(s,u1,u2);
-      }
+  lemma InSetFalseTypes(r: Request, s: EntityStore, e1: Expr, e2: Expr, t1: Type, t2: Type)
+    requires subty(t1,Type.Entity(AnyEntity))
+    requires subty(t2,Type.Entity(AnyEntity))
+    requires IsSafe(r,s,e1,t1)
+    requires IsSafe(r,s,e2,Type.Set(t2))
+    requires forall u1, u2: EntityUID |
+      InstanceOfType(Value.EntityUID(u1), t1) && InstanceOfType(Value.EntityUID(u2), t2) ::
+      !EntityInEntity(s,u1,u2)
+    ensures IsFalse(r,s,BinaryApp(BinaryOp.In,e1,e2))
+  {
+    reveal IsSafe();
+    var evaluator := Evaluator(r,s);
+    var r1 := evaluator.interpret(e1);
+    var r2 := evaluator.interpret(e2);
+    if r1.Ok? && r2.Ok? {
+      var u1 := Value.asEntity(r1.value).value;
+      var s2 := Value.asSet(r2.value).value;
+      assert forall us2 <- s2 :: InstanceOfType(us2,t2);
+      var us2 :- assert evaluator.checkEntitySet(s2);
+      assert forall u2 <- us2 :: !EntityInEntity(s,u1,u2);
     }
   }
 }

--- a/cedar-dafny/validation/thm/model.dfy
+++ b/cedar-dafny/validation/thm/model.dfy
@@ -940,7 +940,7 @@ module validation.thm.model {
   lemma EntityHasImpossibleFalseSafe(r: Request, s: EntityStore, e: Expr, l: Attr, lub: EntityLUB)
     requires IsSafe(r,s,e,Type.Entity(lub))
     requires forall ev: EntityUID | ExistingEntityInLub(s, ev, lub) ::
-                l !in s.entities[ev].attrs
+               l !in s.entities[ev].attrs
     ensures IsFalse(r,s,HasAttr(e,l))
   {
     reveal IsSafe();
@@ -1000,8 +1000,8 @@ module validation.thm.model {
     requires IsSafe(r,s,e1,t1)
     requires IsSafe(r,s,e2,t2)
     requires forall u1, u2: EntityUID |
-      InstanceOfType(Value.EntityUID(u1), t1) && InstanceOfType(Value.EntityUID(u2), t2) ::
-      !EntityInEntity(s,u1,u2)
+               InstanceOfType(Value.EntityUID(u1), t1) && InstanceOfType(Value.EntityUID(u2), t2) ::
+               !EntityInEntity(s,u1,u2)
     ensures IsFalse(r,s,BinaryApp(BinaryOp.In,e1,e2))
   {
     var evaluator := Evaluator(r,s);
@@ -1035,8 +1035,8 @@ module validation.thm.model {
   lemma InSetFalseIfAllFalse(r: Request, s: EntityStore, e1: Expr, e2s: seq<Expr>)
     requires IsSafe(r,s,e1,Type.Entity(AnyEntity))
     requires forall i | 0 <= i < |e2s| ::
-                IsSafe(r,s,e2s[i],Type.Entity(AnyEntity)) &&
-                IsFalse(r,s,BinaryApp(BinaryOp.In,e1,e2s[i]))
+               IsSafe(r,s,e2s[i],Type.Entity(AnyEntity)) &&
+               IsFalse(r,s,BinaryApp(BinaryOp.In,e1,e2s[i]))
     ensures IsFalse(r,s,BinaryApp(BinaryOp.In,e1,Expr.Set(e2s)))
   {
     reveal IsSafe();
@@ -1053,8 +1053,8 @@ module validation.thm.model {
     requires IsSafe(r,s,e1,t1)
     requires IsSafe(r,s,e2,Type.Set(t2))
     requires forall u1, u2: EntityUID |
-      InstanceOfType(Value.EntityUID(u1), t1) && InstanceOfType(Value.EntityUID(u2), t2) ::
-      !EntityInEntity(s,u1,u2)
+               InstanceOfType(Value.EntityUID(u1), t1) && InstanceOfType(Value.EntityUID(u2), t2) ::
+               !EntityInEntity(s,u1,u2)
     ensures IsFalse(r,s,BinaryApp(BinaryOp.In,e1,e2))
   {
     reveal IsSafe();

--- a/cedar-dafny/validation/thm/soundness.dfy
+++ b/cedar-dafny/validation/thm/soundness.dfy
@@ -1178,7 +1178,7 @@ module validation.thm.soundness {
       }
     }
 
-    lemma {:vcs_split_on_every_assert} SoundIn(e1: Expr, e2: Expr, t: Type, effs: Effects)
+    lemma SoundIn(e1: Expr, e2: Expr, t: Type, effs: Effects)
       decreases BinaryApp(BinaryOp.In,e1,e2) , 0 , e2
       requires InstanceOfRequestType(r,reqty)
       requires InstanceOfEntityTypeStore(s,ets)
@@ -1266,7 +1266,7 @@ module validation.thm.soundness {
                   assert IsSafe(r,s,ei2s[i],Type.Entity(AnyEntity)) by { Sound(ei2s[i], Type.Entity(AnyEntity), effs); }
                 }
                 forall i | 0 <= i < |ei2s|
-                  // note: most expensive assertion here
+                  // Note: this is the most expensive part of the proof
                   ensures IsFalse(r,s,BinaryApp(BinaryOp.In,e1,ei2s[i]))
                 {
                   var u2 :- assert typechecker.tryGetEUID(ei2s[i]);

--- a/cedar-dafny/validation/thm/soundness.dfy
+++ b/cedar-dafny/validation/thm/soundness.dfy
@@ -857,11 +857,11 @@ module validation.thm.soundness {
     }
 
     lemma InferRecordLemma(e: Expr, es: seq<(Attr,Expr)>, effs: Effects)
-      requires forall i :: 0 <= i < |es| ==> es[i] < e
+      requires forall i | 0 <= i < |es| :: es[i] < e
       requires Typechecker(ets,acts,reqty).inferRecord(e,es,effs).Ok?
-      ensures forall i :: 0 <= i < |es| ==> es[i].0 in Typechecker(ets,acts,reqty).inferRecord(e,es,effs).value.Keys && Typechecker(ets,acts,reqty).infer(es[i].1,effs).Ok?
-      ensures forall k :: k in Typechecker(ets,acts,reqty).inferRecord(e,es,effs).value.Keys ==> KeyExists(k,es) && Typechecker(ets,acts,reqty).infer(LastOfKey(k,es),effs).value.0 == Typechecker(ets,acts,reqty).inferRecord(e,es,effs).value[k].ty
-      ensures forall k :: !(k in Typechecker(ets,acts,reqty).inferRecord(e,es,effs).value.Keys) ==> !KeyExists(k,es)
+      ensures forall i | 0 <= i < |es| :: es[i].0 in Typechecker(ets,acts,reqty).inferRecord(e,es,effs).value.Keys && Typechecker(ets,acts,reqty).infer(es[i].1,effs).Ok?
+      ensures forall k | k in Typechecker(ets,acts,reqty).inferRecord(e,es,effs).value.Keys :: KeyExists(k,es) && Typechecker(ets,acts,reqty).infer(LastOfKey(k,es),effs).value.0 == Typechecker(ets,acts,reqty).inferRecord(e,es,effs).value[k].ty
+      ensures forall k | !(k in Typechecker(ets,acts,reqty).inferRecord(e,es,effs).value.Keys) :: !KeyExists(k,es)
     {
       reveal Typechecker(ets,acts,reqty).inferRecord();
     }
@@ -911,16 +911,16 @@ module validation.thm.soundness {
     }
 
     lemma InferSetLemma(e: Expr, es: seq<Expr>, effs: Effects)
-      requires forall i :: 0 <= i < |es| ==> es[i] < e
+      requires forall i | 0 <= i < |es| :: es[i] < e
       requires Typechecker(ets,acts,reqty).inferSet(e,es,effs).Ok?
-      ensures forall i :: 0 <= i < |es| ==> Typechecker(ets,acts,reqty).infer(es[i],effs).Ok? && subty(Typechecker(ets,acts,reqty).infer(es[i],effs).value.0,Typechecker(ets,acts,reqty).inferSet(e,es,effs).value)
+      ensures forall i | 0 <= i < |es| :: Typechecker(ets,acts,reqty).infer(es[i],effs).Ok? && subty(Typechecker(ets,acts,reqty).infer(es[i],effs).value.0,Typechecker(ets,acts,reqty).inferSet(e,es,effs).value)
     {
       if es == [] {
       } else {
         var (t,_) := Typechecker(ets,acts,reqty).infer(es[0],effs).value;
         var t1 := Typechecker(ets,acts,reqty).inferSet(e,es[1..],effs).value;
         var t2 := lubOpt(t,t1).value;
-        assert forall i :: 0 <= i < |es| ==> Typechecker(ets,acts,reqty).infer(es[i],effs).Ok? && subty(Typechecker(ets,acts,reqty).infer(es[i],effs).value.0,t2) by {
+        assert forall i | 0 <= i < |es| :: Typechecker(ets,acts,reqty).infer(es[i],effs).Ok? && subty(Typechecker(ets,acts,reqty).infer(es[i],effs).value.0,t2) by {
           forall i | 0 <= i < |es|
             ensures Typechecker(ets,acts,reqty).infer(es[i],effs).Ok? && subty(Typechecker(ets,acts,reqty).infer(es[i],effs).value.0,t2)
           {
@@ -1178,7 +1178,7 @@ module validation.thm.soundness {
       }
     }
 
-    lemma SoundIn(e1: Expr, e2: Expr, t: Type, effs: Effects)
+    lemma {:vcs_split_on_every_assert} SoundIn(e1: Expr, e2: Expr, t: Type, effs: Effects)
       decreases BinaryApp(BinaryOp.In,e1,e2) , 0 , e2
       requires InstanceOfRequestType(r,reqty)
       requires InstanceOfEntityTypeStore(s,ets)
@@ -1251,7 +1251,7 @@ module validation.thm.soundness {
                   }
                   InSingleFalseLiterals(r,s,u1,u2);
               }
-              case Set(ei2s) =>
+              case Set(ei2s) => 
                 var euids2 :- assert typechecker.tryGetEUIDs(e2);
                 var ets2 := set u <- euids2 :: u.ty;
                 // Argument that is the same any time e2 is a set.
@@ -1266,6 +1266,7 @@ module validation.thm.soundness {
                   assert IsSafe(r,s,ei2s[i],Type.Entity(AnyEntity)) by { Sound(ei2s[i], Type.Entity(AnyEntity), effs); }
                 }
                 forall i | 0 <= i < |ei2s|
+                  // note: most expensive assertion here
                   ensures IsFalse(r,s,BinaryApp(BinaryOp.In,e1,ei2s[i]))
                 {
                   var u2 :- assert typechecker.tryGetEUID(ei2s[i]);
@@ -1302,7 +1303,7 @@ module validation.thm.soundness {
 
     lemma InferCallArgsSound(e: Expr, name: base.Name, args: seq<Expr>, tys: seq<Type>, effs: Effects)
       requires |args| == |tys|
-      requires forall i :: 0 <= i < |args| ==> args[i] < e
+      requires forall i | 0 <= i < |args| :: args[i] < e
       requires Typechecker(ets,acts,reqty).inferCallArgs(e,args,tys,effs).Ok?
       ensures forall i | 0 <= i < |args| :: Typesafe(args[i],effs,tys[i])
     {}

--- a/cedar-dafny/validation/thm/soundness.dfy
+++ b/cedar-dafny/validation/thm/soundness.dfy
@@ -34,7 +34,7 @@ module validation.thm.soundness {
 
   type Result<T> = types.Result<T>
 
-  // A value of type SemanticSoundnessProof(model,reqty,ets,acts,q,s) contains a
+  // A value of type SemanticSoundnessProof(reqty,ets,acts,q,s) contains a
   // proof (`lemma SoundToplevel` at the bottom of the file) that any
   // expression `e` typed in context (reqty, ets, acts) and evaluated under (r,s)
   // is safe according to the model, assuming the context assigns correct
@@ -43,7 +43,6 @@ module validation.thm.soundness {
   // The proofs in this file are robust to changes in the evaluator, since they
   // only depend on the abstract `model`.
   datatype SemanticSoundnessProof = SSP(
-    model: SemanticModel,
     reqty: RequestType,
     ets: EntityTypeStore,
     acts: ActionStore,
@@ -76,14 +75,14 @@ module validation.thm.soundness {
     // On input to the typechecking function, for any (e,k) in the Effects,
     // e is a record- or entity-typed expression that has key k.
     ghost predicate {:opaque} EffectsInvariant (effs: Effects) {
-      forall e, k | (e, k) in effs.effs :: model.GetAttrSafe(r,s,e,k)
+      forall e, k | (e, k) in effs.effs :: GetAttrSafe(r,s,e,k)
     }
 
     // The Effects output by the typechecking function, will satisfy
     // `EffectsInvariant` provided that the input expression is true.
     ghost predicate GuardedEffectsInvariant (e: Expr, effs: Effects)
     {
-      model.IsTrueStrong(r,s,e) ==> EffectsInvariant(effs)
+      IsTrueStrong(r,s,e) ==> EffectsInvariant(effs)
     }
 
     lemma EmptyEffectsInvariant ()
@@ -95,23 +94,23 @@ module validation.thm.soundness {
     lemma SoundLit(p: Primitive, t: Type, effs: Effects)
       decreases PrimitiveLit(p) , 0
       requires Typesafe(PrimitiveLit(p),effs,t)
-      ensures model.IsSafe(r,s,PrimitiveLit(p),t)
+      ensures IsSafe(r,s,PrimitiveLit(p),t)
       ensures getEffects(PrimitiveLit(p),effs) == Effects.empty()
     {
       assert InstanceOfType(Primitive(p),typeOfPrim(p)) by {
-        model.PrimSafeAtInferredType(p);
+        PrimSafeAtInferredType(p);
       }
 
-      assert model.SemanticSubty(typeOfPrim(p),t) by {
-        model.SubtyCompat(typeOfPrim(p),t);
+      assert SemanticSubty(typeOfPrim(p),t) by {
+        SubtyCompat(typeOfPrim(p),t);
       }
 
       assert InstanceOfType(Primitive(p),t) by {
-        model.SemSubtyTransportVal(typeOfPrim(p),t,Primitive(p));
+        SemSubtyTransportVal(typeOfPrim(p),t,Primitive(p));
       }
 
-      assert model.IsSafe(r,s,PrimitiveLit(p),t) by{
-        model.PrimSafeLift(r,s,p,t);
+      assert IsSafe(r,s,PrimitiveLit(p),t) by{
+        PrimSafeLift(r,s,p,t);
       }
     }
 
@@ -121,37 +120,37 @@ module validation.thm.soundness {
       requires InstanceOfEntityTypeStore(s,ets)
       requires InstanceOfActionStore(s,acts)
       requires Typesafe(Var(x),effs,t)
-      ensures model.IsSafe(r,s,Var(x),t)
+      ensures IsSafe(r,s,Var(x),t)
       ensures getEffects(Var(x),effs) == Effects.empty()
     {
       var t' :| getType(Var(x),effs) == t' && subty(t',t);
       assert Typechecker(ets,acts,reqty).inferVar(x) == types.Ok(t');
       match x {
         case Principal =>
-          assert model.IsSafe(r,s,Var(Principal),t') by { model.PrincipalIsSafe(r,s,t'); }
-          assert model.IsSafe(r,s,Var(Principal),t) by {
-            model.SubtyCompat(t',t);
-            model.SemSubtyTransport(r,s,Var(Principal),t',t);
+          assert IsSafe(r,s,Var(Principal),t') by { PrincipalIsSafe(r,s,t'); }
+          assert IsSafe(r,s,Var(Principal),t) by {
+            SubtyCompat(t',t);
+            SemSubtyTransport(r,s,Var(Principal),t',t);
           }
         case Action =>
-          assert model.IsSafe(r,s,Var(Action),t') by { model.ActionIsSafe(r,s,t'); }
-          assert model.IsSafe(r,s,Var(Action),t) by {
-            model.SubtyCompat(t',t);
-            model.SemSubtyTransport(r,s,Var(Action),t',t);
+          assert IsSafe(r,s,Var(Action),t') by { ActionIsSafe(r,s,t'); }
+          assert IsSafe(r,s,Var(Action),t) by {
+            SubtyCompat(t',t);
+            SemSubtyTransport(r,s,Var(Action),t',t);
           }
         case Resource =>
-          assert model.IsSafe(r,s,Var(Resource),t') by { model.ResourceIsSafe(r,s,t'); }
-          assert model.IsSafe(r,s,Var(Resource),t) by {
-            model.SubtyCompat(t',t);
-            model.SemSubtyTransport(r,s,Var(Resource),t',t);
+          assert IsSafe(r,s,Var(Resource),t') by { ResourceIsSafe(r,s,t'); }
+          assert IsSafe(r,s,Var(Resource),t) by {
+            SubtyCompat(t',t);
+            SemSubtyTransport(r,s,Var(Resource),t',t);
           }
         case Context =>
-          assert model.IsSafe(r,s,Var(Context),Type.Record(reqty.context)) by {
-            model.ContextIsSafe(r,s,Type.Record(reqty.context));
+          assert IsSafe(r,s,Var(Context),Type.Record(reqty.context)) by {
+            ContextIsSafe(r,s,Type.Record(reqty.context));
           }
-          assert model.IsSafe(r,s,Var(Context),t) by {
-            model.SubtyCompat(Type.Record(reqty.context),t);
-            model.SemSubtyTransport(r,s,Var(Context),Type.Record(reqty.context),t);
+          assert IsSafe(r,s,Var(Context),t) by {
+            SubtyCompat(Type.Record(reqty.context),t);
+            SemSubtyTransport(r,s,Var(Context),Type.Record(reqty.context),t);
           }
       }
     }
@@ -188,13 +187,13 @@ module validation.thm.soundness {
       requires InstanceOfActionStore(s,acts)
       requires EffectsInvariant(effs)
       requires Typesafe(If(e,e1,e2),effs,t)
-      ensures model.IsSafe(r,s,If(e,e1,e2),t)
+      ensures IsSafe(r,s,If(e,e1,e2),t)
       ensures GuardedEffectsInvariant(If(e,e1,e2),getEffects(If(e,e1,e2),effs))
     {
       var t' :| getType(If(e,e1,e2),effs) == t' && subty(t',t);
       assert Typechecker(ets,acts,reqty).inferIf(e,e1,e2,effs).Ok?;
       var (bt, effs1) := Typechecker(ets,acts,reqty).inferBoolType(e,effs).value;
-      assert model.IsSafe(r,s,e,Type.Bool(bt)) && GuardedEffectsInvariant(e,effs1) by {
+      assert IsSafe(r,s,e,Type.Bool(bt)) && GuardedEffectsInvariant(e,effs1) by {
         assert getType(e,effs) == Type.Bool(bt);
         assert subty(Type.Bool(bt),Type.Bool(bt));
         assert Typesafe(e,effs,Type.Bool(bt));
@@ -202,51 +201,51 @@ module validation.thm.soundness {
       }
       match bt {
         case True =>
-          assert model.IsTrue(r,s,e);
+          assert IsTrue(r,s,e);
           var (t1,effs2) := Typechecker(ets,acts,reqty).infer(e1,effs.union(effs1)).value;
           assert Typesafe(e1,effs.union(effs1),t1) by { SubtyRefl(t1); }
-          if model.IsTrueStrong(r,s,e) {
+          if IsTrueStrong(r,s,e) {
             assert EffectsInvariant(effs1);
-            assert model.IsSafe(r,s,e1,t1) && GuardedEffectsInvariant(e1,effs2) by {
+            assert IsSafe(r,s,e1,t1) && GuardedEffectsInvariant(e1,effs2) by {
               EffectsInvariantUnion(effs,effs1);
               Sound(e1,t1,effs.union(effs1));
             }
-            assert model.IsSafe(r,s,If(e,e1,e2),t') by { model.IteTrueSafe(r,s,e,e1,e2,t'); }
-            assert model.IsSafe(r,s,If(e,e1,e2),t) by {
-              model.SubtyCompat(t',t);
-              model.SemSubtyTransport(r,s,If(e,e1,e2),t',t);
+            assert IsSafe(r,s,If(e,e1,e2),t') by { IteTrueSafe(r,s,e,e1,e2,t'); }
+            assert IsSafe(r,s,If(e,e1,e2),t) by {
+              SubtyCompat(t',t);
+              SemSubtyTransport(r,s,If(e,e1,e2),t',t);
             }
             assert GuardedEffectsInvariant(If(e,e1,e2),effs1.union(effs2)) by {
-              if model.IsTrueStrong(r,s,If(e,e1,e2)) {
-                model.IteTrueStrongTrue(r,s,e,e1,e2);
+              if IsTrueStrong(r,s,If(e,e1,e2)) {
+                IteTrueStrongTrue(r,s,e,e1,e2);
                 assert EffectsInvariant(effs2);
                 EffectsInvariantUnion(effs1,effs2);
               }
             }
           } else {
-            assert model.IsSafe(r,s,If(e,e1,e2),t) by {
-              model.IteError(r,s,e,e1,e2,Type.Bool(True),t);
+            assert IsSafe(r,s,If(e,e1,e2),t) by {
+              IteError(r,s,e,e1,e2,Type.Bool(True),t);
             }
             assert GuardedEffectsInvariant(If(e,e1,e2),effs1.union(effs2)) by {
-              model.IteError(r,s,e,e1,e2,Type.Bool(True),Type.Bool(True));
-              assert !model.IsTrueStrong(r,s,If(e,e1,e2));
+              IteError(r,s,e,e1,e2,Type.Bool(True),Type.Bool(True));
+              assert !IsTrueStrong(r,s,If(e,e1,e2));
             }
           }
         case False =>
-          assert model.IsFalse(r,s,e);
+          assert IsFalse(r,s,e);
           var (t2,effs2) := Typechecker(ets,acts,reqty).infer(e2,effs).value;
           assert Typesafe(e2,effs,t2) by { SubtyRefl(t2); }
-          assert model.IsSafe(r,s,e2,t2) && GuardedEffectsInvariant(e2,effs2) by {
+          assert IsSafe(r,s,e2,t2) && GuardedEffectsInvariant(e2,effs2) by {
             Sound(e2,t2,effs);
           }
-          assert model.IsSafe(r,s,If(e,e1,e2),t') by { model.IteFalseSafe(r,s,e,e1,e2,t'); }
-          assert model.IsSafe(r,s,If(e,e1,e2),t) by {
-            model.SubtyCompat(t',t);
-            model.SemSubtyTransport(r,s,If(e,e1,e2),t',t);
+          assert IsSafe(r,s,If(e,e1,e2),t') by { IteFalseSafe(r,s,e,e1,e2,t'); }
+          assert IsSafe(r,s,If(e,e1,e2),t) by {
+            SubtyCompat(t',t);
+            SemSubtyTransport(r,s,If(e,e1,e2),t',t);
           }
           assert GuardedEffectsInvariant(If(e,e1,e2),effs2) by {
-            if model.IsTrueStrong(r,s,If(e,e1,e2)) {
-              model.IteTrueStrongFalse(r,s,e,e1,e2);
+            if IsTrueStrong(r,s,If(e,e1,e2)) {
+              IteTrueStrongFalse(r,s,e,e1,e2);
               assert EffectsInvariant(effs2);
             }
           }
@@ -257,65 +256,65 @@ module validation.thm.soundness {
           assert Typesafe(e2,effs,t2) by { SubtyRefl(t2); }
           assert t' == lubOpt(t1,t2).value;
           assert subty(t1,t') && subty(t2,t') by { LubIsUB(t1,t2,t'); }
-          if model.IsSafeStrong(r,s,e,Type.Bool(bt)) {
-            if model.IsTrue(r,s,e) {
+          if IsSafeStrong(r,s,e,Type.Bool(bt)) {
+            if IsTrue(r,s,e) {
               // `e` evaluates to true
-              model.IsTrueImpliesIsTrueStrong(r,s,e,Type.Bool(bt));
-              assert model.IsTrueStrong(r,s,e);
+              IsTrueImpliesIsTrueStrong(r,s,e,Type.Bool(bt));
+              assert IsTrueStrong(r,s,e);
               assert EffectsInvariant(effs1);
-              assert model.IsSafe(r,s,e1,t1) && GuardedEffectsInvariant(e1,effs2) by {
+              assert IsSafe(r,s,e1,t1) && GuardedEffectsInvariant(e1,effs2) by {
                 EffectsInvariantUnion(effs,effs1);
                 Sound(e1,t1,effs.union(effs1));
               }
-              assert model.IsSafe(r,s,If(e,e1,e2),t1) by { model.IteTrueSafe(r,s,e,e1,e2,t1); }
-              assert model.IsSafe(r,s,If(e,e1,e2),t) by {
-                model.SubtyCompat(t1,t');
-                model.SubtyCompat(t',t);
-                model.SemSubtyTransport(r,s,If(e,e1,e2),t1,t);
+              assert IsSafe(r,s,If(e,e1,e2),t1) by { IteTrueSafe(r,s,e,e1,e2,t1); }
+              assert IsSafe(r,s,If(e,e1,e2),t) by {
+                SubtyCompat(t1,t');
+                SubtyCompat(t',t);
+                SemSubtyTransport(r,s,If(e,e1,e2),t1,t);
               }
               assert GuardedEffectsInvariant(If(e,e1,e2),effs1.union(effs2)) by {
-                if model.IsTrueStrong(r,s,If(e,e1,e2)) {
-                  model.IteTrueStrongTrue(r,s,e,e1,e2);
+                if IsTrueStrong(r,s,If(e,e1,e2)) {
+                  IteTrueStrongTrue(r,s,e,e1,e2);
                   EffectsInvariantUnion(effs1,effs2);
                 }
               }
               assert GuardedEffectsInvariant(If(e,e1,e2),effs1.union(effs2).intersect(effs3)) by {
-                if model.IsTrueStrong(r,s,If(e,e1,e2)) {
+                if IsTrueStrong(r,s,If(e,e1,e2)) {
                   EffectsInvariantIntersectL(effs1.union(effs2),effs3);
                 }
               }
             } else {
               // `e` evaluates to false
-              model.NotTrueImpliesFalse(r,s,e,bt);
-              assert model.IsFalse(r,s,e);
-              assert model.IsSafe(r,s,e2,t2) && GuardedEffectsInvariant(e2,effs3) by {
+              NotTrueImpliesFalse(r,s,e,bt);
+              assert IsFalse(r,s,e);
+              assert IsSafe(r,s,e2,t2) && GuardedEffectsInvariant(e2,effs3) by {
                 Sound(e2,t2,effs);
               }
-              assert model.IsSafe(r,s,If(e,e1,e2),t2) by { model.IteFalseSafe(r,s,e,e1,e2,t2); }
-              assert model.IsSafe(r,s,If(e,e1,e2),t) by {
-                model.SubtyCompat(t2,t');
-                model.SubtyCompat(t',t);
-                model.SemSubtyTransport(r,s,If(e,e1,e2),t2,t);
+              assert IsSafe(r,s,If(e,e1,e2),t2) by { IteFalseSafe(r,s,e,e1,e2,t2); }
+              assert IsSafe(r,s,If(e,e1,e2),t) by {
+                SubtyCompat(t2,t');
+                SubtyCompat(t',t);
+                SemSubtyTransport(r,s,If(e,e1,e2),t2,t);
               }
               assert GuardedEffectsInvariant(If(e,e1,e2),effs3) by {
-                if model.IsTrueStrong(r,s,If(e,e1,e2)) {
-                  model.IteTrueStrongFalse(r,s,e,e1,e2);
+                if IsTrueStrong(r,s,If(e,e1,e2)) {
+                  IteTrueStrongFalse(r,s,e,e1,e2);
                 }
               }
               assert GuardedEffectsInvariant(If(e,e1,e2),effs1.union(effs2).intersect(effs3)) by {
-                if model.IsTrueStrong(r,s,If(e,e1,e2)) {
+                if IsTrueStrong(r,s,If(e,e1,e2)) {
                   EffectsInvariantIntersectR(effs1.union(effs2),effs3);
                 }
               }
             }
           } else {
             // `e` produces an error
-            assert model.IsSafe(r,s,If(e,e1,e2),t) by {
-              model.IteError(r,s,e,e1,e2,Type.Bool(bt),t);
+            assert IsSafe(r,s,If(e,e1,e2),t) by {
+              IteError(r,s,e,e1,e2,Type.Bool(bt),t);
             }
             assert GuardedEffectsInvariant(If(e,e1,e2),effs1.union(effs2).intersect(effs3)) by {
-              model.IteError(r,s,e,e1,e2,Type.Bool(bt),Type.Bool(True));
-              assert !model.IsTrueStrong(r,s,If(e,e1,e2));
+              IteError(r,s,e,e1,e2,Type.Bool(bt),Type.Bool(True));
+              assert !IsTrueStrong(r,s,If(e,e1,e2));
             }
           }
       }
@@ -328,14 +327,14 @@ module validation.thm.soundness {
       requires InstanceOfActionStore(s,acts)
       requires EffectsInvariant(effs)
       requires Typesafe(And(e1,e2),effs,t)
-      ensures model.IsSafe(r,s,And(e1,e2),t)
+      ensures IsSafe(r,s,And(e1,e2),t)
       ensures GuardedEffectsInvariant(And(e1,e2),getEffects(And(e1,e2),effs))
     {
       var t' :| getType(And(e1,e2),effs) == t' && subty(t',t);
       assert Typechecker(ets,acts,reqty).inferAnd(e1,e2,effs).Ok?;
       var (bt1, effs1) := Typechecker(ets,acts,reqty).inferBoolType(e1,effs).value;
       assert Typesafe(e1,effs,Type.Bool(bt1));
-      assert model.IsSafe(r,s,e1,Type.Bool(bt1)) && GuardedEffectsInvariant(e1,effs1) by {
+      assert IsSafe(r,s,e1,Type.Bool(bt1)) && GuardedEffectsInvariant(e1,effs1) by {
         Sound(e1,Type.Bool(bt1),effs);
       }
       assert GuardedEffectsInvariant(And(e1,e2),Effects.empty()) by {
@@ -343,78 +342,78 @@ module validation.thm.soundness {
       }
       match bt1 {
         case False =>
-          assert model.IsSafe(r,s,And(e1,e2),t') by { model.AndLShortSafe(r,s,e1,e2); }
-          assert model.IsSafe(r,s,And(e1,e2),t) by {
-            model.SubtyCompat(t',t);
-            model.SemSubtyTransport(r,s,And(e1,e2),t',t);
+          assert IsSafe(r,s,And(e1,e2),t') by { AndLShortSafe(r,s,e1,e2); }
+          assert IsSafe(r,s,And(e1,e2),t) by {
+            SubtyCompat(t',t);
+            SemSubtyTransport(r,s,And(e1,e2),t',t);
           }
         case _ =>
           var res := Typechecker(ets,acts,reqty).inferBoolType(e2,effs.union(effs1)).value;
           var bt2 := res.0;
           var effs2 := res.1;
           assert Typesafe(e2,effs.union(effs1),Type.Bool(bt2));
-          if model.IsSafeStrong(r,s,e1,Type.Bool(bt1)) {
-            if model.IsTrue(r,s,e1) {
+          if IsSafeStrong(r,s,e1,Type.Bool(bt1)) {
+            if IsTrue(r,s,e1) {
               // `e1` evaluates to true
-              model.IsTrueImpliesIsTrueStrong(r,s,e1,Type.Bool(bt1));
-              assert model.IsTrueStrong(r,s,e1);
+              IsTrueImpliesIsTrueStrong(r,s,e1,Type.Bool(bt1));
+              assert IsTrueStrong(r,s,e1);
               assert EffectsInvariant(effs1);
-              assert model.IsSafe(r,s,e2,Type.Bool(bt2)) && GuardedEffectsInvariant(e2,effs2) by {
+              assert IsSafe(r,s,e2,Type.Bool(bt2)) && GuardedEffectsInvariant(e2,effs2) by {
                 EffectsInvariantUnion(effs,effs1);
                 Sound(e2,Type.Bool(bt2),effs.union(effs1));
               }
               match bt2 {
                 case False =>
-                  assert model.IsFalse(r,s,e2);
-                  assert model.IsSafe(r,s,e1,Type.Bool(AnyBool)) by {
+                  assert IsFalse(r,s,e2);
+                  assert IsSafe(r,s,e1,Type.Bool(AnyBool)) by {
                     assert subty(Type.Bool(bt1),Type.Bool(AnyBool));
-                    model.SubtyCompat(Type.Bool(bt1),Type.Bool(AnyBool));
-                    model.SemSubtyTransport(r,s,e1,Type.Bool(bt1),Type.Bool(AnyBool));
+                    SubtyCompat(Type.Bool(bt1),Type.Bool(AnyBool));
+                    SemSubtyTransport(r,s,e1,Type.Bool(bt1),Type.Bool(AnyBool));
                   }
-                  assert model.IsSafe(r,s,And(e1,e2),t') by {
-                    model.AndRShortSafe(r,s,e1,e2);
+                  assert IsSafe(r,s,And(e1,e2),t') by {
+                    AndRShortSafe(r,s,e1,e2);
                   }
-                  assert model.IsSafe(r,s,And(e1,e2),t) by {
-                    model.SubtyCompat(t',t);
-                    model.SemSubtyTransport(r,s,And(e1,e2),t',t);
+                  assert IsSafe(r,s,And(e1,e2),t) by {
+                    SubtyCompat(t',t);
+                    SemSubtyTransport(r,s,And(e1,e2),t',t);
                   }
                 case True =>
-                  assert model.IsTrue(r,s,e2);
-                  assert model.SemanticSubty(Type.Bool(bt1),Type.Bool(AnyBool)) by {
+                  assert IsTrue(r,s,e2);
+                  assert SemanticSubty(Type.Bool(bt1),Type.Bool(AnyBool)) by {
                     assert subty(Type.Bool(bt1),Type.Bool(AnyBool));
-                    model.SubtyCompat(Type.Bool(bt1),Type.Bool(AnyBool));
+                    SubtyCompat(Type.Bool(bt1),Type.Bool(AnyBool));
                   }
-                  assert model.IsSafe(r,s,And(e1,e2),Type.Bool(bt1)) by {
-                    model.AndLRetSafe(r,s,e1,e2,Type.Bool(bt1));
+                  assert IsSafe(r,s,And(e1,e2),Type.Bool(bt1)) by {
+                    AndLRetSafe(r,s,e1,e2,Type.Bool(bt1));
                   }
-                  assert model.IsSafe(r,s,And(e1,e2),t) by {
-                    model.SubtyCompat(t',t);
-                    model.SemSubtyTransport(r,s,And(e1,e2),t',t);
+                  assert IsSafe(r,s,And(e1,e2),t) by {
+                    SubtyCompat(t',t);
+                    SemSubtyTransport(r,s,And(e1,e2),t',t);
                   }
                   assert GuardedEffectsInvariant(And(e1,e2),effs1.union(effs2)) by {
-                    if model.IsTrueStrong(r,s,And(e1,e2)) {
-                      model.AndTrueStrong(r,s,e1,e2);
+                    if IsTrueStrong(r,s,And(e1,e2)) {
+                      AndTrueStrong(r,s,e1,e2);
                       assert EffectsInvariant(effs2);
                       EffectsInvariantUnion(effs1,effs2);
                     }
                   }
                 case _ =>
-                  assert model.IsSafe(r,s,e1,Type.Bool(AnyBool)) by {
-                    model.SubtyCompat(Type.Bool(bt1),Type.Bool(AnyBool));
-                    model.SemSubtyTransport(r,s,e1,Type.Bool(bt1),Type.Bool(AnyBool));
+                  assert IsSafe(r,s,e1,Type.Bool(AnyBool)) by {
+                    SubtyCompat(Type.Bool(bt1),Type.Bool(AnyBool));
+                    SemSubtyTransport(r,s,e1,Type.Bool(bt1),Type.Bool(AnyBool));
                   }
-                  assert model.IsSafe(r,s,e2,Type.Bool(AnyBool)) by {
-                    model.SubtyCompat(Type.Bool(bt2),Type.Bool(AnyBool));
-                    model.SemSubtyTransport(r,s,e2,Type.Bool(bt2),Type.Bool(AnyBool));
+                  assert IsSafe(r,s,e2,Type.Bool(AnyBool)) by {
+                    SubtyCompat(Type.Bool(bt2),Type.Bool(AnyBool));
+                    SemSubtyTransport(r,s,e2,Type.Bool(bt2),Type.Bool(AnyBool));
                   }
-                  assert model.IsSafe(r,s,And(e1,e2),Type.Bool(AnyBool)) by { model.AndSafe(r,s,e1,e2); }
-                  assert model.IsSafe(r,s,And(e1,e2),t) by {
-                    model.SubtyCompat(t',t);
-                    model.SemSubtyTransport(r,s,And(e1,e2),t',t);
+                  assert IsSafe(r,s,And(e1,e2),Type.Bool(AnyBool)) by { AndSafe(r,s,e1,e2); }
+                  assert IsSafe(r,s,And(e1,e2),t) by {
+                    SubtyCompat(t',t);
+                    SemSubtyTransport(r,s,And(e1,e2),t',t);
                   }
                   assert GuardedEffectsInvariant(And(e1,e2),effs1.union(effs2)) by {
-                    if model.IsTrueStrong(r,s,And(e1,e2)) {
-                      model.AndTrueStrong(r,s,e1,e2);
+                    if IsTrueStrong(r,s,And(e1,e2)) {
+                      AndTrueStrong(r,s,e1,e2);
                       assert EffectsInvariant(effs2);
                       EffectsInvariantUnion(effs1,effs2);
                     }
@@ -422,37 +421,37 @@ module validation.thm.soundness {
               }
             } else {
               // `e1` evaluates to false
-              model.NotTrueImpliesFalse(r,s,e1,bt1);
-              assert model.IsFalse(r,s,e1);
-              assert model.IsFalse(r,s,And(e1,e2)) by { model.AndLShortSafe(r,s,e1,e2); }
-              assert model.IsSafe(r,s,And(e1,e2),t) by {
-                model.SubtyCompat(Type.Bool(False),t);
-                model.SemSubtyTransport(r,s,And(e1,e2),Type.Bool(False),t);
+              NotTrueImpliesFalse(r,s,e1,bt1);
+              assert IsFalse(r,s,e1);
+              assert IsFalse(r,s,And(e1,e2)) by { AndLShortSafe(r,s,e1,e2); }
+              assert IsSafe(r,s,And(e1,e2),t) by {
+                SubtyCompat(Type.Bool(False),t);
+                SemSubtyTransport(r,s,And(e1,e2),Type.Bool(False),t);
               }
               match bt2 {
                 case False =>
                 case True =>
                   assert GuardedEffectsInvariant(And(e1,e2),effs1.union(effs2)) by {
-                    assert model.IsFalse(r,s,And(e1,e2));
-                    model.FalseImpliesNotTrueStrong(r,s,And(e1,e2));
-                    assert !model.IsTrueStrong(r,s,And(e1,e2));
+                    assert IsFalse(r,s,And(e1,e2));
+                    FalseImpliesNotTrueStrong(r,s,And(e1,e2));
+                    assert !IsTrueStrong(r,s,And(e1,e2));
                   }
                 case AnyBool =>
                   assert GuardedEffectsInvariant(And(e1,e2),effs1.union(effs2)) by {
-                    assert model.IsFalse(r,s,And(e1,e2));
-                    model.FalseImpliesNotTrueStrong(r,s,And(e1,e2));
-                    assert !model.IsTrueStrong(r,s,And(e1,e2));
+                    assert IsFalse(r,s,And(e1,e2));
+                    FalseImpliesNotTrueStrong(r,s,And(e1,e2));
+                    assert !IsTrueStrong(r,s,And(e1,e2));
                   }
               }
             }
           } else {
             // `e1` produces an error
-            assert model.IsSafe(r,s,And(e1,e2),t) by {
-              model.AndError(r,s,e1,e2,Type.Bool(bt1),t);
+            assert IsSafe(r,s,And(e1,e2),t) by {
+              AndError(r,s,e1,e2,Type.Bool(bt1),t);
             }
             assert GuardedEffectsInvariant(And(e1,e2),effs1.union(effs2)) by {
-              model.AndError(r,s,e1,e2,Type.Bool(bt1),Type.Bool(True));
-              assert !model.IsTrueStrong(r,s,And(e1,e2));
+              AndError(r,s,e1,e2,Type.Bool(bt1),Type.Bool(True));
+              assert !IsTrueStrong(r,s,And(e1,e2));
             }
           }
       }
@@ -465,14 +464,14 @@ module validation.thm.soundness {
       requires InstanceOfActionStore(s,acts)
       requires EffectsInvariant(effs)
       requires Typesafe(Or(e1,e2),effs,t)
-      ensures model.IsSafe(r,s,Or(e1,e2),t)
+      ensures IsSafe(r,s,Or(e1,e2),t)
       ensures GuardedEffectsInvariant(Or(e1,e2),getEffects(Or(e1,e2),effs))
     {
       var t' :| getType(Or(e1,e2),effs) == t' && subty(t',t);
       assert Typechecker(ets,acts,reqty).inferOr(e1,e2,effs).Ok?;
       var (bt1, effs1) := Typechecker(ets,acts,reqty).inferBoolType(e1,effs).value;
       assert Typesafe(e1,effs,Type.Bool(bt1));
-      assert model.IsSafe(r,s,e1,Type.Bool(bt1)) && GuardedEffectsInvariant(e1,effs1) by {
+      assert IsSafe(r,s,e1,Type.Bool(bt1)) && GuardedEffectsInvariant(e1,effs1) by {
         Sound(e1,Type.Bool(bt1),effs);
       }
       assert GuardedEffectsInvariant(Or(e1,e2),Effects.empty()) by {
@@ -480,91 +479,91 @@ module validation.thm.soundness {
       }
       match bt1 {
         case True =>
-          assert model.IsTrue(r,s,e1);
-          assert model.IsSafe(r,s,Or(e1,e2),t') by { model.OrLShortSafe(r,s,e1,e2); }
-          assert model.IsSafe(r,s,Or(e1,e2),t) by {
-            model.SubtyCompat(t',t);
-            model.SemSubtyTransport(r,s,Or(e1,e2),t',t);
+          assert IsTrue(r,s,e1);
+          assert IsSafe(r,s,Or(e1,e2),t') by { OrLShortSafe(r,s,e1,e2); }
+          assert IsSafe(r,s,Or(e1,e2),t) by {
+            SubtyCompat(t',t);
+            SemSubtyTransport(r,s,Or(e1,e2),t',t);
           }
         case False =>
-          assert model.IsFalse(r,s,e1);
+          assert IsFalse(r,s,e1);
           var (bt2, effs2) := Typechecker(ets,acts,reqty).inferBoolType(e2,effs).value;
           assert Typesafe(e2,effs,Type.Bool(bt2));
-          assert model.IsSafe(r,s,e2,Type.Bool(bt2)) && GuardedEffectsInvariant(e2,effs2) by {
+          assert IsSafe(r,s,e2,Type.Bool(bt2)) && GuardedEffectsInvariant(e2,effs2) by {
             Sound(e2,Type.Bool(bt2),effs);
           }
-          assert model.SemanticSubty(Type.Bool(bt2),Type.Bool(AnyBool)) by {
+          assert SemanticSubty(Type.Bool(bt2),Type.Bool(AnyBool)) by {
             assert subty(Type.Bool(bt2),Type.Bool(AnyBool));
-            model.SubtyCompat(Type.Bool(bt2),Type.Bool(AnyBool));
+            SubtyCompat(Type.Bool(bt2),Type.Bool(AnyBool));
           }
-          assert model.IsSafe(r,s,Or(e1,e2),Type.Bool(bt2)) by { model.OrRRetSafe(r,s,e1,e2,Type.Bool(bt2)); }
-          assert model.IsSafe(r,s,Or(e1,e2),t) by {
-            model.SubtyCompat(t',t);
-            model.SemSubtyTransport(r,s,Or(e1,e2),t',t);
+          assert IsSafe(r,s,Or(e1,e2),Type.Bool(bt2)) by { OrRRetSafe(r,s,e1,e2,Type.Bool(bt2)); }
+          assert IsSafe(r,s,Or(e1,e2),t) by {
+            SubtyCompat(t',t);
+            SemSubtyTransport(r,s,Or(e1,e2),t',t);
           }
           assert GuardedEffectsInvariant(Or(e1,e2),effs2) by {
-            if model.IsTrueStrong(r,s,Or(e1,e2)) {
-              model.OrTrueStrong(r,s,e1,e2);
-              model.FalseImpliesNotTrueStrong(r,s,e1);
-              assert model.IsTrueStrong(r,s,e2);
+            if IsTrueStrong(r,s,Or(e1,e2)) {
+              OrTrueStrong(r,s,e1,e2);
+              FalseImpliesNotTrueStrong(r,s,e1);
+              assert IsTrueStrong(r,s,e2);
               assert EffectsInvariant(effs2);
             }
           }
         case _ =>
           var (bt2, effs2) := Typechecker(ets,acts,reqty).inferBoolType(e2,effs).value;
           assert Typesafe(e2,effs,Type.Bool(bt2));
-          assert model.IsSafe(r,s,e2,Type.Bool(bt2)) && GuardedEffectsInvariant(e2,effs2) by {
+          assert IsSafe(r,s,e2,Type.Bool(bt2)) && GuardedEffectsInvariant(e2,effs2) by {
             Sound(e2,Type.Bool(bt2),effs);
           }
           match bt2 {
             case True =>
-              assert model.IsTrue(r,s,e2);
-              assert model.IsSafe(r,s,e1,Type.Bool(AnyBool)) by {
-                model.SubtyCompat(Type.Bool(bt1),Type.Bool(AnyBool));
-                model.SemSubtyTransport(r,s,e1,Type.Bool(bt1),Type.Bool(AnyBool));
+              assert IsTrue(r,s,e2);
+              assert IsSafe(r,s,e1,Type.Bool(AnyBool)) by {
+                SubtyCompat(Type.Bool(bt1),Type.Bool(AnyBool));
+                SemSubtyTransport(r,s,e1,Type.Bool(bt1),Type.Bool(AnyBool));
               }
-              assert model.IsTrue(r,s,Or(e1,e2)) by { model.OrRShortSafe(r,s,e1,e2); }
-              assert model.IsSafe(r,s,Or(e1,e2),t) by {
-                model.SubtyCompat(Type.Bool(True),t);
-                model.SemSubtyTransport(r,s,Or(e1,e2),Type.Bool(True),t);
+              assert IsTrue(r,s,Or(e1,e2)) by { OrRShortSafe(r,s,e1,e2); }
+              assert IsSafe(r,s,Or(e1,e2),t) by {
+                SubtyCompat(Type.Bool(True),t);
+                SemSubtyTransport(r,s,Or(e1,e2),Type.Bool(True),t);
               }
             case False =>
-              assert model.IsFalse(r,s,e2);
-              assert model.IsSafe(r,s,Or(e1,e2),t) by {
-                model.OrLRetSafe(r,s,e1,e2,Type.Bool(bt1));
-                model.SubtyCompat(Type.Bool(bt1),t);
-                model.SemSubtyTransport(r,s,Or(e1,e2),Type.Bool(bt1),t);
+              assert IsFalse(r,s,e2);
+              assert IsSafe(r,s,Or(e1,e2),t) by {
+                OrLRetSafe(r,s,e1,e2,Type.Bool(bt1));
+                SubtyCompat(Type.Bool(bt1),t);
+                SemSubtyTransport(r,s,Or(e1,e2),Type.Bool(bt1),t);
               }
               assert GuardedEffectsInvariant(Or(e1,e2),effs1) by {
-                if model.IsTrueStrong(r,s,Or(e1,e2)) {
-                  model.OrTrueStrong(r,s,e1,e2);
-                  model.FalseImpliesNotTrueStrong(r,s,e2);
-                  assert model.IsTrueStrong(r,s,e1);
+                if IsTrueStrong(r,s,Or(e1,e2)) {
+                  OrTrueStrong(r,s,e1,e2);
+                  FalseImpliesNotTrueStrong(r,s,e2);
+                  assert IsTrueStrong(r,s,e1);
                   assert EffectsInvariant(effs1);
                 }
               }
             case _ =>
-              assert model.IsSafe(r,s,e1,Type.Bool(AnyBool)) by {
-                model.SubtyCompat(Type.Bool(bt1),Type.Bool(AnyBool));
-                model.SemSubtyTransport(r,s,e1,Type.Bool(bt1),Type.Bool(AnyBool));
+              assert IsSafe(r,s,e1,Type.Bool(AnyBool)) by {
+                SubtyCompat(Type.Bool(bt1),Type.Bool(AnyBool));
+                SemSubtyTransport(r,s,e1,Type.Bool(bt1),Type.Bool(AnyBool));
               }
-              assert model.IsSafe(r,s,e2,Type.Bool(AnyBool)) by {
-                model.SubtyCompat(Type.Bool(bt2),Type.Bool(AnyBool));
-                model.SemSubtyTransport(r,s,e2,Type.Bool(bt2),Type.Bool(AnyBool));
+              assert IsSafe(r,s,e2,Type.Bool(AnyBool)) by {
+                SubtyCompat(Type.Bool(bt2),Type.Bool(AnyBool));
+                SemSubtyTransport(r,s,e2,Type.Bool(bt2),Type.Bool(AnyBool));
               }
-              assert model.IsSafe(r,s,Or(e1,e2),Type.Bool(AnyBool)) by { model.OrSafe(r,s,e1,e2); }
-              assert model.IsSafe(r,s,Or(e1,e2),t) by {
-                model.SubtyCompat(t',t);
-                model.SemSubtyTransport(r,s,Or(e1,e2),t',t);
+              assert IsSafe(r,s,Or(e1,e2),Type.Bool(AnyBool)) by { OrSafe(r,s,e1,e2); }
+              assert IsSafe(r,s,Or(e1,e2),t) by {
+                SubtyCompat(t',t);
+                SemSubtyTransport(r,s,Or(e1,e2),t',t);
               }
               assert GuardedEffectsInvariant(Or(e1,e2),effs1.intersect(effs2)) by {
-                if model.IsTrueStrong(r,s,Or(e1,e2)) {
-                  model.OrTrueStrong(r,s,e1,e2);
-                  if model.IsTrueStrong(r,s,e1) {
+                if IsTrueStrong(r,s,Or(e1,e2)) {
+                  OrTrueStrong(r,s,e1,e2);
+                  if IsTrueStrong(r,s,e1) {
                     assert EffectsInvariant(effs1);
                     EffectsInvariantIntersectL(effs1,effs2);
                   } else {
-                    assert model.IsTrueStrong(r,s,e2);
+                    assert IsTrueStrong(r,s,e2);
                     assert EffectsInvariant(effs2);
                     EffectsInvariantIntersectR(effs1,effs2);
                   }
@@ -581,7 +580,7 @@ module validation.thm.soundness {
       requires InstanceOfActionStore(s,acts)
       requires EffectsInvariant(effs)
       requires Typesafe(UnaryApp(Not,e),effs,t)
-      ensures model.IsSafe(r,s,UnaryApp(Not,e),t)
+      ensures IsSafe(r,s,UnaryApp(Not,e),t)
       ensures getEffects(UnaryApp(Not,e),effs) == Effects.empty()
     {
       var t' :| getType(UnaryApp(Not,e),effs) == t' && subty(t',t);
@@ -589,17 +588,17 @@ module validation.thm.soundness {
       var (bt,_) := Typechecker(ets,acts,reqty).inferBoolType(e,effs).value;
       assert t' == Type.Bool(bt.not());
       assert Typesafe(e,effs,Type.Bool(bt)) by { SubtyRefl(Type.Bool(bt)); }
-      assert model.IsSafe(r,s,e,Type.Bool(bt)) by { Sound(e,Type.Bool(bt),effs); }
-      assert model.IsSafe(r,s,UnaryApp(Not,e),t') by {
+      assert IsSafe(r,s,e,Type.Bool(bt)) by { Sound(e,Type.Bool(bt),effs); }
+      assert IsSafe(r,s,UnaryApp(Not,e),t') by {
         match bt {
-          case AnyBool => model.NotSafe(r,s,e);
-          case True => model.NotTrueSafe(r,s,e);
-          case False => model.NotFalseSafe(r,s,e);
+          case AnyBool => NotSafe(r,s,e);
+          case True => NotTrueSafe(r,s,e);
+          case False => NotFalseSafe(r,s,e);
         }
       }
-      assert model.IsSafe(r,s,UnaryApp(Not,e),t) by {
-        model.SubtyCompat(t',t);
-        model.SemSubtyTransport(r,s,UnaryApp(Not,e),t',t);
+      assert IsSafe(r,s,UnaryApp(Not,e),t) by {
+        SubtyCompat(t',t);
+        SemSubtyTransport(r,s,UnaryApp(Not,e),t',t);
       }
     }
 
@@ -610,18 +609,18 @@ module validation.thm.soundness {
       requires InstanceOfActionStore(s,acts)
       requires EffectsInvariant(effs)
       requires Typesafe(UnaryApp(Neg,e),effs,t)
-      ensures model.IsSafe(r,s,UnaryApp(Neg,e),t)
+      ensures IsSafe(r,s,UnaryApp(Neg,e),t)
       ensures getEffects(UnaryApp(Neg,e),effs) == Effects.empty()
     {
       var t' :| getType(UnaryApp(Neg,e),effs) == t' && subty(t',t);
       assert Typechecker(ets,acts,reqty).inferArith1(Neg,e,effs) == types.Ok(Type.Int);
       assert Typechecker(ets,acts,reqty).ensureIntType(e,effs).Ok?;
       assert Typesafe(e,effs,Type.Int);
-      assert model.IsSafe(r,s,e,Type.Int) by { Sound(e,Type.Int,effs); }
-      assert model.IsSafe(r,s,UnaryApp(Neg,e),t') by { model.NegSafe(r,s,e); }
-      assert model.IsSafe(r,s,UnaryApp(Neg,e),t) by {
-        model.SubtyCompat(t',t);
-        model.SemSubtyTransport(r,s,UnaryApp(Neg,e),t',t);
+      assert IsSafe(r,s,e,Type.Int) by { Sound(e,Type.Int,effs); }
+      assert IsSafe(r,s,UnaryApp(Neg,e),t') by { NegSafe(r,s,e); }
+      assert IsSafe(r,s,UnaryApp(Neg,e),t) by {
+        SubtyCompat(t',t);
+        SemSubtyTransport(r,s,UnaryApp(Neg,e),t',t);
       }
     }
 
@@ -632,18 +631,18 @@ module validation.thm.soundness {
       requires InstanceOfActionStore(s,acts)
       requires EffectsInvariant(effs)
       requires Typesafe(UnaryApp(MulBy(i),e),effs,t)
-      ensures model.IsSafe(r,s,UnaryApp(MulBy(i),e),t)
+      ensures IsSafe(r,s,UnaryApp(MulBy(i),e),t)
       ensures getEffects(UnaryApp(MulBy(i),e),effs) == Effects.empty()
     {
       var t' :| getType(UnaryApp(MulBy(i),e),effs) == t' && subty(t',t);
       assert Typechecker(ets,acts,reqty).inferArith1(MulBy(i),e,effs) == types.Ok(Type.Int);
       assert Typechecker(ets,acts,reqty).ensureIntType(e,effs).Ok?;
       assert Typesafe(e,effs,Type.Int);
-      assert model.IsSafe(r,s,e,Type.Int) by { Sound(e,Type.Int,effs); }
-      assert model.IsSafe(r,s,UnaryApp(MulBy(i),e),t') by { model.MulBySafe(r,s,e,i); }
-      assert model.IsSafe(r,s,UnaryApp(MulBy(i),e),t) by {
-        model.SubtyCompat(t',t);
-        model.SemSubtyTransport(r,s,UnaryApp(MulBy(i),e),t',t);
+      assert IsSafe(r,s,e,Type.Int) by { Sound(e,Type.Int,effs); }
+      assert IsSafe(r,s,UnaryApp(MulBy(i),e),t') by { MulBySafe(r,s,e,i); }
+      assert IsSafe(r,s,UnaryApp(MulBy(i),e),t) by {
+        SubtyCompat(t',t);
+        SemSubtyTransport(r,s,UnaryApp(MulBy(i),e),t',t);
       }
     }
 
@@ -654,18 +653,18 @@ module validation.thm.soundness {
       requires InstanceOfActionStore(s,acts)
       requires EffectsInvariant(effs)
       requires Typesafe(UnaryApp(Like(p),e),effs,t)
-      ensures model.IsSafe(r,s,UnaryApp(Like(p),e),t)
+      ensures IsSafe(r,s,UnaryApp(Like(p),e),t)
       ensures getEffects(UnaryApp(Like(p),e),effs) == Effects.empty()
     {
       var t' :| getType(UnaryApp(Like(p),e),effs) == t' && subty(t',t);
       assert Typechecker(ets,acts,reqty).inferLike(p,e,effs) == types.Ok(Type.Bool(AnyBool));
       assert Typechecker(ets,acts,reqty).ensureStringType(e,effs).Ok?;
       assert Typesafe(e,effs,Type.String);
-      assert model.IsSafe(r,s,e,Type.String) by { Sound(e,Type.String,effs); }
-      assert model.IsSafe(r,s,UnaryApp(Like(p),e),t') by { model.LikeSafe(r,s,e,p); }
-      assert model.IsSafe(r,s,UnaryApp(Like(p),e),t) by {
-        model.SubtyCompat(t',t);
-        model.SemSubtyTransport(r,s,UnaryApp(Like(p),e),t',t);
+      assert IsSafe(r,s,e,Type.String) by { Sound(e,Type.String,effs); }
+      assert IsSafe(r,s,UnaryApp(Like(p),e),t') by { LikeSafe(r,s,e,p); }
+      assert IsSafe(r,s,UnaryApp(Like(p),e),t) by {
+        SubtyCompat(t',t);
+        SemSubtyTransport(r,s,UnaryApp(Like(p),e),t',t);
       }
     }
 
@@ -679,21 +678,21 @@ module validation.thm.soundness {
     lemma UnspecifiedVarHasUnspecifiedEntityType(e: Expr)
       requires Typechecker(ets,acts,reqty).isUnspecifiedVar(e)
       requires InstanceOfRequestType(r,reqty)
-      ensures model.IsSafe(r,s,e,unspecifiedEntityType)
+      ensures IsSafe(r,s,e,unspecifiedEntityType)
     {
       match e {
         case Var(Principal) =>
           assert r.principal == unspecifiedPrincipalEuid;
-          model.PrincipalIsSafe(r,s,unspecifiedEntityType);
+          PrincipalIsSafe(r,s,unspecifiedEntityType);
         case Var(Resource) =>
           assert r.resource == unspecifiedResourceEuid;
-          model.ResourceIsSafe(r,s,unspecifiedEntityType);
+          ResourceIsSafe(r,s,unspecifiedEntityType);
       }
     }
 
     lemma SoundEqAux(u1: EntityUID, u2: EntityUID, t: Type, effs: Effects)
       requires Typesafe(BinaryApp(BinaryOp.Eq,PrimitiveLit(Primitive.EntityUID(u1)),PrimitiveLit(Primitive.EntityUID(u2))),effs,t)
-      ensures model.IsSafe(r,s,BinaryApp(BinaryOp.Eq,PrimitiveLit(Primitive.EntityUID(u1)),PrimitiveLit(Primitive.EntityUID(u2))),t)
+      ensures IsSafe(r,s,BinaryApp(BinaryOp.Eq,PrimitiveLit(Primitive.EntityUID(u1)),PrimitiveLit(Primitive.EntityUID(u2))),t)
     {
       var e1: Expr := PrimitiveLit(Primitive.EntityUID(u1));
       var e2: Expr := PrimitiveLit(Primitive.EntityUID(u2));
@@ -704,16 +703,16 @@ module validation.thm.soundness {
       var t2 := getType(e2,effs);
       if u1 == u2 {
         assert t' == Type.Bool(True);
-        assert model.IsSafe(r,s,BinaryApp(BinaryOp.Eq,e1,e2),t') by { model.EqEntitySameSafe(r,s,u1); }
-        assert model.IsSafe(r,s,BinaryApp(BinaryOp.Eq,e1,e2),t) by {
-          model.SubtyCompat(t',t);
-          model.SemSubtyTransport(r,s,BinaryApp(BinaryOp.Eq,e1,e2),t',t); }
+        assert IsSafe(r,s,BinaryApp(BinaryOp.Eq,e1,e2),t') by { EqEntitySameSafe(r,s,u1); }
+        assert IsSafe(r,s,BinaryApp(BinaryOp.Eq,e1,e2),t) by {
+          SubtyCompat(t',t);
+          SemSubtyTransport(r,s,BinaryApp(BinaryOp.Eq,e1,e2),t',t); }
       } else {
         assert t' == Type.Bool(False);
-        assert model.IsSafe(r,s,BinaryApp(BinaryOp.Eq,e1,e2),t') by { model.EqEntityDiffSafe(r,s,u1,u2); }
-        assert model.IsSafe(r,s,BinaryApp(BinaryOp.Eq,e1,e2),t) by {
-          model.SubtyCompat(t',t);
-          model.SemSubtyTransport(r,s,BinaryApp(BinaryOp.Eq,e1,e2),t',t); }
+        assert IsSafe(r,s,BinaryApp(BinaryOp.Eq,e1,e2),t') by { EqEntityDiffSafe(r,s,u1,u2); }
+        assert IsSafe(r,s,BinaryApp(BinaryOp.Eq,e1,e2),t) by {
+          SubtyCompat(t',t);
+          SemSubtyTransport(r,s,BinaryApp(BinaryOp.Eq,e1,e2),t',t); }
       }
     }
 
@@ -724,7 +723,7 @@ module validation.thm.soundness {
       requires InstanceOfActionStore(s,acts)
       requires EffectsInvariant(effs)
       requires Typesafe(BinaryApp(BinaryOp.Eq,e1,e2),effs,t)
-      ensures model.IsSafe(r,s,BinaryApp(BinaryOp.Eq,e1,e2),t)
+      ensures IsSafe(r,s,BinaryApp(BinaryOp.Eq,e1,e2),t)
       ensures getEffects(BinaryApp(BinaryOp.Eq,e1,e2),effs) == Effects.empty()
     {
       var t' :| getType(BinaryApp(BinaryOp.Eq,e1,e2),effs) == t' && subty(t',t);
@@ -733,26 +732,26 @@ module validation.thm.soundness {
       var t2 := getType(e2,effs);
       assert Typesafe(e1,effs,t1) by { SubtyRefl(t1); }
       assert Typesafe(e2,effs,t2) by { SubtyRefl(t2); }
-      assert model.IsSafe(r,s,e1,t1) by { Sound(e1,t1,effs); }
-      assert model.IsSafe(r,s,e2,t2) by { Sound(e2,t2,effs); }
+      assert IsSafe(r,s,e1,t1) by { Sound(e1,t1,effs); }
+      assert IsSafe(r,s,e2,t2) by { Sound(e2,t2,effs); }
       match (e1,e2,t1,t2) {
         case (PrimitiveLit(EntityUID(u1)),PrimitiveLit(EntityUID(u2)),_,_) =>
           SoundEqAux(u1,u2,t,effs);
         case _ =>
           if t1.Entity? && t2.Entity? && t1.lub.disjoint(t2.lub) {
             assert t' == Type.Bool(False);
-            model.EqFalseIsSafe(r,s,e1,e2,t1.lub,t2.lub);
+            EqFalseIsSafe(r,s,e1,e2,t1.lub,t2.lub);
           } else if Typechecker(ets,acts,reqty).isUnspecifiedVar(e1) && t2.Entity? && t2.lub.specified() {
             assert t' == Type.Bool(False);
             UnspecifiedVarHasUnspecifiedEntityType(e1);
-            model.EqFalseIsSafe(r,s,e1,e2,unspecifiedEntityType.lub,t2.lub);
+            EqFalseIsSafe(r,s,e1,e2,unspecifiedEntityType.lub,t2.lub);
           } else {
             assert t' == Type.Bool(AnyBool);
-            model.EqIsSafe(r,s,e1,e2,t1,t2);
+            EqIsSafe(r,s,e1,e2,t1,t2);
           }
-          assert model.IsSafe(r,s,BinaryApp(BinaryOp.Eq,e1,e2),t) by {
-            model.SubtyCompat(t',t);
-            model.SemSubtyTransport(r,s,BinaryApp(BinaryOp.Eq,e1,e2),t',t);
+          assert IsSafe(r,s,BinaryApp(BinaryOp.Eq,e1,e2),t) by {
+            SubtyCompat(t',t);
+            SemSubtyTransport(r,s,BinaryApp(BinaryOp.Eq,e1,e2),t',t);
           }
       }
     }
@@ -765,7 +764,7 @@ module validation.thm.soundness {
       requires InstanceOfActionStore(s,acts)
       requires EffectsInvariant(effs)
       requires Typesafe(BinaryApp(op,e1,e2),effs,t)
-      ensures model.IsSafe(r,s,BinaryApp(op,e1,e2),t)
+      ensures IsSafe(r,s,BinaryApp(op,e1,e2),t)
       ensures getEffects(BinaryApp(op,e1,e2),effs) == Effects.empty()
     {
       var t' :| getType(BinaryApp(op,e1,e2),effs) == t' && subty(t',t);
@@ -774,12 +773,12 @@ module validation.thm.soundness {
       assert Typesafe(e1,effs,Type.Int);
       assert Typechecker(ets,acts,reqty).ensureIntType(e2,effs).Ok?;
       assert Typesafe(e2,effs,Type.Int);
-      assert model.IsSafe(r,s,e1,Type.Int) by { Sound(e1,Type.Int,effs); }
-      assert model.IsSafe(r,s,e2,Type.Int) by { Sound(e2,Type.Int,effs); }
-      assert model.IsSafe(r,s,BinaryApp(op,e1,e2),t') by { model.IneqSafe(r,s,op,e1,e2); }
-      assert model.IsSafe(r,s,BinaryApp(op,e1,e2),t) by {
-        model.SubtyCompat(t',t);
-        model.SemSubtyTransport(r,s,BinaryApp(op,e1,e2),t',t);
+      assert IsSafe(r,s,e1,Type.Int) by { Sound(e1,Type.Int,effs); }
+      assert IsSafe(r,s,e2,Type.Int) by { Sound(e2,Type.Int,effs); }
+      assert IsSafe(r,s,BinaryApp(op,e1,e2),t') by { IneqSafe(r,s,op,e1,e2); }
+      assert IsSafe(r,s,BinaryApp(op,e1,e2),t) by {
+        SubtyCompat(t',t);
+        SemSubtyTransport(r,s,BinaryApp(op,e1,e2),t',t);
       }
     }
 
@@ -791,7 +790,7 @@ module validation.thm.soundness {
       requires InstanceOfActionStore(s,acts)
       requires EffectsInvariant(effs)
       requires Typesafe(BinaryApp(op,e1,e2),effs,t)
-      ensures model.IsSafe(r,s,BinaryApp(op,e1,e2),t)
+      ensures IsSafe(r,s,BinaryApp(op,e1,e2),t)
       ensures getEffects(BinaryApp(op,e1,e2),effs) == Effects.empty()
     {
       var t' :| getType(BinaryApp(op,e1,e2),effs) == t' && subty(t',t);
@@ -800,12 +799,12 @@ module validation.thm.soundness {
       assert Typesafe(e1,effs,Type.Int);
       assert Typechecker(ets,acts,reqty).ensureIntType(e2,effs).Ok?;
       assert Typesafe(e2,effs,Type.Int);
-      assert model.IsSafe(r,s,e1,Type.Int) by { Sound(e1,Type.Int,effs); }
-      assert model.IsSafe(r,s,e2,Type.Int) by { Sound(e2,Type.Int,effs); }
-      assert model.IsSafe(r,s,BinaryApp(op,e1,e2),t') by { model.ArithSafe(r,s,op,e1,e2); }
-      assert model.IsSafe(r,s,BinaryApp(op,e1,e2),t) by {
-        model.SubtyCompat(t',t);
-        model.SemSubtyTransport(r,s,BinaryApp(op,e1,e2),t',t);
+      assert IsSafe(r,s,e1,Type.Int) by { Sound(e1,Type.Int,effs); }
+      assert IsSafe(r,s,e2,Type.Int) by { Sound(e2,Type.Int,effs); }
+      assert IsSafe(r,s,BinaryApp(op,e1,e2),t') by { ArithSafe(r,s,op,e1,e2); }
+      assert IsSafe(r,s,BinaryApp(op,e1,e2),t) by {
+        SubtyCompat(t',t);
+        SemSubtyTransport(r,s,BinaryApp(op,e1,e2),t',t);
       }
     }
 
@@ -817,7 +816,7 @@ module validation.thm.soundness {
       requires InstanceOfActionStore(s,acts)
       requires EffectsInvariant(effs)
       requires Typesafe(BinaryApp(op,e1,e2),effs,t)
-      ensures model.IsSafe(r,s,BinaryApp(op,e1,e2),t)
+      ensures IsSafe(r,s,BinaryApp(op,e1,e2),t)
       ensures getEffects(BinaryApp(op,e1,e2),effs) == Effects.empty()
     {
       var t' :| getType(BinaryApp(op,e1,e2),effs) == t' && subty(t',t);
@@ -826,12 +825,12 @@ module validation.thm.soundness {
       var t2 := Typechecker(ets,acts,reqty).inferSetType(e2,effs).value;
       assert Typesafe(e1,effs,Type.Set(t1)) by { SubtyRefl(Type.Set(t1)); }
       assert Typesafe(e2,effs,Type.Set(t2)) by { SubtyRefl(Type.Set(t2)); }
-      assert model.IsSafe(r,s,e1,Type.Set(t1)) by { Sound(e1,Type.Set(t1),effs); }
-      assert model.IsSafe(r,s,e2,Type.Set(t2)) by { Sound(e2,Type.Set(t2),effs); }
-      assert model.IsSafe(r,s,BinaryApp(op,e1,e2),t') by { model.ContainsAnyAllSafe(r,s,op,e1,e2,t1,t2); }
-      assert model.IsSafe(r,s,BinaryApp(op,e1,e2),t) by {
-        model.SubtyCompat(t',t);
-        model.SemSubtyTransport(r,s,BinaryApp(op,e1,e2),t',t);
+      assert IsSafe(r,s,e1,Type.Set(t1)) by { Sound(e1,Type.Set(t1),effs); }
+      assert IsSafe(r,s,e2,Type.Set(t2)) by { Sound(e2,Type.Set(t2),effs); }
+      assert IsSafe(r,s,BinaryApp(op,e1,e2),t') by { ContainsAnyAllSafe(r,s,op,e1,e2,t1,t2); }
+      assert IsSafe(r,s,BinaryApp(op,e1,e2),t) by {
+        SubtyCompat(t',t);
+        SemSubtyTransport(r,s,BinaryApp(op,e1,e2),t',t);
       }
     }
 
@@ -842,7 +841,7 @@ module validation.thm.soundness {
       requires InstanceOfActionStore(s,acts)
       requires EffectsInvariant(effs)
       requires Typesafe(BinaryApp(Contains,e1,e2),effs,t)
-      ensures model.IsSafe(r,s,BinaryApp(Contains,e1,e2),t)
+      ensures IsSafe(r,s,BinaryApp(Contains,e1,e2),t)
       ensures getEffects(BinaryApp(Contains,e1,e2),effs) == Effects.empty()
     {
       var t' :| getType(BinaryApp(Contains,e1,e2),effs) == t' && subty(t',t);
@@ -851,10 +850,10 @@ module validation.thm.soundness {
       assert Typesafe(e1,effs,Type.Set(t1)) by { SubtyRefl(Type.Set(t1)); }
       var (t2,_) := Typechecker(ets,acts,reqty).infer(e2,effs).value;
       assert Typesafe(e2,effs,t2) by { SubtyRefl(t2); }
-      assert model.IsSafe(r,s,e1,Type.Set(t1)) by { Sound(e1,Type.Set(t1),effs); }
-      assert model.IsSafe(r,s,e2,t2) by { Sound(e2,t2,effs); }
-      assert model.IsSafe(r,s,BinaryApp(Contains,e1,e2),t') by { model.ContainsSetSafe(r,s,e1,e2,t1,t2); }
-      assert model.IsSafe(r,s,BinaryApp(Contains,e1,e2),t) by { model.SemSubtyTransport(r,s,BinaryApp(Contains,e1,e2),t',t); }
+      assert IsSafe(r,s,e1,Type.Set(t1)) by { Sound(e1,Type.Set(t1),effs); }
+      assert IsSafe(r,s,e2,t2) by { Sound(e2,t2,effs); }
+      assert IsSafe(r,s,BinaryApp(Contains,e1,e2),t') by { ContainsSetSafe(r,s,e1,e2,t1,t2); }
+      assert IsSafe(r,s,BinaryApp(Contains,e1,e2),t) by { SemSubtyTransport(r,s,BinaryApp(Contains,e1,e2),t',t); }
     }
 
     lemma InferRecordLemma(e: Expr, es: seq<(Attr,Expr)>, effs: Effects)
@@ -874,7 +873,7 @@ module validation.thm.soundness {
       requires InstanceOfActionStore(s,acts)
       requires EffectsInvariant(effs)
       requires Typesafe(Expr.Record(es),effs,t)
-      ensures model.IsSafe(r,s,Expr.Record(es),t)
+      ensures IsSafe(r,s,Expr.Record(es),t)
       ensures getEffects(Expr.Record(es),effs) == Effects.empty()
     {
       var t' :| getType(Expr.Record(es),effs) == t' && subty(t',t);
@@ -882,30 +881,32 @@ module validation.thm.soundness {
       InferRecordLemma(Expr.Record(es),es,effs);
       assert t' == Type.Record(rt);
       assert forall i | 0 <= i < |es| :: WellTyped(es[i].1,effs);
-      forall ae | ae in es
-        ensures exists t_ae :: model.IsSafe(r,s,ae.1,t_ae)
-      {
-        assert WellTyped(ae.1,effs);
-        var t_ae := getType(ae.1,effs);
-        assert Typesafe(ae.1,effs,t_ae) by { SubtyRefl(t_ae); }
-        assert model.IsSafe(r,s,ae.1,t_ae) by { Sound(ae.1,t_ae,effs); }
-      }
       assert forall k | k in rt :: KeyExists(k,es) && getType(LastOfKey(k,es),effs) == rt[k].ty by {
         assert Typechecker(ets,acts,reqty).inferRecord(Expr.Record(es),es,effs).Ok?;
       }
       forall k | k in rt
-        ensures KeyExists(k,es) && model.IsSafe(r,s,LastOfKey(k,es),rt[k].ty)
+        ensures KeyExists(k,es) && IsSafe(r,s,LastOfKey(k,es),rt[k].ty)
       {
         assert getType(LastOfKey(k,es),effs) == rt[k].ty;
         assert Typesafe(LastOfKey(k,es),effs,rt[k].ty) by { SubtyRefl(rt[k].ty); }
-        assert model.IsSafe(r,s,LastOfKey(k,es),rt[k].ty) by { Sound(LastOfKey(k,es),rt[k].ty,effs); }
+        assert IsSafe(r,s,LastOfKey(k,es),rt[k].ty) by { Sound(LastOfKey(k,es),rt[k].ty,effs); }
       }
-      assert model.IsSafe(r,s,Expr.Record(es),t') by {
-        model.RecordSafe(r,s,es,rt);
+      assert IsSafe(r,s,Expr.Record(es),t') by {
+        assert forall ae | ae in es :: ExistsSafeType(r,s,ae.1) by {
+          forall ae | ae in es
+          ensures ExistsSafeType(r,s,ae.1)
+          {
+            assert WellTyped(ae.1,effs);
+            var t_ae := getType(ae.1,effs);
+            assert Typesafe(ae.1,effs,t_ae) by { SubtyRefl(t_ae); }
+            assert IsSafe(r,s,ae.1,t_ae) by { Sound(ae.1,t_ae,effs); }
+          }
+        }
+        RecordSafe(r,s,es,rt);
       }
-      assert model.IsSafe(r,s,Expr.Record(es),t) by {
-        model.SubtyCompat(t',t);
-        model.SemSubtyTransport(r,s,Expr.Record(es),t',t);
+      assert IsSafe(r,s,Expr.Record(es),t) by {
+        SubtyCompat(t',t);
+        SemSubtyTransport(r,s,Expr.Record(es),t',t);
       }
     }
 
@@ -944,7 +945,7 @@ module validation.thm.soundness {
       requires InstanceOfActionStore(s,acts)
       requires Typesafe(Expr.Set(es),effs,t)
       requires EffectsInvariant(effs)
-      ensures model.IsSafe(r,s,Expr.Set(es),t)
+      ensures IsSafe(r,s,Expr.Set(es),t)
       ensures getEffects(Expr.Set(es),effs) == Effects.empty()
     {
       var t' :| getType(Expr.Set(es),effs) == t' && subty(t',t);
@@ -952,18 +953,18 @@ module validation.thm.soundness {
       InferSetLemma(Expr.Set(es),es,effs);
       assert t' == Type.Set(st);
       forall i | 0 <= i < |es|
-        ensures model.IsSafe(r,s,es[i],st)
+        ensures IsSafe(r,s,es[i],st)
       {
         InterpretSetLemma(es,r,s);
         assert Typesafe(es[i],effs,st);
         Sound(es[i],st,effs);
       }
-      assert model.IsSafe(r,s,Expr.Set(es),t') by {
-        model.SetConstrSafe(r,s,es,st);
+      assert IsSafe(r,s,Expr.Set(es),t') by {
+        SetConstrSafe(r,s,es,st);
       }
-      assert model.IsSafe(r,s,Expr.Set(es),t) by {
-        model.SubtyCompat(t',t);
-        model.SemSubtyTransport(r,s,Expr.Set(es),t',t);
+      assert IsSafe(r,s,Expr.Set(es),t) by {
+        SubtyCompat(t',t);
+        SemSubtyTransport(r,s,Expr.Set(es),t',t);
       }
     }
 
@@ -974,7 +975,7 @@ module validation.thm.soundness {
       requires InstanceOfActionStore(s,acts)
       requires EffectsInvariant(effs)
       requires Typesafe(GetAttr(e,k),effs,t)
-      ensures model.IsSafe(r,s,GetAttr(e,k),t)
+      ensures IsSafe(r,s,GetAttr(e,k),t)
       ensures getEffects(GetAttr(e,k),effs) == Effects.empty()
     {
       var t' :| getType(GetAttr(e,k),effs) == t' && subty(t',t);
@@ -984,46 +985,46 @@ module validation.thm.soundness {
         case Record(rt) => {
           assert t' == rt[k].ty;
           assert Typesafe(e,effs,Type.Record(rt)) by { SubtyRefl(Type.Record(rt)); }
-          assert model.IsSafe(r,s,e,Type.Record(rt)) by { Sound(e,Type.Record(rt),effs); }
-          assert model.IsSafe(r,s,GetAttr(e,k),t') by {
+          assert IsSafe(r,s,e,Type.Record(rt)) by { Sound(e,Type.Record(rt),effs); }
+          assert IsSafe(r,s,GetAttr(e,k),t') by {
             assert k in rt;
             assert rt[k].isRequired || effs.contains(e,k);
             if rt[k].isRequired {
-              model.ObjectProjSafeRequired(r,s,e,Type.Record(rt),k,rt[k]);
+              ObjectProjSafeRequired(r,s,e,Type.Record(rt),k,rt[k]);
             } else {
               reveal EffectsInvariant();
-              assert model.GetAttrSafe(r,s,e,k);
-              model.ObjectProjSafeGetAttrSafe(r,s,e,Type.Record(rt),k,rt[k]);
+              assert GetAttrSafe(r,s,e,k);
+              ObjectProjSafeGetAttrSafe(r,s,e,Type.Record(rt),k,rt[k]);
             }
           }
-          assert model.IsSafe(r,s,GetAttr(e,k),t) by {
-            model.SubtyCompat(t',t);
-            model.SemSubtyTransport(r,s,GetAttr(e,k),t',t);
+          assert IsSafe(r,s,GetAttr(e,k),t) by {
+            SubtyCompat(t',t);
+            SemSubtyTransport(r,s,GetAttr(e,k),t',t);
           }
         }
         case Entity(lub) => {
           var rt := ets.getLubRecordType(lub).value;
           assert t' == rt[k].ty;
-          assert model.IsSafe(r,s,e,Type.Entity(lub)) by { Sound(e,Type.Entity(lub),effs); }
-          assert model.IsSafe(r,s,GetAttr(e,k),t') by {
+          assert IsSafe(r,s,e,Type.Entity(lub)) by { Sound(e,Type.Entity(lub),effs); }
+          assert IsSafe(r,s,GetAttr(e,k),t') by {
             assert k in rt;
             assert rt[k].isRequired || effs.contains(e,k);
             if !rt[k].isRequired {
               reveal EffectsInvariant();
-              assert model.GetAttrSafe(r,s,e,k);
+              assert GetAttrSafe(r,s,e,k);
             }
             forall euid: EntityUID | InstanceOfType(Primitive(Primitive.EntityUID(euid)),Type.Entity(lub)) && euid in s.entities
               ensures rt[k].isRequired ==> k in s.entities[euid].attrs
               ensures k in s.entities[euid].attrs ==> InstanceOfType(s.entities[euid].attrs[k],t')
             {
               GetLubRecordTypeSubty(lub, euid.ty);
-              model.SubtyCompat(ets.types[euid.ty][k].ty, t');
+              SubtyCompat(ets.types[euid.ty][k].ty, t');
             }
-            model.EntityProjSafe(r,s,e,k,lub,t',rt[k].isRequired);
+            EntityProjSafe(r,s,e,k,lub,t',rt[k].isRequired);
           }
-          assert model.IsSafe(r,s,GetAttr(e,k),t) by {
-            model.SubtyCompat(t',t);
-            model.SemSubtyTransport(r,s,GetAttr(e,k),t',t);
+          assert IsSafe(r,s,GetAttr(e,k),t) by {
+            SubtyCompat(t',t);
+            SemSubtyTransport(r,s,GetAttr(e,k),t',t);
           }
         }
       }
@@ -1040,6 +1041,7 @@ module validation.thm.soundness {
         var al := rtl[k];
         var a1 := rt1[k];
         var a2 := rt2[k];
+        assert lubOpt(a1.ty,a2.ty) == Ok(al.ty);
         LubIsUB(a1.ty, a2.ty, al.ty);
       }
     }
@@ -1085,7 +1087,7 @@ module validation.thm.soundness {
       requires InstanceOfActionStore(s,acts)
       requires EffectsInvariant(effs)
       requires Typesafe(HasAttr(e,k),effs,t)
-      ensures model.IsSafe(r,s,HasAttr(e,k),t)
+      ensures IsSafe(r,s,HasAttr(e,k),t)
       ensures GuardedEffectsInvariant(HasAttr(e,k),getEffects(HasAttr(e,k),effs))
     {
       var t' :| getType(HasAttr(e,k),effs) == t' && subty(t',t);
@@ -1097,82 +1099,82 @@ module validation.thm.soundness {
       match ret {
         case Record(rt) => {
           assert Typesafe(e,effs,Type.Record(rt)) by { SubtyRefl(Type.Record(rt)); }
-          assert model.IsSafe(r,s,e,Type.Record(rt)) by { Sound(e,Type.Record(rt),effs); }
+          assert IsSafe(r,s,e,Type.Record(rt)) by { Sound(e,Type.Record(rt),effs); }
           if k in rt {
             if rt[k].isRequired {
-              assert model.IsSafe(r,s,e,Type.Record(map[k := rt[k]])) by {
+              assert IsSafe(r,s,e,Type.Record(map[k := rt[k]])) by {
                 SubtyRefl(rt[k].ty);
                 assert subtyRecordType(rt,map[k := rt[k]]);
                 assert subty(Type.Record(rt),Type.Record(map[k := rt[k]]));
-                model.SubtyCompat(Type.Record(rt),Type.Record(map[k := rt[k]]));
-                model.SemSubtyTransport(r,s,e,Type.Record(rt),Type.Record(map[k := rt[k]]));
+                SubtyCompat(Type.Record(rt),Type.Record(map[k := rt[k]]));
+                SemSubtyTransport(r,s,e,Type.Record(rt),Type.Record(map[k := rt[k]]));
               }
-              assert model.IsSafe(r,s,HasAttr(e,k),t') by { model.RecordHasRequiredTrueSafe(r,s,e,k,rt[k]); }
+              assert IsSafe(r,s,HasAttr(e,k),t') by { RecordHasRequiredTrueSafe(r,s,e,k,rt[k]); }
             } else if effs.contains(e,k) {
-              assert model.IsSafe(r,s,HasAttr(e,k),t') by {
+              assert IsSafe(r,s,HasAttr(e,k),t') by {
                 reveal EffectsInvariant();
               }
             } else {
-              assert model.IsSafe(r,s,e,Type.Record(map[])) by {
+              assert IsSafe(r,s,e,Type.Record(map[])) by {
                 assert subty(Type.Record(rt),Type.Record(map[]));
-                model.SubtyCompat(Type.Record(rt),Type.Record(map[]));
-                model.SemSubtyTransport(r,s,e,Type.Record(rt),Type.Record(map[]));
+                SubtyCompat(Type.Record(rt),Type.Record(map[]));
+                SemSubtyTransport(r,s,e,Type.Record(rt),Type.Record(map[]));
               }
-              assert model.IsSafe(r,s,HasAttr(e,k),t') by { model.RecordHasOpenRecSafe(r,s,e,k); }
+              assert IsSafe(r,s,HasAttr(e,k),t') by { RecordHasOpenRecSafe(r,s,e,k); }
               assert GuardedEffectsInvariant(HasAttr(e,k),Effects.singleton(e,k)) by {
-                if model.IsTrueStrong(r,s,HasAttr(e,k)) {
-                  model.IsTrueStrongImpliesIsTrue(r,s,HasAttr(e,k));
+                if IsTrueStrong(r,s,HasAttr(e,k)) {
+                  IsTrueStrongImpliesIsTrue(r,s,HasAttr(e,k));
                   reveal EffectsInvariant();
                 }
               }
             }
           } else {
-            assert model.IsSafe(r,s,e,Type.Record(map[])) by {
+            assert IsSafe(r,s,e,Type.Record(map[])) by {
               assert subty(Type.Record(rt),Type.Record(map[]));
-              model.SubtyCompat(Type.Record(rt),Type.Record(map[]));
-              model.SemSubtyTransport(r,s,e,Type.Record(rt),Type.Record(map[]));
+              SubtyCompat(Type.Record(rt),Type.Record(map[]));
+              SemSubtyTransport(r,s,e,Type.Record(rt),Type.Record(map[]));
             }
-            assert model.IsSafe(r,s,HasAttr(e,k),t') by { model.RecordHasOpenRecSafe(r,s,e,k); }
+            assert IsSafe(r,s,HasAttr(e,k),t') by { RecordHasOpenRecSafe(r,s,e,k); }
           }
         }
         case Entity(et) => {
           assert Typesafe(e,effs,Type.Entity(et)) by { SubtyRefl(Type.Entity(et)); }
-          assert model.IsSafe(r,s,e,Type.Entity(et)) by { Sound(e,Type.Entity(et),effs); }
+          assert IsSafe(r,s,e,Type.Entity(et)) by { Sound(e,Type.Entity(et),effs); }
           if !ets.isAttrPossible(et,k) {
-            model.EntityHasImpossibleFalseSafe(r,s,e,k,et);
+            EntityHasImpossibleFalseSafe(r,s,e,k,et);
           } else {
             var m := ets.getLubRecordType(et).value;
             if k in m {
               if effs.contains(e,k) {
-                assert model.IsSafe(r,s,HasAttr(e,k),t') by {
+                assert IsSafe(r,s,HasAttr(e,k),t') by {
                   reveal EffectsInvariant();
                 }
               } else {
-                assert model.IsSafe(r,s,e,Type.Entity(AnyEntity)) by {
-                  model.SubtyCompat(Type.Entity(et),Type.Entity(AnyEntity));
-                  model.SemSubtyTransport(r,s,e,Type.Entity(et),Type.Entity(AnyEntity));
+                assert IsSafe(r,s,e,Type.Entity(AnyEntity)) by {
+                  SubtyCompat(Type.Entity(et),Type.Entity(AnyEntity));
+                  SemSubtyTransport(r,s,e,Type.Entity(et),Type.Entity(AnyEntity));
                 }
-                assert model.IsSafe(r,s,HasAttr(e,k),t') by { model.EntityHasOpenSafe(r,s,e,k); }
+                assert IsSafe(r,s,HasAttr(e,k),t') by { EntityHasOpenSafe(r,s,e,k); }
                 assert GuardedEffectsInvariant(HasAttr(e,k),Effects.singleton(e,k)) by {
-                  if model.IsTrueStrong(r,s,HasAttr(e,k)) {
-                    model.IsTrueStrongImpliesIsTrue(r,s,HasAttr(e,k));
+                  if IsTrueStrong(r,s,HasAttr(e,k)) {
+                    IsTrueStrongImpliesIsTrue(r,s,HasAttr(e,k));
                     reveal EffectsInvariant();
                   }
                 }
               }
             } else {
-              assert model.IsSafe(r,s,e,Type.Entity(AnyEntity)) by {
-                model.SubtyCompat(Type.Entity(et),Type.Entity(AnyEntity));
-                model.SemSubtyTransport(r,s,e,Type.Entity(et),Type.Entity(AnyEntity));
+              assert IsSafe(r,s,e,Type.Entity(AnyEntity)) by {
+                SubtyCompat(Type.Entity(et),Type.Entity(AnyEntity));
+                SemSubtyTransport(r,s,e,Type.Entity(et),Type.Entity(AnyEntity));
               }
-              assert model.IsSafe(r,s,HasAttr(e,k),t') by { model.EntityHasOpenSafe(r,s,e,k); }
+              assert IsSafe(r,s,HasAttr(e,k),t') by { EntityHasOpenSafe(r,s,e,k); }
             }
           }
         }
       }
-      assert model.IsSafe(r,s,HasAttr(e,k),t) by {
-        model.SubtyCompat(t',t);
-        model.SemSubtyTransport(r,s,HasAttr(e,k),t',t);
+      assert IsSafe(r,s,HasAttr(e,k),t) by {
+        SubtyCompat(t',t);
+        SemSubtyTransport(r,s,HasAttr(e,k),t',t);
       }
     }
 
@@ -1183,7 +1185,7 @@ module validation.thm.soundness {
       requires InstanceOfActionStore(s,acts)
       requires EffectsInvariant(effs)
       requires Typesafe(BinaryApp(BinaryOp.In,e1,e2),effs,t)
-      ensures model.IsSafe(r,s,BinaryApp(BinaryOp.In,e1,e2),t)
+      ensures IsSafe(r,s,BinaryApp(BinaryOp.In,e1,e2),t)
       ensures getEffects(BinaryApp(BinaryOp.In,e1,e2),effs) == Effects.empty()
     {
       var t' :| getType(BinaryApp(BinaryOp.In,e1,e2),effs) == t' && subty(t',t);
@@ -1194,7 +1196,7 @@ module validation.thm.soundness {
       var t1 := getType(e1,effs);
       assert t1.Entity?;
       assert subty(t1,Type.Entity(AnyEntity));
-      assert model.IsSafe(r,s,e1,Type.Entity(AnyEntity)) by { Sound(e1,Type.Entity(AnyEntity),effs); }
+      assert IsSafe(r,s,e1,Type.Entity(AnyEntity)) by { Sound(e1,Type.Entity(AnyEntity),effs); }
 
       assert typechecker.ensureEntitySetType(e2,effs).Ok?;
       var t2 := getType(e2,effs);
@@ -1212,25 +1214,25 @@ module validation.thm.soundness {
       match t' {
         // Easy case
         case Bool(AnyBool) =>
-          assert model.IsSafe(r,s,BinaryApp(BinaryOp.In,e1,e2),Type.Bool(AnyBool)) by {
+          assert IsSafe(r,s,BinaryApp(BinaryOp.In,e1,e2),Type.Bool(AnyBool)) by {
             if e2IsSet {
-              assert model.IsSafe(r,s,e2,Type.Set(Type.Entity(AnyEntity))) by { Sound(e2,Type.Set(Type.Entity(AnyEntity)),effs); }
-              model.InSetSafe(r,s,e1,e2);
+              assert IsSafe(r,s,e2,Type.Set(Type.Entity(AnyEntity))) by { Sound(e2,Type.Set(Type.Entity(AnyEntity)),effs); }
+              InSetSafe(r,s,e1,e2);
             } else {
-              assert model.IsSafe(r,s,e2,Type.Entity(AnyEntity)) by { Sound(e2,Type.Entity(AnyEntity),effs); }
-              model.InSingleSafe(r,s,e1,e2);
+              assert IsSafe(r,s,e2,Type.Entity(AnyEntity)) by { Sound(e2,Type.Entity(AnyEntity),effs); }
+              InSingleSafe(r,s,e1,e2);
             }
           }
         // Harder case: we have to prove that the result is false.
         case Bool(False) =>
           if typechecker.isUnspecifiedVar(e1) && e2IsSpecified {
             UnspecifiedVarHasUnspecifiedEntityType(e1);
-            assert model.IsSafe(r,s,e2,t2) by { Sound(e2,t2,effs); }
+            assert IsSafe(r,s,e2,t2) by { Sound(e2,t2,effs); }
             if e2IsSet {
               var Set(t2e) := t2;
-              model.InSetFalseTypes(r,s,e1,e2,unspecifiedEntityType,t2e);
+              InSetFalseTypes(r,s,e1,e2,unspecifiedEntityType,t2e);
             } else {
-              model.InSingleFalseTypes(r,s,e1,e2,unspecifiedEntityType,t2);
+              InSingleFalseTypes(r,s,e1,e2,unspecifiedEntityType,t2);
             }
           } else {
             match e2 {
@@ -1238,16 +1240,16 @@ module validation.thm.soundness {
                 case Var(v1) =>
                   var et1 :- assert typechecker.getPrincipalOrResource(v1);
                   assert t1 == Type.Entity(EntityLUB({et1}));
-                  assert model.IsSafe(r,s,Var(v1),t1) by { Sound(e1,t1,effs); }
+                  assert IsSafe(r,s,Var(v1),t1) by { Sound(e1,t1,effs); }
                   assert !ets.possibleDescendantOf(et1,u2.ty);
-                  model.InSingleFalseEntityTypeAndLiteral(r,s,e1,et1,u2);
+                  InSingleFalseEntityTypeAndLiteral(r,s,e1,et1,u2);
                 case PrimitiveLit(EntityUID(u1)) =>
                   if isAction(u1.ty) {
                     assert !acts.descendantOf(u1,u2);
                   } else {
                     assert !ets.possibleDescendantOf(u1.ty,u2.ty);
                   }
-                  model.InSingleFalseLiterals(r,s,u1,u2);
+                  InSingleFalseLiterals(r,s,u1,u2);
               }
               case Set(ei2s) =>
                 var euids2 :- assert typechecker.tryGetEUIDs(e2);
@@ -1257,14 +1259,14 @@ module validation.thm.soundness {
                 var eltType :| t2 == Type.Set(eltType);
                 InferSetLemma(e2, ei2s, effs);
                 forall i | 0 <= i < |ei2s|
-                  ensures model.IsSafe(r,s,ei2s[i],Type.Entity(AnyEntity))
+                  ensures IsSafe(r,s,ei2s[i],Type.Entity(AnyEntity))
                 {
                   assert subty(getType(ei2s[i],effs), eltType);
                   SubtyTrans(getType(ei2s[i],effs), eltType, Type.Entity(AnyEntity));
-                  assert model.IsSafe(r,s,ei2s[i],Type.Entity(AnyEntity)) by { Sound(ei2s[i], Type.Entity(AnyEntity), effs); }
+                  assert IsSafe(r,s,ei2s[i],Type.Entity(AnyEntity)) by { Sound(ei2s[i], Type.Entity(AnyEntity), effs); }
                 }
                 forall i | 0 <= i < |ei2s|
-                  ensures model.IsFalse(r,s,BinaryApp(BinaryOp.In,e1,ei2s[i]))
+                  ensures IsFalse(r,s,BinaryApp(BinaryOp.In,e1,ei2s[i]))
                 {
                   var u2 :- assert typechecker.tryGetEUID(ei2s[i]);
                   assert u2 in euids2;
@@ -1273,9 +1275,9 @@ module validation.thm.soundness {
                     case Var(v1) =>
                       var et1 :- assert typechecker.getPrincipalOrResource(v1);
                       assert t1 == Type.Entity(EntityLUB({et1}));
-                      assert model.IsSafe(r,s,Var(v1),t1) by { Sound(e1,t1,effs); }
+                      assert IsSafe(r,s,Var(v1),t1) by { Sound(e1,t1,effs); }
                       assert !ets.possibleDescendantOf(et1,u2.ty);
-                      model.InSingleFalseEntityTypeAndLiteral(r,s,e1,et1,u2);
+                      InSingleFalseEntityTypeAndLiteral(r,s,e1,et1,u2);
                     case PrimitiveLit(EntityUID(u1)) =>
                       if isAction(u1.ty) {
                         assert !acts.descendantOfSet(u1,euids2);
@@ -1284,17 +1286,17 @@ module validation.thm.soundness {
                         assert !ets.possibleDescendantOfSet(u1.ty,ets2);
                         assert !ets.possibleDescendantOf(u1.ty,u2.ty);
                       }
-                      model.InSingleFalseLiterals(r,s,u1,u2);
+                      InSingleFalseLiterals(r,s,u1,u2);
                   }
                 }
-                model.InSetFalseIfAllFalse(r,s,e1,ei2s);
+                InSetFalseIfAllFalse(r,s,e1,ei2s);
             }
           }
       }
 
-      assert model.IsSafe(r,s,BinaryApp(BinaryOp.In,e1,e2),t) by {
-        model.SubtyCompat(t',t);
-        model.SemSubtyTransport(r,s,BinaryApp(BinaryOp.In,e1,e2),t',t);
+      assert IsSafe(r,s,BinaryApp(BinaryOp.In,e1,e2),t) by {
+        SubtyCompat(t',t);
+        SemSubtyTransport(r,s,BinaryApp(BinaryOp.In,e1,e2),t',t);
       }
     }
 
@@ -1312,16 +1314,16 @@ module validation.thm.soundness {
       requires InstanceOfActionStore(s,acts)
       requires EffectsInvariant(effs)
       requires Typesafe(Call(name,es),effs,t)
-      ensures model.IsSafe(r,s,Call(name,es),t)
+      ensures IsSafe(r,s,Call(name,es),t)
       ensures getEffects(Call(name,es),effs) == Effects.empty()
     {
       assert Typechecker(ets,acts,reqty).inferCall(Call(name,es),name,es,effs).Ok?;
       var eft := extFunTypes[name];
       InferCallArgsSound(Call(name,es),name,es,eft.args,effs);
-      forall i | 0 <= i < |es| ensures model.IsSafe(r,s,es[i],eft.args[i]) {
+      forall i | 0 <= i < |es| ensures IsSafe(r,s,es[i],eft.args[i]) {
         Sound(es[i],eft.args[i],effs);
       }
-      model.CallSafe(r,s,name,es);
+      CallSafe(r,s,name,es);
     }
 
     lemma Sound(e: Expr, t: Type, effs: Effects)
@@ -1331,7 +1333,7 @@ module validation.thm.soundness {
       requires InstanceOfActionStore(s,acts)
       requires EffectsInvariant(effs)
       requires Typesafe(e,effs,t)
-      ensures model.IsSafe(r,s,e,t)
+      ensures IsSafe(r,s,e,t)
       ensures GuardedEffectsInvariant(e,getEffects(e,effs))
     {
       assert GuardedEffectsInvariant(e,Effects.empty()) by {
@@ -1369,7 +1371,7 @@ module validation.thm.soundness {
       requires InstanceOfEntityTypeStore(s,ets)
       requires InstanceOfActionStore(s,acts)
       requires Typechecker(ets,acts,reqty).typecheck(e,t).Ok?;
-      ensures model.IsSafe(r,s,e,t)
+      ensures IsSafe(r,s,e,t)
     {
       EmptyEffectsInvariant();
       Sound(e,t,Effects.empty());

--- a/cedar-dafny/validation/thm/soundness.dfy
+++ b/cedar-dafny/validation/thm/soundness.dfy
@@ -894,7 +894,7 @@ module validation.thm.soundness {
       assert IsSafe(r,s,Expr.Record(es),t') by {
         assert forall ae | ae in es :: ExistsSafeType(r,s,ae.1) by {
           forall ae | ae in es
-          ensures ExistsSafeType(r,s,ae.1)
+            ensures ExistsSafeType(r,s,ae.1)
           {
             assert WellTyped(ae.1,effs);
             var t_ae := getType(ae.1,effs);
@@ -1251,7 +1251,7 @@ module validation.thm.soundness {
                   }
                   InSingleFalseLiterals(r,s,u1,u2);
               }
-              case Set(ei2s) => 
+              case Set(ei2s) =>
                 var euids2 :- assert typechecker.tryGetEUIDs(e2);
                 var ets2 := set u <- euids2 :: u.ty;
                 // Argument that is the same any time e2 is a set.

--- a/cedar-dafny/validation/thm/toplevel.dfy
+++ b/cedar-dafny/validation/thm/toplevel.dfy
@@ -82,7 +82,7 @@ module validation.thm.toplevel {
   {
     var typechecker := StrictTypechecker(schema.ets, schema.acts, schema.reqty);
     typechecker.typecheck(policies.policies[pid].toExpr(), Type.Bool(AnyBool))
-}
+  }
 
   // If an expression is well-typed according to the strict typechecker,
   // then either evaluation returns a value of that type or it returns an error

--- a/cedar-dafny/validation/thm/toplevel.dfy
+++ b/cedar-dafny/validation/thm/toplevel.dfy
@@ -60,8 +60,7 @@ module validation.thm.toplevel {
     request: Request,
     store: Store,
     schema: Schema,
-    res: base.Result<Value>,
-    model: EvaluatorModel)
+    res: base.Result<Value>)
     requires pid in store.policies.policies.Keys
     requires SatisfiesSchema(request, store.entities, schema)
     requires permissiveTypecheck(pid, store.policies, schema).Ok?
@@ -69,11 +68,12 @@ module validation.thm.toplevel {
     ensures res.Ok? ==> InstanceOfType(res.value, Type.Bool(AnyBool))
     ensures res.Err? ==> res.error.EntityDoesNotExist? || res.error.ExtensionError?
   {
+    reveal IsSafe();
     var policies := store.policies;
     var entities := store.entities;
     var expr := policies.policies[pid].toExpr();
-    assert model.IsSafe(request, entities, expr, Type.Bool(AnyBool)) by {
-      SSP(model, schema.reqty, schema.ets, schema.acts, request, entities).SoundToplevel(expr, Type.Bool(AnyBool));
+    assert IsSafe(request, entities, expr, Type.Bool(AnyBool)) by {
+      SSP(schema.reqty, schema.ets, schema.acts, request, entities).SoundToplevel(expr, Type.Bool(AnyBool));
     }
   }
 
@@ -82,7 +82,7 @@ module validation.thm.toplevel {
   {
     var typechecker := StrictTypechecker(schema.ets, schema.acts, schema.reqty);
     typechecker.typecheck(policies.policies[pid].toExpr(), Type.Bool(AnyBool))
-  }
+}
 
   // If an expression is well-typed according to the strict typechecker,
   // then either evaluation returns a value of that type or it returns an error
@@ -94,8 +94,7 @@ module validation.thm.toplevel {
     request: Request,
     store: Store,
     schema: Schema,
-    res: base.Result<Value>,
-    model: EvaluatorModel)
+    res: base.Result<Value>)
     requires pid in store.policies.policies.Keys
     requires SatisfiesSchema(request, store.entities, schema)
     requires strictTypecheck(pid, store.policies, schema).Ok?
@@ -104,6 +103,6 @@ module validation.thm.toplevel {
     ensures res.Err? ==> res.error.EntityDoesNotExist? || res.error.ExtensionError?
   {
     assert permissiveTypecheck(pid, store.policies, schema).Ok?;
-    PermissiveTypecheckingIsSound(pid, request, store, schema, res, model);
+    PermissiveTypecheckingIsSound(pid, request, store, schema, res);
   }
 }

--- a/cedar-dafny/validation/typechecker.dfy
+++ b/cedar-dafny/validation/typechecker.dfy
@@ -470,7 +470,7 @@ module validation.typechecker {
     }
 
     function {:opaque true} inferRecord(ghost e: Expr, r: seq<(Attr,Expr)>, effs: Effects): (res: Result<RecordType>)
-      requires forall i :: 0 <= i < |r| ==> r[i] < e
+      requires forall i | 0 <= i < |r| :: r[i] < e
       decreases e , 0 , r
     {
       if r == [] then
@@ -551,7 +551,7 @@ module validation.typechecker {
     }
 
     function inferSet(ghost e: Expr, r: seq<Expr>, effs: Effects): (res: Result<Type>)
-      requires forall i :: 0 <= i < |r| ==> r[i] < e
+      requires forall i | 0 <= i < |r| :: r[i] < e
       decreases e , 0 , r
     {
       if r == [] then
@@ -570,7 +570,7 @@ module validation.typechecker {
 
     function inferCallArgs(ghost e: Expr, args: seq<Expr>, tys: seq<Type>, effs: Effects): Result<()>
       requires |args| == |tys|
-      requires forall i :: 0 <= i < |args| ==> args[i] < e
+      requires forall i | 0 <= i < |args| :: args[i] < e
       decreases e , 0 , args
     {
       if args == [] then
@@ -582,7 +582,7 @@ module validation.typechecker {
     }
 
     function inferCall(ghost e: Expr, name: base.Name, args: seq<Expr>, effs: Effects): Result<Type>
-      requires forall i :: 0 <= i < |args| ==> args[i] < e
+      requires forall i | 0 <= i < |args| :: args[i] < e
       decreases e , 0
     {
       if name in extFunTypes.Keys

--- a/cedar-dafny/validation/validator.dfy
+++ b/cedar-dafny/validation/validator.dfy
@@ -92,9 +92,9 @@ module validation.validator {
     function Typecheck (e: Expr, ets: EntityTypeStore, acts: ActionStore, reqty: RequestType): std.Result<Type, StrictTypeError> {
       if mode.Permissive?
       then match Typechecker(ets, acts, reqty).typecheck(e, Type.Bool(AnyBool)) {
-        case Ok(ty) => std.Ok(ty)
-        case Err(er) => std.Err(strict.TypeError(er))
-      }
+             case Ok(ty) => std.Ok(ty)
+             case Err(er) => std.Err(strict.TypeError(er))
+           }
       else StrictTypechecker(ets, acts, reqty).typecheck(e, Type.Bool(AnyBool))
     }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The primary change in this PR is to remove the `trait`/`class` in the type soundness proof, which was used to isolate the `Evaluator` from the rest of the proof. The rework (largely completed by @emina) uses `opaque` predicates instead.

Also snuck in a couple other changes:
* Updated `def/util.dfy` to get compilation working with Dafny version 4.1.0, per [this thread](https://github.com/dafny-lang/dafny/issues/4013).
* Switched from the `:: ==>` notation to the preferred `| ::` whenever doing so did not increase the proof "resource usage".
* Whitespace changes, suggested by the Dafny formatter.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
