### PR TITLE
Update DRT build instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ cedar-dafny/.dotnet
 cedar-dafny/.local
 cedar-dafny/.nuget
 cedar-dafny/build
+cedar-dafny/TestResults
 
 # cedar-dafny-java-wrapper build artifacts
 cedar-dafny-java-wrapper/build
@@ -29,8 +30,5 @@ cedar-drt/fuzz/target
 cedar-drt/fuzz/Cargo.lock
 cedar-drt/fuzz/corpus
 cedar-drt/fuzz/artifacts
-
-# cedar if checkout out in root dir
-cedar/
 
 .vscode

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "cedar"]
+	path = cedar
+	url = https://github.com/cedar-policy/cedar.git

--- a/README.md
+++ b/README.md
@@ -7,19 +7,19 @@ This repository contains the Dafny formalization of Cedar and infrastructure for
 * `cedar-spec` contains the Dafny formalization of, and proofs about, Cedar.
 * `cedar-dafny-java-wrapper` contains the Java interface for DRT.
 * `cedar-drt` contains code for input generation, fuzzing, property-based testing, and differential testing of Cedar.
+* `cedar` is a git submodule, pinned to the `main` branch of [cedar](https://github.com/cedar-policy/cedar).
 
 ## Build
 
 To build the Dafny formalization and proofs:
 
-* Install Dafny 4, following the instructions [here](https://github.com/dafny-lang/dafny/wiki/INSTALL). Our proofs expect Z3 version 4.12.1, so if you have another copy of Z3 installed locally, you may need to adjust your PATH.
+* Install Dafny 4.0, following the instructions [here](https://github.com/dafny-lang/dafny/wiki/INSTALL). Our proofs expect Z3 version 4.12.1, so if you have another copy of Z3 installed locally, you may need to adjust your PATH.
 * `cd cedar-dafny && make`
 
 To build the DRT framework:
 
-* Set JAVA_HOME
-* Set LD_LIBRARY_PATH to include `$JAVA_HOME/lib/server`
-* Clone [cedar](https://github.com/cedar-policy/cedar) to `cedar-spec/cedar`
+* Install Dafny, following the instructions above
+* Ensure that JAVA_HOME is set
 * `./build.sh`
 
 ## Run

--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+# Check out the cedar submodule
+git submodule update --init
+
+# Set LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$JAVA_HOME/lib/server
+
 # Build the formalization and extract Java code
 cd cedar-dafny && make compile-difftest
 cd ..

--- a/cedar-drt/Cargo.toml
+++ b/cedar-drt/Cargo.toml
@@ -10,10 +10,10 @@ highway = "0.8.1"
 env_logger = "0.10"
 log = "0.4"
 libfuzzer-sys = "0.4"
-cedar-policy = { path = "../cedar/cedar-policy", version = "2.0.0", features = ["integration_testing"] }
-cedar-policy-core = { path = "../cedar/cedar-policy-core", version = "2.0.0" }
-cedar-policy-validator = { path = "../cedar/cedar-policy-validator", version = "2.0.0" }
-cedar-policy-formatter = { path = "../cedar/cedar-policy-formatter", version = "2.0.0" }
+cedar-policy = { path = "../cedar/cedar-policy", version = "2.*", features = ["integration_testing"] }
+cedar-policy-core = { path = "../cedar/cedar-policy-core", version = "2.*" }
+cedar-policy-validator = { path = "../cedar/cedar-policy-validator", version = "2.*" }
+cedar-policy-formatter = { path = "../cedar/cedar-policy-formatter", version = "2.*" }
 jni = { version = "0.19.0", features = ["invocation"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/cedar-drt/fuzz/Cargo.toml
+++ b/cedar-drt/fuzz/Cargo.toml
@@ -15,9 +15,9 @@ libfuzzer-sys = "0.4"
 serde = { version = "1.0", feature = ["derive"] }
 serde_json = "1.0"
 cedar-drt = { version = "2.0.0", path = ".." }
-cedar-policy-core = { path = "../../cedar/cedar-policy-core", version = "2.0.0" }
-cedar-policy-validator = { path = "../../cedar/cedar-policy-validator", version = "2.0.0" }
-cedar-policy-formatter = { path = "../../cedar/cedar-policy-formatter", version = "2.0.0" }
+cedar-policy-core = { path = "../../cedar/cedar-policy-core", version = "2.*" }
+cedar-policy-validator = { path = "../../cedar/cedar-policy-validator", version = "2.*" }
+cedar-policy-formatter = { path = "../../cedar/cedar-policy-formatter", version = "2.*" }
 smol_str = { version = "0.2", features = ["serde"] }
 regex = "1"
 rayon = { version = "1.5", optional = true }


### PR DESCRIPTION
*Issue #, if available:*

---------

*Description of changes:*

* Added `cedar` as a submodule instead of requiring users to create their own local clone.
* Minor updates to the build instructions.
* Marked as "draft" until we decide which version of `cedar-*` we want to pin.

**Note:** We can use the `cedar-*` packages in crates.io instead of the submodule, if desired. But we still need to include `cedar` as a submodule because the integration tests in `cedar-spec/cedar-drt` depend on the source in `cedar/cedar-integration-tests`.

---------

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
