### PR TITLE
Enable generating unknowns for PE fuzzing

### DIFF
--- a/cedar-drt/fuzz/fuzz_targets/pp.rs
+++ b/cedar-drt/fuzz/fuzz_targets/pp.rs
@@ -41,7 +41,7 @@ const SETTINGS: ABACSettings = ABACSettings {
     enable_like: true,
     enable_action_groups_and_attrs: true,
     enable_arbitrary_func_call: false,
-    enable_unknowns: false,
+    enable_unknowns: true,
 };
 
 impl<'a> Arbitrary<'a> for FuzzTargetInput {


### PR DESCRIPTION
I think we want this setting on.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
