### PR TITLE
Optimize proof RUs

### DIFF
--- a/cedar-dafny/thm/eval/basic.dfy
+++ b/cedar-dafny/thm/eval/basic.dfy
@@ -112,7 +112,7 @@ module eval.basic {
   {}
 
   lemma ListSemanticsOk(es: seq<Expr>, E: Evaluator)
-    requires forall e <- es :: E.interpret(e).Ok?
+    requires forall i | 0 <= i < |es| :: E.interpret(es[i]).Ok?
     ensures E.interpretList(es).Ok?
     ensures |E.interpretList(es).value| == |es|
     ensures forall i | 0 <= i < |es| :: E.interpret(es[i]) == base.Ok(E.interpretList(es).value[i])

--- a/cedar-dafny/validation/thm/model.dfy
+++ b/cedar-dafny/validation/thm/model.dfy
@@ -1050,6 +1050,9 @@ module validation.thm.model {
     var res := evaluator.interpret(BinaryApp(BinaryOp.In,e1,Expr.Set(e2s)));
     var r1 := evaluator.interpret(e1);
     var r2 := evaluator.interpret(Expr.Set(e2s));
+    if r1.Ok? {
+    } else {
+    }
   }
 
   lemma InSetFalseTypes(r: Request, s: EntityStore, e1: Expr, e2: Expr, t1: Type, t2: Type)

--- a/cedar-dafny/validation/thm/soundness.dfy
+++ b/cedar-dafny/validation/thm/soundness.dfy
@@ -72,6 +72,10 @@ module validation.thm.soundness {
       WellTyped(e,effs) && subty(getType(e, effs), t)
     }
 
+    ghost predicate {:opaque} WellFormedRequestAndStore() {
+      InstanceOfRequestType(r,reqty) && InstanceOfEntityTypeStore(s,ets) && InstanceOfActionStore(s,acts)
+    }
+
     // On input to the typechecking function, for any (e,k) in the Effects,
     // e is a record- or entity-typed expression that has key k.
     ghost predicate {:opaque} EffectsInvariant (effs: Effects) {
@@ -116,13 +120,12 @@ module validation.thm.soundness {
 
     lemma SoundVar(x: Var, t: Type, effs: Effects)
       decreases Var(x) , 0
-      requires InstanceOfRequestType(r,reqty)
-      requires InstanceOfEntityTypeStore(s,ets)
-      requires InstanceOfActionStore(s,acts)
+      requires WellFormedRequestAndStore()
       requires Typesafe(Var(x),effs,t)
       ensures IsSafe(r,s,Var(x),t)
       ensures getEffects(Var(x),effs) == Effects.empty()
     {
+      assert InstanceOfRequestType(r, reqty) by { reveal WellFormedRequestAndStore(); }
       var t' :| getType(Var(x),effs) == t' && subty(t',t);
       assert Typechecker(ets,acts,reqty).inferVar(x) == types.Ok(t');
       match x {
@@ -182,9 +185,7 @@ module validation.thm.soundness {
 
     lemma SoundIf(e: Expr, e1: Expr, e2: Expr, t: Type, effs: Effects)
       decreases If(e,e1,e2) , 0
-      requires InstanceOfRequestType(r,reqty)
-      requires InstanceOfEntityTypeStore(s,ets)
-      requires InstanceOfActionStore(s,acts)
+      requires WellFormedRequestAndStore()
       requires EffectsInvariant(effs)
       requires Typesafe(If(e,e1,e2),effs,t)
       ensures IsSafe(r,s,If(e,e1,e2),t)
@@ -322,9 +323,7 @@ module validation.thm.soundness {
 
     lemma SoundAnd(e1: Expr, e2: Expr, t: Type, effs: Effects)
       decreases And(e1,e2) , 0
-      requires InstanceOfRequestType(r,reqty)
-      requires InstanceOfEntityTypeStore(s,ets)
-      requires InstanceOfActionStore(s,acts)
+      requires WellFormedRequestAndStore()
       requires EffectsInvariant(effs)
       requires Typesafe(And(e1,e2),effs,t)
       ensures IsSafe(r,s,And(e1,e2),t)
@@ -459,9 +458,7 @@ module validation.thm.soundness {
 
     lemma SoundOr(e1: Expr, e2: Expr, t: Type, effs: Effects)
       decreases Or(e1,e2) , 0
-      requires InstanceOfRequestType(r,reqty)
-      requires InstanceOfEntityTypeStore(s,ets)
-      requires InstanceOfActionStore(s,acts)
+      requires WellFormedRequestAndStore()
       requires EffectsInvariant(effs)
       requires Typesafe(Or(e1,e2),effs,t)
       ensures IsSafe(r,s,Or(e1,e2),t)
@@ -575,9 +572,7 @@ module validation.thm.soundness {
 
     lemma SoundNot(e: Expr, t: Type, effs: Effects)
       decreases UnaryApp(Not,e) , 0
-      requires InstanceOfRequestType(r,reqty)
-      requires InstanceOfEntityTypeStore(s,ets)
-      requires InstanceOfActionStore(s,acts)
+      requires WellFormedRequestAndStore()
       requires EffectsInvariant(effs)
       requires Typesafe(UnaryApp(Not,e),effs,t)
       ensures IsSafe(r,s,UnaryApp(Not,e),t)
@@ -604,9 +599,7 @@ module validation.thm.soundness {
 
     lemma SoundNeg(e: Expr, t: Type, effs: Effects)
       decreases UnaryApp(Neg,e) , 0
-      requires InstanceOfRequestType(r,reqty)
-      requires InstanceOfEntityTypeStore(s,ets)
-      requires InstanceOfActionStore(s,acts)
+      requires WellFormedRequestAndStore()
       requires EffectsInvariant(effs)
       requires Typesafe(UnaryApp(Neg,e),effs,t)
       ensures IsSafe(r,s,UnaryApp(Neg,e),t)
@@ -626,9 +619,7 @@ module validation.thm.soundness {
 
     lemma SoundMulBy(i: int, e: Expr, t: Type, effs: Effects)
       decreases UnaryApp(MulBy(i),e) , 0
-      requires InstanceOfRequestType(r,reqty)
-      requires InstanceOfEntityTypeStore(s,ets)
-      requires InstanceOfActionStore(s,acts)
+      requires WellFormedRequestAndStore()
       requires EffectsInvariant(effs)
       requires Typesafe(UnaryApp(MulBy(i),e),effs,t)
       ensures IsSafe(r,s,UnaryApp(MulBy(i),e),t)
@@ -648,9 +639,7 @@ module validation.thm.soundness {
 
     lemma SoundLike(e: Expr, p: Pattern, t: Type, effs: Effects)
       decreases UnaryApp(Like(p),e) , 0
-      requires InstanceOfRequestType(r,reqty)
-      requires InstanceOfEntityTypeStore(s,ets)
-      requires InstanceOfActionStore(s,acts)
+      requires WellFormedRequestAndStore()
       requires EffectsInvariant(effs)
       requires Typesafe(UnaryApp(Like(p),e),effs,t)
       ensures IsSafe(r,s,UnaryApp(Like(p),e),t)
@@ -718,9 +707,7 @@ module validation.thm.soundness {
 
     lemma SoundEq(e1: Expr, e2: Expr, t: Type, effs: Effects)
       decreases BinaryApp(BinaryOp.Eq,e1,e2) , 0
-      requires InstanceOfRequestType(r,reqty)
-      requires InstanceOfEntityTypeStore(s,ets)
-      requires InstanceOfActionStore(s,acts)
+      requires WellFormedRequestAndStore()
       requires EffectsInvariant(effs)
       requires Typesafe(BinaryApp(BinaryOp.Eq,e1,e2),effs,t)
       ensures IsSafe(r,s,BinaryApp(BinaryOp.Eq,e1,e2),t)
@@ -743,6 +730,7 @@ module validation.thm.soundness {
             EqFalseIsSafe(r,s,e1,e2,t1.lub,t2.lub);
           } else if Typechecker(ets,acts,reqty).isUnspecifiedVar(e1) && t2.Entity? && t2.lub.specified() {
             assert t' == Type.Bool(False);
+            reveal WellFormedRequestAndStore();
             UnspecifiedVarHasUnspecifiedEntityType(e1);
             EqFalseIsSafe(r,s,e1,e2,unspecifiedEntityType.lub,t2.lub);
           } else {
@@ -759,9 +747,7 @@ module validation.thm.soundness {
     lemma SoundIneq(op: BinaryOp, e1: Expr, e2: Expr, t: Type, effs: Effects)
       decreases BinaryApp(op,e1,e2) , 0
       requires op == Less || op == BinaryOp.LessEq
-      requires InstanceOfRequestType(r,reqty)
-      requires InstanceOfEntityTypeStore(s,ets)
-      requires InstanceOfActionStore(s,acts)
+      requires WellFormedRequestAndStore()
       requires EffectsInvariant(effs)
       requires Typesafe(BinaryApp(op,e1,e2),effs,t)
       ensures IsSafe(r,s,BinaryApp(op,e1,e2),t)
@@ -785,9 +771,7 @@ module validation.thm.soundness {
     lemma SoundArith(op: BinaryOp, e1: Expr, e2: Expr, t: Type, effs: Effects)
       decreases BinaryApp(op,e1,e2) , 0
       requires op == Add || op == Sub
-      requires InstanceOfRequestType(r,reqty)
-      requires InstanceOfEntityTypeStore(s,ets)
-      requires InstanceOfActionStore(s,acts)
+      requires WellFormedRequestAndStore()
       requires EffectsInvariant(effs)
       requires Typesafe(BinaryApp(op,e1,e2),effs,t)
       ensures IsSafe(r,s,BinaryApp(op,e1,e2),t)
@@ -811,9 +795,7 @@ module validation.thm.soundness {
     lemma SoundContainsAnyAll(op: BinaryOp, e1: Expr, e2: Expr, t: Type, effs: Effects)
       decreases BinaryApp(op,e1,e2) , 0
       requires op == ContainsAny || op == ContainsAll
-      requires InstanceOfRequestType(r,reqty)
-      requires InstanceOfEntityTypeStore(s,ets)
-      requires InstanceOfActionStore(s,acts)
+      requires WellFormedRequestAndStore()
       requires EffectsInvariant(effs)
       requires Typesafe(BinaryApp(op,e1,e2),effs,t)
       ensures IsSafe(r,s,BinaryApp(op,e1,e2),t)
@@ -836,9 +818,7 @@ module validation.thm.soundness {
 
     lemma SoundContains(e1: Expr, e2: Expr, t: Type, effs: Effects)
       decreases BinaryApp(Contains,e1,e2) , 0
-      requires InstanceOfRequestType(r,reqty)
-      requires InstanceOfEntityTypeStore(s,ets)
-      requires InstanceOfActionStore(s,acts)
+      requires WellFormedRequestAndStore()
       requires EffectsInvariant(effs)
       requires Typesafe(BinaryApp(Contains,e1,e2),effs,t)
       ensures IsSafe(r,s,BinaryApp(Contains,e1,e2),t)
@@ -868,9 +848,7 @@ module validation.thm.soundness {
 
     lemma SoundRecord(es: seq<(Attr,Expr)>, t: Type, effs: Effects)
       decreases Expr.Record(es) , 0
-      requires InstanceOfRequestType(r,reqty)
-      requires InstanceOfEntityTypeStore(s,ets)
-      requires InstanceOfActionStore(s,acts)
+      requires WellFormedRequestAndStore()
       requires EffectsInvariant(effs)
       requires Typesafe(Expr.Record(es),effs,t)
       ensures IsSafe(r,s,Expr.Record(es),t)
@@ -940,9 +918,7 @@ module validation.thm.soundness {
 
     lemma SoundSet(es: seq<Expr>, t: Type, effs: Effects)
       decreases Expr.Set(es) , 0
-      requires InstanceOfRequestType(r,reqty)
-      requires InstanceOfEntityTypeStore(s,ets)
-      requires InstanceOfActionStore(s,acts)
+      requires WellFormedRequestAndStore()
       requires Typesafe(Expr.Set(es),effs,t)
       requires EffectsInvariant(effs)
       ensures IsSafe(r,s,Expr.Set(es),t)
@@ -970,9 +946,7 @@ module validation.thm.soundness {
 
     lemma SoundGetAttr(e: Expr, k: Attr, t: Type, effs: Effects)
       decreases GetAttr(e,k) , 0
-      requires InstanceOfRequestType(r,reqty)
-      requires InstanceOfEntityTypeStore(s,ets)
-      requires InstanceOfActionStore(s,acts)
+      requires WellFormedRequestAndStore()
       requires EffectsInvariant(effs)
       requires Typesafe(GetAttr(e,k),effs,t)
       ensures IsSafe(r,s,GetAttr(e,k),t)
@@ -1017,6 +991,7 @@ module validation.thm.soundness {
               ensures rt.attrs[k].isRequired ==> k in s.entities[euid].attrs
               ensures k in s.entities[euid].attrs ==> InstanceOfType(s.entities[euid].attrs[k],t')
             {
+              reveal WellFormedRequestAndStore();
               GetLubRecordTypeSubty(lub, euid.ty);
               SubtyCompat(ets.types[euid.ty].attrs[k].ty, t');
             }
@@ -1040,6 +1015,7 @@ module validation.thm.soundness {
       assert rt2.isOpen() ==> rtl.isOpen();
       assert !rtl.isOpen() ==> rt1.attrs.Keys == rt2.attrs.Keys;
 
+      reveal WellFormedRequestAndStore();
       forall k | k in rtl.attrs.Keys
         ensures subtyAttrType(rt1.attrs[k], rtl.attrs[k]) && subtyAttrType(rt2.attrs[k], rtl.attrs[k]) {
         var al := rtl.attrs[k];
@@ -1091,9 +1067,7 @@ module validation.thm.soundness {
 
     lemma SoundHasAttr(e: Expr, k: Attr, t: Type, effs: Effects)
       decreases HasAttr(e,k) , 0
-      requires InstanceOfRequestType(r,reqty)
-      requires InstanceOfEntityTypeStore(s,ets)
-      requires InstanceOfActionStore(s,acts)
+      requires WellFormedRequestAndStore()
       requires EffectsInvariant(effs)
       requires Typesafe(HasAttr(e,k),effs,t)
       ensures IsSafe(r,s,HasAttr(e,k),t)
@@ -1152,6 +1126,7 @@ module validation.thm.soundness {
           assert Typesafe(e,effs,Type.Entity(et)) by { SubtyRefl(Type.Entity(et)); }
           assert IsSafe(r,s,e,Type.Entity(et)) by { Sound(e,Type.Entity(et),effs); }
           if !ets.isAttrPossible(et,k) {
+            reveal WellFormedRequestAndStore();
             EntityHasImpossibleFalseSafe(r,s,e,k,et);
           } else {
             var m := ets.getLubRecordType(et).value;
@@ -1209,9 +1184,7 @@ module validation.thm.soundness {
 
     lemma SoundInSetMemberFalse(e1: Expr, ei2s: seq<Expr>, i: nat, effs: Effects)
       decreases BinaryApp(BinaryOp.In,e1,Expr.Set(ei2s)) , 0 , Expr.Set(ei2s) , 0
-      requires InstanceOfRequestType(r,reqty)
-      requires InstanceOfEntityTypeStore(s,ets)
-      requires InstanceOfActionStore(s,acts)
+      requires WellFormedRequestAndStore()
       requires EffectsInvariant(effs)
       requires WellTyped(BinaryApp(BinaryOp.In,e1,Expr.Set(ei2s)),effs)
       requires getType(BinaryApp(BinaryOp.In,e1,Expr.Set(ei2s)),effs) == Type.Bool(False)
@@ -1239,6 +1212,7 @@ module validation.thm.soundness {
           assert t1 == Type.Entity(EntityLUB({et1}));
           assert IsSafe(r,s,Var(v1),t1) by { Sound(e1,t1,effs); }
           assert !ets.possibleDescendantOf(et1,u2.ty);
+          reveal WellFormedRequestAndStore();
           InSingleFalseEntityTypeAndLiteral(r,s,e1,et1,u2);
         case PrimitiveLit(EntityUID(u1)) =>
           if isAction(u1.ty) {
@@ -1248,15 +1222,14 @@ module validation.thm.soundness {
             assert !ets.possibleDescendantOfSet(u1.ty,ets2);
             assert !ets.possibleDescendantOf(u1.ty,u2.ty);
           }
+          reveal WellFormedRequestAndStore();
           InSingleFalseLiterals(r,s,u1,u2);
       }
     }
 
     lemma SoundIn(e1: Expr, e2: Expr, t: Type, effs: Effects)
       decreases BinaryApp(BinaryOp.In,e1,e2) , 0 , e2
-      requires InstanceOfRequestType(r,reqty)
-      requires InstanceOfEntityTypeStore(s,ets)
-      requires InstanceOfActionStore(s,acts)
+      requires WellFormedRequestAndStore()
       requires EffectsInvariant(effs)
       requires Typesafe(BinaryApp(BinaryOp.In,e1,e2),effs,t)
       ensures IsSafe(r,s,BinaryApp(BinaryOp.In,e1,e2),t)
@@ -1288,6 +1261,7 @@ module validation.thm.soundness {
       match t' {
         // Easy case
         case Bool(AnyBool) =>
+          reveal WellFormedRequestAndStore();
           assert IsSafe(r,s,BinaryApp(BinaryOp.In,e1,e2),Type.Bool(AnyBool)) by {
             if e2IsSet {
               assert IsSafe(r,s,e2,Type.Set(Type.Entity(AnyEntity))) by { Sound(e2,Type.Set(Type.Entity(AnyEntity)),effs); }
@@ -1300,6 +1274,7 @@ module validation.thm.soundness {
         // Harder case: we have to prove that the result is false.
         case Bool(False) =>
           if typechecker.isUnspecifiedVar(e1) && e2IsSpecified {
+            reveal WellFormedRequestAndStore();
             UnspecifiedVarHasUnspecifiedEntityType(e1);
             assert IsSafe(r,s,e2,t2) by { Sound(e2,t2,effs); }
             if e2IsSet {
@@ -1316,6 +1291,7 @@ module validation.thm.soundness {
                   assert t1 == Type.Entity(EntityLUB({et1}));
                   assert IsSafe(r,s,Var(v1),t1) by { Sound(e1,t1,effs); }
                   assert !ets.possibleDescendantOf(et1,u2.ty);
+                  reveal WellFormedRequestAndStore();
                   InSingleFalseEntityTypeAndLiteral(r,s,e1,et1,u2);
                 case PrimitiveLit(EntityUID(u1)) =>
                   if isAction(u1.ty) {
@@ -1323,6 +1299,7 @@ module validation.thm.soundness {
                   } else {
                     assert !ets.possibleDescendantOf(u1.ty,u2.ty);
                   }
+                  reveal WellFormedRequestAndStore();
                   InSingleFalseLiterals(r,s,u1,u2);
               }
               case Set(ei2s) =>
@@ -1368,9 +1345,7 @@ module validation.thm.soundness {
 
     lemma SoundCall(name: base.Name, es: seq<Expr>, t: Type, effs: Effects)
       decreases Call(name,es) , 0
-      requires InstanceOfRequestType(r,reqty)
-      requires InstanceOfEntityTypeStore(s,ets)
-      requires InstanceOfActionStore(s,acts)
+      requires WellFormedRequestAndStore()
       requires EffectsInvariant(effs)
       requires Typesafe(Call(name,es),effs,t)
       ensures IsSafe(r,s,Call(name,es),t)
@@ -1387,9 +1362,7 @@ module validation.thm.soundness {
 
     lemma Sound(e: Expr, t: Type, effs: Effects)
       decreases e , 1
-      requires InstanceOfRequestType(r,reqty)
-      requires InstanceOfEntityTypeStore(s,ets)
-      requires InstanceOfActionStore(s,acts)
+      requires WellFormedRequestAndStore()
       requires EffectsInvariant(effs)
       requires Typesafe(e,effs,t)
       ensures IsSafe(r,s,e,t)
@@ -1433,6 +1406,7 @@ module validation.thm.soundness {
       ensures IsSafe(r,s,e,t)
     {
       EmptyEffectsInvariant();
+      reveal WellFormedRequestAndStore();
       Sound(e,t,Effects.empty());
     }
   }


### PR DESCRIPTION
Reduces proofs over 10,000,000 RU limit from 12 to 6.

The first commit tweaks some proofs in `model.dfy`. The second commit hides some common preconditions in `model.dfy` behind `opaque`. 

Before:
```
validation.thm.soundness.SemanticSoundnessProof.SoundIn (correctness)(Passed) - Duration = 00:00:19.0112924, Resource Count = 23905971
validation.thm.soundness.SemanticSoundnessProof.SoundGetAttr (correctness)(Passed) - Duration = 00:00:20.4276508, Resource Count = 21252770
validation.thm.soundness.SemanticSoundnessProof.SoundCall (correctness)(Passed) - Duration = 00:00:16.1544087, Resource Count = 20447879
validation.thm.model.CallSafe (correctness)(Passed) - Duration = 00:00:16.4184827, Resource Count = 19604861
validation.thm.model.InSetFalseTypes (correctness)(Passed) - Duration = 00:00:11.1384372, Resource Count = 18854443
validation.thm.model.InterpretRecordLemmaOk (correctness)(Passed) - Duration = 00:00:17.8690448, Resource Count = 18617886
validation.thm.soundness.SemanticSoundnessProof.SoundInSetMemberFalse (correctness)(Passed) - Duration = 00:00:14.7439875, Resource Count = 17814454
validation.thm.soundness.SemanticSoundnessProof.SoundEq (correctness)(Passed) - Duration = 00:00:23.4532100, Resource Count = 16979533
validation.thm.soundness.SemanticSoundnessProof.SoundHasAttr (correctness)(Passed) - Duration = 00:00:14.7334905, Resource Count = 15451607
validation.thm.soundness.SemanticSoundnessProof.SoundContains (correctness)(Passed) - Duration = 00:00:13.0147554, Resource Count = 13884065
validation.thm.model.DecimalComparisonSafe (correctness)(Passed) - Duration = 00:00:10.1198876, Resource Count = 12154290
validation.thm.soundness.SemanticSoundnessProof.SoundLike (correctness)(Passed) - Duration = 00:00:14.4489338, Resource Count = 10872901
Proofs Over threshold: 12
```

After:
```
validation.thm.soundness.SemanticSoundnessProof.SoundHasAttr (correctness)(Passed) - Duration = 00:00:14.1801322, Resource Count = 14727577
validation.thm.soundness.SemanticSoundnessProof.SoundInSetMemberFalse (correctness)(Passed) - Duration = 00:00:11.2315846, Resource Count = 12361170
validation.thm.soundness.SemanticSoundnessProof.SoundEqAux (correctness)(Passed) - Duration = 00:00:14.0085325, Resource Count = 11894526
validation.thm.soundness.SemanticSoundnessProof.SoundCall (correctness)(Passed) - Duration = 00:00:10.9589261, Resource Count = 11373800
validation.thm.soundness.SemanticSoundnessProof.SoundEq (correctness)(Passed) - Duration = 00:00:20.4325853, Resource Count = 10249359
validation.thm.soundness.SemanticSoundnessProof.SoundGetAttr (correctness)(Passed) - Duration = 00:00:12.6768589, Resource Count = 10182414
Proofs Over threshold: 6
```