### PR TITLE
Fix set_env_vars.sh for macOS

### DIFF
--- a/cedar-drt/set_env_vars.sh
+++ b/cedar-drt/set_env_vars.sh
@@ -6,15 +6,21 @@ if [ -z "${JAVA_HOME-}" ]; then
     export JAVA_HOME="$(java -XshowSettings:properties -version 2>&1 | sed -ne 's,^ *java\.home = ,,p')"
 fi
 
-# Set LD_LIBRARY_PATH
-libjvm_dirs=($(find "$JAVA_HOME" -name 'libjvm.*'))
-if [ ${#libjvm_dirs[@]} = 1 ]; then
-    # Accessing an array element in both bash and zsh: https://stackoverflow.com/a/56311706
-    export LD_LIBRARY_PATH=${LD_LIBRARY_PATH+$LD_LIBRARY_PATH:}${libjvm_dirs[@]:0:1}
-else
-    echo >&2 'Error: Failed to find libjvm'
-fi
-unset libjvm_dirs
+# Set LD_LIBRARY_PATH and DYLD_LIBRARY_PATH (for macOS)
+function add_lib_to_path {
+  lib_dirs=($(find "$JAVA_HOME" -name "lib${1}.*" -exec dirname {} \;))
+  if [ ${#lib_dirs[@]} = 1 ]; then
+      # Accessing an array element in both bash and zsh: https://stackoverflow.com/a/56311706
+      lib_dir=${lib_dirs[@]:0:1}
+      export LD_LIBRARY_PATH=${LD_LIBRARY_PATH+$LD_LIBRARY_PATH:}${lib_dir}
+      export DYLD_LIBRARY_PATH=${DYLD_LIBRARY_PATH+$DYLD_LIBRARY_PATH:}${lib_dir}
+  else
+      echo >&2 "Error: Failed to find lib${1}"
+  fi
+}
+add_lib_to_path jvm
+add_lib_to_path jli
+unset -f add_lib_to_path
 
 # Set CLASSPATH
 if [ -f "$(pwd)/../cedar-dafny-java-wrapper/build/libs/cedar-dafny-java-wrapper.jar" ]; then


### PR DESCRIPTION
CC @aaronjeline

*Issue #, if available:* N/A

*Description of changes:*

- Set `DYLD_LIBRARY_PATH` as well as `LD_LIBRARY_PATH`.
- Include the path to `libjli` as well as `libjvm` (c.f. https://stackoverflow.com/q/62563102).
- The `find` command needs to use `dirname` to get the parent directory, rather than the path to the library file itself.

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*