### PR TITLE
Log output of dafny-reportgenerator in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,11 +27,15 @@ jobs:
           echo "$(pwd)/z3-4.12.1-x64-glibc-2.35/bin" >> $GITHUB_PATH
       - name: verify dafny
         working-directory: ./cedar-dafny
-        run: make verify
+        run: make GEN_STATS=1 verify
       - name: test dafny
         working-directory: ./cedar-dafny
         run: make test
-
+      - name: log resource usage
+        working-directory: ./cedar-dafny
+        run: |
+          dotnet tool restore
+          dotnet tool run dafny-reportgenerator summarize-csv-results --max-resource-count 10000000 . || true
 
   build_and_test_drt:
     name: Build and Test DRT


### PR DESCRIPTION
This doesn't do any checking that the new RU is reasonable and not a regression over the old, but it makes it easier for reviewers to see RU at a glance without pulling and running everything themselves.

Related to (but does not resolved) #53. 

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
