### PR TITLE
Make `cedar-drt` compatible with the parse error changes

### DIFF
--- a/cedar-drt/fuzz/fuzz_targets/formatter.rs
+++ b/cedar-drt/fuzz/fuzz_targets/formatter.rs
@@ -90,7 +90,7 @@ fn attach_comment(p: &str, uuids: &mut Vec<String>) -> String {
 
 // round-tripping of a policy
 // i.e., print a policy to string, format it, and parse it back
-fn round_trip(p: &StaticPolicy) -> Result<StaticPolicy, Vec<err::ParseError>> {
+fn round_trip(p: &StaticPolicy) -> Result<StaticPolicy, err::ParseErrors> {
     let config = Config {
         indent_width: 2,
         line_width: 80,

--- a/cedar-drt/fuzz/fuzz_targets/pp.rs
+++ b/cedar-drt/fuzz/fuzz_targets/pp.rs
@@ -67,7 +67,7 @@ fn contains_unspecified_entities(p: &StaticPolicy) -> bool {
 
 // round-tripping of a policy
 // i.e., print a policy to string and parse it back
-fn round_trip(p: &StaticPolicy) -> Result<StaticPolicy, Vec<err::ParseError>> {
+fn round_trip(p: &StaticPolicy) -> Result<StaticPolicy, err::ParseErrors> {
     parse_policy(None, &p.to_string())
 }
 

--- a/cedar-drt/fuzz/src/schema.rs
+++ b/cedar-drt/fuzz/src/schema.rs
@@ -270,7 +270,7 @@ fn uid_for_action_name(namespace: Option<SmolStr>, action_name: &SmolStr) -> ast
     let namespace_prefix = namespace.map(|ns| format!("{ns}::")).unwrap_or_default();
     format!("{}Action::\"{}\"", namespace_prefix, action_name)
                 .parse()
-                .unwrap_or_else(|e| panic!("schema actions should all be valid EntityUIDs in this context, but {:?} led to an invalid one: {}", action_name, cedar_policy_core::parser::err::ParseErrors(e)))
+                .unwrap_or_else(|e| panic!("schema actions should all be valid EntityUIDs in this context, but {:?} led to an invalid one: {}", action_name, e))
 }
 
 /// internal helper function, convert a SchemaType to a Type (loses some


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

Sync up `cedar-drt` with https://github.com/cedar-policy/cedar/pull/148

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*