### PR TITLE
Fix build error caused by https://github.com/cedar-policy/cedar/pull/216

### DIFF
--- a/cedar-policy-generators/Cargo.toml
+++ b/cedar-policy-generators/Cargo.toml
@@ -11,6 +11,7 @@ cedar-policy-validator = { path = "../cedar/cedar-policy-validator", version = "
 clap = { version = "4.3.16", features = ["derive"] }
 highway = "0.8.1"
 serde = { version = "1.0", features = ["derive"] }
+serde_json = { version = "1.0" }
 smol_str = "0.2"
 rand = "0.8.5"
 anyhow = "1.0.72"

--- a/cedar-policy-generators/src/schema.rs
+++ b/cedar-policy-generators/src/schema.rs
@@ -3542,7 +3542,8 @@ impl Schema {
 
     /// Get the underlying schema file, as a String containing JSON
     pub fn schemafile_string(&self) -> String {
-        self.schema.to_string()
+        serde_json::to_string_pretty(&self.schema)
+            .expect("failed to serialize schema NamespaceDefinition")
     }
 }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Fix build error caused by https://github.com/cedar-policy/cedar/pull/216

This should build against the current cedar-policy main, so we can merge this before the larger panic annotation PR. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
