### PR TITLE
fix underflow bug

### DIFF
--- a/cedar-policy-generators/src/expr.rs
+++ b/cedar-policy-generators/src/expr.rs
@@ -248,7 +248,7 @@ impl<'a> ExprGenerator<'a> {
         u: &mut Unstructured<'_>,
     ) -> Result<ast::Expr> {
         if self.should_generate_unknown(max_depth, u)? {
-            let v = self.generate_value_for_type(target_type, max_depth - 1, u)?;
+            let v = self.generate_value_for_type(target_type, max_depth, u)?;
             let name = self.unknown_pool.alloc(target_type.clone(), v);
             Ok(ast::Expr::unknown(name))
         } else {


### PR DESCRIPTION
This is safe because `generate_value_for_type()` does not itself recurse into anything without decrementing `max_depth`.  We can just delegate to `generate_value_for_type()` without decrementing `max_depth`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
