### PR TITLE
Better testing for entity caching

### DIFF
--- a/cedar-drt/fuzz/fuzz_targets/abac-type-directed.rs
+++ b/cedar-drt/fuzz/fuzz_targets/abac-type-directed.rs
@@ -136,15 +136,35 @@ fuzz_target!(|input: FuzzTargetInput| {
     debug!("Schema: {}\n", input.schema.schemafile_string());
     debug!("Policies: {policyset}\n");
     debug!("Entities: {}\n", input.entities);
-    let entities = if input.should_cache_entities {
-        input.entities.evaluate().unwrap()
+    let original_entities = input.entities.clone();
+    let cached_entities = if input.should_cache_entities {
+        Some(input.entities.evaluate())
     } else {
-        input.entities
+        None
     };
     for q in input.requests.into_iter().map(Into::into) {
         debug!("Request : {q}");
         let (rust_res, total_dur) =
-            time_function(|| diff_tester.run_single_test(&q, &policyset, &entities));
+            time_function(|| diff_tester.run_single_test(&q, &policyset, &original_entities));
+
+        if let Some(ref entities) = cached_entities {
+            match entities {
+                Ok(entities) => {
+                    let (cached_rust_res, _total_dur) =
+                        time_function(|| diff_tester.run_single_test(&q, &policyset, entities));
+                    assert_eq!(rust_res, cached_rust_res);
+                }
+                Err(eval_er) => match &rust_res.diagnostics.errors[0] {
+                    authorizer::AuthorizationError::AttributeEvaluationError(e) => {
+                        assert_eq!(eval_er, e)
+                    }
+                    authorizer::AuthorizationError::PolicyEvaluationError { id, error } => {
+                        panic!("Wrong error! Got policy eval error {id} {error}")
+                    }
+                },
+            }
+        }
+
         info!("{}{}", TOTAL_MSG, total_dur.as_nanos());
 
         // additional invariant:


### PR DESCRIPTION
Fixing a bug in the entity cache tester, and actually difftests it against not using the entity cache


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
