### PR TITLE
cedar-policy-generators: handle existing schemas using common types

### DIFF
--- a/cedar-policy-generators/src/expr.rs
+++ b/cedar-policy-generators/src/expr.rs
@@ -3,8 +3,8 @@ use crate::collections::HashMap;
 use crate::err::{while_doing, Error, Result};
 use crate::hierarchy::{generate_uid_with_type, EntityUIDGenMode, Hierarchy};
 use crate::schema::{
-    arbitrary_specified_uid_without_schema, build_qualified_entity_type_name,
-    entity_type_name_to_schema_type, uid_for_action_name, unwrap_attrs_or_context, Schema,
+    arbitrary_specified_uid_without_schema, attrs_from_attrs_or_context,
+    build_qualified_entity_type_name, entity_type_name_to_schema_type, uid_for_action_name, Schema,
 };
 use crate::settings::ABACSettings;
 use crate::size_hint_utils::{size_hint_for_choose, size_hint_for_range, size_hint_for_ratio};
@@ -520,8 +520,8 @@ impl<'a> ExprGenerator<'a> {
                                 )
                                 .expect("Failed to select entity from map.");
                             let attr_names: Vec<&SmolStr> =
-                                unwrap_attrs_or_context(&entity_type.shape)
-                                    .0
+                                attrs_from_attrs_or_context(&self.schema.schema, &entity_type.shape)
+                                    .attrs
                                     .keys()
                                     .collect::<Vec<_>>();
                             let attr_name = SmolStr::clone(u.choose(&attr_names)?);

--- a/cedar-policy-generators/src/expr.rs
+++ b/cedar-policy-generators/src/expr.rs
@@ -4,8 +4,7 @@ use crate::err::{while_doing, Error, Result};
 use crate::hierarchy::{generate_uid_with_type, EntityUIDGenMode, Hierarchy};
 use crate::schema::{
     arbitrary_specified_uid_without_schema, build_qualified_entity_type_name,
-    entity_type_name_to_schema_type, uid_for_action_name, unwrap_attrs_or_context,
-    Schema,
+    entity_type_name_to_schema_type, uid_for_action_name, unwrap_attrs_or_context, Schema,
 };
 use crate::settings::ABACSettings;
 use crate::size_hint_utils::{size_hint_for_choose, size_hint_for_range, size_hint_for_ratio};
@@ -1683,7 +1682,15 @@ impl<'a> ExprGenerator<'a> {
         use cedar_policy_validator::SchemaType;
         use cedar_policy_validator::SchemaTypeVariant;
         match target_type {
-            SchemaType::TypeDef { type_name } => self.generate_attr_value_for_schematype(self.schema.schema.common_types.get(type_name).unwrap_or_else(|| panic!("reference to undefined common type: {type_name}")), max_depth, u),
+            SchemaType::TypeDef { type_name } => self.generate_attr_value_for_schematype(
+                self.schema
+                    .schema
+                    .common_types
+                    .get(type_name)
+                    .unwrap_or_else(|| panic!("reference to undefined common type: {type_name}")),
+                max_depth,
+                u,
+            ),
             SchemaType::Type(SchemaTypeVariant::Boolean) => {
                 self.generate_attr_value_for_type(&Type::bool(), max_depth, u)
             }
@@ -1774,7 +1781,9 @@ impl<'a> ExprGenerator<'a> {
                     self.arbitrary_uid_with_type(&entity_type_name, u)?,
                 ))
             }
-            SchemaType::Type(SchemaTypeVariant::Extension { .. }) if !self.settings.enable_extensions => {
+            SchemaType::Type(SchemaTypeVariant::Extension { .. })
+                if !self.settings.enable_extensions =>
+            {
                 panic!("shouldn't have SchemaTypeVariant::Extension with extensions disabled")
             }
             SchemaType::Type(SchemaTypeVariant::Extension { name }) => match name.as_str() {
@@ -1889,9 +1898,21 @@ impl<'a> ExprGenerator<'a> {
         use cedar_policy_validator::SchemaType;
         use cedar_policy_validator::SchemaTypeVariant;
         match target_type {
-            SchemaType::TypeDef { type_name } => self.generate_value_for_schematype(self.schema.schema.common_types.get(type_name).unwrap_or_else(|| panic!("reference to undefined common type: {type_name}")), max_depth, u),
-            SchemaType::Type(SchemaTypeVariant::Boolean) => self.generate_value_for_type(&Type::bool(), max_depth, u),
-            SchemaType::Type(SchemaTypeVariant::Long) => self.generate_value_for_type(&Type::long(), max_depth, u),
+            SchemaType::TypeDef { type_name } => self.generate_value_for_schematype(
+                self.schema
+                    .schema
+                    .common_types
+                    .get(type_name)
+                    .unwrap_or_else(|| panic!("reference to undefined common type: {type_name}")),
+                max_depth,
+                u,
+            ),
+            SchemaType::Type(SchemaTypeVariant::Boolean) => {
+                self.generate_value_for_type(&Type::bool(), max_depth, u)
+            }
+            SchemaType::Type(SchemaTypeVariant::Long) => {
+                self.generate_value_for_type(&Type::long(), max_depth, u)
+            }
             SchemaType::Type(SchemaTypeVariant::String) => {
                 self.generate_value_for_type(&Type::string(), max_depth, u)
             }

--- a/cedar-policy-generators/src/hierarchy.rs
+++ b/cedar-policy-generators/src/hierarchy.rs
@@ -2,7 +2,7 @@ use crate::abac::Type;
 use crate::collections::{HashMap, HashSet};
 use crate::err::{while_doing, Error, Result};
 use crate::expr::name_with_default_namespace;
-use crate::schema::{build_qualified_entity_type_name, unwrap_attrs_or_context, Schema};
+use crate::schema::{attrs_from_attrs_or_context, build_qualified_entity_type_name, Schema};
 use crate::size_hint_utils::{size_hint_for_choose, size_hint_for_ratio};
 use arbitrary::{Arbitrary, Unstructured};
 use cedar_policy_core::ast::{self, Eid, Entity, EntityUID};
@@ -511,13 +511,14 @@ impl<'a, 'u> HierarchyGenerator<'a, 'u> {
                         let Some(entitytypes_by_type) = &entitytypes_by_type else {
                             unreachable!("in schema-based mode, this should always be Some")
                         };
-                        let (attr_or_context, additional_attrs) = unwrap_attrs_or_context(
+                        let attributes = attrs_from_attrs_or_context(
+                            &schema.schema,
                             &entitytypes_by_type
                                 .get(name)
                                 .expect("typename should have an EntityType")
                                 .shape,
                         );
-                        if additional_attrs {
+                        if attributes.additional_attrs {
                             // maybe add some additional attributes with arbitrary types
                             self.u.arbitrary_loop(
                                 None,
@@ -544,7 +545,7 @@ impl<'a, 'u> HierarchyGenerator<'a, 'u> {
                                 },
                             )?;
                         }
-                        for (attr, ty) in attr_or_context {
+                        for (attr, ty) in attributes.attrs {
                             // now add the actual optional and required attributes, with the
                             // correct types.
                             // Doing this second ensures that we overwrite any "additional"

--- a/cedar-policy-generators/src/main.rs
+++ b/cedar-policy-generators/src/main.rs
@@ -67,7 +67,7 @@ fn generate_hierarchy_from_schema(byte_length: usize, args: &HierarchyArgs) -> R
     let f = File::open(&args.schema_file)?;
     let fragment = SchemaFragment::from_file(f)?;
     let mut rng = thread_rng();
-    let mut bytes = Vec::new();
+    let mut bytes = Vec::with_capacity(byte_length);
     bytes.resize_with(byte_length, || rng.gen());
     let mut u = Unstructured::new(&bytes);
     let schema = Schema::from_schemafrag(fragment, args.into(), &mut u)


### PR DESCRIPTION
Fixes the part of #96 that relates to handling existing schemas using common types.  (`Schema::arbitrary()` still doesn't generate schemas with common types.)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
