### PR TITLE
Make the generator to produce special `i64` values easier

### DIFF
--- a/cedar-policy-generators/src/abac.rs
+++ b/cedar-policy-generators/src/abac.rs
@@ -128,7 +128,8 @@ impl<'a> Arbitrary<'a> for BiasedI64 {
         Ok(gen!(u,
             1 => std::i64::MAX,
             1 => std::i64::MIN,
-            8 => <i64 as Arbitrary>::arbitrary(u)?
+            1 => -1,
+            7 => <i64 as Arbitrary>::arbitrary(u)?
         )
         .into())
     }

--- a/cedar-policy-generators/src/abac.rs
+++ b/cedar-policy-generators/src/abac.rs
@@ -129,7 +129,8 @@ impl<'a> Arbitrary<'a> for BiasedI64 {
             1 => std::i64::MAX,
             1 => std::i64::MIN,
             1 => -1,
-            7 => <i64 as Arbitrary>::arbitrary(u)?
+            1 => 0,
+            6 => <i64 as Arbitrary>::arbitrary(u)?
         )
         .into())
     }


### PR DESCRIPTION
This commit also uses library implementations of the `Arbitrary` trait for IP addresses.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
