### PR TITLE
Dont' generate record literals w/ dup keys

### DIFF
--- a/cedar-policy-generators/src/expr.rs
+++ b/cedar-policy-generators/src/expr.rs
@@ -856,7 +856,6 @@ impl<'a> ExprGenerator<'a> {
                                     Ok(std::ops::ControlFlow::Continue(()))
                                 },
                             )?;
-                            println!("Vector before conversion: {:?}", r);
                             Ok(ast::Expr::record(r).expect("can't have duplicate keys because `r` was already a HashMap"))
                         },
                         // if-then-else expression, where both arms are records

--- a/cedar-policy-generators/src/expr.rs
+++ b/cedar-policy-generators/src/expr.rs
@@ -839,7 +839,7 @@ impl<'a> ExprGenerator<'a> {
                         gen!(u,
                         // record literal
                         2 => {
-                            let mut r = Vec::new();
+                            let mut r = HashMap::new();
                             u.arbitrary_loop(
                                 Some(0),
                                 Some(self.settings.max_width as u32),
@@ -849,13 +849,14 @@ impl<'a> ExprGenerator<'a> {
                                         max_depth - 1,
                                         u,
                                     )?;
-                                    r.push((
+                                    r.insert(
                                         self.constant_pool.arbitrary_string_constant(u)?,
                                         attr_val,
-                                    ));
+                                    );
                                     Ok(std::ops::ControlFlow::Continue(()))
                                 },
                             )?;
+                            println!("Vector before conversion: {:?}", r);
                             Ok(ast::Expr::record(r).expect("can't have duplicate keys because `r` was already a HashMap"))
                         },
                         // if-then-else expression, where both arms are records


### PR DESCRIPTION
*Issue #, if available:*
N/A
*Description of changes:*
Generator for record literals wasn't correctly generating records w/ unique keys. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
