### PR TITLE
Change log to log ESTs

### DIFF
--- a/cedar-drt/fuzz/fuzz_targets/eval-type-directed.rs
+++ b/cedar-drt/fuzz/fuzz_targets/eval-type-directed.rs
@@ -15,6 +15,7 @@
  */
 
 #![no_main]
+use cedar_drt::utils::expr_to_est;
 use cedar_drt::*;
 use cedar_drt_inner::*;
 use cedar_policy_core::{
@@ -43,6 +44,7 @@ struct FuzzTargetInput {
     #[serde(skip)]
     pub entities: Entities,
     /// generated expression
+    #[serde(serialize_with = "expr_to_est")]
     pub expression: Expr,
     /// the requests to try for this hierarchy and policy. We try 8 requests per
     /// policy/hierarchy

--- a/cedar-drt/src/lib.rs
+++ b/cedar-drt/src/lib.rs
@@ -18,6 +18,7 @@
 mod cedar_test_impl;
 mod dafny_java_impl;
 mod logger;
+pub mod utils;
 
 pub use cedar_test_impl::*;
 pub use dafny_java_impl::*;

--- a/cedar-drt/src/utils.rs
+++ b/cedar-drt/src/utils.rs
@@ -1,0 +1,9 @@
+use cedar_policy_core::ast::Expr;
+use cedar_policy_core::est;
+use serde::Serialize;
+use serde::Serializer;
+
+pub fn expr_to_est<S: Serializer>(e: &Expr, s: S) -> Result<S::Ok, S::Error> {
+    let est: est::Expr = e.clone().into();
+    est.serialize(s)
+}

--- a/cedar-policy-generators/src/policy.rs
+++ b/cedar-policy-generators/src/policy.rs
@@ -3,10 +3,10 @@ use crate::err::Result;
 use crate::hierarchy::Hierarchy;
 use crate::size_hint_utils::size_hint_for_ratio;
 use arbitrary::{Arbitrary, Unstructured};
-use cedar_policy_core::ast;
 use cedar_policy_core::ast::{
-    Effect, EntityUID, Expr, Id, PolicyID, PolicySet, StaticPolicy, Template,
+    Effect, EntityUID, Expr, Id, Policy, PolicyID, PolicySet, StaticPolicy, Template,
 };
+use cedar_policy_core::{ast, est};
 use serde::Serialize;
 use smol_str::SmolStr;
 use std::fmt::Display;
@@ -18,7 +18,7 @@ use std::fmt::Display;
 // `arbitrary_for_hierarchy()`. But as of this writing, it feels like renaming
 // `GeneratedPolicy` to something like `GeneratedTemplate` seems unduly
 // disruptive.
-#[serde(into = "String")]
+#[serde(into = "est::Policy")]
 pub struct GeneratedPolicy {
     id: PolicyID,
     // use String for the impl of Arbitrary
@@ -28,6 +28,14 @@ pub struct GeneratedPolicy {
     action_constraint: ActionConstraint,
     resource_constraint: PrincipalOrResourceConstraint,
     abac_constraints: Expr,
+}
+
+impl From<GeneratedPolicy> for est::Policy {
+    fn from(gp: GeneratedPolicy) -> est::Policy {
+        let sp: StaticPolicy = gp.into();
+        let p: Policy = sp.into();
+        p.into()
+    }
 }
 
 impl GeneratedPolicy {


### PR DESCRIPTION
*Issue #, if available:*
N/A
*Description of changes:*
Before the logging option logged the debug printer form of policies. What we actually want is to log the EST format so we can read it back in.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
