### PR TITLE
Followup to #145

### DIFF
--- a/cedar-policy-generators/src/policy.rs
+++ b/cedar-policy-generators/src/policy.rs
@@ -292,7 +292,7 @@ impl PrincipalOrResourceConstraint {
                     1 => Ok(Self::IsTypeInSlot(hierarchy.arbitrary_entity_type(u)?))
                 )
             } else {
-                // 32% Eq, 32% In (16% with and without Is), 32% Is (16% with and without In)
+                // 32% Eq, 16% In, 16% Is, 16% IsIn
                 let uid = hierarchy.arbitrary_uid(u)?;
                 gen!(u,
                     2 => Ok(Self::Eq(uid)),

--- a/cedar-policy-generators/src/schema.rs
+++ b/cedar-policy-generators/src/schema.rs
@@ -1039,7 +1039,9 @@ impl Schema {
             Ok(PrincipalOrResourceConstraint::NoConstraint)
         } else {
             // 32% Eq, 16% In, 16% Is, 16% IsIn
-            let uid = self.exprgenerator(Some(hierarchy)).arbitrary_principal_uid(u)?;
+            let uid = self
+                .exprgenerator(Some(hierarchy))
+                .arbitrary_principal_uid(u)?;
             let ety = u.choose(self.entity_types())?.clone();
             gen!(u,
                 2 => Ok(PrincipalOrResourceConstraint::Eq(uid)),
@@ -1070,7 +1072,9 @@ impl Schema {
             Ok(PrincipalOrResourceConstraint::NoConstraint)
         } else {
             // 32% Eq, 16% In, 16% Is, 16% IsIn
-            let uid = self.exprgenerator(Some(hierarchy)).arbitrary_resource_uid(u)?;
+            let uid = self
+                .exprgenerator(Some(hierarchy))
+                .arbitrary_resource_uid(u)?;
             let ety = u.choose(self.entity_types())?.clone();
             gen!(u,
                 2 => Ok(PrincipalOrResourceConstraint::Eq(uid)),

--- a/cedar-policy-generators/src/schema.rs
+++ b/cedar-policy-generators/src/schema.rs
@@ -1034,15 +1034,20 @@ impl Schema {
         hierarchy: &Hierarchy,
         u: &mut Unstructured<'_>,
     ) -> Result<PrincipalOrResourceConstraint> {
-        // 20% of the time, NoConstraint; 40%, Eq; 40%, In
-        gen!(u,
-        2 => Ok(PrincipalOrResourceConstraint::NoConstraint),
-        4 => Ok(PrincipalOrResourceConstraint::Eq(
-            self.exprgenerator(Some(hierarchy)).arbitrary_principal_uid(u)?,
-        )),
-        4 => Ok(PrincipalOrResourceConstraint::In(
-            self.exprgenerator(Some(hierarchy)).arbitrary_principal_uid(u)?,
-        )))
+        // 20% of the time, NoConstraint
+        if u.ratio(1, 5)? {
+            Ok(PrincipalOrResourceConstraint::NoConstraint)
+        } else {
+            // 32% Eq, 16% In, 16% Is, 16% IsIn
+            let uid = self.exprgenerator(Some(hierarchy)).arbitrary_principal_uid(u)?;
+            let ety = u.choose(self.entity_types())?.clone();
+            gen!(u,
+                2 => Ok(PrincipalOrResourceConstraint::Eq(uid)),
+                1 => Ok(PrincipalOrResourceConstraint::In(uid)),
+                1 => Ok(PrincipalOrResourceConstraint::IsType(ety)),
+                1 => Ok(PrincipalOrResourceConstraint::IsTypeIn(ety, uid))
+            )
+        }
     }
     fn arbitrary_principal_constraint_size_hint(depth: usize) -> (usize, Option<usize>) {
         arbitrary::size_hint::and(
@@ -1060,15 +1065,20 @@ impl Schema {
         hierarchy: &Hierarchy,
         u: &mut Unstructured<'_>,
     ) -> Result<PrincipalOrResourceConstraint> {
-        // 20% of the time, NoConstraint; 40%, Eq; 40%, In
-        gen!(u,
-        2 => Ok(PrincipalOrResourceConstraint::NoConstraint),
-        4 => Ok(PrincipalOrResourceConstraint::Eq(
-            self.exprgenerator(Some(hierarchy)).arbitrary_resource_uid(u)?,
-        )),
-        4 => Ok(PrincipalOrResourceConstraint::In(
-            self.exprgenerator(Some(hierarchy)).arbitrary_resource_uid(u)?,
-        )))
+        // 20% of the time, NoConstraint
+        if u.ratio(1, 5)? {
+            Ok(PrincipalOrResourceConstraint::NoConstraint)
+        } else {
+            // 32% Eq, 16% In, 16% Is, 16% IsIn
+            let uid = self.exprgenerator(Some(hierarchy)).arbitrary_resource_uid(u)?;
+            let ety = u.choose(self.entity_types())?.clone();
+            gen!(u,
+                2 => Ok(PrincipalOrResourceConstraint::Eq(uid)),
+                1 => Ok(PrincipalOrResourceConstraint::In(uid)),
+                1 => Ok(PrincipalOrResourceConstraint::IsType(ety)),
+                1 => Ok(PrincipalOrResourceConstraint::IsTypeIn(ety, uid))
+            )
+        }
     }
     fn arbitrary_resource_constraint_size_hint(depth: usize) -> (usize, Option<usize>) {
         arbitrary::size_hint::and(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Followup to #145, which updated generators with support for the `is` operator. This PR adds support for generating `is` in scope constraints to `schema.rs` (which is used for most DRT targets). It mirrors the corresponding change made previously in `policy.rs` (which is used for the `rbac` target).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
