### PR TITLE
Make .lt strict.

### DIFF
--- a/cedar-lean/Cedar/Data/Int64.lean
+++ b/cedar-lean/Cedar/Data/Int64.lean
@@ -15,6 +15,7 @@
 -/
 
 import Std
+import Cedar.Data.LT
 
 /-!
 This file defines a signed 64-bit integer datatype similar to Rust's `i64`.
@@ -74,6 +75,23 @@ instance int64Le (i₁ i₂ : Int64) : Decidable (i₁ ≤ i₂) :=
 if h : Int64.le i₁ i₂ then isTrue h else isFalse h
 
 deriving instance Repr, DecidableEq for Int64
+
+instance strictLT : StrictLT Int64 where
+  asymmetric a b   := by
+    cases a ; cases b
+    simp [LT.lt, Int64.lt, Int.lt]
+    apply Int.strictLT.asymmetric
+  transitive a b c := by
+    simp [LT.lt, Int64.lt, Int.lt]
+    exact Int.strictLT.transitive a b c
+  connected  a b   := by
+    simp [LT.lt, Int64.lt, Int.lt]
+    intro h₁
+    apply Int.strictLT.connected a b
+    simp [h₁]
+    by_contra h₂
+    rcases (Subtype.eq h₂) with h₃
+    contradiction
 
 end Int64
 

--- a/cedar-lean/Cedar/Data/List.lean
+++ b/cedar-lean/Cedar/Data/List.lean
@@ -91,6 +91,26 @@ def mapM₂ {m : Type u → Type v} [Monad m] {γ : Type u} [SizeOf α] [SizeOf 
 
 ----- Theorems -----
 
+theorem mapM_pmap_subtype [Monad m] [LawfulMonad m]
+  {p : α → Prop}
+  (f : α → m β)
+  (as : List α)
+  (h : ∀ a, a ∈ as → p a)
+  : List.mapM (fun x : { a : α // p a } => f x.val) (List.pmap Subtype.mk as h)
+    =
+    List.mapM f as
+:= by
+  rw [←List.mapM'_eq_mapM]
+  induction as <;> simp [*]
+
+theorem mapM₁_eq_mapM [Monad m] [LawfulMonad m]
+  (f : α → m β)
+  (as : List α) :
+  List.mapM₁ as (fun x : { x // x ∈ as } => f x.val) =
+  List.mapM f as
+:= by
+  simp [mapM₁, attach, mapM_pmap_subtype]
+
 theorem Equiv.refl {a : List α} :
   a ≡ a
 := by unfold List.Equiv; simp

--- a/cedar-lean/Cedar/Data/Set.lean
+++ b/cedar-lean/Cedar/Data/Set.lean
@@ -34,7 +34,7 @@ deriving Repr, DecidableEq, Inhabited, Lean.ToJson
 
 namespace Set
 
-private def elts {α : Type u} : (Set α) -> (List α)
+def elts {α : Type u} : (Set α) -> (List α)
 | .mk elts => elts
 
 open Except
@@ -154,6 +154,17 @@ theorem make_eq_if_eqv [LT α] [DecidableLT α] [StrictLT α] (xs ys : List α) 
 := by
   intro h; unfold make; simp
   apply List.if_equiv_strictLT_then_canonical _ _ h
+
+theorem make_mem [LT α] [DecidableLT α] [StrictLT α] (x : α) (xs : List α) :
+  x ∈ xs ↔ x ∈ Set.make xs
+:= by
+  simp [make, Membership.mem, elts]
+  rcases (List.canonicalize_equiv xs) with h₁
+  simp [List.Equiv, List.subset_def] at h₁
+  rcases h₁ with ⟨h₁, h₂⟩
+  constructor <;> intro h₃
+  case mp => apply h₁ h₃
+  case mpr => apply h₂ h₃
 
 end Set
 

--- a/cedar-lean/Cedar/Spec/Ext/IPAddr.lean
+++ b/cedar-lean/Cedar/Spec/Ext/IPAddr.lean
@@ -251,8 +251,8 @@ def ip (str : String) : Option IPNet := parse str
 def IPNet.lt : IPNet → IPNet → Bool
   | .V4 _ _, .V6 _ _ => true
   | .V6 _ _, .V4 _ _ => false
-  | .V4 v₁ p₁, .V4 v₂ p₂ => v₁ < v₂ || (v₁ = v₂ && p₁ < p₂)
-  | .V6 v₁ p₁, .V6 v₂ p₂ => v₁ < v₂ || (v₁ = v₂ && p₁ < p₂)
+  | .V4 v₁ p₁, .V4 v₂ p₂ => v₁.val < v₂.val || (v₁.val = v₂.val && p₁.val < p₂.val)
+  | .V6 v₁ p₁, .V6 v₂ p₂ => v₁.val < v₂.val || (v₁.val = v₂.val && p₁.val < p₂.val)
 
 ----- IPNet deriviations -----
 

--- a/cedar-lean/Cedar/Spec/ExtFun.lean
+++ b/cedar-lean/Cedar/Spec/ExtFun.lean
@@ -39,7 +39,7 @@ inductive ExtFun where
   | isMulticast
   | isInRange
 
-private def res {α} [Coe α Ext] : Option α → Result Value
+def res {α} [Coe α Ext] : Option α → Result Value
   | some v => ok v
   | none   => error .extensionError
 


### PR DESCRIPTION
This PR makes the `.lt` relation strict on Cedar values and other auxiliary types.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
