### PR TITLE
Simplify the specification of Decimal.

### DIFF
--- a/cedar-lean/Cedar/Spec/Ext/Decimal.lean
+++ b/cedar-lean/Cedar/Spec/Ext/Decimal.lean
@@ -14,9 +14,13 @@
  limitations under the License.
 -/
 
+import Cedar.Data.Int64
+
 /-! This file defines Cedar decimal values and functions. -/
 
 namespace Cedar.Spec.Ext
+
+open Cedar.Data
 
 /--
 A decimal number consists of an integer part and a fractional part.
@@ -27,19 +31,15 @@ We restrict the number of the digits after the decimal point to 4.
 -/
 
 def DECIMAL_DIGITS : Nat := 4
-def DECIMAL_MIN : Int := -9223372036854775808
-def DECIMAL_MAX : Int :=  9223372036854775807
 
-abbrev Decimal := { i : Int // DECIMAL_MIN ≤ i ∧ i ≤ DECIMAL_MAX }
+abbrev Decimal := Int64
 
 namespace Decimal
 
 ----- Definitions -----
 
 def decimal? (i : Int) : Option Decimal :=
-  if h : DECIMAL_MIN ≤ i ∧ i ≤ DECIMAL_MAX
-  then .some (Subtype.mk i h)
-  else .none
+  Int64.mk? i
 
 def parse (str : String) : Option Decimal :=
   match str.split (· = '.') with
@@ -58,27 +58,6 @@ def parse (str : String) : Option Decimal :=
   | _ => .none
 
 abbrev decimal := parse
-
-def lt (d₁ d₂ : Decimal) : Bool := d₁.1 < d₂.1
-
-def le (d₁ d₂ : Decimal) : Bool := d₁.1 ≤ d₂.1
-
------ Derivations -----
-
-instance : LT Decimal where
-  lt := fun d₁ d₂ => Decimal.lt d₁ d₂
-
-instance : LE Decimal where
-  le := fun d₁ d₂ => Decimal.le d₁ d₂
-
-instance decLt (d₁ d₂ : Decimal) : Decidable (d₁ < d₂) :=
-if h : Decimal.lt d₁ d₂ then isTrue h else isFalse h
-
-instance decLe (d₁ d₂ : Decimal) : Decidable (d₁ ≤ d₂) :=
-if h : Decimal.le d₁ d₂ then isTrue h else isFalse h
-
-instance : Inhabited Decimal where
-  default := Subtype.mk 0 (by decide)
 
 end Decimal
 

--- a/cedar-lean/Cedar/Thm/Core/LT.lean
+++ b/cedar-lean/Cedar/Thm/Core/LT.lean
@@ -35,24 +35,6 @@ namespace Decide
 @[simp] theorem not_decide_eq_true {h : Decidable p} : ((!decide p) = true) = ¬ p := by cases h <;> simp [decide, *]
 end Decide
 
------ `<` is strict on `Decimal` -----
-
-instance Decimal.strictLT : StrictLT Ext.Decimal where
-  asymmetric a b   := by
-    cases a ; cases b
-    simp [LT.lt, Ext.Decimal.lt, Int.lt]
-    apply Int.strictLT.asymmetric
-  transitive a b c := by
-    simp [LT.lt, Ext.Decimal.lt, Int.lt]
-    exact Int.strictLT.transitive a b c
-  connected  a b   := by
-    simp [LT.lt, Ext.Decimal.lt, Int.lt]
-    intro h₁
-    apply Int.strictLT.connected a b
-    simp [h₁]
-    by_contra h₂
-    rcases (Subtype.eq h₂) with h₃
-    contradiction
 
 ----- `<` is strict on `IPNet` -----
 
@@ -154,9 +136,9 @@ instance Ext.strictLT : StrictLT Ext where
     cases a <;> cases b <;> simp [LT.lt, Ext.lt] <;>
     rename_i x₁ x₂ <;> intro h₁
     case decimal =>
-      rcases (Decimal.strictLT.asymmetric x₁ x₂) with h₂
+      rcases (Int64.strictLT.asymmetric x₁ x₂) with h₂
       simp [LT.lt] at h₂
-      cases h₃ : Ext.Decimal.lt x₁ x₂ <;>
+      cases h₃ : Int64.lt x₁ x₂ <;>
       simp [h₃] at h₁ h₂ ; simp [h₂]
     case ipaddr =>
       rcases (IPNet.strictLT.asymmetric x₁ x₂) with h₂
@@ -167,10 +149,10 @@ instance Ext.strictLT : StrictLT Ext where
     cases a <;> cases b <;> cases c <;> simp [LT.lt, Ext.lt] <;>
     rename_i x₁ x₂ x₃ <;> intro h₁ h₂
     case decimal =>
-      rcases (Decimal.strictLT.transitive x₁ x₂ x₃) with h₃
+      rcases (Int64.strictLT.transitive x₁ x₂ x₃) with h₃
       simp [LT.lt] at h₃
-      cases h₄ : Ext.Decimal.lt x₁ x₂ <;> simp [h₄] at *
-      cases h₅ : Ext.Decimal.lt x₂ x₃ <;> simp [h₅] at *
+      cases h₄ : Int64.lt x₁ x₂ <;> simp [h₄] at *
+      cases h₅ : Int64.lt x₂ x₃ <;> simp [h₅] at *
       simp [h₃]
     case ipaddr =>
       rcases (IPNet.strictLT.transitive x₁ x₂ x₃) with h₃
@@ -182,7 +164,7 @@ instance Ext.strictLT : StrictLT Ext where
     cases a <;> cases b <;> simp [LT.lt, Ext.lt] <;>
     rename_i x₁ x₂ <;> intro h₁
     case decimal =>
-      rcases (Decimal.strictLT.connected x₁ x₂) with h₂
+      rcases (Int64.strictLT.connected x₁ x₂) with h₂
       simp [LT.lt, h₁] at h₂
       rcases h₂ with h₂ | h₂ <;> simp [h₂]
     case ipaddr =>


### PR DESCRIPTION
This PR simplifies the specification of the Decimal type (and the accompanying proofs) by making it an abbreviation for `Int64`.  Its current specification repeats various parts of `Int64`, and this eliminates the repetition.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
