### PR TITLE
Fix decimal parsing bug

### DIFF
--- a/cedar-lean/Cedar/Spec/Ext/Decimal.lean
+++ b/cedar-lean/Cedar/Spec/Ext/Decimal.lean
@@ -43,6 +43,7 @@ def decimal? (i : Int) : Option Decimal :=
 
 def parse (str : String) : Option Decimal :=
   match str.split (· = '.') with
+  | ["-", _] => .none -- String.toInt? "-" == some 0
   | [left, right] =>
     let rlen := right.length
     if 0 < rlen ∧ rlen ≤ DECIMAL_DIGITS

--- a/cedar-lean/UnitTest/Decimal.lean
+++ b/cedar-lean/UnitTest/Decimal.lean
@@ -50,6 +50,7 @@ def testsForInvalidStrings :=
     testInvalid "1.-2" "invalid use of -",
     testInvalid "12" "no decimal point",
     testInvalid ".12" "no integer part",
+    testInvalid "-.12" "no integer part",
     testInvalid "12." "no fractional part",
     testInvalid "1.23456" "too many fractional digits",
     testInvalid "922337203685477.5808" "overflow",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Parsing bug uncovered by `eval-drt-type-directed-lean` fuzz target. Apparently `String.toInt? "-" == some 0` in Lean, which means that values like `-.12` were being interpreted the same way as `0.12`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
