### PR TITLE
Disable `like` in ABAC DRT targets

### DIFF
--- a/cedar-drt/fuzz/fuzz_targets/abac_shared.rs
+++ b/cedar-drt/fuzz/fuzz_targets/abac_shared.rs
@@ -55,7 +55,7 @@ const SETTINGS: ABACSettings = ABACSettings {
     max_depth: 3,
     max_width: 7,
     enable_additional_attributes: false,
-    enable_like: true,
+    enable_like: false,
     // ABAC fuzzing restricts the use of action because it is used to generate
     // the corpus tests which will be run on Cedar and CedarCLI.
     // These packages only expose the restricted action behavior.

--- a/cedar-drt/fuzz/fuzz_targets/abac_type_directed_shared.rs
+++ b/cedar-drt/fuzz/fuzz_targets/abac_type_directed_shared.rs
@@ -55,7 +55,7 @@ const SETTINGS: ABACSettings = ABACSettings {
     max_depth: 3,
     max_width: 3,
     enable_additional_attributes: false,
-    enable_like: true,
+    enable_like: false,
     enable_action_groups_and_attrs: true,
     enable_arbitrary_func_call: true,
     enable_unknowns: false,

--- a/cedar-drt/fuzz/fuzz_targets/eval_type_directed_shared.rs
+++ b/cedar-drt/fuzz/fuzz_targets/eval_type_directed_shared.rs
@@ -54,7 +54,7 @@ const SETTINGS: ABACSettings = ABACSettings {
     max_depth: 3,
     max_width: 3,
     enable_additional_attributes: false,
-    enable_like: true,
+    enable_like: false,
     enable_action_groups_and_attrs: true,
     enable_arbitrary_func_call: true,
     enable_unknowns: false,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Disallow `like` expressions from being generated by the ABAC DRT targets, pending a solution for #173. 

This is in the "shared" code, so it will affect both the Dafny and Lean targets. Obviously we will need to revert this PR in the future, but it will be convenient for now to ignore this (known) failure so it doesn't mask other (unknown) failures. Note that `like` expressions can still be generated in PBT targets.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
