### PR TITLE
call the modified fuzz_target! that logs

### DIFF
--- a/cedar-drt/fuzz/fuzz_targets/abac-type-directed.rs
+++ b/cedar-drt/fuzz/fuzz_targets/abac-type-directed.rs
@@ -18,7 +18,7 @@
 mod abac_type_directed_shared;
 
 use cedar_drt::*;
-use libfuzzer_sys::fuzz_target;
+use cedar_drt_inner::fuzz_target;
 
 fuzz_target!(|input: abac_type_directed_shared::FuzzTargetInput| {
     let def_engine = JavaDefinitionalEngine::new().expect("failed to create definitional engine");

--- a/cedar-drt/fuzz/fuzz_targets/abac.rs
+++ b/cedar-drt/fuzz/fuzz_targets/abac.rs
@@ -18,7 +18,7 @@
 mod abac_shared;
 
 use cedar_drt::*;
-use libfuzzer_sys::fuzz_target;
+use cedar_drt_inner::fuzz_target;
 
 fuzz_target!(|input: abac_shared::FuzzTargetInput| {
     let def_engine = JavaDefinitionalEngine::new().expect("failed to create definitional engine");

--- a/cedar-drt/fuzz/fuzz_targets/eval-type-directed.rs
+++ b/cedar-drt/fuzz/fuzz_targets/eval-type-directed.rs
@@ -18,7 +18,7 @@
 mod eval_type_directed_shared;
 
 use cedar_drt::*;
-use libfuzzer_sys::fuzz_target;
+use cedar_drt_inner::fuzz_target;
 
 fuzz_target!(|input: eval_type_directed_shared::FuzzTargetInput| {
     let def_engine = JavaDefinitionalEngine::new().expect("failed to create definitional engine");


### PR DESCRIPTION
*Issue #, if available:*
N/A
*Description of changes:*
Change recently reverted the call to `fuzz_target!` to directly use the one from `libfuzzer`. We want to call our modified one so we can log if we want to.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
