### PR TITLE
Cleanup in integration tests

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 # Check out the cedar submodule
-# git submodule update --init
+git submodule update --init
 
 # Set environment variables
 cd cedar-drt

--- a/build.sh
+++ b/build.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 # Check out the cedar submodule
-git submodule update --init
+# git submodule update --init
 
 # Set environment variables
 cd cedar-drt

--- a/cedar-drt/Cargo.toml
+++ b/cedar-drt/Cargo.toml
@@ -18,6 +18,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 lazy_static = "1.4"
 smol_str = { version = "0.2", features = ["serde"] }
+walkdir = "2.4"
 
 [dependencies.uuid]
 version = "1.3.1"

--- a/cedar-drt/Cargo.toml
+++ b/cedar-drt/Cargo.toml
@@ -18,6 +18,8 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 lazy_static = "1.4"
 smol_str = { version = "0.2", features = ["serde"] }
+
+[dev-dependencies]
 walkdir = "2.4"
 
 [dependencies.uuid]


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Followup to [cedar#550](https://github.com/cedar-policy/cedar/pull/550). Rather than explicitly listing which integration tests to run (which is difficult to maintain), we can now just just run every test in the `tests` folder.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
