### PR TITLE
Add scripts to generate corpus

### DIFF
--- a/cedar-drt/README.md
+++ b/cedar-drt/README.md
@@ -32,8 +32,12 @@ The sampling rate can be controlled by the `RATE` environment variable, which de
 ## Generating corpus tests
 
 When using the `abac` or `abac-type-directed` targets, you can set `DUMP_TEST_DIR` and `DUMP_TEST_NAME` to have the fuzzer write out inputs in the format used by our [integration tests](https://github.com/cedar-policy/cedar/tree/main/cedar-integration-tests).
-The `create_corpus.sh` script will run the fuzzer for a set amount of time (currently 15min), and then write the (minimized) corpus inputs into the `corpus_tests/` folder using the integration test format.
-You can control parameters (timeout and target) using the variables at the top of the script. 
+The `create_corpus.sh` script will run the fuzzer for a set amount of time and then write the (minimized) corpus inputs into a folder using the integration test format.
+You can adjust the script's behavior using the following environment variables:
+* `FUZZ_TARGET`: `abac` or `abac-type-directed` (default = `abac`)
+* `TIMEOUT`: how long to run (default = 15m)
+* `JOBS`: number of jobs (default = 4)
+* `DUMP_DIR`: where to write the results (default = `./corpus_tests`)
 
 ## Debugging build failures
 

--- a/cedar-drt/README.md
+++ b/cedar-drt/README.md
@@ -29,6 +29,11 @@ The table below lists all available fuzz targets, including which component of t
 If the fuzz targets are compiled with the `log` features, then they will log their entire corpus to the file pointed at in the `LOGFILE` environment variable.
 The sampling rate can be controlled by the `RATE` environment variable, which defaults to 100% if not set.
 
+## Generating corpus tests
+
+When using the `abac` or `abac-type-directed` targets, you can set `DUMP_TEST_DIR` and `DUMP_TEST_NAME` to have the fuzzer write out inputs in the format used by our [integration tests](https://github.com/cedar-policy/cedar/tree/main/cedar-integration-tests).
+The `create_corpus.sh` script will run the fuzzer for a set amount of time (currently 15min), and then write the (minimized) corpus inputs into the `corpus_tests/` folder using the integration test format.
+You can control parameters (timeout and target) using the variables at the top of the script. 
 
 ## Debugging build failures
 

--- a/cedar-drt/create_corpus.sh
+++ b/cedar-drt/create_corpus.sh
@@ -1,11 +1,14 @@
 #!/bin/bash
 
-FUZZ_TARGET=abac-type-directed
-TIMEOUT="15m" # 15m = 900s
+FUZZ_TARGET="${FUZZ_TARGET:-abac}"
+TIMEOUT="${TIMEOUT:-15m}" # 15m = 900s
+JOBS="${JOBS:-4}"
+DUMP_DIR="${DUMP_DIR:-corpus_tests}"
 
 # Assumes cedar-drt is already correctly built and configured
-rm -rf corpus_tests
+rm -rf $DUMP_DIR
 source set_env_vars.sh
 export FUZZ_TARGET
-timeout $TIMEOUT cargo fuzz run -s none $FUZZ_TARGET -j4 -- -rss_limit_mb=8196
+export DUMP_DIR
+timeout $TIMEOUT cargo fuzz run -s none $FUZZ_TARGET -j $JOBS -- -rss_limit_mb=8196
 ./synthesize_tests.sh

--- a/cedar-drt/create_corpus.sh
+++ b/cedar-drt/create_corpus.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+FUZZ_TARGET=abac-type-directed
+TIMEOUT="15m" # 15m = 900s
+
+# Assumes cedar-drt is already correctly built and configured
+rm -rf corpus_tests
+source set_env_vars.sh
+export FUZZ_TARGET
+timeout $TIMEOUT cargo fuzz run -s none $FUZZ_TARGET -j4 -- -rss_limit_mb=8196
+./synthesize_tests.sh

--- a/cedar-drt/fuzz/fuzz_targets/abac_shared.rs
+++ b/cedar-drt/fuzz/fuzz_targets/abac_shared.rs
@@ -134,12 +134,13 @@ pub fn fuzz(input: FuzzTargetInput, def_impl: &impl CedarTestImplementation) {
             let mut policyset = ast::PolicySet::new();
             let policy = policy.new_id(ast::PolicyID::from_string("policy0"));
             policyset.add_static(policy).unwrap();
-            let mut responses = Vec::with_capacity(requests.len());
-            for request in requests.iter() {
-                let authorizer = Authorizer::new();
-                let response = authorizer.is_authorized(request.clone(), &policyset, &entities);
-                responses.push(response);
-            }
+            let responses = requests
+                .iter()
+                .map(|request| {
+                    let authorizer = Authorizer::new();
+                    authorizer.is_authorized(request.clone(), &policyset, &entities)
+                })
+                .collect::<Vec<_>>();
             let dump_dir = std::env::var("DUMP_TEST_DIR").unwrap_or_else(|_| ".".to_string());
             dump(
                 dump_dir,
@@ -147,7 +148,7 @@ pub fn fuzz(input: FuzzTargetInput, def_impl: &impl CedarTestImplementation) {
                 &input.schema.into(),
                 &policyset,
                 &entities,
-                std::iter::zip(requests.iter(), responses.iter()),
+                std::iter::zip(requests, responses),
             )
             .expect("failed to dump test case");
         }

--- a/cedar-drt/fuzz/fuzz_targets/abac_type_directed_shared.rs
+++ b/cedar-drt/fuzz/fuzz_targets/abac_type_directed_shared.rs
@@ -17,6 +17,7 @@
 use cedar_drt::*;
 use cedar_drt_inner::*;
 use cedar_policy_core::ast;
+use cedar_policy_core::authorizer::Authorizer;
 use cedar_policy_core::entities::Entities;
 use cedar_policy_generators::{
     abac::{ABACPolicy, ABACRequest},
@@ -111,7 +112,8 @@ impl<'a> Arbitrary<'a> for FuzzTargetInput {
 pub fn fuzz(input: FuzzTargetInput, def_impl: &impl CedarTestImplementation) {
     initialize_log();
     let mut policyset = ast::PolicySet::new();
-    policyset.add_static(input.policy.into()).unwrap();
+    let policy: ast::StaticPolicy = input.policy.into();
+    policyset.add_static(policy.clone()).unwrap();
     debug!("Schema: {}\n", input.schema.schemafile_string());
     debug!("Policies: {policyset}\n");
     debug!("Entities: {}\n", input.entities);
@@ -121,7 +123,6 @@ pub fn fuzz(input: FuzzTargetInput, def_impl: &impl CedarTestImplementation) {
         .into_iter()
         .map(Into::into)
         .collect::<Vec<_>>();
-    let mut responses = Vec::with_capacity(requests.len());
 
     for request in requests.iter().cloned() {
         debug!("Request : {request}");
@@ -142,11 +143,20 @@ pub fn fuzz(input: FuzzTargetInput, def_impl: &impl CedarTestImplementation) {
                 .collect::<Vec<String>>(),
             Vec::<String>::new()
         );
-
-        responses.push(rust_res);
     }
 
     if let Ok(test_name) = std::env::var("DUMP_TEST_NAME") {
+        // When the corpus is re-parsed, the policy will be given id "policy0".
+        // Recreate the policy set and compute responses here to account for this.
+        let mut policyset = ast::PolicySet::new();
+        let policy = policy.new_id(ast::PolicyID::from_string("policy0"));
+        policyset.add_static(policy).unwrap();
+        let mut responses = Vec::with_capacity(requests.len());
+        for request in requests.iter() {
+            let authorizer = Authorizer::new();
+            let response = authorizer.is_authorized(request.clone(), &policyset, &input.entities);
+            responses.push(response);
+        }
         let dump_dir = std::env::var("DUMP_TEST_DIR").unwrap_or_else(|_| ".".to_string());
         dump(
             dump_dir,

--- a/cedar-drt/fuzz/src/dump.rs
+++ b/cedar-drt/fuzz/src/dump.rs
@@ -43,10 +43,9 @@ pub fn dump<'a>(
     entities: &Entities,
     requests: impl IntoIterator<Item = (&'a Request, &'a Response)>,
 ) -> std::io::Result<()> {
-    // If the policy cannot be re-parsed, or cannot be converted to json
-    // (both possible with our current generators), then ignore it. The
-    // corpus test format currently has no way to convey that a policy
-    // should fail to parse.
+    // If the policy cannot be re-parsed (which is possible with our current
+    // generators), then ignore it. The corpus test format currently has no way
+    // to convey that a policy should fail to parse.
     if !well_formed(policies) {
         return Ok(());
     }
@@ -133,19 +132,12 @@ pub fn dump<'a>(
     Ok(())
 }
 
-/// Check whether a policy set can be successfully parsed and converted to json
+/// Check whether a policy set can be successfully parsed
 fn well_formed(policies: &PolicySet) -> bool {
-    let valid_json = policies
-        .policies()
-        .cloned()
-        .all(|p| serde_json::to_value(cedar_policy_core::est::Policy::from(p)).is_ok());
-
-    let parsable = policies
+    policies
         .static_policies()
         .map(ToString::to_string)
-        .all(|p| Policy::from_str(&p).is_ok());
-
-    valid_json && parsable
+        .all(|p| Policy::from_str(&p).is_ok())
 }
 
 /// Check whether a policy set passes validation

--- a/cedar-drt/fuzz/src/dump.rs
+++ b/cedar-drt/fuzz/src/dump.rs
@@ -35,17 +35,17 @@ use std::str::FromStr;
 ///
 /// `testcasename`: a name to use for the testcase. Will be used in various
 /// filenames etc.
-pub fn dump<'a>(
+pub fn dump(
     dirname: impl AsRef<Path>,
     testcasename: &str,
     schema: &SchemaFragment,
     policies: &PolicySet,
     entities: &Entities,
-    requests: impl IntoIterator<Item = (&'a Request, &'a Response)>,
+    requests: impl IntoIterator<Item = (Request, Response)>,
 ) -> std::io::Result<()> {
-    // If the policy cannot be re-parsed (which is possible with our current
+    // If the policy set cannot be re-parsed (which is possible with our current
     // generators), then ignore it. The corpus test format currently has no way
-    // to convey that a policy should fail to parse.
+    // to convey that the input should fail to parse.
     if !well_formed(policies) {
         return Ok(());
     }
@@ -118,7 +118,7 @@ pub fn dump<'a>(
                         .reason()
                         .cloned()
                         .collect(),
-                    errors: cedar_policy::Response::from(a.clone())
+                    errors: cedar_policy::Response::from(a)
                         .diagnostics()
                         .errors()
                         .map(AuthorizationError::id)

--- a/cedar-drt/fuzz/src/dump.rs
+++ b/cedar-drt/fuzz/src/dump.rs
@@ -14,13 +14,15 @@
  * limitations under the License.
  */
 
-use cedar_policy_core::ast::{EntityUIDEntry, PolicyID, PolicySet, Request, RestrictedExpr};
-use cedar_policy_core::authorizer::{Decision, Response};
-use cedar_policy_core::entities::Entities;
+use cedar_policy::integration_testing::{JsonRequest, JsonTest};
+use cedar_policy_core::ast::{
+    Context, EntityType, EntityUID, EntityUIDEntry, PolicySet, Request, RestrictedExpr,
+};
+use cedar_policy_core::authorizer::Response;
+use cedar_policy_core::entities::{Entities, TypeAndId};
+use cedar_policy_core::jsonvalue::JsonValueWithNoDuplicateKeys;
 use cedar_policy_generators::collections::HashMap;
 use cedar_policy_validator::{SchemaFragment, ValidationMode, Validator, ValidatorSchema};
-use serde::Serialize;
-use smol_str::SmolStr;
 use std::io::Write;
 use std::path::Path;
 
@@ -83,45 +85,34 @@ pub fn dump<'a>(
         .open(testcase_filename)?;
     serde_json::to_writer_pretty(
         testcase_file,
-        &IntegrationTestCase {
-            schema: &schema_filename,
-            policies: &policies_filename,
-            entities: &entities_filename,
+        &JsonTest {
+            schema: schema_filename.display().to_string(),
+            policies: policies_filename.display().to_string(),
+            entities: entities_filename.display().to_string(),
             should_validate: passes_validation(schema.clone(), policies),
-            queries: requests
+            requests: requests
                 .into_iter()
                 .enumerate()
-                .map(|(i, (q, a))| IntegrationRequest {
+                .map(|(i, (q, a))| JsonRequest {
                     desc: format!("Request {i}"),
                     principal: dump_request_var(q.principal()),
                     action: dump_request_var(q.action()),
                     resource: dump_request_var(q.resource()),
-                    context: q
-                        .context()
-                        .map(|ctx| {
-                            ctx.iter()
-                                .map(|it| {
-                                    it.map(|(k, pval)| {
-                                        (
-                                            k.clone(),
-                                            RestrictedExpr::try_from(pval)
-                                                .unwrap()
-                                                .to_natural_json()
-                                                .unwrap(),
-                                        )
-                                    })
-                                    .collect::<HashMap<_, _>>()
-                                })
-                                .unwrap_or_default() // for purely-unknown Context, use empty map
-                        })
-                        .unwrap_or_default(),
+                    context: dump_context(
+                        q.context()
+                            .expect("`dump` does not support requests missing context"),
+                    ),
+                    enable_request_validation: true,
                     decision: a.decision,
-                    reasons: &a.diagnostics.reason,
-                    errors: a
-                        .diagnostics
-                        .errors
-                        .iter()
-                        .map(|e| e.id)
+                    reasons: cedar_policy::Response::from(a.clone())
+                        .diagnostics()
+                        .reason()
+                        .cloned()
+                        .collect(),
+                    errors: cedar_policy::Response::from(a.clone())
+                        .diagnostics()
+                        .error_policy_ids()
+                        .cloned()
                         .collect(),
                 })
                 .collect(),
@@ -131,7 +122,7 @@ pub fn dump<'a>(
     Ok(())
 }
 
-/// Check whether a policyset passes validation
+/// Check whether a policy set passes validation
 fn passes_validation(schema: SchemaFragment, policies: &PolicySet) -> bool {
     if let Ok(schema) = ValidatorSchema::try_from(schema) {
         let validator = Validator::new(schema);
@@ -143,55 +134,42 @@ fn passes_validation(schema: SchemaFragment, policies: &PolicySet) -> bool {
     }
 }
 
-/// Dump the entity uid to a string if it is specified, otherwise return `None`,
-/// which will appear as `null` in the JSON dump.
-fn dump_request_var(var: &EntityUIDEntry) -> Option<String> {
+/// Dump the entity uid to a json value if it is specified, otherwise return `None`
+fn dump_request_var(var: &EntityUIDEntry) -> Option<JsonValueWithNoDuplicateKeys> {
     match var {
-        EntityUIDEntry::Unknown { .. } => None,
+        EntityUIDEntry::Unknown { .. } => {
+            panic!("`dump` does not support requests with unknown fields")
+        }
         EntityUIDEntry::Known { euid, .. } => match euid.entity_type() {
-            cedar_policy_core::ast::EntityType::Unspecified => None,
-            cedar_policy_core::ast::EntityType::Specified(_) => Some(euid.to_string()),
+            EntityType::Unspecified => None,
+            EntityType::Specified(_) => {
+                let json = serde_json::to_value(TypeAndId::from(euid as &EntityUID))
+                    .expect("failed to serialize euid")
+                    .into();
+                Some(json)
+            }
         },
     }
 }
 
-/// Serde format for an integration test case
-// TODO (#191): Unify with `JsonTest` type from `cedar-policy::integration_testing`
-#[derive(Debug, Clone, Serialize)]
-struct IntegrationTestCase<'a> {
-    /// Schema filename
-    schema: &'a Path,
-    /// Policies filename
-    policies: &'a Path,
-    /// Whether the policies in the policies file should pass validation with
-    /// the schema in the schema file
-    should_validate: bool,
-    /// Entities filename
-    entities: &'a Path,
-    /// One or more queries
-    queries: Vec<IntegrationRequest<'a>>,
-}
-
-/// Serde format for an integration request
-// TODO (#191): Unify with `JsonRequest` type from `cedar-policy::integration_testing`
-#[derive(Debug, Clone, Serialize)]
-struct IntegrationRequest<'a> {
-    /// Description of the behavior that we're testing/expecting.
-    /// For the automated testcases we're dumping here, we don't use this for
-    /// anything useful.
-    desc: String,
-    /// Principal
-    principal: Option<String>,
-    /// Action
-    action: Option<String>,
-    /// Resource
-    resource: Option<String>,
-    /// Context
-    context: HashMap<SmolStr, serde_json::Value>,
-    /// Decision
-    decision: Decision,
-    /// Reasons
-    reasons: &'a std::collections::HashSet<PolicyID>,
-    /// List of policies that are expected to return errors
-    errors: &'a std::collections::HashSet<PolicyID>,
+/// Dump the context to a "natural" json value
+fn dump_context(context: &Context) -> JsonValueWithNoDuplicateKeys {
+    let context = context
+        .iter()
+        .map(|it| {
+            it.map(|(k, pval)| {
+                (
+                    k.clone(),
+                    RestrictedExpr::try_from(pval)
+                        .unwrap()
+                        .to_natural_json()
+                        .unwrap(),
+                )
+            })
+            .collect::<HashMap<_, _>>()
+        })
+        .unwrap_or_default();
+    serde_json::to_value(context)
+        .expect("failed to serialize context")
+        .into()
 }

--- a/cedar-drt/fuzz/src/dump.rs
+++ b/cedar-drt/fuzz/src/dump.rs
@@ -87,7 +87,7 @@ pub fn dump<'a>(
             schema: &schema_filename,
             policies: &policies_filename,
             entities: &entities_filename,
-            should_validate: passes_validation(schema, policies),
+            should_validate: passes_validation(schema.clone(), policies),
             queries: requests
                 .into_iter()
                 .enumerate()
@@ -121,7 +121,7 @@ pub fn dump<'a>(
                         .diagnostics
                         .errors
                         .iter()
-                        .map(ToString::to_string)
+                        .map(|e| e.id)
                         .collect(),
                 })
                 .collect(),
@@ -132,8 +132,8 @@ pub fn dump<'a>(
 }
 
 /// Check whether a policyset passes validation
-fn passes_validation(schema: &SchemaFragment, policies: &PolicySet) -> bool {
-    if let Ok(schema) = ValidatorSchema::try_from(schema.clone()) {
+fn passes_validation(schema: SchemaFragment, policies: &PolicySet) -> bool {
+    if let Ok(schema) = ValidatorSchema::try_from(schema) {
         let validator = Validator::new(schema);
         validator
             .validate(policies, ValidationMode::default())
@@ -156,6 +156,7 @@ fn dump_request_var(var: &EntityUIDEntry) -> Option<String> {
 }
 
 /// Serde format for an integration test case
+// TODO (#191): Unify with `JsonTest` type from `cedar-policy::integration_testing`
 #[derive(Debug, Clone, Serialize)]
 struct IntegrationTestCase<'a> {
     /// Schema filename
@@ -172,6 +173,7 @@ struct IntegrationTestCase<'a> {
 }
 
 /// Serde format for an integration request
+// TODO (#191): Unify with `JsonRequest` type from `cedar-policy::integration_testing`
 #[derive(Debug, Clone, Serialize)]
 struct IntegrationRequest<'a> {
     /// Description of the behavior that we're testing/expecting.
@@ -190,6 +192,6 @@ struct IntegrationRequest<'a> {
     decision: Decision,
     /// Reasons
     reasons: &'a std::collections::HashSet<PolicyID>,
-    /// Errors
-    errors: Vec<String>,
+    /// List of policies that are expected to return errors
+    errors: &'a std::collections::HashSet<PolicyID>,
 }

--- a/cedar-drt/synthesize_tests.sh
+++ b/cedar-drt/synthesize_tests.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+set -ex
+
+DUMP_DIR="./corpus_tests"
+
+CURDIR=$(realpath .)
+
+mkdir -p $DUMP_DIR
+source set_env_vars.sh
+
+set -u
+
+# Minimize corpus to remove redundant seeds
+cargo fuzz cmin "$FUZZ_TARGET" -s none
+
+run_single_test () {
+    # We could use `cargo fuzz run "$FUZZ_TARGET" -s none "$1"``
+    # but this adds extra overhead to every test. We accept that overhead
+    # the first time (see below), but subsequent times we just directly invoke
+    # the executable.
+    "./fuzz/target/x86_64-unknown-linux-gnu/release/$FUZZ_TARGET" -artifact_prefix="$CURDIR/fuzz/artifacts/$FUZZ_TARGET" "$1"
+}
+
+# Run the first input to make sure everything is built
+hash=$(ls "fuzz/corpus/$FUZZ_TARGET" | head -n 1)
+DUMP_TEST_DIR=$DUMP_DIR \
+DUMP_TEST_NAME=$hash \
+cargo fuzz run "$FUZZ_TARGET" -s none "fuzz/corpus/$FUZZ_TARGET/$hash"
+
+for hash in $(ls "fuzz/corpus/$FUZZ_TARGET"); do
+    DUMP_TEST_DIR=$DUMP_DIR \
+    DUMP_TEST_NAME=$hash \
+    run_single_test "fuzz/corpus/$FUZZ_TARGET/$hash"
+done

--- a/cedar-drt/synthesize_tests.sh
+++ b/cedar-drt/synthesize_tests.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 set -ex
 
-DUMP_DIR="./corpus_tests"
-
 CURDIR=$(realpath .)
 
 mkdir -p $DUMP_DIR
@@ -14,7 +12,7 @@ set -u
 cargo fuzz cmin "$FUZZ_TARGET" -s none
 
 run_single_test () {
-    # We could use `cargo fuzz run "$FUZZ_TARGET" -s none "$1"``
+    # We could use `cargo fuzz run "$FUZZ_TARGET" -s none "$1"`
     # but this adds extra overhead to every test. We accept that overhead
     # the first time (see below), but subsequent times we just directly invoke
     # the executable.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Added scripts to generate corpus files, towards solving [cedar#552](https://github.com/cedar-policy/cedar/issues/552). Also included some minor refactoring + added support for logging corpus tests from the `abac-type-directed` targets and resolves #191.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
