### PR TITLE
set_env_vars.sh: better behavior when lean not installed or not on PATH

### DIFF
--- a/cedar-drt/set_env_vars.sh
+++ b/cedar-drt/set_env_vars.sh
@@ -28,12 +28,16 @@ if [ -f "$(pwd)/../cedar-dafny-java-wrapper/build/libs/cedar-dafny-java-wrapper.
 fi
 
 # Set environment variables for Lean
-export LEAN_LIB_DIR=$(lean --print-libdir)
-export LD_LIBRARY_PATH=${LD_LIBRARY_PATH+$LD_LIBRARY_PATH:}$(lean --print-libdir)
-export DYLD_LIBRARY_PATH=${DYLD_LIBRARY_PATH+$DYLD_LIBRARY_PATH:}$(lean --print-libdir)
+if ! command -v lean &> /dev/null; then
+    echo "lean executable could not be found. is lean installed?"
+else
+    export LEAN_LIB_DIR=$(lean --print-libdir)
+    export LD_LIBRARY_PATH=${LD_LIBRARY_PATH+$LD_LIBRARY_PATH:}$(lean --print-libdir)
+    export DYLD_LIBRARY_PATH=${DYLD_LIBRARY_PATH+$DYLD_LIBRARY_PATH:}$(lean --print-libdir)
 
-# if the version of GLIBC is too old (< 2.27), then use the verison of libm.so packaged with Lean
-GLIBC_VERSION=`ldd --version | awk '/ldd/{print $NF}'`
-if awk "BEGIN {exit !($GLIBC_VERSION < 2.27)}"; then
-    export LD_PRELOAD=${LD_PRELOAD+$LD_PRELOAD:}$(lean --print-prefix)/lib/glibc/libm.so
+    # if the version of GLIBC is too old (< 2.27), then use the verison of libm.so packaged with Lean
+    GLIBC_VERSION=`ldd --version | awk '/ldd/{print $NF}'`
+    if awk "BEGIN {exit !($GLIBC_VERSION < 2.27)}"; then
+        export LD_PRELOAD=${LD_PRELOAD+$LD_PRELOAD:}$(lean --print-prefix)/lib/glibc/libm.so
+    fi
 fi


### PR DESCRIPTION
*Issue #, if available:*

Tangentially mentioned in #194 

*Description of changes:*

Have `set_env_vars.sh` provide an error message and skip Lean-related initialization if `lean` is not installed or not on `PATH`.  Before this PR, it will (among other things) set `LD_PRELOAD` to a bogus path, which has undesirable effects.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
