### PR TITLE
chore: use omega for linear arithmetic

### DIFF
--- a/cedar-lean/Cedar/Data/Int64.lean
+++ b/cedar-lean/Cedar/Data/Int64.lean
@@ -69,24 +69,27 @@ if h : Int64.lt i₁ i₂ then isTrue h else isFalse h
 instance int64Le (i₁ i₂ : Int64) : Decidable (i₁ ≤ i₂) :=
 if h : Int64.le i₁ i₂ then isTrue h else isFalse h
 
+theorem ext_iff {i₁ i₂ : Int64} : i₁ = i₂ ↔ i₁.1 = i₂.1 := by
+  cases i₁; cases i₂; simp
+
+theorem lt_def {i₁ i₂ : Int64} : i₁ < i₂ ↔ i₁.1 < i₂.1 := by
+  simp [LT.lt, Int64.lt]
+
+theorem le_def {i₁ i₂ : Int64} : i₁ ≤ i₂ ↔ i₁.1 ≤ i₂.1 := by
+  simp [LE.le, Int64.le]
+
 deriving instance Repr, DecidableEq for Int64
 
 instance strictLT : StrictLT Int64 where
   asymmetric a b   := by
-    cases a ; cases b
-    simp [LT.lt, Int64.lt, Int.lt]
-    apply Int.strictLT.asymmetric
+    simp [Int64.lt_def]
+    omega
   transitive a b c := by
-    simp [LT.lt, Int64.lt, Int.lt]
-    exact Int.strictLT.transitive a b c
+    simp [Int64.lt_def]
+    omega
   connected  a b   := by
-    simp [LT.lt, Int64.lt, Int.lt]
-    intro h₁
-    apply Int.strictLT.connected a b
-    simp [h₁]
-    by_contra h₂
-    rcases (Subtype.eq h₂) with h₃
-    contradiction
+    simp [Int64.lt_def, Int64.ext_iff]
+    omega
 
 end Int64
 

--- a/cedar-lean/Cedar/Data/LT.lean
+++ b/cedar-lean/Cedar/Data/LT.lean
@@ -208,35 +208,24 @@ instance Bool.strictLT : StrictLT Bool where
 instance Nat.strictLT : StrictLT Nat where
   asymmetric a b   := Nat.lt_asymm
   transitive a b c := Nat.lt_trans
-  connected  a b   := by
-    intro h₁
-    rcases (Nat.lt_trichotomy a b) with h₂
-    simp [h₁] at h₂
-    exact h₂
+  connected  a b   := by omega
 
 instance Int.strictLT : StrictLT Int where
-  asymmetric a b   := by
-    intro h₁
-    rw [Int.not_lt]
-    rw [Int.lt_iff_le_not_le] at h₁
-    simp [h₁]
+  asymmetric a b   := by omega
   transitive a b c := Int.lt_trans
-  connected  a b   := by
-    intro h₁
-    rcases (Int.lt_trichotomy a b) with h₂
-    simp [h₁] at h₂
-    exact h₂
+  connected  a b   := by omega
+
+theorem UInt32.lt_iff {x y : UInt32} : x < y ↔ x.1.1 < y.1.1 := by
+  cases x; cases y; simp [LT.lt]
+theorem UInt32.ext_iff {x y : UInt32} : x = y ↔ x.1.1 = y.1.1 :=
+  ⟨by simp_all, UInt32.ext⟩
 
 instance UInt32.strictLT : StrictLT UInt32 where
   asymmetric a b   := by apply Nat.strictLT.asymmetric
   transitive a b c := by apply Nat.strictLT.transitive
   connected  a b   := by
-    intro h₁
-    apply Nat.strictLT.connected
-    by_contra h₂
-    have h₃ : a.val = b.val := by apply Fin.eq_of_val_eq; exact h₂
-    have h₄ : a = b := by apply congrArg mk h₃
-    contradiction
+    simp [UInt32.lt_iff, UInt32.ext_iff]
+    omega
 
 instance Char.strictLT : StrictLT Char where
   asymmetric a b   := by apply UInt32.strictLT.asymmetric

--- a/cedar-lean/Cedar/Data/List.lean
+++ b/cedar-lean/Cedar/Data/List.lean
@@ -69,17 +69,9 @@ theorem sizeOf_snd_lt_sizeOf_list {α : Type u} {β : Type v} [SizeOf α] [SizeO
   x ∈ xs → sizeOf x.snd < 1 + sizeOf xs
 := by
   intro h
-  rw [Nat.add_comm]
-  apply Nat.lt_add_right
-  apply @Nat.lt_trans (sizeOf x.snd) (sizeOf x) (sizeOf xs)
-  {
-    simp [Prod._sizeOf_inst, Prod._sizeOf_1]
-    rw [Nat.add_comm]
-    apply Nat.lt_add_of_pos_right
-    apply Nat.add_pos_left
-    apply Nat.one_pos
-  }
-  { apply List.sizeOf_lt_of_mem; exact h }
+  have := List.sizeOf_lt_of_mem h
+  have : sizeOf x = 1 + sizeOf x.1 + sizeOf x.2 := rfl
+  omega
 
 def attach₂ {α : Type u} {β : Type v} [SizeOf α] [SizeOf β] (xs : List (α × β)) :
 List { x : α × β // sizeOf x.snd < 1 + sizeOf xs } :=

--- a/cedar-lean/Cedar/Thm/Core/LT.lean
+++ b/cedar-lean/Cedar/Thm/Core/LT.lean
@@ -40,49 +40,18 @@ end Decide
 
 theorem IPNet.lt_asymm {a₁ a₂ p₁ p₂ : Nat} :
   a₁ < a₂ ∨ a₁ = a₂ ∧ p₁ < p₂ → ¬(a₂ < a₁ ∨ a₂ = a₁ ∧ p₂ < p₁)
-:= by
-  intro h₁
-  rcases h₁ with h₁ | h₁ <;> by_contra h₂
-  case inl =>
-    rcases h₂ with h₂ | h₂
-    case inl =>
-      rcases (Nat.lt_asymm h₁) with h₂
-      contradiction
-    case inr =>
-      rcases (StrictLT.not_eq a₁ a₂ h₁) with h₃
-      rw [eq_comm] at h₃
-      simp [h₃] at h₂
-  case inr =>
-    simp [h₁] at h₂
-    rcases h₁ with ⟨_, h₁⟩
-    rcases (Nat.lt_asymm h₁) with h₃
-    contradiction
+:= by omega
 
 theorem IPNet.lt_trans {a₁ a₂ a₃ p₁ p₂ p₃ : Nat}
   (h₁ : a₁ < a₂ ∨ a₁ = a₂ ∧ p₁ < p₂)
   (h₂ : a₂ < a₃ ∨ a₂ = a₃ ∧ p₂ < p₃) :
   a₁ < a₃ ∨ a₁ = a₃ ∧ p₁ < p₃
-:= by
-  rcases h₁ with h₁ | h₁ <;> rcases h₂ with h₂ | h₂
-  case inl.inl =>
-    rcases (Nat.lt_trans h₁ h₂) with h₃ ; simp [h₃]
-  case inl.inr =>
-    rcases h₂ with ⟨h₂, _⟩ ; subst h₂ ; simp [h₁]
-  case inr.inl =>
-    rcases h₁ with ⟨h₁, _⟩ ; subst h₁ ; simp [h₂]
-  case inr.inr =>
-    rcases h₁ with ⟨hl₁, h₁⟩ ; subst hl₁
-    rcases h₂ with ⟨hl₂, h₂⟩ ; subst hl₂
-    rcases (Nat.lt_trans h₁ h₂) with h₃ ; simp [h₃]
+:= by omega
 
 theorem IPNet.lt_conn {a₁ a₂ p₁ p₂ : Nat}
   (h₁ : a₁ = a₂ → ¬p₁ = p₂) :
   (a₁ < a₂ ∨ a₁ = a₂ ∧ p₁ < p₂) ∨ a₂ < a₁ ∨ a₂ = a₁ ∧ p₂ < p₁
-:= by
-  rcases (Nat.lt_trichotomy a₁ a₂) with h₂
-  rcases h₂ with h₂ | h₂ | h₂ <;> simp [h₂]
-  simp [h₂] at h₁
-  apply Nat.strictLT.connected ; simp [h₁]
+:= by omega
 
 instance IPNet.strictLT : StrictLT Ext.IPAddr.IPNet where
   asymmetric a b   := by

--- a/cedar-lean/Cedar/Thm/Core/Std.lean
+++ b/cedar-lean/Cedar/Thm/Core/Std.lean
@@ -52,11 +52,7 @@ functions.
 
 theorem Nat.lt_add_of_one_and_other (n m : Nat) :
   n < 1 + m + n
-:= by
-  rw [Nat.add_comm]
-  apply Nat.lt_add_of_pos_right
-  apply Nat.add_pos_left
-  apply Nat.one_pos
+:= by omega
 
 -- List.mapM lemmas
 

--- a/cedar-lean/lake-manifest.json
+++ b/cedar-lean/lake-manifest.json
@@ -4,7 +4,7 @@
  [{"url": "https://github.com/leanprover/std4",
    "type": "git",
    "subDir": null,
-   "rev": "3959bc5de5142d06d7673ec091d406e5abe45bf0",
+   "rev": "ca91956e8d5c311e00d6a69eb93d5eb5eef9b37d",
    "name": "std",
    "manifestFile": "lake-manifest.json",
    "inputRev": "main",


### PR DESCRIPTION
*Description of changes:*

This PR updates the dependency on the Lean Standard Library to the latest version, and then uses the new tactic `omega` to handle all the proofs about inequalities in `Nat` and `Int`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Please feel free to accept or reject the various changes separately, as they should all be independent.