### PR TITLE
replace trivial `rcases` with `have`

### DIFF
--- a/cedar-lean/Cedar/Data/LT.lean
+++ b/cedar-lean/Cedar/Data/LT.lean
@@ -32,7 +32,7 @@ theorem StrictLT.irreflexive [LT α] [StrictLT α] (x : α) :
   ¬ x < x
 := by
   by_contra h₁
-  rcases (StrictLT.asymmetric x x h₁) with h₂
+  have h₂ := StrictLT.asymmetric x x h₁
   contradiction
 
 theorem StrictLT.if_not_lt_gt_then_eq [LT α] [StrictLT α] (x y : α) :
@@ -40,7 +40,7 @@ theorem StrictLT.if_not_lt_gt_then_eq [LT α] [StrictLT α] (x y : α) :
 := by
   intro h₁ h₂
   by_contra h₃
-  rcases (StrictLT.connected x y h₃) with h₄
+  have h₄ := StrictLT.connected x y h₃
   simp [h₁, h₂] at h₄
 
 theorem StrictLT.not_eq [LT α] [StrictLT α] (x y : α) :
@@ -49,7 +49,7 @@ theorem StrictLT.not_eq [LT α] [StrictLT α] (x y : α) :
   intro h₁
   by_contra h₂
   subst h₂
-  rcases (StrictLT.irreflexive x) with h₃
+  have h₃ := StrictLT.irreflexive x
   contradiction
 
 abbrev DecidableLT (α) [LT α] := DecidableRel (α := α) (· < ·)
@@ -82,14 +82,14 @@ theorem List.lt_irrefl [LT α] [StrictLT α] (xs : List α) :
   case nil => by_contra; contradiction
   case cons _ _ hd tl ih =>
     by_contra h₁
-    rcases (StrictLT.irreflexive hd) with h₂
+    have h₂ := StrictLT.irreflexive hd
     cases tl
     case nil =>
-      rcases (List.lt_cons_cases h₁) with h₃
+      have h₃ := List.lt_cons_cases h₁
       simp [h₂] at h₃
       contradiction
     case cons _ _ hd' tl' =>
-      rcases (List.lt_cons_cases h₁) with h₃
+      have h₃ := List.lt_cons_cases h₁
       simp [h₂] at h₃
       contradiction
 
@@ -105,19 +105,19 @@ theorem List.lt_trans [LT α] [StrictLT α] {xs ys zs : List α} :
       apply List.lt.head
       apply StrictLT.transitive _ _ _ h₃ h₄
     case tail _ _ zhd ztl h₄ h₅ h₆ =>
-      rcases (StrictLT.if_not_lt_gt_then_eq yhd zhd h₄ h₅) with h₇
+      have h₇ := StrictLT.if_not_lt_gt_then_eq yhd zhd h₄ h₅
       subst h₇
       apply List.lt.head
       exact h₃
   case tail _ _ xhd xtl yhd ytl h₃ h₄ h₅ =>
     cases h₂
     case head _ _ zhd ztl h₆ =>
-      rcases (StrictLT.if_not_lt_gt_then_eq xhd yhd h₃ h₄) with h₇
+      have h₇ := StrictLT.if_not_lt_gt_then_eq xhd yhd h₃ h₄
       subst h₇
       apply List.lt.head
       exact h₆
     case tail _ _ zhd ztl h₆ h₇ h₈ =>
-      rcases (StrictLT.if_not_lt_gt_then_eq xhd yhd h₃ h₄) with h₉
+      have h₉ := StrictLT.if_not_lt_gt_then_eq xhd yhd h₃ h₄
       subst h₉
       apply List.lt.tail h₆ h₇
       apply List.lt_trans h₅ h₈
@@ -135,8 +135,8 @@ theorem List.lt_asymm [LT α] [StrictLT α] {xs ys : List α} :
     case nil => contradiction
     case cons _ _ hd' tl' =>
       by_contra h₂
-      rcases (List.lt_trans h₁ h₂) with h₃
-      rcases (List.lt_irrefl (hd :: tl)) with h₄
+      have h₃ := List.lt_trans h₁ h₂
+      have h₄ := List.lt_irrefl (hd :: tl)
       contradiction
 
 theorem List.lt_conn [LT α] [StrictLT α] {xs ys : List α} :
@@ -145,36 +145,36 @@ theorem List.lt_conn [LT α] [StrictLT α] {xs ys : List α} :
   intro h₁
   by_contra h₂
   simp [not_or] at h₂
-  rcases h₂ with ⟨h₂, h₃⟩
+  have ⟨h₂, h₃⟩ := h₂
   cases xs <;> cases ys
-  case intro.nil.nil => contradiction
-  case intro.nil.cons _ _ xhd xtl =>
-    rcases (List.lt.nil xhd xtl) with h₄
+  case nil.nil => contradiction
+  case nil.cons _ _ xhd xtl _ =>
+    have h₄ := List.lt.nil xhd xtl
     contradiction
-  case intro.cons.nil _ _ yhd ytl =>
-    rcases (List.lt.nil yhd ytl) with h₄
+  case cons.nil _ _ yhd ytl _ =>
+    have h₄ := List.lt.nil yhd ytl
     contradiction
-  case intro.cons.cons _ _ xhd xtl yhd ytl =>
+  case cons.cons _ _ xhd xtl yhd ytl _ =>
     by_cases (xhd < yhd)
     case pos h₄ =>
-      rcases (List.lt.head xtl ytl h₄) with h₅
+      have h₅ := List.lt.head xtl ytl h₄
       contradiction
     case neg h₄ =>
       by_cases (yhd < xhd)
       case pos h₅ =>
-        rcases (List.lt.head ytl xtl h₅) with h₆
+        have h₆ := List.lt.head ytl xtl h₅
         contradiction
       case neg h₅ =>
-        rcases (StrictLT.if_not_lt_gt_then_eq xhd yhd h₄ h₅) with h₆
+        have h₆ := StrictLT.if_not_lt_gt_then_eq xhd yhd h₄ h₅
         subst h₆
         simp at h₁
-        rcases (List.lt_conn h₁) with h₆
+        have h₆ := List.lt_conn h₁
         cases h₆
         case inl _ _ h₆ =>
-          rcases (List.cons_lt_cons xhd xtl ytl h₆) with h₇
+          have h₇ := List.cons_lt_cons xhd xtl ytl h₆
           contradiction
         case inr _ _ h₆ =>
-          rcases (List.cons_lt_cons xhd ytl xtl h₆) with h₇
+          have h₇ := List.cons_lt_cons xhd ytl xtl h₆
           contradiction
 
 instance List.strictLT (α) [LT α] [StrictLT α] : StrictLT (List α) where

--- a/cedar-lean/Cedar/Data/List.lean
+++ b/cedar-lean/Cedar/Data/List.lean
@@ -131,7 +131,7 @@ theorem cons_equiv_cons (x : α) (xs ys : List α) :
 := by
   unfold List.Equiv
   intro h₁
-  rcases h₁ with ⟨h₁, h₂⟩
+  have ⟨h₁, h₂⟩ := h₁
   apply And.intro
   all_goals {
     apply List.cons_subset_cons; assumption
@@ -197,16 +197,16 @@ theorem if_strictly_sorted_equiv_then_head_eq [LT α] [StrictLT α] (x y : α) (
 := by
   intro h₁ h₂
   unfold List.Equiv; intro h₃
-  rcases h₃ with ⟨h₃, h₄⟩
+  have ⟨h₃, h₄⟩ := h₃
   simp at h₃; simp at h₄
-  rcases h₃ with ⟨h₃, _⟩
-  rcases h₄ with ⟨h₄, _⟩
+  have ⟨h₃, _⟩ := h₃
+  have ⟨h₄, _⟩ := h₄
   cases h₃ <;> cases h₄ <;> try { assumption }
-  case intro _ h₅ => simp [h₅]
-  case intro h₅ h₆ =>
-    rcases (if_strictly_sorted_then_head_lt_tail x xs h₁ y h₆) with hc₁
-    rcases (if_strictly_sorted_then_head_lt_tail y ys h₂ x h₅) with hc₂
-    rcases (StrictLT.asymmetric x y hc₁) with hc₃
+  case _ _ h₅ => simp [h₅]
+  case _ h₅ h₆ =>
+    have hc₁ := if_strictly_sorted_then_head_lt_tail x xs h₁ y h₆
+    have hc₂ := if_strictly_sorted_then_head_lt_tail y ys h₂ x h₅
+    have hc₃ := StrictLT.asymmetric x y hc₁
     contradiction
 
 theorem if_strictly_sorted_equiv_then_tail_subset [LT α] [StrictLT α] (x : α) (xs ys : List α) :
@@ -225,8 +225,8 @@ theorem if_strictly_sorted_equiv_then_tail_subset [LT α] [StrictLT α] (x : α)
   case inr => assumption
   case inl _ h₅ =>
     subst h₅
-    rcases (if_strictly_sorted_then_head_lt_tail y xs h₁ y h₄) with h₆
-    rcases (StrictLT.irreflexive y) with h₇
+    have h₆ := if_strictly_sorted_then_head_lt_tail y xs h₁ y h₄
+    have h₇ := StrictLT.irreflexive y
     contradiction
 
 theorem if_strictly_sorted_equiv_then_tail_equiv [LT α] [StrictLT α] (x : α) (xs ys : List α) :
@@ -314,19 +314,19 @@ theorem insertCanonical_sorted [LT α] [StrictLT α] [DecidableLT α] (x : α) (
       case neg _ _ h₃ =>
         simp [h₃]
         unfold GT.gt at h₃
-        rcases (StrictLT.if_not_lt_gt_then_eq x hd h₂ h₃) with h₄
+        have h₄ := StrictLT.if_not_lt_gt_then_eq x hd h₂ h₃
         subst h₄
         exact h₁
       case pos _ _ h₃ =>
         simp [h₃]
         cases tl
         case nil =>
-          rcases (insertCanonical_singleton id x) with h₄
+          have h₄ := insertCanonical_singleton id x
           simp [h₄]
           apply Sorted.cons_cons (by apply h₃) Sorted.cons_nil
         case cons _ _ hd' tl' =>
           simp at ih
-          rcases (insertCanonical_cases x hd' tl') with h₄
+          have h₄ := insertCanonical_cases x hd' tl'
           cases h₄
           case inl _ _ _ h₄ =>
             rcases h₄ with ⟨h₄, h₅⟩
@@ -346,7 +346,7 @@ theorem insertCanonical_sorted [LT α] [StrictLT α] [DecidableLT α] (x : α) (
               rcases h₄ with ⟨h₄, h₅, h₆⟩
               simp [h₆]
               unfold GT.gt at h₅
-              rcases (StrictLT.if_not_lt_gt_then_eq x hd' h₄ h₅) with h₇
+              have h₇ := StrictLT.if_not_lt_gt_then_eq x hd' h₄ h₅
               subst h₇
               exact h₁
 
@@ -363,18 +363,18 @@ theorem insertCanonical_equiv [LT α] [StrictLT α] [DecidableLT α] (x : α) (x
     case inr _ _ h₁ =>
       split
       case inr _ _ h₂ =>
-        rcases (StrictLT.if_not_lt_gt_then_eq x hd h₁ h₂) with h₃
+        have h₃ := StrictLT.if_not_lt_gt_then_eq x hd h₁ h₂
         subst h₃
         exact dup_head_equiv x tl
       case inl _ _ h₂ =>
         cases tl
         case nil =>
-          rcases (insertCanonical_singleton id x) with h₃
+          have h₃ := insertCanonical_singleton id x
           simp [h₃]
           apply swap_cons_cons_equiv
         case cons _ _ _ hd' tl' =>
           simp at ih
-          rcases (insertCanonical_cases x hd' tl') with h₃
+          have h₃ := insertCanonical_cases x hd' tl'
           cases h₃
           case inl _ _ _ h₃ =>
             simp [h₃]
@@ -391,7 +391,7 @@ theorem insertCanonical_equiv [LT α] [StrictLT α] [DecidableLT α] (x : α) (x
               rcases h₃ with ⟨h₃, h₄, h₅⟩
               simp [h₅]
               unfold GT.gt at h₄
-              rcases (StrictLT.if_not_lt_gt_then_eq x hd' h₃ h₄) with h₆
+              have h₆ := StrictLT.if_not_lt_gt_then_eq x hd' h₃ h₄
               subst h₆
               unfold List.Equiv
               simp only [cons_subset, mem_cons, true_or, or_true, Subset.refl, and_self, subset_cons]
@@ -399,7 +399,7 @@ theorem insertCanonical_equiv [LT α] [StrictLT α] [DecidableLT α] (x : α) (x
               rcases h₃ with ⟨h₃, h₄, h₅⟩
               simp [h₅]
               simp [h₃, h₄] at ih
-              rcases (swap_cons_cons_equiv x hd (hd' :: tl')) with h₆
+              have h₆ := swap_cons_cons_equiv x hd (hd' :: tl')
               apply Equiv.trans h₆
               apply cons_equiv_cons
               exact ih
@@ -433,7 +433,7 @@ theorem canonicalize_equiv [LT α] [StrictLT α] [DecidableLT α] (xs : List α)
     unfold canonicalize
     generalize h₁ : canonicalize id tl = ys
     simp [h₁] at ih
-    rcases (insertCanonical_equiv hd ys) with h₂
+    have h₂ := insertCanonical_equiv hd ys
     apply Equiv.trans _ h₂
     apply cons_equiv_cons
     exact ih
@@ -455,8 +455,8 @@ theorem if_equiv_strictLT_then_canonical [LT α] [StrictLT α] [DecidableLT α] 
   apply if_strictly_sorted_equiv_then_eq
   exact (canonicalize_sorted xs)
   exact (canonicalize_sorted ys)
-  rcases (Equiv.symm (canonicalize_equiv xs)) with h₂
-  rcases (Equiv.symm (canonicalize_equiv ys)) with h₃
+  have h₂ := Equiv.symm (canonicalize_equiv xs)
+  have h₃ := Equiv.symm (canonicalize_equiv ys)
   apply Equiv.trans h₂
   apply Equiv.symm
   apply Equiv.trans h₃
@@ -485,7 +485,7 @@ theorem insertCanonical_preserves_forallᵥ {α β γ} [LT α] [StrictLT α] [De
       apply Forall₂.cons (by exact h₃) (by exact h₄)
     case inl.inr h₅ h₆ =>
       simp [h₁, h₃] at h₅
-      rcases (StrictLT.asymmetric kv₂.fst hd₂.fst h₅) with _
+      have _ := StrictLT.asymmetric kv₂.fst hd₂.fst h₅
       split <;> contradiction
     case inr.inl h₅ h₆ =>
       simp [h₁, h₃] at h₅ h₆
@@ -511,7 +511,7 @@ theorem canonicalize_preserves_forallᵥ {α β γ} [LT α] [StrictLT α] [Decid
     simp [canonicalize_nil]
   case cons hd₁ hd₂ tl₁ tl₂ h₂ h₃ =>
     simp [canonicalize]
-    rcases (canonicalize_preserves_forallᵥ p tl₁ tl₂ h₃) with h₄
+    have h₄ := canonicalize_preserves_forallᵥ p tl₁ tl₂ h₃
     apply insertCanonical_preserves_forallᵥ h₂ h₄
 
 theorem any_of_mem {f : α → Bool} {x : α} {xs : List α}

--- a/cedar-lean/Cedar/Data/Set.lean
+++ b/cedar-lean/Cedar/Data/Set.lean
@@ -178,7 +178,7 @@ theorem make_eqv [LT α] [DecidableLT α] [StrictLT α] {xs ys : List α} :
   Set.make xs = Set.mk ys → xs ≡ ys
 := by
   simp [make] ; intro h₁
-  rcases (List.canonicalize_equiv xs) with h₂
+  have h₂ := List.canonicalize_equiv xs
   subst h₁
   exact h₂
 
@@ -186,9 +186,9 @@ theorem make_mem [LT α] [DecidableLT α] [StrictLT α] (x : α) (xs : List α) 
   x ∈ xs ↔ x ∈ Set.make xs
 := by
   simp [make, Membership.mem, elts]
-  rcases (List.canonicalize_equiv xs) with h₁
+  have h₁ := List.canonicalize_equiv xs
   simp [List.Equiv, List.subset_def] at h₁
-  rcases h₁ with ⟨h₁, h₂⟩
+  have ⟨h₁, h₂⟩ := h₁
   constructor <;> intro h₃
   case mp => apply h₁ h₃
   case mpr => apply h₂ h₃
@@ -197,19 +197,19 @@ theorem make_any_iff_any [LT α] [DecidableLT α] [StrictLT α] (f : α → Bool
   (Set.make xs).any f = xs.any f
 := by
   simp [make, any, elts]
-  rcases (List.canonicalize_equiv xs) with h₁
+  have h₁ := List.canonicalize_equiv xs
   simp [List.Equiv, List.subset_def] at h₁
-  rcases h₁ with ⟨hl₁, hr₁⟩
+  have ⟨hl₁, hr₁⟩ := h₁
   cases h₃ : List.any xs f
   case false =>
     by_contra h₄
     simp only [Bool.not_eq_false, List.any_eq_true] at h₄
-    rcases h₄ with ⟨x, h₄, h₅⟩
+    have ⟨x, h₄, h₅⟩ := h₄
     specialize hr₁ h₄
     simp [List.any_of_mem hr₁ h₅] at h₃
   case true =>
     simp [List.any_eq_true] at *
-    rcases h₃ with ⟨x, h₃, h₄⟩
+    have ⟨x, h₃, h₄⟩ := h₃
     exists x ; simp [h₄]
     apply hl₁ h₃
 

--- a/cedar-lean/Cedar/Thm/Authorization.lean
+++ b/cedar-lean/Cedar/Thm/Authorization.lean
@@ -80,7 +80,7 @@ theorem default_deny (request : Request) (entities : Entities) (policies : Polic
   by_contra h2
   cases dec
   case allow =>
-    rcases (allowed_if_explicitly_permitted request entities policies h1) with h3
+    have h3 := allowed_if_explicitly_permitted request entities policies h1
     contradiction
   case deny => contradiction
 
@@ -93,8 +93,8 @@ theorem order_and_dup_independent (request : Request) (entities : Entities) (pol
   isAuthorized request entities policies₁ = isAuthorized request entities policies₂
 := by
   intro h
-  rcases (satisfiedPolicies_order_and_dup_independent forbid request entities policies₁ policies₂ h) with hf
-  rcases (satisfiedPolicies_order_and_dup_independent permit request entities policies₁ policies₂ h) with hp
+  have hf := satisfiedPolicies_order_and_dup_independent forbid request entities policies₁ policies₂ h
+  have hp := satisfiedPolicies_order_and_dup_independent permit request entities policies₁ policies₂ h
   unfold isAuthorized
   simp [hf, hp]
 

--- a/cedar-lean/Cedar/Thm/Authorization/Authorizer.lean
+++ b/cedar-lean/Cedar/Thm/Authorization/Authorizer.lean
@@ -36,7 +36,7 @@ theorem if_satisfied_then_satisfiedPolicies_non_empty (effect : Effect) (policie
   intro h0
   cases h0
   case intro policy h1 =>
-    rcases h1 with ⟨ha, hb, hc⟩
+    have ⟨ha, hb, hc⟩ := h1
     unfold satisfiedPolicies
     rw [←Set.make_non_empty]
     apply @List.ne_nil_of_mem _ policy.id
@@ -56,9 +56,9 @@ theorem if_satisfiedPolicies_non_empty_then_satisfied (effect : Effect) (policie
   unfold satisfiedPolicies
   intro h0
   rw [←Set.make_non_empty] at h0
-  rcases List.exists_mem_of_ne_nil _ h0 with ⟨pid, h1⟩
+  have ⟨pid, h1⟩ := List.exists_mem_of_ne_nil _ h0
   rw [List.mem_filterMap] at h1
-  rcases h1 with ⟨policy, h1, h2⟩
+  have ⟨policy, h1, h2⟩ := h1
   unfold satisfiedWithEffect at h2
   apply Exists.intro policy
   simp [h1]
@@ -118,7 +118,7 @@ theorem satisfied_implies_principal_scope {policy : Policy} {request : Request} 
   intro h₁ h₂
   simp [satisfied] at h₁
   unfold Policy.toExpr at h₁
-  rcases (and_true_implies_left_true h₁) with h₃
+  have h₃ := and_true_implies_left_true h₁
   clear h₁
   simp [PrincipalScope.toExpr, Scope.toExpr] at h₃
   simp [Scope.bound, PrincipalScope.scope] at h₂
@@ -133,7 +133,7 @@ theorem satisfied_implies_principal_scope {policy : Policy} {request : Request} 
     simp [evaluate, Var.inEntityUID, apply₂] at h₃
     exact h₃
   case isMem =>
-    rcases (and_true_implies_right_true h₃) with h₅
+    have h₅ := and_true_implies_right_true h₃
     simp [evaluate, Var.inEntityUID, apply₂] at h₅
     exact h₅
 
@@ -163,7 +163,7 @@ theorem satisfied_implies_resource_scope {policy : Policy} {request : Request} {
     simp [evaluate, Var.inEntityUID, apply₂] at h₃
     exact h₃
   case isMem =>
-    rcases (and_true_implies_right_true h₃) with h₅
+    have h₅ := and_true_implies_right_true h₃
     simp [evaluate, Var.inEntityUID, apply₂] at h₅
     exact h₅
 

--- a/cedar-lean/Cedar/Thm/Authorization/Evaluator.lean
+++ b/cedar-lean/Cedar/Thm/Authorization/Evaluator.lean
@@ -53,7 +53,7 @@ theorem and_true_implies_right_true {e₁ e₂ : Expr} {request : Request} {enti
   evaluate e₂ request entities = .ok true
 := by
   intro h₁
-  rcases (and_true_implies_left_true h₁) with h₂
+  have h₂ := and_true_implies_left_true h₁
   simp [evaluate, h₂, Result.as, Coe.coe, Value.asBool] at h₁
   generalize h₃ : (evaluate e₂ request entities) = r₂
   simp [h₃] at h₁

--- a/cedar-lean/Cedar/Thm/Core/LT.lean
+++ b/cedar-lean/Cedar/Thm/Core/LT.lean
@@ -71,7 +71,7 @@ instance IPNet.strictLT : StrictLT Ext.IPAddr.IPNet where
     simp [LT.lt, Ext.IPAddr.IPNet.lt] at h₁ h₂ ; split at h₁ <;> split at h₂ <;>
     simp [LT.lt, Ext.IPAddr.IPNet.lt] at * <;>
     rename_i h₃ <;>
-    rcases h₃ with ⟨h₃, h₄⟩ <;> subst h₃ h₄
+    have ⟨h₃, h₄⟩ := h₃ <;> subst h₃ h₄
     case h_3 a₁ p₁ a₂ p₂ _ _ a₃ p₃ =>
       cases a₁ ; rename_i a₁ ; cases a₁
       cases a₂ ; rename_i a₂ ; cases a₂
@@ -108,12 +108,12 @@ instance Ext.strictLT : StrictLT Ext where
     cases a <;> cases b <;> simp [LT.lt, Ext.lt] <;>
     rename_i x₁ x₂ <;> intro h₁
     case decimal =>
-      rcases (Int64.strictLT.asymmetric x₁ x₂) with h₂
+      have h₂ := Int64.strictLT.asymmetric x₁ x₂
       simp [LT.lt] at h₂
       cases h₃ : Int64.lt x₁ x₂ <;>
       simp [h₃] at h₁ h₂ ; simp [h₂]
     case ipaddr =>
-      rcases (IPNet.strictLT.asymmetric x₁ x₂) with h₂
+      have h₂ := IPNet.strictLT.asymmetric x₁ x₂
       simp [LT.lt] at h₂
       cases h₃ : Ext.IPAddr.IPNet.lt x₁ x₂ <;>
       simp [h₃] at h₁ h₂ ; simp [h₂]
@@ -121,13 +121,13 @@ instance Ext.strictLT : StrictLT Ext where
     cases a <;> cases b <;> cases c <;> simp [LT.lt, Ext.lt] <;>
     rename_i x₁ x₂ x₃ <;> intro h₁ h₂
     case decimal =>
-      rcases (Int64.strictLT.transitive x₁ x₂ x₃) with h₃
+      have h₃ := Int64.strictLT.transitive x₁ x₂ x₃
       simp [LT.lt] at h₃
       cases h₄ : Int64.lt x₁ x₂ <;> simp [h₄] at *
       cases h₅ : Int64.lt x₂ x₃ <;> simp [h₅] at *
       simp [h₃]
     case ipaddr =>
-      rcases (IPNet.strictLT.transitive x₁ x₂ x₃) with h₃
+      have h₃ := IPNet.strictLT.transitive x₁ x₂ x₃
       simp [LT.lt] at h₃
       cases h₄ : Ext.IPAddr.IPNet.lt x₁ x₂ <;> simp [h₄] at *
       cases h₅ : Ext.IPAddr.IPNet.lt x₂ x₃ <;> simp [h₅] at *
@@ -136,11 +136,11 @@ instance Ext.strictLT : StrictLT Ext where
     cases a <;> cases b <;> simp [LT.lt, Ext.lt] <;>
     rename_i x₁ x₂ <;> intro h₁
     case decimal =>
-      rcases (Int64.strictLT.connected x₁ x₂) with h₂
+      have h₂ := Int64.strictLT.connected x₁ x₂
       simp [LT.lt, h₁] at h₂
       rcases h₂ with h₂ | h₂ <;> simp [h₂]
     case ipaddr =>
-      rcases (IPNet.strictLT.connected x₁ x₂) with h₂
+      have h₂ := IPNet.strictLT.connected x₁ x₂
       simp [LT.lt, h₁] at h₂
       rcases h₂ with h₂ | h₂ <;> simp [h₂]
 
@@ -171,20 +171,20 @@ theorem EntityUID.lt_asymm {a b : EntityUID} :
   simp [LT.lt, EntityUID.lt]
   intro h₁
   by_contra h₂
-  rcases (Name.strictLT.asymmetric a.ty b.ty) with h₃
+  have h₃ := Name.strictLT.asymmetric a.ty b.ty
   simp [LT.lt] at h₃
   rcases h₁ with h₁ | h₁ <;> rcases h₂ with h₂ | h₂
   case inl.inl =>
     simp only [h₁, h₂, forall_const] at h₃
   case inl.inr =>
-    rcases h₂ with ⟨h₂, _⟩
+    have ⟨h₂, _⟩ := h₂
     rw [h₂] at h₁ h₃
     simp [h₁] at h₃
   case inr.inl =>
-    rcases (StrictLT.not_eq b.ty a.ty h₂) with h₄
+    have h₄ := StrictLT.not_eq b.ty a.ty h₂
     simp [h₁] at h₄
   case inr.inr =>
-    rcases (String.strictLT.asymmetric a.eid b.eid) with h₄
+    have h₄ := String.strictLT.asymmetric a.eid b.eid
     simp [LT.lt, h₁, h₂] at h₄
 
 theorem EntityUID.lt_trans {a b c : EntityUID} :
@@ -194,22 +194,22 @@ theorem EntityUID.lt_trans {a b c : EntityUID} :
   intro h₁ h₂
   rcases h₁ with h₁ | h₁ <;> rcases h₂ with h₂ | h₂
   case inl.inl =>
-    rcases (Name.strictLT.transitive a.ty b.ty c.ty h₁ h₂) with h₃
+    have h₃ := Name.strictLT.transitive a.ty b.ty c.ty h₁ h₂
     simp only [LT.lt] at h₃
     simp [h₃]
   case inl.inr =>
-    rcases h₂ with ⟨h₂, _⟩
+    have ⟨h₂, _⟩ := h₂
     simp [h₂] at h₁
     simp [h₁]
   case inr.inl =>
-    rcases h₁ with ⟨h₁, _⟩
+    have ⟨h₁, _⟩ := h₁
     simp [←h₁] at h₂
     simp [h₂]
   case inr.inr =>
-    rcases h₁ with ⟨hl₁, hr₁⟩
-    rcases h₂ with ⟨hl₂, hr₂⟩
+    have ⟨hl₁, hr₁⟩ := h₁
+    have ⟨hl₂, hr₂⟩ := h₂
     simp [hl₁] at * ; simp [hl₂] at *
-    rcases (String.strictLT.transitive a.eid b.eid c.eid hr₁ hr₂) with h₃
+    have h₃ := String.strictLT.transitive a.eid b.eid c.eid hr₁ hr₂
     simp only [LT.lt] at h₃
     simp [h₃]
 
@@ -227,7 +227,7 @@ theorem EntityUID.lt_conn {a b : EntityUID} :
     apply String.strictLT.connected
     simp [h₁]
   case neg h₂ =>
-    rcases (Name.strictLT.connected ty₁ ty₂ h₂) with h₃
+    have h₃ := Name.strictLT.connected ty₁ ty₂ h₂
     rcases h₃ with h₃ | h₃ <;> simp [h₃]
 
 instance EntityUID.strictLT : StrictLT EntityUID where
@@ -282,11 +282,11 @@ theorem Value.lt_irrefl (v : Value) :
   case prim => exact StrictLT.irreflexive w
   case set =>
     cases w ; rename_i ws ; simp [Value.lt]
-    rcases (Values.lt_irrefl ws) with h₁
+    have h₁ := Values.lt_irrefl ws
     simp [h₁]
   case record =>
     cases w ; rename_i ws ; simp [Value.lt]
-    rcases (ValueAttrs.lt_irrefl ws) with h₁
+    have h₁ := ValueAttrs.lt_irrefl ws
     simp [h₁]
   case ext => exact StrictLT.irreflexive w
 
@@ -297,10 +297,10 @@ theorem Values.lt_irrefl (vs : List Value) :
   by_contra h₁
   rcases h₁ with h₁ | h₁
   case inl =>
-    rcases (Value.lt_irrefl hd) with h₂
+    have h₂ := Value.lt_irrefl hd
     simp [h₁] at h₂
   case inr =>
-    rcases (Values.lt_irrefl tl) with h₂
+    have h₂ := Values.lt_irrefl tl
     simp [h₁] at h₂
 
 theorem ValueAttrs.lt_irrefl (vs : List (Attr × Value)) :
@@ -313,13 +313,13 @@ theorem ValueAttrs.lt_irrefl (vs : List (Attr × Value)) :
   case inl =>
     rcases h₁ with h₁ | h₁
     case inl =>
-      rcases (StrictLT.irreflexive a) with h₂
+      have h₂ := StrictLT.irreflexive a
       contradiction
     case inr =>
-      rcases (Value.lt_irrefl v) with h₂
+      have h₂ := Value.lt_irrefl v
       contradiction
   case inr =>
-    rcases (ValueAttrs.lt_irrefl tl) with h₂
+    have h₂ := ValueAttrs.lt_irrefl tl
     contradiction
 
 end
@@ -330,7 +330,7 @@ theorem Value.lt_not_eq {x y : Value} :
   intro h₁
   by_contra h₂
   subst h₂
-  rcases (Value.lt_irrefl x) with h₃
+  have h₃ := Value.lt_irrefl x
   contradiction
 
 mutual
@@ -343,13 +343,13 @@ theorem Value.lt_asymm {a b : Value} :
     cases s₁ ; cases s₂ ; rename_i vs₁ vs₂
     simp [Value.lt]
     intro h₁
-    rcases (Values.lt_asym h₁) with h₂
+    have h₂ := Values.lt_asym h₁
     simp [h₂]
   case record r₁ r₂ =>
     cases r₁ ; cases r₂ ; rename_i avs₁ avs₂
     simp [Value.lt]
     intro h₁
-    rcases (ValueAttrs.lt_asym h₁) with h₂
+    have h₂ := ValueAttrs.lt_asym h₁
     simp [h₂]
   case ext x₁ x₂ => apply Ext.strictLT.asymmetric x₁ x₂
 
@@ -360,14 +360,14 @@ theorem Values.lt_asym {vs₁ vs₂: List Value} :
   rename_i hd₁ tl₁ hd₂ tl₂
   intro h₁ ; rcases h₁ with h₁ | h₁
   case inl =>
-    rcases (Value.lt_asymm h₁) with h₂
+    have h₂ := Value.lt_asymm h₁
     simp [LT.lt] at h₂
     simp [h₂] ; intro h₃ ; subst h₃
     simp [h₁] at h₂
   case inr =>
-    rcases h₁ with ⟨hl₁, h₁⟩
+    have ⟨hl₁, h₂⟩ := h₁
     subst hl₁ ; simp only [true_and]
-    rcases (Values.lt_asym h₁) with h₂
+    have h₂ := Values.lt_asym h₂
     simp [h₂, Value.lt_irrefl hd₁]
 
 theorem ValueAttrs.lt_asym {vs₁ vs₂: List (Attr × Value)} :
@@ -381,27 +381,29 @@ theorem ValueAttrs.lt_asym {vs₁ vs₂: List (Attr × Value)} :
   case inl =>
     rcases h₁ with h₁ | h₁
     case inl =>
-      rcases (String.strictLT.asymmetric a₁ a₂ h₁) with h₂
-      rcases (StrictLT.not_eq a₁ a₂ h₁) with h₃
+      have h₂ := String.strictLT.asymmetric a₁ a₂ h₁
+      have h₃ := StrictLT.not_eq a₁ a₂ h₁
       rw [eq_comm] at h₃
       simp [h₂, h₃]
     case inr =>
-      rcases h₁ with ⟨hl₁, h₁⟩ ; subst hl₁
+      have ⟨hl₁, h₂⟩ := h₁
+      subst hl₁
       simp only [decide_True, Bool.true_and]
-      rcases (Value.lt_asymm h₁) with h₂
-      simp [LT.lt] at h₂ ; simp [h₂]
-      rcases (StrictLT.irreflexive a₁) with h₃
-      rcases (Value.lt_not_eq h₁) with h₄
-      rw [eq_comm] at h₄
-      simp [h₃, h₄]
+      have h₃ := Value.lt_asymm h₂
+      simp [LT.lt] at h₃ ; simp [h₃]
+      have h₄ := StrictLT.irreflexive a₁
+      have h₅ := Value.lt_not_eq h₂
+      rw [eq_comm] at h₅
+      simp [h₄, h₅]
   case inr =>
-    rcases h₁ with ⟨h₂, h₁⟩
-    rcases h₂ with ⟨hl₂, hr₂⟩ ; subst hl₂ hr₂
+    have ⟨h₂, h₃⟩ := h₁
+    have ⟨hl₂, hr₂⟩ := h₂
+    subst hl₂ hr₂
     simp only [decide_True, Bool.true_and, Bool.and_self]
-    rcases (ValueAttrs.lt_asym h₁) with h₂
-    rcases (StrictLT.irreflexive a₁) with h₃
-    rcases (Value.lt_irrefl v₁) with h₄
-    simp [h₂, h₃, h₄]
+    have h₃ := ValueAttrs.lt_asym h₃
+    have h₄ := StrictLT.irreflexive a₁
+    have h₅ := Value.lt_irrefl v₁
+    simp [h₃, h₄, h₅]
 
 end
 
@@ -433,16 +435,18 @@ theorem Values.lt_trans {vs₁ vs₂ vs₃: List Value}
   rename_i hd₁ tl₁ hd₂ tl₂ hd₃ tl₃
   rcases h₁ with h₁ | h₁ <;> rcases h₂ with h₂ | h₂
   case inl.inl =>
-    rcases (Value.lt_trans h₁ h₂) with h₃
+    have h₃ := Value.lt_trans h₁ h₂
     simp [LT.lt] at h₃ ; simp [h₃]
   case inl.inr =>
-    rcases h₂ with ⟨h₂, _⟩ ; subst h₂ ; simp [h₁]
+    have ⟨h₂, _⟩ := h₂
+    subst h₂ ; simp [h₁]
   case inr.inl =>
-    rcases h₁ with ⟨h₁, _⟩ ; subst h₁ ; simp [h₂]
+    have ⟨h₁, _⟩ := h₁
+    subst h₁ ; simp [h₂]
   case inr.inr =>
-    rcases h₁ with ⟨hl₁, h₁⟩ ; subst hl₁
-    rcases h₂ with ⟨hl₂, h₂⟩ ; subst hl₂
-    rcases (Values.lt_trans h₁ h₂) with h₃
+    have ⟨hl₁, h₃⟩ := h₁ ; subst hl₁
+    have ⟨hl₂, h₄⟩ := h₂ ; subst hl₂
+    have h₃ := Values.lt_trans h₃ h₄
     simp [h₃]
 
 theorem ValueAttrs.lt_trans {vs₁ vs₂ vs₃: List (Attr × Value)}
@@ -458,31 +462,31 @@ theorem ValueAttrs.lt_trans {vs₁ vs₂ vs₃: List (Attr × Value)}
   case inl.inl =>
     rcases h₁ with h₁ | h₁ <;> rcases h₂ with h₂ | h₂
     case inl.inl =>
-      rcases (String.strictLT.transitive a₁ a₂ a₃ h₁ h₂) with h₃
+      have h₃ := String.strictLT.transitive a₁ a₂ a₃ h₁ h₂
       simp [h₃]
     case inl.inr =>
-      rcases h₂ with ⟨h₂, _⟩ ; subst h₂ ; simp [h₁]
+      have ⟨h₂, _⟩ := h₂ ; subst h₂ ; simp [h₁]
     case inr.inl =>
-      rcases h₁ with ⟨h₁, _⟩ ; subst h₁ ; simp [h₂]
+      have ⟨h₁, _⟩ := h₁ ; subst h₁ ; simp [h₂]
     case inr.inr =>
-      rcases h₁ with ⟨hl₁, h₁⟩ ; subst hl₁
-      rcases h₂ with ⟨hl₂, h₂⟩ ; subst hl₂
-      rcases (Value.lt_trans h₁ h₂) with h₃
+      have ⟨hl₁, h₃⟩ := h₁ ; subst hl₁
+      have ⟨hl₂, h₄⟩ := h₂ ; subst hl₂
+      have h₃ := Value.lt_trans h₃ h₄
       simp [LT.lt] at h₃ ; simp [h₃]
   case inl.inr =>
-    rcases h₂ with ⟨h₂, _⟩
-    rcases h₂ with ⟨hl₂, hr₂⟩ ; subst hl₂ hr₂
+    have ⟨⟨hl₂, hr₂⟩, _⟩ := h₂
+    subst hl₂ hr₂
     simp [h₁]
   case inr.inl =>
-    rcases h₁ with ⟨h₁, _⟩
-    rcases h₁ with ⟨hl₁, hr₁⟩ ; subst hl₁ hr₁
+    have ⟨⟨hl₁, hr₁⟩, _⟩ := h₁
+    subst hl₁ hr₁
     simp [h₂]
   case inr.inr =>
-    rcases h₁ with ⟨h₁, h₃⟩
-    rcases h₁ with ⟨hl₁, hr₁⟩ ; subst hl₁ hr₁
-    rcases h₂ with ⟨h₂, h₄⟩
-    rcases h₂ with ⟨hl₂, hr₂⟩ ; subst hl₂ hr₂
-    rcases (ValueAttrs.lt_trans h₃ h₄) with h₅
+    have ⟨⟨hl₁, hr₁⟩, h₃⟩ := h₁
+    subst hl₁ hr₁
+    have ⟨⟨hl₂, hr₂⟩, h₄⟩ := h₂
+    subst hl₂ hr₂
+    have h₅ := ValueAttrs.lt_trans h₃ h₄
     simp [h₅]
 end
 
@@ -515,10 +519,10 @@ theorem Values.lt_conn {vs₁ vs₂ : List Value}
   by_cases h₂ : (hd₁ = hd₂)
   case pos =>
     simp [h₂] at *
-    rcases (Values.lt_conn h₁) with h₃
+    have h₃ := Values.lt_conn h₁
     rcases h₃ with h₃ | h₃ <;> simp [h₃]
   case neg =>
-    rcases (Value.lt_conn h₂) with h₃
+    have h₃ := Value.lt_conn h₂
     simp [LT.lt] at h₃
     rcases h₃ with h₃ | h₃ <;> simp [h₃]
 
@@ -537,14 +541,14 @@ theorem ValueAttrs.lt_conn {vs₁ vs₂ : List (Attr × Value)}
     by_cases h₃ : (v₁ = v₂)
     case pos =>
       subst h₃ ; simp only [forall_const, true_and] at *
-      rcases (ValueAttrs.lt_conn h₁) with h₂
+      have h₂ := ValueAttrs.lt_conn h₁
       rcases h₂ with h₂ | h₂ <;> simp [h₂]
     case neg =>
-      rcases (Value.lt_conn h₃) with h₄
+      have h₄ := Value.lt_conn h₃
       simp [LT.lt] at h₄
       rcases h₄ with h₄ | h₄ <;> simp [h₄]
   case neg =>
-    rcases (String.strictLT.connected a₁ a₂) with h₃
+    have h₃ := String.strictLT.connected a₁ a₂
     simp [h₂] at h₃
     rcases h₃ with h₃ | h₃ <;> simp [h₃]
 

--- a/cedar-lean/Cedar/Thm/Core/Std.lean
+++ b/cedar-lean/Cedar/Thm/Core/Std.lean
@@ -95,20 +95,20 @@ theorem List.foldlM_of_assoc_some (f : α → α → Option α) (x₀ x₁ x₂ 
     simp [List.foldlM] at *
     cases h₄ : f x₂ hd <;> simp [h₄] at h₃
     rename_i x₄
-    rcases (h₁ x₀ x₁ hd) with h₅
+    have h₅ := h₁ x₀ x₁ hd
     simp [h₂, h₄] at h₅
     cases h₆ : f x₁ hd <;> simp [h₆] at h₅
     rename_i x₅
-    rcases (List.foldlM_of_assoc_some f x₂ hd x₄ x₃ tl h₁ h₄ h₃) with h₇
+    have h₇ := List.foldlM_of_assoc_some f x₂ hd x₄ x₃ tl h₁ h₄ h₃
     cases h₈ : List.foldlM f hd tl <;> simp [h₈] at h₇
     rename_i x₆
     rw [eq_comm] at h₅
     cases h₉ : List.foldlM f x₅ tl <;> simp [h₉]
     case none =>
-      rcases (List.foldlM_of_assoc_some f x₀ x₅ x₄ x₃ tl h₁ h₅ h₃) with h₁₀
+      have h₁₀ := List.foldlM_of_assoc_some f x₀ x₅ x₄ x₃ tl h₁ h₅ h₃
       simp [h₉] at h₁₀
     case some x₇ =>
-      rcases (List.foldlM_of_assoc_some f x₁ hd x₅ x₇ tl h₁ h₆ h₉) with h₁₀
+      have h₁₀ := List.foldlM_of_assoc_some f x₁ hd x₅ x₇ tl h₁ h₆ h₉
       simp [h₈] at h₁₀
       specialize h₁ x₀ x₁ x₆
       simp [h₂, h₁₀] at h₁
@@ -129,7 +129,7 @@ theorem List.foldlM_of_assoc_none' (f : α → α → Option α) (x₀ x₁ x₂
     simp [List.foldlM] at h₃
     cases h₄ : f x₁ hd <;> simp [h₄] at h₃
     rename_i x₃
-    rcases (List.foldlM_of_assoc_some f x₁ hd x₃ x₂ tl h₁ h₄ h₃) with h₅
+    have h₅ := List.foldlM_of_assoc_some f x₁ hd x₃ x₂ tl h₁ h₄ h₃
     cases h₆ : List.foldlM f hd tl <;> simp [h₆] at h₅
     rename_i x₄
     specialize h₁ x₀ x₁ x₄
@@ -153,20 +153,20 @@ theorem List.foldlM_of_assoc_none (f : α → α → Option α) (x₀ x₁ x₂ 
     rename_i x₃
     cases h₅ : List.foldlM f x₃ tl <;> simp [h₅]
     rename_i x₄
-    rcases (List.foldlM_of_assoc_some f x₁ hd x₃ x₄ tl h₁ h₄ h₅) with h₆
+    have h₆ := List.foldlM_of_assoc_some f x₁ hd x₃ x₄ tl h₁ h₄ h₅
     cases h₇ : List.foldlM f hd tl <;> simp [h₇] at h₆
     rename_i x₅
     simp [List.foldlM] at h₃
     cases h₈ : f x₂ hd <;> simp [h₈] at h₃
     case none =>
-      rcases (List.foldlM_of_assoc_none' f x₂ hd x₅ tl h₁ h₈ h₇) with h₉
-      rcases (h₁ x₀ x₁ x₅) with h₁₀
+      have h₉ := List.foldlM_of_assoc_none' f x₂ hd x₅ tl h₁ h₈ h₇
+      have h₁₀ := h₁ x₀ x₁ x₅
       simp [h₂, h₆] at h₁₀
       simp [←h₁₀, h₉]
     case some x₆ =>
-      rcases (List.foldlM_of_assoc_none f x₂ hd x₆ tl h₁ h₈ h₃) with h₉
+      have h₉ := List.foldlM_of_assoc_none f x₂ hd x₆ tl h₁ h₈ h₃
       simp [h₇] at h₉
-      rcases (h₁ x₀ x₁ x₅) with h₁₀
+      have h₁₀ := h₁ x₀ x₁ x₅
       simp [h₂, h₆] at h₁₀
       simp [←h₁₀, h₉]
 

--- a/cedar-lean/Cedar/Thm/Typechecking.lean
+++ b/cedar-lean/Cedar/Thm/Typechecking.lean
@@ -50,10 +50,10 @@ theorem typecheck_is_sound (policy : Policy) (env : Environment) (t : CedarType)
   cases h₃ : typeOf (Policy.toExpr policy) [] env <;> simp [h₃] at h₂
   split at h₂ <;> simp at h₂
   rename_i ht
-  rcases (empty_capabilities_invariant request entities) with hc
-  rcases (type_of_is_sound hc h₁ h₃) with ⟨_, v, h₄, h₅⟩
+  have hc := empty_capabilities_invariant request entities
+  have ⟨_, v, h₄, h₅⟩ := type_of_is_sound hc h₁ h₃
   rw [h₂] at ht h₅
-  rcases (instance_of_type_bool_is_bool v t h₅ ht) with ⟨b, h₆⟩
+  have ⟨b, h₆⟩ := instance_of_type_bool_is_bool v t h₅ ht
   subst h₆
   exists b
 

--- a/cedar-lean/Cedar/Thm/Validation/Typechecker.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Typechecker.lean
@@ -55,30 +55,30 @@ theorem type_of_is_sound {e : Expr} {c₁ c₂ : Capabilities} {env : Environmen
   | .lit l => exact type_of_lit_is_sound h₃
   | .var var => exact type_of_var_is_sound h₂ h₃
   | .ite x₁ x₂ x₃ =>
-    rcases (@type_of_is_sound x₁) with ih₁
-    rcases (@type_of_is_sound x₂) with ih₂
-    rcases (@type_of_is_sound x₃) with ih₃
+    have ih₁ := @type_of_is_sound x₁
+    have ih₂ := @type_of_is_sound x₂
+    have ih₃ := @type_of_is_sound x₃
     exact type_of_ite_is_sound h₁ h₂ h₃ ih₁ ih₂ ih₃
   | .and x₁ x₂ =>
-    rcases (@type_of_is_sound x₁) with ih₁
-    rcases (@type_of_is_sound x₂) with ih₂
+    have ih₁ := @type_of_is_sound x₁
+    have ih₂ := @type_of_is_sound x₂
     exact type_of_and_is_sound h₁ h₂ h₃ ih₁ ih₂
   | .or x₁ x₂ =>
-    rcases (@type_of_is_sound x₁) with ih₁
-    rcases (@type_of_is_sound x₂) with ih₂
+    have ih₁ := @type_of_is_sound x₁
+    have ih₂ := @type_of_is_sound x₂
     exact type_of_or_is_sound h₁ h₂ h₃ ih₁ ih₂
   | .unaryApp op₁ x₁ =>
-    rcases (@type_of_is_sound x₁) with ih
+    have ih := @type_of_is_sound x₁
     exact type_of_unaryApp_is_sound h₁ h₂ h₃ ih
   | .binaryApp op₂ x₁ x₂ =>
-    rcases (@type_of_is_sound x₁) with ih₁
-    rcases (@type_of_is_sound x₂) with ih₂
+    have ih₁ := @type_of_is_sound x₁
+    have ih₂ := @type_of_is_sound x₂
     exact type_of_binaryApp_is_sound h₁ h₂ h₃ ih₁ ih₂
   | .hasAttr x₁ a =>
-    rcases (@type_of_is_sound x₁) with ih
+    have ih := @type_of_is_sound x₁
     exact type_of_hasAttr_is_sound h₁ h₂ h₃ ih
   | .getAttr x₁ a =>
-    rcases (@type_of_is_sound x₁) with ih
+    have ih := @type_of_is_sound x₁
     exact type_of_getAttr_is_sound h₁ h₂ h₃ ih
   | .set xs =>
     have ih : ∀ xᵢ, xᵢ ∈ xs → TypeOfIsSound xᵢ := by

--- a/cedar-lean/Cedar/Thm/Validation/Typechecker/And.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Typechecker/And.lean
@@ -46,23 +46,25 @@ theorem type_of_and_inversion {x₁ x₂ : Expr} {c c' : Capabilities} {env : En
   case ok.h_1 h₃ =>
     exists BoolType.ff, res₁.snd ; simp [h₁]
     simp at h₃
-    rcases h₁ with ⟨h₁, _⟩ ; subst h₁
-    rcases h₃ with ⟨h₃, _⟩
+    have ⟨h₁, _⟩ := h₁ ; subst h₁
+    have ⟨h₃, _⟩ := h₃
     simp [←h₃]
   case ok.h_2 bty₁ c₁ h₃ h₄ =>
     exists bty₁, c₁
-    simp at h₄ ; rcases h₄ with ⟨hty₁, hc₁⟩ ; simp [←hty₁, ←hc₁]
+    simp at h₄
+    have ⟨hty₁, hc₁⟩ := h₄
+    simp [←hty₁, ←hc₁]
     split ; contradiction
     cases h₄ : typeOf x₂ (c ∪ res₁.snd) env <;> simp [h₄] at *
     rename_i res₂
     split at h₁ <;> simp at h₁ <;>
-    rcases h₁ with ⟨hty, hc⟩ <;> subst hty hc
-    case h_1.intro hty₂ =>
+    have ⟨hty, hc⟩ := h₁ <;> subst hty hc
+    case inr.ok.h_1 hty₂ =>
       exists BoolType.ff, res₂.snd ; simp [←hty₂]
-    case h_2.intro hty₂ =>
+    case inr.ok.h_2 hty₂ =>
       exists BoolType.tt, res₂.snd ; simp [←hty₂, hc₁]
       cases bty₁ <;> simp at h₃ <;> simp [lubBool]
-    case h_3.intro bty₂ h₄ h₅ hty₂ =>
+    case inr.ok.h_3 bty₂ h₄ h₅ hty₂ =>
       exists BoolType.anyBool, res₂.snd
       cases bty₂ <;> simp at *
       simp [←hty₂, hc₁, lubBool]
@@ -79,18 +81,20 @@ theorem type_of_and_is_sound {x₁ x₂ : Expr} {c₁ c₂ : Capabilities} {env 
   GuardedCapabilitiesInvariant (Expr.and x₁ x₂) c₂ request entities ∧
   ∃ v, EvaluatesTo (Expr.and x₁ x₂) request entities v ∧ InstanceOfType v ty
 := by
-  rcases (type_of_and_inversion h₃) with ⟨bty₁, rc₁, h₄, h₅⟩
+  have ⟨bty₁, rc₁, h₄, h₅⟩ := type_of_and_inversion h₃
   specialize ih₁ h₁ h₂ h₄
-  rcases ih₁ with ⟨ih₁₁, v₁, ih₁₂, ih₁₃⟩
-  rcases (instance_of_bool_is_bool ih₁₃) with ⟨b₁, hb₁⟩ ; subst hb₁
+  have ⟨ih₁₁, v₁, ih₁₂, ih₁₃⟩ := ih₁
+  have ⟨b₁, hb₁⟩ := instance_of_bool_is_bool ih₁₃
+  subst hb₁
   split at h₅
   case inl h₆ =>
     subst h₆
-    rcases h₅ with ⟨hty, hc⟩ ; subst hty hc
+    have ⟨hty, hc⟩ := h₅
+    subst hty hc
     apply And.intro
     case left => exact empty_guarded_capabilities_invariant
     case right =>
-      rcases (instance_of_ff_is_false ih₁₃) with h₇
+      have h₇ := instance_of_ff_is_false ih₁₃
       simp at h₇ ; subst h₇
       simp [EvaluatesTo] at ih₁₂
       rcases ih₁₂ with ih₁₂ | ih₁₂ | ih₁₂ | ih₁₂ <;>
@@ -98,9 +102,9 @@ theorem type_of_and_is_sound {x₁ x₂ : Expr} {c₁ c₂ : Capabilities} {env 
       try exact type_is_inhabited (CedarType.bool BoolType.ff)
       exact false_is_instance_of_ff
   case inr h₆ =>
-    rcases h₅ with ⟨bty₂, rc₂, h₅, h₇⟩
-    split at h₇ <;> rcases h₇ with ⟨hty, hc⟩ <;> subst hty hc
-    case inl.intro h₈ =>
+    have ⟨bty₂, rc₂, hₜ, h₇⟩ := h₅
+    split at h₇ <;> have ⟨hty, hc⟩ := h₇ <;> subst hty hc
+    case inl h₈ =>
       subst h₈
       apply And.intro
       case left => exact empty_guarded_capabilities_invariant
@@ -115,16 +119,16 @@ theorem type_of_and_is_sound {x₁ x₂ : Expr} {c₁ c₂ : Capabilities} {env 
           simp [EvaluatesTo, evaluate, Result.as, ih₁₂, Coe.coe, Value.asBool]
           simp [GuardedCapabilitiesInvariant] at ih₁₁
           specialize ih₁₁ ih₁₂
-          rcases (capability_union_invariant h₁ ih₁₁) with h₇
-          specialize ih₂ h₇ h₂ h₅
-          rcases ih₂ with ⟨_, v₂, ih₂₂, ih₂₃⟩
+          have h₇ := capability_union_invariant h₁ ih₁₁
+          specialize ih₂ h₇ h₂ hₜ
+          have ⟨_, v₂, ih₂₂, ih₂₃⟩ := ih₂
           simp [EvaluatesTo] at ih₂₂
           rcases ih₂₂ with ih₂₂ | ih₂₂ | ih₂₂ | ih₂₂ <;>
           simp [Result.as, ih₂₂, Coe.coe, Value.asBool, Lean.Internal.coeM, pure, Except.pure]
-          rcases (instance_of_ff_is_false ih₂₃) with h₈
+          have h₈ := instance_of_ff_is_false ih₂₃
           subst h₈
           simp [CoeT.coe, CoeHTCT.coe, CoeHTC.coe, CoeOTC.coe, CoeTC.coe, Coe.coe]
-    case inr.intro h₈ =>
+    case inr h₈ =>
       cases b₁
       case false =>
         rcases ih₁₂ with ih₁₂ | ih₁₂ | ih₁₂ | ih₁₂ <;>
@@ -138,14 +142,15 @@ theorem type_of_and_is_sound {x₁ x₂ : Expr} {c₁ c₂ : Capabilities} {env 
         try exact type_is_inhabited (CedarType.bool (lubBool bty₁ bty₂))
         simp [GuardedCapabilitiesInvariant] at ih₁₁
         specialize ih₁₁ ih₁₂
-        rcases (capability_union_invariant h₁ ih₁₁) with h₇
-        specialize ih₂ h₇ h₂ h₅
-        rcases ih₂ with ⟨ih₂₁, v₂, ih₂₂, ih₂₃⟩
+        have h₇ := capability_union_invariant h₁ ih₁₁
+        specialize ih₂ h₇ h₂ hₜ
+        have ⟨ih₂₁, v₂, ih₂₂, ih₂₃⟩ := ih₂
         simp [EvaluatesTo] at ih₂₂
         rcases ih₂₂ with ih₂₂ | ih₂₂ | ih₂₂ | ih₂₂ <;>
         simp [EvaluatesTo, evaluate, Result.as, ih₂₂, Coe.coe, Value.asBool, Lean.Internal.coeM, pure, Except.pure] <;>
         try exact type_is_inhabited (CedarType.bool (lubBool bty₁ bty₂))
-        rcases (instance_of_bool_is_bool ih₂₃) with ⟨b₂, hb₂⟩ ; subst hb₂
+        have ⟨b₂, hb₂⟩ := instance_of_bool_is_bool ih₂₃
+        subst hb₂
         cases b₂ <;> simp [CoeT.coe, CoeHTCT.coe, CoeHTC.coe, CoeOTC.coe, CoeTC.coe, Coe.coe]
         case false =>
           apply instance_of_lubBool ; simp [ih₂₃]

--- a/cedar-lean/Cedar/Thm/Validation/Typechecker/BinaryApp.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Typechecker/BinaryApp.lean
@@ -111,7 +111,7 @@ theorem type_of_eq_is_sound {x₁ x₂ : Expr} {c₁ c₂ : Capabilities} {env :
   GuardedCapabilitiesInvariant (Expr.binaryApp .eq x₁ x₂) c₂ request entities ∧
   ∃ v, EvaluatesTo (Expr.binaryApp .eq x₁ x₂) request entities v ∧ InstanceOfType v ty
 := by
-  rcases (type_of_eq_inversion h₃) with ⟨hc, hty⟩
+  have ⟨hc, hty⟩ := type_of_eq_inversion h₃
   subst hc
   constructor
   case left => exact empty_guarded_capabilities_invariant
@@ -130,15 +130,15 @@ theorem type_of_eq_is_sound {x₁ x₂ : Expr} {c₁ c₂ : Capabilities} {env :
         case false => exact false_is_instance_of_ff
         case true  => contradiction
     case h_2 =>
-      rcases hty with ⟨ty₁, c₁', ty₂, c₂', ht₁, ht₂, hty⟩
-      specialize ih₁ h₁ h₂ ht₁ ; rcases ih₁ with ⟨_, v₁, ih₁⟩
-      specialize ih₂ h₁ h₂ ht₂ ; rcases ih₂ with ⟨_, v₂, ih₂⟩
+      have ⟨ty₁, c₁', ty₂, c₂', ht₁, ht₂, hty⟩ := hty
+      specialize ih₁ h₁ h₂ ht₁ ; have ⟨_, v₁, ih₁⟩ := ih₁
+      specialize ih₂ h₁ h₂ ht₂ ; have ⟨_, v₂, ih₂⟩ := ih₂
       simp [EvaluatesTo, evaluate] at *
       cases h₄ : evaluate x₁ request entities <;> simp [h₄] at * <;>
       cases h₅ : evaluate x₂ request entities <;> simp [h₅] at * <;>
       try { simp [ih₁, ih₂] ; apply type_is_inhabited }
-      rcases ih₁ with ⟨ihl₁, ih₁⟩
-      rcases ih₂ with ⟨ihl₂, ih₂⟩
+      have ⟨ihl₁, ih₃⟩ := ih₁ ; clear ih₁
+      have ⟨ihl₂, ih₄⟩ := ih₂ ; clear ih₂
       rw [eq_comm] at ihl₁ ihl₂; subst ihl₁ ihl₂
       simp [apply₂]
       split at hty
@@ -146,9 +146,9 @@ theorem type_of_eq_is_sound {x₁ x₂ : Expr} {c₁ c₂ : Capabilities} {env :
         rw [hty]
         apply bool_is_instance_of_anyBool
       case h_2 heq =>
-        rcases hty with ⟨hty₀, ⟨ety₁, hty₁⟩, ⟨ety₂, hty₂⟩⟩
+        have ⟨hty₀, ⟨ety₁, hty₁⟩, ⟨ety₂, hty₂⟩⟩ := hty
         subst hty₀ hty₁ hty₂
-        rcases (no_entity_type_lub_implies_not_eq ih₁ ih₂ heq) with h₆
+        have h₆ := no_entity_type_lub_implies_not_eq ih₃ ih₄ heq
         cases h₇ : v₁ == v₂ <;>
         simp only [beq_iff_eq, beq_eq_false_iff_ne, ne_eq, Value.prim.injEq] at h₇
         case false => exact false_is_instance_of_ff
@@ -187,24 +187,24 @@ theorem type_of_int_cmp_is_sound {op₂ : BinaryOp} {x₁ x₂ : Expr} {c₁ c�
   GuardedCapabilitiesInvariant (Expr.binaryApp op₂ x₁ x₂) c₂ request entities ∧
   ∃ v, EvaluatesTo (Expr.binaryApp op₂ x₁ x₂) request entities v ∧ InstanceOfType v ty
 := by
-  rcases (type_of_int_cmp_inversion h₀ h₃) with ⟨hc, hty, ht₁, ht₂⟩
+  have ⟨hc, hty, ht₁, ht₂⟩ := type_of_int_cmp_inversion h₀ h₃
   subst hc hty
   constructor
   case left => exact empty_guarded_capabilities_invariant
   case right =>
-    rcases ht₁ with ⟨c₁', ht₁⟩
-    rcases ht₂ with ⟨c₂', ht₂⟩
-    specialize ih₁ h₁ h₂ ht₁ ; rcases ih₁ with ⟨_, v₁, ih₁⟩
-    specialize ih₂ h₁ h₂ ht₂ ; rcases ih₂ with ⟨_, v₂, ih₂⟩
+    have ⟨c₁', ht₁⟩ := ht₁
+    have ⟨c₂', ht₂⟩ := ht₂
+    specialize ih₁ h₁ h₂ ht₁ ; have ⟨_, v₁, ih₁⟩ := ih₁
+    specialize ih₂ h₁ h₂ ht₂ ; have ⟨_, v₂, ih₂⟩ := ih₂
     simp [EvaluatesTo, evaluate] at *
     cases h₄ : evaluate x₁ request entities <;> simp [h₄] at * <;>
     cases h₅ : evaluate x₂ request entities <;> simp [h₅] at * <;>
     try { simp [ih₁, ih₂] ; exact type_is_inhabited (.bool .anyBool) }
-    rcases ih₁ with ⟨ihl₁, ih₁⟩
-    rcases ih₂ with ⟨ihl₂, ih₂⟩
+    have ⟨ihl₁, ih₃⟩ := ih₁ ; clear ih₁
+    have ⟨ihl₂, ih₄⟩ := ih₂ ; clear ih₂
     rw [eq_comm] at ihl₁ ihl₂; subst ihl₁ ihl₂
-    rcases (instance_of_int_is_int ih₁) with ⟨i₁, ih₁⟩
-    rcases (instance_of_int_is_int ih₂) with ⟨i₂, ih₂⟩
+    have ⟨i₁, ih₁⟩ := instance_of_int_is_int ih₃
+    have ⟨i₂, ih₂⟩ := instance_of_int_is_int ih₄
     subst ih₁ ih₂
     rcases h₀ with h₀ | h₀
     all_goals {
@@ -231,7 +231,7 @@ theorem type_of_int_arith_inversion {op₂ : BinaryOp} {x₁ x₂ : Expr} {c c' 
     split at h₂ <;> try contradiction
     simp at h₂ ; simp [h₂]
     rename_i tc₁ tc₂ _ _ _ _ h₅ h₆
-    rcases h₂ with ⟨h₂, _⟩
+    have ⟨h₂, _⟩ := h₂
     constructor
     case left  => exists tc₁.snd ; simp [←h₂, ←h₅]
     case right => exists tc₂.snd ; simp [←h₂, ←h₆]
@@ -247,24 +247,24 @@ theorem type_of_int_arith_is_sound {op₂ : BinaryOp} {x₁ x₂ : Expr} {c₁ c
   GuardedCapabilitiesInvariant (Expr.binaryApp op₂ x₁ x₂) c₂ request entities ∧
   ∃ v, EvaluatesTo (Expr.binaryApp op₂ x₁ x₂) request entities v ∧ InstanceOfType v ty
 := by
-  rcases (type_of_int_arith_inversion h₀ h₃) with ⟨hc, hty, ht₁, ht₂⟩
+  have ⟨hc, hty, ht₁, ht₂⟩ := type_of_int_arith_inversion h₀ h₃
   subst hc hty
   constructor
   case left => exact empty_guarded_capabilities_invariant
   case right =>
-    rcases ht₁ with ⟨c₁', ht₁⟩
-    rcases ht₂ with ⟨c₂', ht₂⟩
-    specialize ih₁ h₁ h₂ ht₁ ; rcases ih₁ with ⟨_, v₁, ih₁⟩
-    specialize ih₂ h₁ h₂ ht₂ ; rcases ih₂ with ⟨_, v₂, ih₂⟩
+    have ⟨c₁', ht₁⟩ := ht₁
+    have ⟨c₂', ht₂⟩ := ht₂
+    specialize ih₁ h₁ h₂ ht₁ ; have ⟨_, v₁, ih₁⟩ := ih₁
+    specialize ih₂ h₁ h₂ ht₂ ; have ⟨_, v₂, ih₂⟩ := ih₂
     simp [EvaluatesTo, evaluate] at *
     cases h₄ : evaluate x₁ request entities <;> simp [h₄] at * <;>
     cases h₅ : evaluate x₂ request entities <;> simp [h₅] at * <;>
     try { simp [ih₁, ih₂] ; exact type_is_inhabited .int }
-    rcases ih₁ with ⟨ihl₁, ih₁⟩
-    rcases ih₂ with ⟨ihl₂, ih₂⟩
+    have ⟨ihl₁, ih₃⟩ := ih₁ ; clear ih₁
+    have ⟨ihl₂, ih₄⟩ := ih₂ ; clear ih₂
     rw [eq_comm] at ihl₁ ihl₂; subst ihl₁ ihl₂
-    rcases (instance_of_int_is_int ih₁) with ⟨i₁, ih₁⟩
-    rcases (instance_of_int_is_int ih₂) with ⟨i₂, ih₂⟩
+    have ⟨i₁, ih₁⟩ := instance_of_int_is_int ih₃
+    have ⟨i₂, ih₂⟩ := instance_of_int_is_int ih₄
     subst ih₁ ih₂
     rcases h₀ with h₀ | h₀ <;> subst h₀ <;> simp [apply₂, intOrErr]
     case inl =>
@@ -310,23 +310,23 @@ theorem type_of_contains_is_sound {x₁ x₂ : Expr} {c₁ c₂ : Capabilities} 
   GuardedCapabilitiesInvariant (Expr.binaryApp .contains x₁ x₂) c₂ request entities ∧
   ∃ v, EvaluatesTo (Expr.binaryApp .contains x₁ x₂) request entities v ∧ InstanceOfType v ty
 := by
-  rcases (type_of_contains_inversion h₃) with ⟨hc, hty, ty₁, ty₂, _, ht₁, ht₂⟩
+  have ⟨hc, hty, ty₁, ty₂, _, ht₁, ht₂⟩ := type_of_contains_inversion h₃
   subst hc hty
   constructor
   case left => exact empty_guarded_capabilities_invariant
   case right =>
-    rcases ht₁ with ⟨c₁', ht₁⟩
-    rcases ht₂ with ⟨c₂', ht₂⟩
-    specialize ih₁ h₁ h₂ ht₁ ; rcases ih₁ with ⟨_, v₁, ih₁⟩
-    specialize ih₂ h₁ h₂ ht₂ ; rcases ih₂ with ⟨_, v₂, ih₂⟩
+    have ⟨c₁', ht₁⟩ := ht₁
+    have ⟨c₂', ht₂⟩ := ht₂
+    specialize ih₁ h₁ h₂ ht₁ ; have ⟨_, v₁, ih₁⟩ := ih₁
+    specialize ih₂ h₁ h₂ ht₂ ; have ⟨_, v₂, ih₂⟩ := ih₂
     simp [EvaluatesTo, evaluate] at *
     cases h₄ : evaluate x₁ request entities <;> simp [h₄] at * <;>
     cases h₅ : evaluate x₂ request entities <;> simp [h₅] at * <;>
     try { simp [ih₁, ih₂] ; apply type_is_inhabited }
-    rcases ih₁ with ⟨ihl₁, ih₁⟩
-    rcases ih₂ with ⟨ihl₂, ih₂⟩
+    have ⟨ihl₁, ih₃⟩ := ih₁ ; clear ih₁
+    have ⟨ihl₂, ih₄⟩ := ih₂ ; clear ih₂
     rw [eq_comm] at ihl₁ ihl₂; subst ihl₁ ihl₂
-    rcases (instance_of_set_type_is_set ih₁) with ⟨s₁, ih₁⟩
+    have ⟨s₁, ih₁⟩ := instance_of_set_type_is_set ih₃
     subst ih₁
     simp [apply₂]
     apply bool_is_instance_of_anyBool
@@ -371,24 +371,24 @@ theorem type_of_containsA_is_sound {op₂ : BinaryOp} {x₁ x₂ : Expr} {c₁ c
   GuardedCapabilitiesInvariant (Expr.binaryApp op₂ x₁ x₂) c₂ request entities ∧
   ∃ v, EvaluatesTo (Expr.binaryApp op₂ x₁ x₂) request entities v ∧ InstanceOfType v ty
 := by
-  rcases (type_of_containsA_inversion h₀ h₃) with ⟨hc, hty, ty₁, ty₂, _, ht₁, ht₂⟩
+  have ⟨hc, hty, ty₁, ty₂, _, ht₁, ht₂⟩ := type_of_containsA_inversion h₀ h₃
   subst hc hty
   constructor
   case left => exact empty_guarded_capabilities_invariant
   case right =>
-    rcases ht₁ with ⟨c₁', ht₁⟩
-    rcases ht₂ with ⟨c₂', ht₂⟩
-    specialize ih₁ h₁ h₂ ht₁ ; rcases ih₁ with ⟨_, v₁, ih₁⟩
-    specialize ih₂ h₁ h₂ ht₂ ; rcases ih₂ with ⟨_, v₂, ih₂⟩
+    have ⟨c₁', ht₁⟩ := ht₁
+    have ⟨c₂', ht₂⟩ := ht₂
+    specialize ih₁ h₁ h₂ ht₁ ; have ⟨_, v₁, ih₁⟩ := ih₁
+    specialize ih₂ h₁ h₂ ht₂ ; have ⟨_, v₂, ih₂⟩ := ih₂
     simp [EvaluatesTo, evaluate] at *
     cases h₄ : evaluate x₁ request entities <;> simp [h₄] at * <;>
     cases h₅ : evaluate x₂ request entities <;> simp [h₅] at * <;>
     try { simp [ih₁, ih₂] ; apply type_is_inhabited }
-    rcases ih₁ with ⟨ihl₁, ih₁⟩
-    rcases ih₂ with ⟨ihl₂, ih₂⟩
+    have ⟨ihl₁, ih₃⟩ := ih₁ ; clear ih₁
+    have ⟨ihl₂, ih₄⟩ := ih₂ ; clear ih₂
     rw [eq_comm] at ihl₁ ihl₂; subst ihl₁ ihl₂
-    rcases (instance_of_set_type_is_set ih₁) with ⟨s₁, ih₁⟩
-    rcases (instance_of_set_type_is_set ih₂) with ⟨s₂, ih₂⟩
+    have ⟨s₁, ih₁⟩ := instance_of_set_type_is_set ih₃
+    have ⟨s₂, ih₂⟩ := instance_of_set_type_is_set ih₄
     subst ih₁ ih₂
     rcases h₀ with h₀ | h₀
     all_goals {
@@ -440,7 +440,7 @@ theorem actionUID?_some_implies_action_lit {x : Expr} {euid : EntityUID} {acts :
   cases h₂ : entityUID? x <;> simp [h₂] at h₁
   replace h₂ := entityUID?_some_implies_entity_lit h₂
   rename_i euid'
-  rcases h₁ with ⟨h₀, h₁⟩
+  have ⟨h₀, h₁⟩ := h₁
   subst h₀
   simp [h₁, h₂]
 
@@ -459,11 +459,11 @@ theorem entityUIDs?_some_implies_entity_lits {x : Expr} {euids : List EntityUID}
     rename_i hd' tl'
     cases h₂ : entityUID? hd' <;> simp [h₂] at h₁
     cases h₃ : List.mapM' entityUID? tl' <;> simp [h₃] at h₁
-    rcases h₁ with ⟨hhd, htl⟩ ; rw [eq_comm] at hhd htl ; subst hhd htl
+    have ⟨hhd, htl⟩ := h₁ ; rw [eq_comm] at hhd htl ; subst hhd htl
     replace h₂ := entityUID?_some_implies_entity_lit h₂
     simp [h₂]
     rw [List.mapM'_eq_mapM] at h₃
-    rcases (@entityUIDs?_some_implies_entity_lits (.set tl') tl) with h₄
+    have h₄ := @entityUIDs?_some_implies_entity_lits (.set tl') tl
     simp [entityUIDs?, h₃] at h₄
     exact h₄
 
@@ -481,7 +481,7 @@ theorem entity_type_in_false_implies_inₑ_false {euid₁ euid₂ : EntityUID} {
   split at h₃
   case h_1 data h₄ =>
     rw [Set.contains_prop_bool_equiv] at h₃
-    rcases (h₁ euid₁ data h₄) with ⟨entry, h₂₁, _, h₂₂⟩
+    have ⟨entry, h₂₁, _, h₂₂⟩ := h₁ euid₁ data h₄
     specialize h₂₂ euid₂ h₃
     rw [←Set.contains_prop_bool_equiv] at h₂₂
     simp [h₂₁, h₂₂] at h₂
@@ -496,7 +496,7 @@ theorem action_type_in_eq_action_inₑ (euid₁ euid₂ : EntityUID) {env : Envi
   simp [ActionStore.contains] at h₂
   cases h₃ : Map.find? env.acts euid₁ <;> simp [h₃] at h₂
   rename_i entry
-  rcases (h₁ euid₁ entry h₃) with ⟨data, h₁₁, h₁₂⟩
+  have ⟨data, h₁₁, h₁₂⟩ := h₁ euid₁ entry h₃
   simp [inₑ, ActionStore.descendentOf, h₃, Entities.ancestorsOrEmpty, h₁₁]
   rcases h₄ : euid₁ == euid₂ <;> simp at h₄ <;> simp [h₄, h₁₂]
 
@@ -511,8 +511,8 @@ theorem type_of_mem_is_soundₑ {x₁ x₂ : Expr} {c₁ c₁' c₂' : Capabilit
     EvaluatesTo (Expr.binaryApp BinaryOp.mem x₁ x₂) request entities v ∧
     InstanceOfType v (CedarType.bool (typeOfInₑ ety₁ ety₂ x₁ x₂ env))
 := by
-  rcases (ih₁ h₁ h₂ h₃) with ⟨_, v₁, hev₁, hty₁⟩
-  rcases (ih₂ h₁ h₂ h₄) with ⟨_, v₂, hev₂, hty₂⟩
+  have ⟨_, v₁, hev₁, hty₁⟩ := ih₁ h₁ h₂ h₃
+  have ⟨_, v₂, hev₂, hty₂⟩ := ih₂ h₁ h₂ h₄
   simp [EvaluatesTo] at *
   simp [evaluate]
   cases h₅ : evaluate x₁ request entities <;> simp [h₅] at hev₁ <;> simp [h₅, hev₁] <;>
@@ -522,16 +522,18 @@ theorem type_of_mem_is_soundₑ {x₁ x₂ : Expr} {c₁ c₁' c₂' : Capabilit
   try { apply type_is_inhabited }
   rw [eq_comm] at hev₂ ; subst hev₂
   replace hty₁ := instance_of_entity_type_is_entity hty₁
-  rcases hty₁ with ⟨euid₁, hty₁, hty₁'⟩ ; subst hty₁ hty₁'
+  have ⟨euid₁, hty₁, hty₁'⟩ := hty₁
+  subst hty₁ hty₁'
   replace hty₂ := instance_of_entity_type_is_entity hty₂
-  rcases hty₂ with ⟨euid₂, hty₂, hty₂'⟩ ; subst hty₂ hty₂'
+  have ⟨euid₂, hty₂, hty₂'⟩ := hty₂
+  subst hty₂ hty₂'
   simp [apply₂]
   apply InstanceOfType.instance_of_bool
   simp [InstanceOfBoolType]
   split <;> try simp only
   rename_i b bty  h₇ h₈ h₉
   simp [typeOfInₑ] at *
-  rcases h₂ with ⟨_, hents, hacts⟩
+  have ⟨_, hents, hacts⟩ := h₂
   cases ha : actionUID? x₁ env.acts <;> simp [ha] at h₇ h₈ h₉
   case none =>
     cases hin : EntityTypeStore.descendentOf env.ets euid₁.ty euid₂.ty <;>
@@ -545,11 +547,12 @@ theorem type_of_mem_is_soundₑ {x₁ x₂ : Expr} {c₁ c₁' c₂' : Capabilit
       simp [entity_type_in_false_implies_inₑ_false hents hin] at h₉
     case some =>
       replace ha := actionUID?_some_implies_action_lit ha
-      rcases ha with ⟨ha', ha⟩ ; subst ha'
+      have ⟨ha', ha''⟩ := ha ; clear ha
+      subst ha'
       replace he := entityUID?_some_implies_entity_lit he ; subst he
       rename_i auid euid _ _
       simp [evaluate] at h₅ h₆ ; subst h₅ h₆
-      rcases (action_type_in_eq_action_inₑ auid euid hacts ha) with h₁₀
+      have h₁₀ := action_type_in_eq_action_inₑ auid euid hacts ha''
       simp [h₁₀] at h₈ h₉
       cases heq : ActionStore.descendentOf env.acts auid euid <;> simp [heq] at h₈ h₉
 
@@ -566,10 +569,11 @@ theorem entity_set_type_implies_set_of_entities {vs : List Value} {ety : EntityT
   case cons hd tl =>
     simp only [List.mapM'_cons]
     cases h₁ ; rename_i h₁
-    rcases (h₁ hd) with h₂
+    have h₂ := h₁ hd
     simp [Set.mem_cons_self] at h₂
     replace h₂ := instance_of_entity_type_is_entity h₂
-    rcases h₂ with ⟨heuid, hdty, h₂⟩ ; subst h₂
+    have ⟨heuid, hdty, h₂⟩ := h₂
+    subst h₂
     rw [Value.asEntityUID] ; simp
     rw [List.mapM'_eq_mapM]
     have h₃ : InstanceOfType (Value.set (Set.mk tl)) (CedarType.set (CedarType.entity ety)) := by
@@ -578,7 +582,7 @@ theorem entity_set_type_implies_set_of_entities {vs : List Value} {ety : EntityT
       apply h₁ v
       apply Set.mem_cons_of_mem
       exact h₃
-    rcases (entity_set_type_implies_set_of_entities h₃) with ⟨tleuids, h₄, h₅⟩
+    have ⟨tleuids, h₄, h₅⟩ := entity_set_type_implies_set_of_entities h₃
     simp [h₄, pure, Except.pure, hdty]
     intro euid heuid
     apply h₅ euid heuid
@@ -593,7 +597,7 @@ theorem entity_type_in_false_implies_inₛ_false {euid : EntityUID} {euids : Lis
   simp [EntityTypeStore.descendentOf] at h₂
   rw [Set.make_any_iff_any]
   by_contra h₄ ; simp at h₄
-  rcases h₄ with ⟨euid', h₄, h₅⟩
+  have ⟨euid', h₄, h₅⟩ := h₄
   simp [inₑ] at h₅
   rcases h₅ with h₅ | h₅
   case inl =>
@@ -604,14 +608,14 @@ theorem entity_type_in_false_implies_inₛ_false {euid : EntityUID} {euids : Lis
     simp [Entities.ancestorsOrEmpty, Set.contains, Set.elts, Set.empty] at h₅
     cases h₆ : Map.find? entities euid <;> simp [h₆] at h₅
     rename_i data
-    rcases (h₁ euid data h₆) with ⟨entry, h₁, _, h₇⟩
+    have ⟨entry, h₁, _, h₇⟩ := h₁ euid data h₆
     specialize h₇ euid' h₅
     split at h₂ <;> try contradiction
     rename_i h₈
     specialize h₃ euid' h₄ ; subst h₃
     split at h₂ <;> rename_i h₉ <;> simp [h₁] at h₉
     subst h₉
-    rcases (Set.in_set_in_list euid'.ty entry.ancestors h₇) with h₉
+    have h₉ := Set.in_set_in_list euid'.ty entry.ancestors h₇
     simp [Set.contains, Set.elts] at h₂ h₉
     rw [←List.elem_iff] at h₉
     rw [h₂] at h₉
@@ -681,7 +685,7 @@ theorem evaluate_entity_set_eqv {vs : List Value} {euids euids' : List EntityUID
   replace h₁ := Set.make_eqv h₁
   subst h₂ h₃
   simp [List.Equiv, List.subset_def] at *
-  rcases h₁ with ⟨hl₁, hr₁⟩
+  have ⟨hl₁, hr₁⟩ := h₁
   constructor
   case left  => apply hr₁
   case right => apply hl₁
@@ -701,12 +705,12 @@ theorem action_type_in_eq_action_inₛ {auid : EntityUID} {euids euids' : List E
   specialize h₁ auid entry
   constructor <;> intro h₄ <;> rename_i hfnd <;>
   simp [hfnd] at h₁ <;>
-  rcases h₁ with ⟨data, hl₁, hr₁⟩
+  have ⟨data, hl₁, hr₁⟩ := h₁
   case some.mp =>
     rw [List.any_eq_true] at h₄
-    rcases h₄ with ⟨euid, h₄, h₅⟩
+    have ⟨euid, h₄, h₅⟩ := h₄
     exists euid
-    rcases h₃ with ⟨h₃, _⟩
+    have ⟨h₃, _⟩ := h₃
     simp [List.subset_def] at h₃
     specialize h₃ h₄ ; simp [h₃]
     simp [inₑ] at h₅
@@ -720,9 +724,9 @@ theorem action_type_in_eq_action_inₛ {auid : EntityUID} {euids euids' : List E
       exact h₅
   case some.mpr =>
     rw [List.any_eq_true]
-    rcases h₄ with ⟨euid, h₄, h₅⟩
+    have ⟨euid, h₄, h₅⟩ := h₄
     exists euid
-    rcases h₃ with ⟨_, h₃⟩
+    have ⟨_, h₃⟩ := h₃
     simp [List.subset_def] at h₃
     specialize h₃ h₄ ; simp [h₃]
     simp [ActionStore.descendentOf, hfnd] at h₅
@@ -743,8 +747,8 @@ theorem type_of_mem_is_soundₛ {x₁ x₂ : Expr} {c₁ c₁' c₂' : Capabilit
     EvaluatesTo (Expr.binaryApp BinaryOp.mem x₁ x₂) request entities v ∧
     InstanceOfType v (CedarType.bool (typeOfInₛ ety₁ ety₂ x₁ x₂ env))
 := by
-  rcases (ih₁ h₁ h₂ h₃) with ⟨_, v₁, hev₁, hty₁⟩
-  rcases (ih₂ h₁ h₂ h₄) with ⟨_, v₂, hev₂, hty₂⟩
+  have ⟨_, v₁, hev₁, hty₁⟩ := ih₁ h₁ h₂ h₃
+  have ⟨_, v₂, hev₂, hty₂⟩ := ih₂ h₁ h₂ h₄
   simp [EvaluatesTo] at *
   simp [evaluate]
   cases h₅ : evaluate x₁ request entities <;> simp [h₅] at hev₁ <;> simp [h₅, hev₁] <;>
@@ -753,18 +757,20 @@ theorem type_of_mem_is_soundₛ {x₁ x₂ : Expr} {c₁ c₁' c₂' : Capabilit
   cases h₆ : evaluate x₂ request entities <;> simp [h₆] at hev₂ <;> simp [h₆, hev₂] <;>
   try { apply type_is_inhabited }
   rw [eq_comm] at hev₂ ; subst hev₂
-  rcases (instance_of_entity_type_is_entity hty₁) with ⟨euid, hty₁, hty₁'⟩ ; subst hty₁ hty₁'
-  rcases (instance_of_set_type_is_set hty₂) with ⟨vs, hset⟩ ; subst hset
+  have ⟨euid, hty₁, hty₁'⟩ := instance_of_entity_type_is_entity hty₁
+  subst hty₁ hty₁'
+  have ⟨vs, hset⟩ := instance_of_set_type_is_set hty₂
+  subst hset
   cases vs ; rename_i vs
   simp [apply₂, inₛ]
   simp [Set.mapOrErr, Set.elts]
-  rcases (entity_set_type_implies_set_of_entities hty₂) with ⟨euids, h₇, hty₇⟩
+  have ⟨euids, h₇, hty₇⟩ := entity_set_type_implies_set_of_entities hty₂
   simp [h₇]
   apply InstanceOfType.instance_of_bool
   simp [InstanceOfBoolType]
   split <;> try simp
   rename_i h₈ h₉ h₁₀
-  rcases h₂ with ⟨_, hents, hacts⟩
+  have ⟨_, hents, hacts⟩ := h₂
   simp [typeOfInₛ] at *
   cases ha : actionUID? x₁ env.acts <;> simp [ha] at h₈ h₉ h₁₀
   case none =>
@@ -778,12 +784,14 @@ theorem type_of_mem_is_soundₛ {x₁ x₂ : Expr} {c₁ c₁' c₂' : Capabilit
       simp [hin] at h₈ h₉ h₁₀
       simp [entity_type_in_false_implies_inₛ_false hents hin hty₇] at h₁₀
     case some =>
-      rcases (actionUID?_some_implies_action_lit ha) with ⟨ha', hac⟩ ; subst ha'
-      rcases (entityUIDs?_some_implies_entity_lits he) with he ; subst he
+      have ⟨ha', hac⟩ := actionUID?_some_implies_action_lit ha
+      subst ha'
+      have he := entityUIDs?_some_implies_entity_lits he
+      subst he
       simp [evaluate] at h₅ ; rw [eq_comm] at h₅ ; subst h₅
       rename_i euids' _ _
-      rcases (evaluate_entity_set_eqv h₆ h₇) with h₁₁
-      rcases (action_type_in_eq_action_inₛ hacts hac h₁₁) with h₁₂
+      have h₁₁ := evaluate_entity_set_eqv h₆ h₇
+      have h₁₂ := action_type_in_eq_action_inₛ hacts hac h₁₁
       cases h₁₃ : Set.any (fun x => inₑ euid x entities) (Set.make euids) <;>
       simp [h₁₃] at h₉ h₁₀ h₁₂
       case false =>
@@ -794,7 +802,7 @@ theorem type_of_mem_is_soundₛ {x₁ x₂ : Expr} {c₁ c₁' c₂' : Capabilit
       case true =>
         apply h₉
         intro h₁₃
-        rcases h₁₂ with ⟨euid', hl₁₂, hr₁₂⟩
+        have ⟨euid', hl₁₂, hr₁₂⟩ := h₁₂
         specialize h₁₃ euid' hl₁₂
         simp [hr₁₂] at h₁₃
 
@@ -807,16 +815,15 @@ theorem type_of_mem_is_sound {x₁ x₂ : Expr} {c₁ c₂ : Capabilities} {env 
   GuardedCapabilitiesInvariant (Expr.binaryApp .mem x₁ x₂) c₂ request entities ∧
   ∃ v, EvaluatesTo (Expr.binaryApp .mem x₁ x₂) request entities v ∧ InstanceOfType v ty
 := by
-  rcases (type_of_mem_inversion h₃) with ⟨hc, ety₁, ety₂, ⟨c₁', h₄⟩ , c₂', h₅⟩
+  have ⟨hc, ety₁, ety₂, ⟨c₁', h₄⟩ , c₂', h₅⟩ := type_of_mem_inversion h₃
   subst hc
   constructor
   case left => exact empty_guarded_capabilities_invariant
   case right =>
-    rcases h₅ with h₅ | h₅ <;>
-    rcases h₅ with ⟨h₅, h₆⟩ <;> subst h₆
-    case inl.intro =>
+    rcases h₅ with ⟨h₅, h₆⟩ | ⟨h₅, h₆⟩ <;> subst h₆
+    case inl =>
       apply type_of_mem_is_soundₑ h₁ h₂ h₄ h₅ ih₁ ih₂
-    case inr.intro =>
+    case inr =>
       apply type_of_mem_is_soundₛ h₁ h₂ h₄ h₅ ih₁ ih₂
 
 theorem type_of_binaryApp_is_sound {op₂ : BinaryOp} {x₁ x₂ : Expr} {c₁ c₂ : Capabilities} {env : Environment} {ty : CedarType} {request : Request} {entities : Entities}

--- a/cedar-lean/Cedar/Thm/Validation/Typechecker/Call.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Typechecker/Call.lean
@@ -51,13 +51,13 @@ theorem type_of_call_decimal_is_sound {xs : List Expr} {c₁ c₂ : Capabilities
   GuardedCapabilitiesInvariant (Expr.call .decimal xs) c₂ request entities ∧
   ∃ v, EvaluatesTo (Expr.call .decimal xs) request entities v ∧ InstanceOfType v ty
 := by
-  rcases (type_of_call_decimal_inversion h₁) with ⟨h₂, h₃, s, h₄, h₅⟩
+  have ⟨h₂, h₃, s, h₄, h₅⟩ := type_of_call_decimal_inversion h₁
   subst h₂ h₃ h₄
   apply And.intro
   case left => exact empty_guarded_capabilities_invariant
   case right =>
     rw [Option.isSome_iff_exists] at h₅
-    rcases h₅ with ⟨d, h₅⟩
+    have ⟨d, h₅⟩ := h₅
     exists .ext d
     apply And.intro
     case left =>
@@ -91,13 +91,13 @@ theorem type_of_call_ip_is_sound {xs : List Expr} {c₁ c₂ : Capabilities} {en
   GuardedCapabilitiesInvariant (Expr.call .ip xs) c₂ request entities ∧
   ∃ v, EvaluatesTo (Expr.call .ip xs) request entities v ∧ InstanceOfType v ty
 := by
-  rcases (type_of_call_ip_inversion h₁) with ⟨h₂, h₃, s, h₄, h₅⟩
+  have ⟨h₂, h₃, s, h₄, h₅⟩ := type_of_call_ip_inversion h₁
   subst h₂ h₃ h₄
   apply And.intro
   case left => exact empty_guarded_capabilities_invariant
   case right =>
     rw [Option.isSome_iff_exists] at h₅
-    rcases h₅ with ⟨ip, h₅⟩
+    have ⟨ip, h₅⟩ := h₅
     exists .ext ip
     apply And.intro
     case left =>
@@ -135,7 +135,7 @@ theorem typeOf_of_binary_call_inversion {xs : List Expr} {c : Capabilities} {env
         rename_i res₁ h₂ _ res₂ h₃
         exists hd₁, hd₂, res₁.2, res₂.2
         simp [ok]
-        rcases h₁ with ⟨hl₁, hr₁⟩
+        have ⟨hl₁, hr₁⟩ := h₁
         subst hl₁ hr₁
         simp at h₂ h₃
         simp [h₂, h₃]
@@ -194,17 +194,17 @@ theorem type_of_call_decimal_comparator_is_sound {xfn : ExtFun} {xs : List Expr}
   GuardedCapabilitiesInvariant (Expr.call xfn xs) c₂ request entities ∧
   ∃ v, EvaluatesTo (Expr.call xfn xs) request entities v ∧ InstanceOfType v ty
 := by
-  rcases (type_of_call_decimal_comparator_inversion h₀ h₃) with ⟨h₄, h₅, x₁, x₂, c₁', c₂', h₆, h₇, h₈⟩
+  have ⟨h₄, h₅, x₁, x₂, c₁', c₂', h₆, h₇, h₈⟩ := type_of_call_decimal_comparator_inversion h₀ h₃
   subst h₄ h₅ h₆
   apply And.intro
   case left => exact empty_guarded_capabilities_invariant
   case right =>
     simp [EvaluatesTo, evaluate, List.mapM₁, List.attach]
-    rcases (ih x₁) with ih₁ ; simp at ih₁
-    rcases (ih x₂) with ih₂ ; simp at ih₂
+    have ih₁ := ih x₁
+    have ih₂ := ih x₂
     simp [TypeOfIsSound] at ih₁ ih₂
-    rcases (ih₁ h₁ h₂ h₇) with ⟨_, v₁, hl₁, hr₁⟩
-    rcases (ih₂ h₁ h₂ h₈) with ⟨_, v₂, hl₂, hr₂⟩
+    have ⟨_, v₁, hl₁, hr₁⟩ := ih₁ h₁ h₂ h₇
+    have ⟨_, v₂, hl₂, hr₂⟩ := ih₂ h₁ h₂ h₈
     simp [EvaluatesTo] at hl₁
     rcases hl₁ with hl₁ | hl₁ | hl₁ | hl₁ <;>
     simp [hl₁] <;>
@@ -212,8 +212,8 @@ theorem type_of_call_decimal_comparator_is_sound {xfn : ExtFun} {xs : List Expr}
     rcases hl₂ with hl₂ | hl₂ | hl₂ | hl₂ <;>
     simp [hl₂] <;>
     try { exact type_is_inhabited (CedarType.bool BoolType.anyBool)}
-    rcases (instance_of_decimal_type_is_decimal hr₁) with ⟨d₁, hr₁⟩
-    rcases (instance_of_decimal_type_is_decimal hr₂) with ⟨d₂, hr₂⟩
+    have ⟨d₁, hr₁⟩ := instance_of_decimal_type_is_decimal hr₁
+    have ⟨d₂, hr₂⟩ := instance_of_decimal_type_is_decimal hr₂
     subst hr₁ hr₂
     simp [IsDecimalComparator] at h₀
     split at h₀ <;>
@@ -251,17 +251,17 @@ theorem type_of_call_isInRange_comparator_is_sound {xs : List Expr} {c₁ c₂ :
   GuardedCapabilitiesInvariant (Expr.call .isInRange xs) c₂ request entities ∧
   ∃ v, EvaluatesTo (Expr.call .isInRange xs) request entities v ∧ InstanceOfType v ty
 := by
-  rcases (type_of_call_isInRange_inversion h₃) with ⟨h₄, h₅, x₁, x₂, c₁', c₂', h₆, h₇, h₈⟩
+  have ⟨h₄, h₅, x₁, x₂, c₁', c₂', h₆, h₇, h₈⟩ := type_of_call_isInRange_inversion h₃
   subst h₄ h₅ h₆
   apply And.intro
   case left => exact empty_guarded_capabilities_invariant
   case right =>
     simp [EvaluatesTo, evaluate, List.mapM₁, List.attach]
-    rcases (ih x₁) with ih₁ ; simp at ih₁
-    rcases (ih x₂) with ih₂ ; simp at ih₂
+    have ih₁ := ih x₁
+    have ih₂ := ih x₂
     simp [TypeOfIsSound] at ih₁ ih₂
-    rcases (ih₁ h₁ h₂ h₇) with ⟨_, v₁, hl₁, hr₁⟩
-    rcases (ih₂ h₁ h₂ h₈) with ⟨_, v₂, hl₂, hr₂⟩
+    have ⟨_, v₁, hl₁, hr₁⟩ := ih₁ h₁ h₂ h₇
+    have ⟨_, v₂, hl₂, hr₂⟩ := ih₂ h₁ h₂ h₈
     simp [EvaluatesTo] at hl₁
     rcases hl₁ with hl₁ | hl₁ | hl₁ | hl₁ <;>
     simp [hl₁] <;>
@@ -269,8 +269,8 @@ theorem type_of_call_isInRange_comparator_is_sound {xs : List Expr} {c₁ c₂ :
     rcases hl₂ with hl₂ | hl₂ | hl₂ | hl₂ <;>
     simp [hl₂] <;>
     try { exact type_is_inhabited (CedarType.bool BoolType.anyBool)}
-    rcases (instance_of_ipAddr_type_is_ipAddr hr₁) with ⟨d₁, hr₁⟩
-    rcases (instance_of_ipAddr_type_is_ipAddr hr₂) with ⟨d₂, hr₂⟩
+    have ⟨d₁, hr₁⟩ := instance_of_ipAddr_type_is_ipAddr hr₁
+    have ⟨d₂, hr₂⟩ := instance_of_ipAddr_type_is_ipAddr hr₂
     subst hr₁ hr₂
     simp [call]
     apply bool_is_instance_of_anyBool
@@ -351,20 +351,20 @@ theorem type_of_call_ipAddr_recognizer_is_sound {xfn : ExtFun} {xs : List Expr} 
   GuardedCapabilitiesInvariant (Expr.call xfn xs) c₂ request entities ∧
   ∃ v, EvaluatesTo (Expr.call xfn xs) request entities v ∧ InstanceOfType v ty
 := by
-  rcases (type_of_call_ipAddr_recognizer_inversion h₀ h₃) with ⟨h₄, h₅, x₁, c₁', h₆, h₇⟩
+  have ⟨h₄, h₅, x₁, c₁', h₆, h₇⟩ := type_of_call_ipAddr_recognizer_inversion h₀ h₃
   subst h₄ h₅ h₆
   apply And.intro
   case left => exact empty_guarded_capabilities_invariant
   case right =>
     simp [EvaluatesTo, evaluate, List.mapM₁, List.attach]
-    rcases (ih x₁) with ih₁ ; simp at ih₁
+    have ih₁ := ih x₁
     simp [TypeOfIsSound] at ih₁
-    rcases (ih₁ h₁ h₂ h₇) with ⟨_, v₁, hl₁, hr₁⟩
+    have ⟨_, v₁, hl₁, hr₁⟩ := ih₁ h₁ h₂ h₇
     simp [EvaluatesTo] at hl₁
     rcases hl₁ with hl₁ | hl₁ | hl₁ | hl₁ <;>
     simp [hl₁] <;>
     try { exact type_is_inhabited (CedarType.bool BoolType.anyBool)}
-    rcases (instance_of_ipAddr_type_is_ipAddr hr₁) with ⟨ip₁, hr₁⟩
+    have ⟨ip₁, hr₁⟩ := instance_of_ipAddr_type_is_ipAddr hr₁
     subst hr₁
     simp [IsIpAddrRecognizer] at h₀
     split at h₀ <;>

--- a/cedar-lean/Cedar/Thm/Validation/Typechecker/GetAttr.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Typechecker/GetAttr.lean
@@ -47,13 +47,13 @@ theorem type_of_getAttr_inversion {x₁ : Expr} {a : Attr} {c₁ c₂ : Capabili
   simp [typeOf] at h₁
   cases h₂ : typeOf x₁ c₁ env <;> simp [h₂] at h₁
   case ok res =>
-    rcases res with ⟨ty₁, c₁'⟩
+    have ⟨ty₁, c₁'⟩ := res
     simp [typeOfGetAttr] at h₁
     split at h₁ <;> try contradiction
-    case mk.h_1 =>
+    case h_1 =>
       simp
       apply getAttrInRecord_has_empty_capabilities h₁
-    case mk.h_2 =>
+    case h_2 =>
       simp
       split at h₁ <;> try simp [err] at h₁
       apply getAttrInRecord_has_empty_capabilities h₁
@@ -71,24 +71,24 @@ theorem type_of_getAttr_is_sound_for_records {x₁ : Expr} {a : Attr} {c₁ c₁
    getAttr v₁ a entities = Except.ok v) ∧
    InstanceOfType v ty
 := by
-  rcases (instance_of_record_type_is_record h₅) with ⟨r, h₆⟩
+  have ⟨r, h₆⟩ := instance_of_record_type_is_record h₅
   subst h₆
   simp [getAttr, attrsOf, Map.findOrErr]
   cases h₈ : Map.find? r a
-  case intro.none =>
+  case none =>
     simp only [or_self, false_and, exists_const]
     simp [typeOf, h₃, typeOfGetAttr, getAttrInRecord] at h₂
     split at h₂ <;> simp [ok, err] at h₂
     case h_1 _ _ h₉ =>
       subst h₂
-      rcases (required_attribute_is_present h₅ h₉) with ⟨_, h₁₀⟩
+      have ⟨_, h₁₀⟩ := required_attribute_is_present h₅ h₉
       simp [h₈] at h₁₀
     case h_2 =>
       split at h₂ <;> simp at h₂
       subst h₂ ; rename_i h₁₀
-      rcases (capability_implies_record_attribute h₁ h₄ h₁₀) with ⟨_, h₁₁⟩
+      have ⟨_, h₁₁⟩ := capability_implies_record_attribute h₁ h₄ h₁₀
       simp [h₈] at h₁₁
-  case intro.some vₐ =>
+  case some vₐ =>
     simp only [Except.ok.injEq, false_or, exists_eq_left']
     simp [typeOf, h₃, typeOfGetAttr, getAttrInRecord] at h₂
     split at h₂ <;> simp [ok, err] at h₂
@@ -114,14 +114,14 @@ theorem type_of_getAttr_is_sound_for_entities {x₁ : Expr} {a : Attr} {c₁ c�
    getAttr v₁ a entities = Except.ok v) ∧
    InstanceOfType v ty
 := by
-  rcases (instance_of_entity_type_is_entity h₆) with ⟨uid, h₇, h₈⟩
+  have ⟨uid, h₇, h₈⟩ := instance_of_entity_type_is_entity h₆
   subst h₈
   simp [getAttr, attrsOf, Entities.attrs, Map.findOrErr]
   cases h₈ : Map.find? entities uid
-  case intro.intro.none =>
+  case none =>
     simp only [Except.bind_err, Except.error.injEq, or_self, or_false, true_and]
     exact type_is_inhabited ty
-  case intro.intro.some d =>
+  case some d =>
     subst h₇
     simp only [Except.bind_ok]
     cases h₉ : Map.find? d.attrs a
@@ -132,13 +132,13 @@ theorem type_of_getAttr_is_sound_for_entities {x₁ : Expr} {a : Attr} {c₁ c�
       split at h₃ <;> try simp at h₃
       case h_1.h_1 _ _ h₁₀ _ _ h₁₁ =>
         subst h₃
-        rcases (well_typed_entity_attributes h₂ h₈ h₁₀) with h₁₂
-        rcases (required_attribute_is_present h₁₂ h₁₁) with ⟨aᵥ, h₁₃⟩
+        have h₁₂ := well_typed_entity_attributes h₂ h₈ h₁₀
+        have ⟨aᵥ, h₁₃⟩ := required_attribute_is_present h₁₂ h₁₁
         simp [h₉] at h₁₃
       case h_1.h_2 =>
         split at h₃ <;> simp at h₃
         subst h₃ ; rename_i h₁₃
-        rcases (capability_implies_entity_attribute h₁ h₅ h₈ h₁₃) with ⟨_, h₁₄⟩
+        have ⟨_, h₁₄⟩ := capability_implies_entity_attribute h₁ h₅ h₈ h₁₃
         simp [h₉] at h₁₄
     case some vₐ =>
       simp only [Except.ok.injEq, false_or, exists_eq_left']
@@ -163,19 +163,19 @@ theorem type_of_getAttr_is_sound {x₁ : Expr} {a : Attr} {c₁ c₂ : Capabilit
   GuardedCapabilitiesInvariant (Expr.getAttr x₁ a) c₂ request entities ∧
   ∃ v, EvaluatesTo (Expr.getAttr x₁ a) request entities v ∧ InstanceOfType v ty
 := by
-  rcases (type_of_getAttr_inversion h₃) with ⟨h₅, c₁', h₄⟩
+  have ⟨h₅, c₁', h₄⟩ := type_of_getAttr_inversion h₃
   subst h₅
   apply And.intro
   case left => exact empty_guarded_capabilities_invariant
   case right =>
     rcases h₄ with ⟨ety, h₄⟩ | ⟨rty, h₄⟩ <;>
-    rcases (ih h₁ h₂ h₄) with ⟨_, v₁, h₆, h₇⟩ <;>
+    have ⟨_, v₁, h₆, h₇⟩ := ih h₁ h₂ h₄ <;>
     simp [EvaluatesTo] at h₆ <;>
     simp [EvaluatesTo, evaluate] <;>
     rcases h₆ with h₆ | h₆ | h₆ | h₆ <;> simp [h₆]
-    case inl.intro.intro.intro.intro.inr.inr.inr =>
+    case inl.intro.inr.inr.inr =>
       exact type_of_getAttr_is_sound_for_entities h₁ h₂ h₃ h₄ h₆ h₇
-    case inr.intro.intro.intro.intro.inr.inr.inr =>
+    case inr.intro.inr.inr.inr =>
       exact type_of_getAttr_is_sound_for_records h₁ h₃ h₄ h₆ h₇
     all_goals {
       exact type_is_inhabited ty

--- a/cedar-lean/Cedar/Thm/Validation/Typechecker/HasAttr.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Typechecker/HasAttr.lean
@@ -36,16 +36,16 @@ theorem type_of_hasAttr_inversion {x₁ : Expr} {a : Attr} {c₁ c₂ : Capabili
   simp [typeOf, typeOfHasAttr] at h₁
   cases h₂ : typeOf x₁ c₁ env <;> simp [h₂] at h₁
   case ok res =>
-    rcases res with ⟨ty₁, c₁'⟩
+    have ⟨ty₁, c₁'⟩ := res
     simp at h₁
     split at h₁ <;> try simp [err, ok, hasAttrInRecord] at h₁
-    case mk.h_1 _ _ =>
+    case h_1 _ _ =>
       split at h₁ <;> try split at h₁
       all_goals {
         simp [ok] at h₁
         simp [h₁]
       }
-    case mk.h_2 _ _ =>
+    case h_2 _ _ =>
       split at h₁
       split at h₁ <;> try split at h₁
       all_goals {
@@ -66,37 +66,37 @@ theorem type_of_hasAttr_is_sound_for_records {x₁ : Expr} {a : Attr} {c₁ c₁
    hasAttr v₁ a entities = Except.ok v) ∧
   InstanceOfType v ty
 := by
-  rcases (instance_of_record_type_is_record h₅) with ⟨r, h₅⟩
+  have ⟨r, h₅⟩ := instance_of_record_type_is_record h₅
   subst h₅
   simp [hasAttr, attrsOf]
   simp [typeOf, h₃, typeOfHasAttr, hasAttrInRecord] at h₂
   split at h₂
-  case intro.h_1 =>
-    split at h₂ <;> simp [ok] at h₂ <;> rcases h₂ with ⟨h₂, _⟩ <;>
-    simp [←h₂] <;>
+  case h_1 =>
+    split at h₂ <;> simp [ok] at h₂ <;>
+    have ⟨hₜ, _⟩ := h₂ <;> simp [←hₜ] <;>
     apply InstanceOfType.instance_of_bool <;>
     simp [InstanceOfBoolType]
     cases h₆ : (Map.contains r a) <;> simp
     rename_i h₇ _
     cases h₇
-    case inl.intro.h₁.false.inl _ h₇ =>
+    case inl.h₁.false.inl _ h₇ =>
       simp [CapabilitiesInvariant] at h₁
       specialize h₁ x₁ a h₇
       simp [EvaluatesTo, evaluate, h₄, hasAttr, attrsOf, h₆] at h₁
-    case inl.intro.h₁.false.inr h₇ _ h₈ =>
+    case inl.h₁.false.inr h₇ _ h₈ =>
       simp [Qualified.isRequired] at h₈
       split at h₈ <;> simp at h₈
-      rcases (required_attribute_is_present h₅ h₇) with h₉
+      have h₉ := required_attribute_is_present h₅ h₇
       simp [←Map.contains_iff_some_find?, h₆] at h₉
-  case intro.h_2 =>
+  case h_2 =>
     simp [ok] at h₂
-    rcases h₂ with ⟨h₂, _⟩
+    have ⟨h₂, _⟩ := h₂
     simp [←h₂]
     apply InstanceOfType.instance_of_bool
     simp [InstanceOfBoolType]
     cases h₆ : (Map.contains r a) <;> simp
-    rename_i _ h₇ _
-    rcases (absent_attribute_is_absent h₅ h₇) with h₇
+    rename_i _ h₇ _ _
+    have h₇ := absent_attribute_is_absent h₅ h₇
     simp [Map.contains_iff_some_find?, h₇] at h₆
 
 
@@ -114,14 +114,14 @@ theorem type_of_hasAttr_is_sound_for_entities {x₁ : Expr} {a : Attr} {c₁ c�
    hasAttr v₁ a entities = Except.ok v) ∧
    InstanceOfType v ty
 := by
-  rcases (instance_of_entity_type_is_entity h₆) with ⟨uid, h₆, h₇⟩
+  have ⟨uid, h₆, h₇⟩ := instance_of_entity_type_is_entity h₆
   subst h₆ h₇
   simp [hasAttr, attrsOf]
   simp [typeOf, h₄, typeOfHasAttr] at h₃
   split at h₃ <;> try simp [err, hasAttrInRecord] at h₃
   rename_i _ rty h₇
   split at h₃
-  case intro.intro.h_1.h_1 =>
+  case h_1.h_1 =>
     split at h₃ <;> rcases h₃ with ⟨h₃, _⟩ <;>
     apply InstanceOfType.instance_of_bool <;>
     simp [InstanceOfBoolType]
@@ -130,21 +130,21 @@ theorem type_of_hasAttr_is_sound_for_entities {x₁ : Expr} {a : Attr} {c₁ c�
     simp [CapabilitiesInvariant] at h₁
     specialize h₁ x₁ a h₉
     simp [EvaluatesTo, evaluate, h₅, hasAttr, attrsOf, h₈] at h₁
-  case intro.intro.h_1.h_2 =>
+  case h_1.h_2 =>
     simp [ok] at h₃
-    rcases h₃ with ⟨h₃, _⟩
+    have ⟨h₃, _⟩ := h₃
     simp [←h₃]
     apply InstanceOfType.instance_of_bool
     simp [InstanceOfBoolType]
     cases h₈ : Map.contains (Entities.attrsOrEmpty entities uid) a <;> simp
-    rename_i _ _ h₉ _
+    rename_i _ _ h₉ _ _
     simp [Entities.attrsOrEmpty] at h₈
     split at h₈
-    case intro.h₁.true.h_1 _ _ _ _ _ h₁₀ =>
-      rcases (well_typed_entity_attributes h₂ h₁₀ h₇) with h₁₁
-      rcases (absent_attribute_is_absent h₁₁ h₉) with h₁₂
+    case h₁.true.h_1 _ _ _ _ _ h₁₀ =>
+      have h₁₁ := well_typed_entity_attributes h₂ h₁₀ h₇
+      have h₁₂ := absent_attribute_is_absent h₁₁ h₉
       simp [Map.contains_iff_some_find?, h₁₂] at h₈
-    case intro.h₁.true.h_2 =>
+    case h₁.true.h_2 =>
       rcases (Map.not_contains_of_empty a) with _
       contradiction
 
@@ -156,24 +156,24 @@ theorem type_of_hasAttr_is_sound {x₁ : Expr} {a : Attr} {c₁ c₂ : Capabilit
   GuardedCapabilitiesInvariant (Expr.hasAttr x₁ a) c₂ request entities ∧
   ∃ v, EvaluatesTo (Expr.hasAttr x₁ a) request entities v ∧ InstanceOfType v ty
 := by
-  rcases (type_of_hasAttr_inversion h₃) with ⟨h₅, c₁', h₄⟩
+  have ⟨h₅, c₁', h₄⟩ := type_of_hasAttr_inversion h₃
   apply And.intro
   case left =>
     simp [GuardedCapabilitiesInvariant, CapabilitiesInvariant]
     intro h₆ x aₓ h₇
     cases h₅ <;> rename_i h₈ <;> subst h₈ <;> simp [Capabilities.singleton] at h₇
-    rcases h₇ with ⟨h₇, h₈⟩
+    have ⟨h₇, h₈⟩ := h₇
     subst h₇; subst h₈
     simp [EvaluatesTo, h₆]
   case right =>
     rcases h₄ with ⟨ety, h₄⟩ | ⟨rty, h₄⟩ <;>
-    rcases (ih h₁ h₂ h₄) with ⟨_, v₁, h₆, h₇⟩ <;>
+    have ⟨_, v₁, h₆, h₇⟩ := ih h₁ h₂ h₄ <;>
     simp [EvaluatesTo] at h₆ <;>
     simp [EvaluatesTo, evaluate] <;>
     rcases h₆ with h₆ | h₆ | h₆ | h₆ <;> simp [h₆]
-    case inl.intro.intro.intro.intro.inr.inr.inr =>
+    case inl.intro.inr.inr.inr =>
       exact type_of_hasAttr_is_sound_for_entities h₁ h₂ h₃ h₄ h₆ h₇
-    case inr.intro.intro.intro.intro.inr.inr.inr =>
+    case inr.intro.inr.inr.inr =>
       exact type_of_hasAttr_is_sound_for_records h₁ h₃ h₄ h₆ h₇
     all_goals {
       exact type_is_inhabited ty

--- a/cedar-lean/Cedar/Thm/Validation/Typechecker/IfThenElse.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Typechecker/IfThenElse.lean
@@ -44,12 +44,12 @@ theorem type_of_ite_inversion {x₁ x₂ x₃ : Expr} {c c' : Capabilities} {env
   cases h₂ : typeOf x₁ c env <;> simp [h₂, typeOfIf] at *
   rename_i res₁
   split at h₁ <;> try { simp [ok, err] at h₁ } <;>
-  rename_i c₁ hr₁ <;> simp at hr₁ <;> rcases hr₁ with ⟨ht₁, hc₁⟩
+  rename_i c₁ hr₁ <;> simp at hr₁ <;> have ⟨ht₁, hc₁⟩ := hr₁
   case ok.h_1 =>
     exists BoolType.tt, res₁.snd ; simp [←ht₁]
     cases h₃ : typeOf x₂ (c ∪ res₁.snd) env <;> simp [h₃] at h₁
     rename_i res₂ ; simp [ok] at h₁
-    rcases h₁ with ⟨ht₂, hc₂⟩
+    have ⟨ht₂, hc₂⟩ := h₁
     exists res₂.fst, res₂.snd
     subst ht₂ hc₂ hc₁
     simp only [and_self]
@@ -62,7 +62,8 @@ theorem type_of_ite_inversion {x₁ x₂ x₃ : Expr} {c c' : Capabilities} {env
     cases h₄ : typeOf x₃ c env <;> simp [h₄] at h₁
     split at h₁ <;> simp [ok, err] at h₁
     rename_i ty' res₂ res₃ _ ty' hty
-    rcases h₁ with ⟨ht, hc⟩ ; subst ht hc hc₁
+    have ⟨ht, hc⟩ := h₁
+    subst ht hc hc₁
     exists res₂.fst, res₂.snd
     simp only [Except.ok.injEq, true_and]
     exists res₃.fst, res₃.snd
@@ -77,20 +78,21 @@ theorem type_of_ite_is_sound {x₁ x₂ x₃ : Expr} {c₁ c₂ : Capabilities} 
   GuardedCapabilitiesInvariant (Expr.ite x₁ x₂ x₃) c₂ request entities ∧
   ∃ v, EvaluatesTo (Expr.ite x₁ x₂ x₃) request entities v ∧ InstanceOfType v ty
 := by
-  rcases (type_of_ite_inversion h₃) with ⟨bty₁, rc₁, ty₂, rc₂, ty₃, rc₃, h₄, h₅⟩
+  have ⟨bty₁, rc₁, ty₂, rc₂, ty₃, rc₃, h₄, h₅⟩ := type_of_ite_inversion h₃
   specialize ih₁ h₁ h₂ h₄
-  rcases ih₁ with ⟨ih₁₁, v₁, ih₁₂, ih₁₃⟩
-  rcases (instance_of_bool_is_bool ih₁₃) with ⟨b₁, hb₁⟩ ; subst hb₁
+  have ⟨ih₁₁, v₁, ih₁₂, ih₁₃⟩ := ih₁
+  have ⟨b₁, hb₁⟩ := instance_of_bool_is_bool ih₁₃
+  subst hb₁
   cases bty₁ <;> simp at h₅
   case anyBool =>
-    rcases h₅ with ⟨h₅, h₆, ht, hc⟩
+    have ⟨h₅, h₆, ht, hc⟩ := h₅
     cases b₁
     case false =>
       rcases ih₁₂ with ih₁₂ | ih₁₂ | ih₁₂ | ih₁₂ <;>
       simp [EvaluatesTo, evaluate, Result.as, ih₁₂, Coe.coe, Value.asBool, GuardedCapabilitiesInvariant] <;>
       try exact type_is_inhabited ty
       specialize ih₃ h₁ h₂ h₆
-      rcases ih₃ with ⟨ih₃₁, v₃, ih₃₂, ih₃₃⟩
+      have ⟨ih₃₁, v₃, ih₃₂, ih₃₃⟩ := ih₃
       rcases ih₃₂ with ih₃₂ | ih₃₂ | ih₃₂ | ih₃₂ <;> simp [ih₃₂] <;>
       try exact type_is_inhabited ty
       apply And.intro
@@ -107,9 +109,9 @@ theorem type_of_ite_is_sound {x₁ x₂ x₃ : Expr} {c₁ c₂ : Capabilities} 
       simp [EvaluatesTo, evaluate, Result.as, ih₁₂, Coe.coe, Value.asBool, GuardedCapabilitiesInvariant] <;>
       try exact type_is_inhabited ty
       simp [GuardedCapabilitiesInvariant, ih₁₂] at ih₁₁
-      rcases (capability_union_invariant h₁ ih₁₁) with h₇
+      have h₇ := capability_union_invariant h₁ ih₁₁
       specialize ih₂ h₇ h₂ h₅
-      rcases ih₂ with ⟨ih₂₁, v₂, ih₂₂, ih₂₃⟩
+      have ⟨ih₂₁, v₂, ih₂₂, ih₂₃⟩ := ih₂
       apply And.intro
       case left =>
         intro h₈
@@ -124,16 +126,16 @@ theorem type_of_ite_is_sound {x₁ x₂ x₃ : Expr} {c₁ c₂ : Capabilities} 
         apply instance_of_lub ht
         simp [ih₂₃]
   case tt =>
-    rcases h₅ with ⟨h₅, ht, hc⟩
+    have ⟨h₅, ht, hc⟩ := h₅
     rcases ih₁₂ with ih₁₂ | ih₁₂ | ih₁₂ | ih₁₂ <;>
     simp [EvaluatesTo, evaluate, Result.as, ih₁₂, Coe.coe, Value.asBool, GuardedCapabilitiesInvariant] <;>
     try exact type_is_inhabited ty
-    rcases (instance_of_tt_is_true ih₁₃) with hb₁
+    have hb₁ := instance_of_tt_is_true ih₁₃
     simp at hb₁ ; subst hb₁ ; simp only [ite_true]
     simp [GuardedCapabilitiesInvariant, ih₁₂] at ih₁₁
-    rcases (capability_union_invariant h₁ ih₁₁) with h₆
+    have h₆ := capability_union_invariant h₁ ih₁₁
     specialize ih₂ h₆ h₂ h₅
-    rcases ih₂ with ⟨ih₂₁, v₂, ih₂₂, ih₂₃⟩
+    have ⟨ih₂₁, v₂, ih₂₂, ih₂₃⟩ := ih₂
     rcases ih₂₂ with ih₂₂ | ih₂₂ | ih₂₂ | ih₂₂ <;> simp [ih₂₂] <;>
     try exact type_is_inhabited ty
     subst ht hc ; simp [ih₂₃]
@@ -141,14 +143,14 @@ theorem type_of_ite_is_sound {x₁ x₂ x₃ : Expr} {c₁ c₂ : Capabilities} 
     simp [GuardedCapabilitiesInvariant, ih₂₂] at ih₂₁
     exact capability_union_invariant ih₁₁ ih₂₁
   case ff =>
-    rcases h₅ with ⟨h₅, ht, hc⟩
+    have ⟨h₅, ht, hc⟩ := h₅
     rcases ih₁₂ with ih₁₂ | ih₁₂ | ih₁₂ | ih₁₂ <;>
     simp [EvaluatesTo, evaluate, Result.as, ih₁₂, Coe.coe, Value.asBool, GuardedCapabilitiesInvariant] <;>
     try exact type_is_inhabited ty
-    rcases (instance_of_ff_is_false ih₁₃) with hb₁
+    have hb₁ := instance_of_ff_is_false ih₁₃
     simp at hb₁ ; simp [hb₁]
     specialize ih₃ h₁ h₂ h₅
-    rcases ih₃ with ⟨ih₃₁, v₃, ih₃₂, ih₃₃⟩
+    have ⟨ih₃₁, v₃, ih₃₂, ih₃₃⟩ := ih₃
     subst ht hc
     apply And.intro
     case left =>

--- a/cedar-lean/Cedar/Thm/Validation/Typechecker/LUB.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Typechecker/LUB.lean
@@ -101,8 +101,8 @@ theorem lubRecord_contains_left {a : Attr} {rty rty₁ rty₂ : List (Attr × Qu
   Map.contains (Map.mk rty) a = true
 := by
   simp [Map.contains_iff_some_find?] at *
-  rcases h₂ with ⟨qty₁, h₂⟩
-  rcases (lubRecord_find_implied_by_find_left h₁ h₂) with ⟨qty, _, h₃⟩
+  have ⟨qty₁, h₂⟩ := h₂
+  have ⟨qty, _, h₃⟩ := lubRecord_find_implied_by_find_left h₁ h₂
   exists qty ; simp [h₃]
 
 theorem lubRecord_find_implies_find_left {a : Attr} {qty : QualifiedType} {rty rty₁ rty₂ : List (Attr × Qualified CedarType)}
@@ -112,7 +112,7 @@ theorem lubRecord_find_implies_find_left {a : Attr} {qty : QualifiedType} {rty r
     Map.find? (Map.mk rty₁) a = some qty₁ ∧
     Qualified.isRequired qty₁ = Qualified.isRequired qty
 := by
-  rcases (lubRecord_find_implies_find h₁ h₂) with ⟨qty₁, qty₂, h₃, h₄, h₅⟩
+  have ⟨qty₁, qty₂, h₃, h₄, h₅⟩ := lubRecord_find_implies_find h₁ h₂
   exists qty₁ ; simp [h₃]
   unfold lubQualifiedType at h₅
   split at h₅ <;> try simp at h₅
@@ -145,7 +145,7 @@ theorem lubQualified_comm {qty₁ qty₂ : Qualified CedarType} :
   split
   case h_1 | h_2 =>
     rename_i ty₁ ty₂
-    rcases (@lub_comm ty₁ ty₂) with h
+    have h := @lub_comm ty₁ ty₂
     simp [h]
   case h_3 =>
     rename_i h₁ h₂
@@ -163,8 +163,8 @@ theorem lubRecord_comm {rty₁ rty₂ : List (Attr × Qualified CedarType)} :
     rename_i a₁ hd₁ tl₁ a₂ hd₂ tl₂
     split <;> rename_i h₃ <;> rw [eq_comm] at h₃ <;> simp [h₃]
     subst h₃
-    rcases (@lubQualified_comm hd₁ hd₂) with h₄
-    rcases (@lubRecord_comm tl₁ tl₂) with h₅
+    have h₄ := @lubQualified_comm hd₁ hd₂
+    have h₅ := @lubRecord_comm tl₁ tl₂
     simp [h₄, h₅]
   case h_3 =>
     rename_i h₁ h₂
@@ -182,11 +182,11 @@ theorem lub_comm {ty₁ ty₂ : CedarType} :
   case h_1 => simp [lubBool_comm]
   case h_2 =>
     rename_i s₁ s₂
-    rcases (@lub_comm s₁ s₂) with h
+    have h := @lub_comm s₁ s₂
     simp [h]
   case h_3 =>
     rename_i rty₁ rty₂
-    rcases (@lubRecord_comm rty₁ rty₂) with h
+    have h := @lubRecord_comm rty₁ rty₂
     simp [h]
   case h_4 =>
     rename_i h₁ h₂ h₃
@@ -212,10 +212,10 @@ theorem lub_refl (ty : CedarType) :
   split <;> try simp
   case h_1 => simp [lubBool]
   case h_2 eltTy =>
-    rcases (lub_refl eltTy) with h₁
+    have h₁ := lub_refl eltTy
     simp [h₁]
   case h_3 rty =>
-    rcases (lubRecordType_refl rty) with h₁
+    have h₁ := lubRecordType_refl rty
     simp [h₁]
 
 theorem lubRecordType_refl (rty : List (Attr × QualifiedType)) :
@@ -224,8 +224,8 @@ theorem lubRecordType_refl (rty : List (Attr × QualifiedType)) :
   unfold lubRecordType
   split <;> try simp
   case h_2 k qty tl =>
-    rcases (lubQualifiedType_refl qty) with h₁
-    rcases (lubRecordType_refl tl) with h₂
+    have h₁ := lubQualifiedType_refl qty
+    have h₂ := lubRecordType_refl tl
     simp [h₁, h₂]
   case h_3 h₁ h₂ =>
     cases rty <;> simp at h₁
@@ -248,7 +248,7 @@ theorem lubQualifiedType_refl (qty : QualifiedType) :
     }
   all_goals {
     rename_i ty
-    rcases (lub_refl ty) with h₁
+    have h₁ := lub_refl ty
     simp [h₁]
   }
 end
@@ -289,7 +289,7 @@ theorem lub_trans {ty₁ ty₂ ty₃ : CedarType} :
     cases h₃ : sty₁ ⊔ sty₂ <;> simp [h₃] at h₁
     cases h₄ : sty₂ ⊔ sty₃ <;> simp [h₄] at h₂
     rw [eq_comm] at h₁ h₂ ; subst h₁ h₂
-    rcases (lub_trans h₃ h₄) with h₅
+    have h₅ := lub_trans h₃ h₄
     simp [h₅]
   case h_3 rty₁ rty₃ =>
     unfold lub? at h₁ h₂
@@ -299,7 +299,7 @@ theorem lub_trans {ty₁ ty₂ ty₃ : CedarType} :
     cases h₃ : lubRecordType rty₁ rty₂ <;> simp [h₃] at h₁
     cases h₄ : lubRecordType rty₂ rty₃ <;> simp [h₄] at h₂
     rw [eq_comm] at h₁ h₂ ; subst h₁ h₂
-    rcases (lubRecordType_trans h₃ h₄) with h₅
+    have h₅ := lubRecordType_trans h₃ h₄
     simp [h₅]
   case h_4 =>
     split
@@ -343,13 +343,13 @@ theorem lubRecordType_trans {rty₁ rty₂ rty₃ : List (Attr × QualifiedType)
     cases h₇ : lubQualifiedType hd₂.snd hd₃.snd <;> simp [h₇] at h₂
     cases h₈ : lubRecordType tl₂ tl₃ <;> simp [h₈] at h₂
     rename_i qty₂ rty₂'
-    rcases h₁ with ⟨hl₁, hr₁⟩
-    rcases h₂ with ⟨hl₂, hr₂⟩
+    have ⟨hl₁, hr₁⟩ := h₁
+    have ⟨hl₂, hr₂⟩ := h₂
     rw [eq_comm] at hl₁ hl₂ hr₁ hr₂
     subst hl₁ hl₂ hr₁ hr₂
     simp [Prod.snd] at *
-    rcases (lubQualifiedType_trans h₅ h₇) with h₉
-    rcases (lubRecordType_trans h₆ h₈) with h₁₀
+    have h₉ := lubQualifiedType_trans h₅ h₇
+    have h₁₀ := lubRecordType_trans h₆ h₈
     simp [h₉, h₁₀]
   all_goals {
     cases rty₂ <;> simp at h₁ h₂
@@ -369,7 +369,7 @@ theorem lubQualifiedType_trans {qty₁ qty₂ qty₃ : QualifiedType} :
     cases h₃ : ty₁' ⊔ ty₂' <;> simp [h₃] at h₁
     cases h₄ : ty₂' ⊔ ty₃' <;> simp [h₄] at h₂
     rw [eq_comm] at h₁ h₂ ; subst h₁ h₂
-    rcases (lub_trans h₃ h₄) with h₅
+    have h₅ := lub_trans h₃ h₄
     simp [h₅]
   all_goals {
     cases qty₂ <;> simp at h₁ h₂
@@ -386,7 +386,7 @@ theorem subty_trans {ty₁ ty₂ ty₃ : CedarType} :
   split at h₂ <;> try contradiction
   rename_i ty₄ h₃ _ ty₅ h₄
   simp at h₁ h₂ ; rw [eq_comm] at h₁ h₂; subst h₁ h₂
-  rcases (lub_trans h₃ h₄) with h₅
+  have h₅ := lub_trans h₃ h₄
   simp [h₅]
 
 mutual
@@ -412,7 +412,7 @@ theorem lub_left_subty {ty₁ ty₂ ty₃ : CedarType} :
     simp [lub?]
     cases h₃ : sty₁ ⊔ sty₃ <;>
     simp [h₃] <;>
-    rcases (lub_left_subty h₂) with h₄ <;>
+    have h₄ := lub_left_subty h₂ <;>
     simp [subty, h₃] at h₄
     assumption
   case h_3 rty₁ rty₂ =>
@@ -422,7 +422,7 @@ theorem lub_left_subty {ty₁ ty₂ ty₃ : CedarType} :
     simp [lub?]
     cases h₃ : lubRecordType rty₁ rty₃ <;>
     simp [h₃] <;>
-    rcases (lubRecordType_left_subty h₂) with h₄ <;>
+    have h₄ := lubRecordType_left_subty h₂ <;>
     simp [h₃] at h₄
     assumption
   case h_4 =>
@@ -449,8 +449,8 @@ theorem lubRecordType_left_subty {rty₁ rty₂ rty₃ : List (Attr × Qualified
     rename_i qty₃
     cases h₃ : lubRecordType rty₁' rty₂' <;> simp [h₃] at h₁
     rename_i rty₃'
-    rcases (lubQualifiedType_left_subty h₂) with h₄
-    rcases (lubRecordType_left_subty h₃) with h₅
+    have h₄ := lubQualifiedType_left_subty h₂
+    have h₅ := lubRecordType_left_subty h₃
     simp [←h₁, h₄, h₅]
 
 theorem lubQualifiedType_left_subty {qty₁ qty₂ qty₃ : QualifiedType} :
@@ -465,7 +465,7 @@ theorem lubQualifiedType_left_subty {qty₁ qty₂ qty₃ : QualifiedType} :
     cases h₂ : aty₁ ⊔ aty₂ <;> simp [h₂] at h₁
     rename_i aty₃
     subst h₁ ; simp only
-    rcases (lub_left_subty h₂) with h₃
+    have h₃ := lub_left_subty h₂
     simp [subty] at h₃
     split at h₃ <;> try contradiction
     rename_i aty₄ h₄
@@ -520,7 +520,7 @@ theorem lub_assoc_none_some {ty₁ ty₂ ty₃ ty₄ : CedarType}
     cases ty₁ <;> simp at *
     rename_i ty₁'
     cases h₄ : ty₁' ⊔ sty₂ <;> simp [h₄] at h₁
-    rcases (lub_assoc_none_some h₄ h₃) with h₅
+    have h₅ := lub_assoc_none_some h₄ h₃
     simp [h₅]
   case h_3 rty₂ rty₃ =>
     cases h₃ : lubRecordType rty₂ rty₃ <;> simp [h₃] at h₂
@@ -530,7 +530,7 @@ theorem lub_assoc_none_some {ty₁ ty₂ ty₃ ty₄ : CedarType}
     rename_i mty₁ ; cases mty₁ ; rename_i rty₁
     simp at *
     cases h₄ : lubRecordType rty₁ rty₂ <;> simp [h₄] at h₁
-    rcases (lubRecordType_assoc_none_some h₄ h₃) with h₅
+    have h₅ := lubRecordType_assoc_none_some h₄ h₃
     simp [h₅]
   case h_4 =>
     split at h₂ <;> try contradiction
@@ -571,11 +571,11 @@ theorem lubRecordType_assoc_none_some {rty₁ rty₂ rty₃ rty₄ : List (Attr 
           have _ : sizeOf hd.snd < sizeOf rty₁ := by -- termination
             rw [hrty₁]
             apply sizeOf_qualified_lt_sizeOf_record_type hd tl
-          rcases (lubQualifiedType_assoc_none_some h₇ h₄) with h₈
+          have h₈ := lubQualifiedType_assoc_none_some h₇ h₄
           simp [h₈]
         case some =>
           cases h₈ : lubRecordType tl rty₂' <;> simp [h₈] at h₁
-          rcases (lubRecordType_assoc_none_some h₈ h₅) with h₉
+          have h₉ := lubRecordType_assoc_none_some h₈ h₅
           simp [h₉]
       case neg =>
         unfold lubRecordType
@@ -597,7 +597,7 @@ theorem lubQualifiedType_assoc_none_some {qty₁ qty₂ qty₃ qty₄ : Qualifie
     simp [lubQualifiedType]
     rename_i ty₁'
     cases h₄ : ty₁' ⊔ ty₂' <;> simp [h₄] at h₁
-    rcases (lub_assoc_none_some h₄ h₃) with h₅
+    have h₅ := lub_assoc_none_some h₄ h₃
     simp [h₅]
   }
 
@@ -629,16 +629,16 @@ theorem lub_assoc_some_some {ty₁ ty₂ ty₃ ty₄ ty₅ : CedarType}
     subst h₁ h₂
     simp [lub?]
   case entity | ext =>
-    rcases h₁ with ⟨h₀, h₁⟩
-    rcases h₂ with ⟨h₂, h₃⟩
-    subst h₀ h₁ h₂ h₃
+    have ⟨hl₁, hr₁⟩ := h₁
+    have ⟨hl₂, hr₂⟩ := h₂
+    subst hl₁ hr₁ hl₂ hr₂
     simp [lub?]
   case set sty₁ sty₂ sty₃ =>
     cases h₃ : sty₁ ⊔ sty₂ <;> simp [h₃] at h₁
     cases h₄ : sty₂ ⊔ sty₃ <;> simp [h₄] at h₂
     rename_i sty₄ sty₅ ; subst h₁ h₂
     simp [lub?]
-    rcases (lub_assoc_some_some h₃ h₄) with h₅
+    have h₅ := lub_assoc_some_some h₃ h₄
     simp [h₅]
   case record mty₁ mty₂ mty₃ =>
     cases mty₁ ; cases mty₂ ; cases mty₃
@@ -648,7 +648,7 @@ theorem lub_assoc_some_some {ty₁ ty₂ ty₃ ty₄ ty₅ : CedarType}
     cases h₄ : lubRecordType rty₂ rty₃ <;> simp [h₄] at h₂
     rename_i rty₄ rty₅ ; subst h₁ h₂
     simp [lub?]
-    rcases (lubRecordType_assoc_some_some h₃ h₄) with h₅
+    have h₅ := lubRecordType_assoc_some_some h₃ h₄
     simp [h₅]
 
 theorem lubRecordType_assoc_some_some {rty₁ rty₂ rty₃ rty₄ rty₅ : List (Attr × QualifiedType)}
@@ -659,9 +659,9 @@ theorem lubRecordType_assoc_some_some {rty₁ rty₂ rty₃ rty₄ rty₅ : List
   cases hrty₁ : rty₁
   case nil =>
     subst hrty₁
-    rcases (lubRecordType_nil_some h₁) with ⟨h₃, h₄⟩
+    have ⟨h₃, h₄⟩ := lubRecordType_nil_some h₁
     subst h₃ h₄
-    rcases (lubRecordType_nil_some h₂) with ⟨h₃, h₄⟩
+    have ⟨h₃, h₄⟩ := lubRecordType_nil_some h₂
     subst h₃ h₄
     rfl
   case cons hd₁ tl₁ =>
@@ -669,7 +669,7 @@ theorem lubRecordType_assoc_some_some {rty₁ rty₂ rty₃ rty₄ rty₅ : List
     case nil =>
       subst hrty₂
       rw [lubRecord_comm] at h₁
-      rcases (lubRecordType_nil_some h₁) with ⟨h₃, _⟩
+      have ⟨h₃, _⟩ := lubRecordType_nil_some h₁
       subst h₃
       contradiction
     case cons hd₂ tl₂ =>
@@ -677,7 +677,7 @@ theorem lubRecordType_assoc_some_some {rty₁ rty₂ rty₃ rty₄ rty₅ : List
       case nil =>
         subst hrty₂
         rw [lubRecord_comm] at h₂
-        rcases (lubRecordType_nil_some h₂) with ⟨_, _⟩
+        have ⟨_, _⟩ := lubRecordType_nil_some h₂
         contradiction
       case cons hd₃ tl₃ =>
         have _ : sizeOf hd₁.snd < sizeOf rty₁ := by -- termination
@@ -698,8 +698,8 @@ theorem lubRecordType_assoc_some_some {rty₁ rty₂ rty₃ rty₄ rty₅ : List
         cases h₆ : lubRecordType tl₂ tl₃ <;> simp [h₆] at h₂
         subst h₁ h₂
         simp [h₁₂, h₂₃]
-        rcases (lubQualifiedType_assoc_some_some h₃ h₅) with h₇
-        rcases (lubRecordType_assoc_some_some h₄ h₆) with h₈
+        have h₇ := lubQualifiedType_assoc_some_some h₃ h₅
+        have h₈ := lubRecordType_assoc_some_some h₄ h₆
         simp [h₇, h₈]
 
 theorem lubQualifiedType_assoc_some_some {qty₁ qty₂ qty₃ qty₄ qty₅ : QualifiedType}
@@ -713,7 +713,7 @@ theorem lubQualifiedType_assoc_some_some {qty₁ qty₂ qty₃ qty₄ qty₅ : Q
     rename_i ty₁' ty₂' ty₃'
     cases h₃ : (ty₁' ⊔ ty₂') <;> simp [h₃] at h₁
     cases h₄ : (ty₂' ⊔ ty₃') <;> simp [h₄] at h₂
-    rcases (lub_assoc_some_some h₃ h₄) with h₅
+    have h₅ := lub_assoc_some_some h₃ h₄
     subst h₁ h₂
     simp [h₄, h₅]
   }

--- a/cedar-lean/Cedar/Thm/Validation/Typechecker/LitVar.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Typechecker/LitVar.lean
@@ -37,7 +37,9 @@ theorem type_of_lit_is_sound {l : Prim} {c₁ c₂ : Capabilities} {env : Enviro
   split at h₃ <;> try { simp [err] at h₃ }
   simp at h₃
   all_goals {
-    rcases h₃ with ⟨h₃, h₄⟩; rw [←h₃, ←h₄]; constructor
+    have ⟨h₃, h₄⟩ := h₃
+    rw [←h₃, ←h₄]
+    constructor
     case left => exact empty_guarded_capabilities_invariant
     case right => first |
       exact true_is_instance_of_tt |
@@ -55,19 +57,19 @@ theorem type_of_var_is_sound {var : Var} {c₁ c₂ : Capabilities} {env : Envir
 := by
   simp [EvaluatesTo, evaluate]
   simp [typeOf, typeOfVar] at h₃
-  rcases h₂ with ⟨h₂, _⟩
+  have ⟨h₂, _⟩ := h₂
   simp [InstanceOfRequestType] at h₂
   split at h₃ <;> simp <;> simp [ok] at h₃ <;>
-  rcases h₃ with ⟨h₃, h₄⟩ <;> rw [←h₃, ←h₄] <;> constructor <;>
-  try { exact empty_guarded_capabilities_invariant }
-  case intro.h_1.intro.right =>
+  have ⟨h₃, h₄⟩ := h₃ <;> rw [←h₃, ←h₄] <;>
+  constructor <;> try { exact empty_guarded_capabilities_invariant }
+  case h_1.right =>
     apply InstanceOfType.instance_of_entity; simp [h₂]
-  case intro.h_2.intro.right =>
+  case h_2.right =>
     apply InstanceOfType.instance_of_entity
     simp [h₂, InstanceOfEntityType]
-  case intro.h_3.intro.right =>
+  case h_3.right =>
     apply InstanceOfType.instance_of_entity; simp [h₂]
-  case intro.h_4.intro.right =>
+  case h_4.right =>
     simp [h₂]
 
 end Cedar.Thm

--- a/cedar-lean/Cedar/Thm/Validation/Typechecker/Or.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Typechecker/Or.lean
@@ -48,17 +48,18 @@ theorem type_of_or_inversion {x₁ x₂ : Expr} {c c' : Capabilities} {env : Env
   simp [typeOfOr] at h₁
   split at h₁ <;> simp [ok, err] at h₁ <;>
   rename_i hr₁ <;> simp at hr₁ <;>
-  rcases hr₁ with ⟨ht₁, hc₁⟩
+  have ⟨ht₁, hc₁⟩ := hr₁
   case ok.h_1 c₁  =>
     exists BoolType.tt, c₁
-    rcases h₁ with ⟨ht, hc⟩
+    have ⟨ht, hc⟩ := h₁
     simp [←ht₁, ←hc₁, hc, ←ht]
   case ok.h_2 c₁ =>
     cases h₃ : typeOf x₂ c env <;> simp [h₃] at *
     rename_i res₂
     split at h₁ <;> simp [ok, err] at h₁
     rename_i bty₂ hr₂
-    rcases h₁ with ⟨ht, hc⟩ ; subst ht hc
+    have ⟨ht, hc⟩ := h₁
+    subst ht hc
     exists BoolType.ff, c₁
     simp [←ht₁, ←hc₁]
     exists bty₂
@@ -71,14 +72,14 @@ theorem type_of_or_inversion {x₁ x₂ : Expr} {c c' : Capabilities} {env : Env
     rename_i res₂
     split at h₁ <;> simp [ok, err] at h₁ <;>
     rename_i hr₂ <;>
-    rcases h₁ with ⟨ht, hc⟩ <;> subst ht hc <;> simp
-    case h_1.intro =>
+    have ⟨ht, hc⟩ := h₁ <;> subst ht hc <;> simp
+    case anyBool.ok.h_1 =>
       exists BoolType.tt, res₂.snd
       simp [←hr₂]
-    case h_2.intro =>
+    case anyBool.ok.h_2 =>
       exists BoolType.ff, res₂.snd
       simp [←hr₂, ht₁, hc₁]
-    case h_3.intro bty₂ hneq₁ hneq₂ =>
+    case anyBool.ok.h_3 bty₂ hneq₁ hneq₂ =>
       exists bty₂, res₂.snd
       simp [←hr₂, ←ht₁, ←hc₁]
       cases bty₂ <;> simp at *
@@ -92,18 +93,18 @@ theorem type_of_or_is_sound {x₁ x₂ : Expr} {c₁ c₂ : Capabilities} {env :
   GuardedCapabilitiesInvariant (Expr.or x₁ x₂) c₂ request entities ∧
   ∃ v, EvaluatesTo (Expr.or x₁ x₂) request entities v ∧ InstanceOfType v ty
 := by
-  rcases (type_of_or_inversion h₃) with ⟨bty₁, rc₁, h₄, h₅⟩
+  have ⟨bty₁, rc₁, h₄, h₅⟩ := type_of_or_inversion h₃
   specialize ih₁ h₁ h₂ h₄
-  rcases ih₁ with ⟨ih₁₁, v₁, ih₁₂, ih₁₃⟩
-  rcases (instance_of_bool_is_bool ih₁₃) with ⟨b₁, hb₁⟩ ; subst hb₁
+  have ⟨ih₁₁, v₁, ih₁₂, ih₁₃⟩ := ih₁
+  have ⟨b₁, hb₁⟩ := instance_of_bool_is_bool ih₁₃ ; subst hb₁
   split at h₅
   case inl h₆ =>
     subst h₆
-    rcases h₅ with ⟨hty, hc⟩ ; subst hty hc
+    have ⟨hty, hc⟩ := h₅ ; subst hty hc
     apply And.intro
     case left => exact empty_guarded_capabilities_invariant
     case right =>
-      rcases (instance_of_tt_is_true ih₁₃) with h₇
+      have h₇ := instance_of_tt_is_true ih₁₃
       simp at h₇ ; subst h₇
       simp [EvaluatesTo] at ih₁₂
       rcases ih₁₂ with ih₁₂ | ih₁₂ | ih₁₂ | ih₁₂ <;>
@@ -111,10 +112,11 @@ theorem type_of_or_is_sound {x₁ x₂ : Expr} {c₁ c₂ : Capabilities} {env :
       try exact type_is_inhabited (CedarType.bool BoolType.tt)
       exact true_is_instance_of_tt
   case inr =>
-    rcases h₅ with ⟨bty₂, rc₂, h₅, h₇⟩
-    specialize ih₂ h₁ h₂ h₅
-    rcases ih₂ with ⟨ih₂₁, v₂, ih₂₂, ih₂₃⟩
-    rcases (instance_of_bool_is_bool ih₂₃) with ⟨b₂, hb₂⟩ ; subst hb₂
+    have ⟨bty₂, rc₂, h₅', h₇⟩ := h₅
+    specialize ih₂ h₁ h₂ h₅'
+    have ⟨ih₂₁, v₂, ih₂₂, ih₂₃⟩ := ih₂
+    have ⟨b₂, hb₂⟩ := instance_of_bool_is_bool ih₂₃
+    subst hb₂
     simp [EvaluatesTo]
     cases b₁ <;>
     rcases ih₁₂ with ih₁₂ | ih₁₂ | ih₁₂ | ih₁₂ <;>
@@ -128,20 +130,26 @@ theorem type_of_or_is_sound {x₁ x₂ : Expr} {c₁ c₂ : Capabilities} {env :
         cases bty₁ <;> simp at h₆ h₇
         case anyBool =>
           cases bty₂ <;> simp at h₇ <;>
-          rcases h₇ with ⟨h₇, _⟩ <;> subst h₇ <;>
+          have ⟨h₇, _⟩ := h₇ <;> subst h₇ <;>
           try exact bool_is_instance_of_anyBool false
           exact ih₂₃
-        case ff => rcases h₇ with ⟨h₇, _⟩ ; subst h₇ ; exact ih₂₃
+        case ff =>
+          rw [h₇.left]
+          exact ih₂₃
       case true h₆ =>
         cases bty₁ <;> cases bty₂ <;> simp at h₆ h₇ <;>
-        rcases h₇ with ⟨hty, hc⟩ <;> simp [hty, hc] at *
-        case ff.ff.intro => rcases ih₂₃ with ⟨_, _, ih₂₃⟩ ; simp [InstanceOfBoolType] at ih₂₃
-        case anyBool.ff.intro => rcases ih₂₃ with ⟨_, _, ih₂₃⟩ ; simp [InstanceOfBoolType] at ih₂₃
-        case anyBool.tt.intro =>
+        have ⟨hty, hc⟩ := h₇ <;> simp [hty, hc] at *
+        case ff.ff =>
+          rcases ih₂₃ with ⟨_, _, ih₂₃⟩
+          simp [InstanceOfBoolType] at ih₂₃
+        case anyBool.ff =>
+          rcases ih₂₃ with ⟨_, _, ih₂₃⟩
+          simp [InstanceOfBoolType] at ih₂₃
+        case anyBool.tt =>
           apply And.intro
           case left => apply empty_capabilities_invariant
           case right => apply true_is_instance_of_tt
-        case anyBool.anyBool.intro =>
+        case anyBool.anyBool =>
           apply And.intro
           case left =>
             simp [GuardedCapabilitiesInvariant, ih₂₂] at ih₂₁
@@ -159,10 +167,11 @@ theorem type_of_or_is_sound {x₁ x₂ : Expr} {c₁ c₂ : Capabilities} {env :
       simp [GuardedCapabilitiesInvariant] at ih₁₁ ih₂₁
       simp [ih₁₂] at ih₁₁ ; simp [ih₂₂] at ih₂₁
       rename_i h₆
-      rcases ih₁₃ with ⟨_, _, ih₁₃⟩ ; simp [InstanceOfBoolType] at ih₁₃
+      rcases ih₁₃ with ⟨_, _, ih₁₃⟩
+      simp [InstanceOfBoolType] at ih₁₃
       cases bty₁ <;> simp at h₆ ih₁₃ h₇
       cases bty₂ <;> simp at h₇ <;>
-      rcases h₇ with ⟨ht, hc⟩ <;> simp [ht, hc] at * <;>
+      have ⟨ht, hc⟩ := h₇ <;> simp [ht, hc] at * <;>
       simp [true_is_instance_of_tt, bool_is_instance_of_anyBool] <;>
       try { apply empty_capabilities_invariant } <;>
       try { assumption }

--- a/cedar-lean/Cedar/Thm/Validation/Typechecker/Record.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Typechecker/Record.lean
@@ -56,7 +56,8 @@ theorem type_of_record_inversion_forall {axs : List (Attr × Expr)} {c : Capabil
         cases h₂ : requiredAttr hd.fst (typeOf hd.snd c env) <;> simp [h₂] at h₁
         cases h₃ : List.mapM' (fun x => requiredAttr x.fst (typeOf x.snd c env)) tl <;> simp [h₃] at h₁
         simp [pure, Except.pure] at h₁
-        rcases h₁ with ⟨hl₁, hr₁⟩ ; rw [eq_comm] at hl₁ hr₁ ; subst hl₁ hr₁
+        have ⟨hl₁, hr₁⟩ := h₁
+        rw [eq_comm] at hl₁ hr₁ ; subst hl₁ hr₁
         simp [requiredAttr, Except.map] at h₂
         split at h₂ <;> simp at h₂
         subst h₂
@@ -100,10 +101,10 @@ theorem mk_vals_instance_of_mk_types₁ {a : Attr} {avs : List (Attr × Value)} 
   case cons ahd atl rhd rtl h₃ h₄ =>
     simp [Map.contains, Map.find?, List.find?] at *
     simp [AttrValueHasAttrType] at h₃
-    rcases h₃ with ⟨h₃, _⟩ ; simp [h₃] at *
+    have ⟨h₃, _⟩ := h₃ ; simp [h₃] at *
     cases h₅ : rhd.fst == a <;> simp [h₅] at *
     cases h₆ : List.find? (fun x => x.fst == a) atl <;> simp [h₆] at h₂
-    rcases (@mk_vals_instance_of_mk_types₁ a atl rtl h₄) with h₇
+    have h₇ := @mk_vals_instance_of_mk_types₁ a atl rtl h₄
     simp [Map.contains, Map.find?, Map.kvs, h₆] at h₇
     exact h₇
 
@@ -119,7 +120,7 @@ theorem mk_vals_instance_of_mk_types₂ {a : Attr} {v : Value} {qty : QualifiedT
   case cons ahd atl rhd rtl h₄ h₅ =>
     simp [Map.find?, List.find?] at h₂ h₃
     simp [AttrValueHasAttrType] at h₄
-    rcases h₄ with ⟨hl₄, hr₄⟩ ; simp [hl₄] at *
+    have ⟨hl₄, hr₄⟩ := h₄ ; simp [hl₄] at *
     cases h₆ : rhd.fst == a <;> simp [h₆] at h₂ h₃
     case true =>
       subst h₂ h₃
@@ -140,10 +141,10 @@ theorem mk_vals_instance_of_mk_types₃ {a : Attr} {qty : QualifiedType} {avs : 
     simp [Map.contains, Map.find?, List.find?]
     simp [Map.find?, List.find?] at h₂
     simp [AttrValueHasAttrType] at h₄
-    rcases h₄ with ⟨h₄, _⟩ ; simp [h₄] at *
+    have ⟨h₄, _⟩ := h₄ ; simp [h₄] at *
     cases h₆ : rhd.fst == a <;> simp [h₆] at *
     cases h₇ : List.find? (fun x => x.fst == a) rtl <;> simp [h₇] at h₂
-    rcases (@mk_vals_instance_of_mk_types₃ a qty atl rtl h₅) with h₈
+    have h₈ := @mk_vals_instance_of_mk_types₃ a qty atl rtl h₅
     simp [Map.find?, List.find?, Map.kvs, h₇, h₂, Map.contains] at h₈
     exact h₈
 
@@ -171,9 +172,9 @@ theorem head_of_vals_instance_of_head_of_types {xhd : Attr × Expr} {c₁ : Capa
   AttrValueHasAttrType vhd rhd
 := by
   simp [TypeOfIsSound] at h₁
-  rcases h₄ with ⟨ty', c', h₄, h₆⟩ ; subst h₄
+  have ⟨ty', c', h₄, h₆⟩ := h₄ ; subst h₄
   specialize h₁ h₂ h₃ h₆
-  rcases h₁ with ⟨_, v, h₁, h₇⟩
+  have ⟨_, v, h₁, h₇⟩ := h₁
   simp [bindAttr] at h₅
   cases h₈ : evaluate xhd.snd request entities <;> simp [h₈] at h₅
   simp [EvaluatesTo, h₈] at h₁ ; subst h₁ h₅
@@ -218,8 +219,8 @@ theorem type_of_record_is_sound_ok {axs : List (Attr × Expr)} {c₁ : Capabilit
 := by
   apply mk_vals_instance_of_mk_types
   let p := fun (v : Value) (qty : QualifiedType) => InstanceOfType v qty.getType
-  rcases (vals_instance_of_types ih h₁ h₂ h₃ h₄) with h₅
-  rcases (List.canonicalize_preserves_forallᵥ p avs rty) with h₆
+  have h₅ := vals_instance_of_types ih h₁ h₂ h₃ h₄
+  have h₆ := List.canonicalize_preserves_forallᵥ p avs rty
   simp [List.Forallᵥ] at h₆
   exact h₆ h₅
 
@@ -244,9 +245,9 @@ theorem type_of_record_is_sound_err {axs : List (Attr × Expr)} {c₁ : Capabili
       subst h₄ h₅
       specialize ih hd
       simp only [List.mem_cons, true_or, TypeOfIsSound, forall_const] at ih
-      rcases hh₃ with ⟨ty', c', _, hh₃⟩
+      have ⟨ty', c', _, hh₃⟩ := hh₃
       specialize ih h₁ h₂ hh₃
-      rcases ih with ⟨_, v, ih, _⟩
+      have ⟨_, v, ih, _⟩ := ih
       simp [EvaluatesTo, h₆] at ih
       exact ih
     case ok vhd =>
@@ -268,7 +269,7 @@ theorem type_of_record_is_sound {axs : List (Attr × Expr)} {c₁ c₂ : Capabil
   GuardedCapabilitiesInvariant (Expr.record axs) c₂ request entities ∧
   ∃ v, EvaluatesTo (Expr.record axs) request entities v ∧ InstanceOfType v ty
 := by
-  rcases (type_of_record_inversion h₃) with ⟨h₆, rty, h₅, h₄⟩
+  have ⟨h₆, rty, h₅, h₄⟩ := type_of_record_inversion h₃
   subst h₅ h₆
   apply And.intro
   case left => exact empty_guarded_capabilities_invariant

--- a/cedar-lean/Cedar/Thm/Validation/Typechecker/Set.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Typechecker/Set.lean
@@ -32,9 +32,9 @@ theorem lub_lub_fixed {ty₁ ty₂ ty₃ ty₄ : CedarType}
   (h₂ : (ty₃ ⊔ ty₄) = some ty₄) :
   (ty₁ ⊔ ty₄) = some ty₄
 := by
-  rcases (lub_left_subty h₁) with h₃
-  rcases (lub_left_subty h₂) with h₄
-  rcases (subty_trans h₃ h₄) with h₅
+  have h₃ := lub_left_subty h₁
+  have h₄ := lub_left_subty h₂
+  have h₅ := subty_trans h₃ h₄
   simp [subty] at h₅
   split at h₅ <;> simp at h₅ ; subst h₅
   assumption
@@ -75,7 +75,7 @@ theorem type_of_set_tail
 := by
   cases xtl
   case nil =>
-    rcases (List.not_mem_nil x) with _
+    have _ := List.not_mem_nil x
     contradiction
   case cons xhd' xtl' =>
     simp [typeOf]
@@ -90,20 +90,20 @@ theorem type_of_set_tail
     case cons hd' tl' =>
       simp [List.mapM₁] at h₁ ; unfold List.attach at h₁
       rw [List.mapM_pmap_subtype (fun x => justType (typeOf x c env))] at h₁
-      rcases (List.mapM_head_tail h₁) with h₁
+      have h₁ := List.mapM_head_tail h₁
       rw [←List.mapM₁_eq_mapM] at h₁
       simp [h₁, typeOfSet]
       cases h₄ : List.foldlM lub? hd' tl' <;>
       simp [h₄, err, ok]
       case none =>
-        rcases (foldlM_of_lub_assoc hd hd' tl') with h₅
+        have h₅ := foldlM_of_lub_assoc hd hd' tl'
         rw [h₂, h₄] at h₅
         simp at h₅
       case some ty' =>
-        rcases (foldlM_of_lub_assoc hd hd' tl') with h₅
+        have h₅ := foldlM_of_lub_assoc hd hd' tl'
         rw [h₂, h₄] at h₅
         simp at h₅ ; rw [eq_comm, lub_comm] at h₅
-        rcases (lub_left_subty h₅) with h₆
+        have h₆ := lub_left_subty h₅
         simp [subty] at h₆
         split at h₆ <;> simp at h₆
         subst h₆
@@ -127,7 +127,7 @@ theorem type_of_set_inversion {xs : List Expr} {c c' : Capabilities} {env : Envi
   rename_i hd tl
   split at h₁ <;> simp at h₁
   rename_i ty h₃
-  rcases h₁ with ⟨hl₁, hr₁⟩
+  have ⟨hl₁, hr₁⟩ := h₁
   subst hl₁ hr₁
   simp only [List.empty_eq, CedarType.set.injEq, exists_and_right, exists_eq_left', true_and]
   intro x h₄
@@ -139,7 +139,7 @@ theorem type_of_set_inversion {xs : List Expr} {c c' : Capabilities} {env : Envi
     simp [List.mapM_pmap_subtype (fun x => justType (typeOf x c env))] at h₂
     rcases h₆ : List.mapM (fun x => justType (typeOf x c env)) xtl <;>
     simp [h₆, pure, Except.pure] at h₂
-    rcases h₂ with ⟨hl₂, hr₂⟩ ; subst hl₂ hr₂
+    have ⟨hl₂, hr₂⟩ := h₂ ; subst hl₂ hr₂
     rename_i hdty tlty
     simp [justType, Except.map] at h₅
     split at h₅ <;> simp at h₅
@@ -152,13 +152,13 @@ theorem type_of_set_inversion {xs : List Expr} {c c' : Capabilities} {env : Envi
     case right =>
       exact foldlM_of_lub_is_LUB h₃
   case tail xhd xtl h₄ =>
-    rcases (type_of_set_tail h₂ h₃ h₄) with ⟨ty', h₅, h₆⟩
-    rcases (@type_of_set_inversion xtl c ∅ env (.set ty')) with h₇
+    have ⟨ty', h₅, h₆⟩ := type_of_set_tail h₂ h₃ h₄
+    have h₇ := @type_of_set_inversion xtl c ∅ env (.set ty')
     simp [h₅] at h₇
     specialize h₇ x h₄
-    rcases h₇ with ⟨tyᵢ, h₇, h₈⟩
+    have ⟨tyᵢ, h₇, h₈⟩ := h₇
     exists tyᵢ
-    rcases h₇ with ⟨cᵢ, h₇⟩
+    have ⟨cᵢ, h₇⟩ := h₇
     apply And.intro
     case left  => exists cᵢ
     case right => apply lub_lub_fixed h₈ h₆
@@ -195,13 +195,13 @@ theorem type_of_set_is_sound_err {xs : List Expr} {c₁ : Capabilities} {env : E
     simp [List.mapM₁, List.attach, pure, Except.pure] at h₅
   case cons hd tl =>
     simp [List.mapM₁, List.attach, h₆] at h₅
-    rcases (h₄ hd) with h₄
+    have h₄ := h₄ hd
     simp only [h₆, List.mem_cons, true_or, forall_const] at h₄
-    rcases h₄ with ⟨tyᵢ, cᵢ, h₇, _⟩
-    rcases (ih hd) with h₉ ; simp [h₆, TypeOfIsSound] at h₉
-    specialize (h₉ h₁ h₂ h₇) ; rcases h₉ with ⟨_, v, h₉⟩
+    have ⟨tyᵢ, cᵢ, h₇, _⟩ := h₄
+    have h₉ := ih hd ; simp [h₆, TypeOfIsSound] at h₉
+    specialize (h₉ h₁ h₂ h₇) ; have ⟨_, v, h₉⟩ := h₉
     simp [EvaluatesTo] at h₉
-    rcases h₉ with ⟨h₉, _⟩
+    have ⟨h₉, _⟩ := h₉
     rcases h₉ with h₉ | h₉ | h₉ | h₉ <;>
     simp [h₉] at h₅ <;>
     try { simp [h₅] }
@@ -243,11 +243,11 @@ theorem type_of_set_is_sound_ok { xs : List Expr } { c₁ : Capabilities } { env
     case head =>
       specialize h₃ hd
       simp only [List.mem_cons, true_or, forall_const] at h₃
-      rcases h₃ with ⟨tyᵢ, cᵢ, h₃, h₆⟩
+      have ⟨tyᵢ, cᵢ, h₃, h₆⟩ := h₃
       specialize ih hd
       simp [TypeOfIsSound] at ih
       specialize ih h₁ h₂ h₃
-      rcases ih with ⟨_, v', ihl, ihr⟩
+      have ⟨_, v', ihl, ihr⟩ := ih
       simp [EvaluatesTo] at ihl
       rcases ihl with ihl | ihl | ihl | ihl <;>
       simp [ihl] at h₇
@@ -270,7 +270,7 @@ theorem type_of_set_is_sound {xs : List Expr} {c₁ c₂ : Capabilities} {env : 
   GuardedCapabilitiesInvariant (Expr.set xs) c₂ request entities ∧
   ∃ v, EvaluatesTo (Expr.set xs) request entities v ∧ InstanceOfType v sty
 := by
-  rcases (type_of_set_inversion h₃) with ⟨h₆, ty, h₄, h₅⟩
+  have ⟨h₆, ty, h₄, h₅⟩ := type_of_set_inversion h₃
   subst h₆ h₄
   apply And.intro
   case left => exact empty_guarded_capabilities_invariant

--- a/cedar-lean/Cedar/Thm/Validation/Typechecker/Types.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Typechecker/Types.lean
@@ -274,10 +274,10 @@ theorem well_typed_entity_attributes {env : Environment} {request : Request} {en
   (h₃ : EntityTypeStore.attrs? env.ets uid.ty = some rty) :
   InstanceOfType d.attrs (.record rty)
 := by
-  rcases h₁ with ⟨_, h₁, _⟩
+  have ⟨_, h₁, _⟩ := h₁
   simp [InstanceOfEntityTypeStore] at h₁
   specialize h₁ uid d h₂
-  rcases h₁ with ⟨entry, h₁₂, h₁, _⟩
+  have ⟨entry, h₁₂, h₁, _⟩ := h₁
   unfold EntityTypeStore.attrs? at h₃
   simp [h₁₂] at h₃
   subst h₃
@@ -375,7 +375,7 @@ theorem type_is_inhabited (ty : CedarType) :
 := by
   match ty with
   | .bool bty =>
-    rcases (bool_type_is_inhabited bty) with ⟨b, h₁⟩
+    have ⟨b, h₁⟩ := bool_type_is_inhabited bty
     exists (.prim (.bool b))
     apply InstanceOfType.instance_of_bool _ _ h₁
   | .int =>
@@ -385,17 +385,17 @@ theorem type_is_inhabited (ty : CedarType) :
     exists (.prim (.string default))
     apply InstanceOfType.instance_of_string
   | .entity ety =>
-    rcases (entity_type_is_inhabited ety) with ⟨euid, h₁⟩
+    have ⟨euid, h₁⟩ := entity_type_is_inhabited ety
     exists (.prim (.entityUID euid))
     apply InstanceOfType.instance_of_entity _ _ h₁
   | .set ty₁ =>
     exists (.set Set.empty)
     apply InstanceOfType.instance_of_set
     intro v₁ h₁
-    rcases (Set.in_set_means_list_non_empty v₁ Set.empty h₁) with h₂
+    have h₂ := Set.in_set_means_list_non_empty v₁ Set.empty h₁
     simp [Set.empty, Set.elts] at h₂
   | .ext xty =>
-    rcases (ext_type_is_inhabited xty) with ⟨x, h₁⟩
+    have ⟨x, h₁⟩ := ext_type_is_inhabited xty
     exists (.ext x)
     apply InstanceOfType.instance_of_ext _ _ h₁
   | .record (Map.mk rty) =>
@@ -416,9 +416,9 @@ theorem type_is_inhabited (ty : CedarType) :
         case a =>
           simp [Nat.add_assoc]
           simp [←Nat.succ_eq_one_add]
-      rcases (type_is_inhabited hd.snd.getType) with ⟨rhd, h₂⟩
-      rcases (type_is_inhabited (.record (Map.mk tl))) with ⟨vtl, h₃⟩
-      rcases (instance_of_record_type_is_record h₃) with ⟨mtl, h₄⟩
+      have ⟨rhd, h₂⟩ := type_is_inhabited hd.snd.getType
+      have ⟨vtl, h₃⟩ := type_is_inhabited (.record (Map.mk tl))
+      have ⟨mtl, h₄⟩ := instance_of_record_type_is_record h₃
       subst h₄ ; cases mtl ; rename_i rtl
       exists (.record (Map.mk ((hd.fst, rhd) :: rtl)))
       exact instance_of_record_cons h₂ h₃
@@ -464,7 +464,7 @@ theorem sizeOf_attr_type_lt_sizeOf_record_type {a : Attr} {qty : QualifiedType }
         simp [Map.find?, Map.kvs] at h₂
         split at h₂ <;> simp at h₂
         rename_i a' qty' h₃ ; rw [eq_comm] at h₂ ; subst h₂
-        rcases (List.mem_of_find?_eq_some h₃) with h₄
+        have h₄ := List.mem_of_find?_eq_some h₃
         apply @Nat.lt_trans _ (sizeOf (a', qty))
         case h₁ =>
           simp only [Prod.mk.sizeOf_spec]
@@ -501,7 +501,7 @@ theorem instance_of_lub_left {v : Value} {ty ty₁ ty₂ : CedarType}
   case h_3 _ _ rty₁ rty₂ =>
     cases h₃ : lubRecordType rty₁ rty₂ <;> simp [h₃] at h₁
     rename_i rty
-    rcases (lubRecordType_is_lub_of_record_types h₃) with hl
+    have hl := lubRecordType_is_lub_of_record_types h₃
     subst h₁ ; simp [←hty₁] at h₂
     cases h₂ ; rename_i r h₄ h₅ h₆
     apply InstanceOfType.instance_of_record
@@ -511,15 +511,15 @@ theorem instance_of_lub_left {v : Value} {ty ty₁ ty₂ : CedarType}
       exact lubRecord_contains_left hl h₄
     case h₂ =>
       intro a v qty h₇ h₈
-      rcases (lubRecord_find_implies_find hl h₈) with ⟨qty₁, qty₂, h₉, _, h₁₁⟩
+      have ⟨qty₁, qty₂, h₉, _, h₁₁⟩ := lubRecord_find_implies_find hl h₈
       specialize h₅ a v qty₁ h₇ h₉
-      rcases (lubQualified_is_lub_of_getType h₁₁) with h₁₂
+      have h₁₂ := lubQualified_is_lub_of_getType h₁₁
       have _ : sizeOf qty₁.getType < sizeOf ty₁' :=  -- termination
         sizeOf_attr_type_lt_sizeOf_record_type hty₁ h₉
       apply instance_of_lub_left h₁₂ h₅
     case h₃ =>
       intro a qty h₇ h₈
-      rcases (lubRecord_find_implies_find_left hl h₇) with ⟨qty₁, h₉, h₁₀⟩
+      have ⟨qty₁, h₉, h₁₀⟩ := lubRecord_find_implies_find_left hl h₇
       apply h₆ a qty₁ h₉
       simp [h₁₀, h₈]
   case h_4 =>

--- a/cedar-lean/Cedar/Thm/Validation/Typechecker/UnaryApp.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Typechecker/UnaryApp.lean
@@ -36,10 +36,10 @@ theorem type_of_not_inversion {x₁ : Expr} {c₁ c₂ : Capabilities} {env : En
   simp [typeOf] at h₁
   cases h₂ : typeOf x₁ c₁ env <;> simp [h₂] at h₁
   case ok res =>
-    rcases res with ⟨ty₁, c₁'⟩
+    have ⟨ty₁, c₁'⟩ := res
     simp [typeOfUnaryApp] at h₁
     split at h₁ <;> try contradiction
-    case mk.h_1 _ ty₁ bty _ =>
+    case h_1 _ ty₁ bty _ =>
       simp [ok] at h₁
       apply And.intro
       case left => simp [h₁]
@@ -55,30 +55,30 @@ theorem type_of_not_is_sound {x₁ : Expr} {c₁ c₂ : Capabilities} {env : Env
   GuardedCapabilitiesInvariant (Expr.unaryApp .not x₁) c₂ request entities ∧
   ∃ v, EvaluatesTo (Expr.unaryApp .not x₁) request entities v ∧ InstanceOfType v ty
 := by
-  rcases (type_of_not_inversion h₃) with ⟨h₅, bty, c₁', h₆, h₄⟩
+  have ⟨h₅, bty, c₁', h₆, h₄⟩ := type_of_not_inversion h₃
   subst h₅; subst h₆
   apply And.intro
   case left => exact empty_guarded_capabilities_invariant
   case right =>
-    rcases (ih h₁ h₂ h₄) with ⟨_, v₁, h₆, h₇⟩ -- IH
+    have ⟨_, v₁, h₆, h₇⟩ := ih h₁ h₂ h₄ -- IH
     simp [EvaluatesTo] at h₆
     simp [EvaluatesTo, evaluate]
     rcases h₆ with h₆ | h₆ | h₆ | h₆ <;> simp [h₆]
-    case intro.intro.intro.inr.inr.inr =>
+    case inr.inr.inr =>
       cases bty
       case anyBool =>
-        rcases (instance_of_anyBool_is_bool h₇) with ⟨b, h₈⟩
+        have ⟨b, h₈⟩ := instance_of_anyBool_is_bool h₇
         cases b <;>
         subst h₈ <;>
         simp [apply₁] <;>
         apply bool_is_instance_of_anyBool
       case tt =>
-        rcases (instance_of_tt_is_true h₇) with h₈
+        have h₈ := instance_of_tt_is_true h₇
         subst h₈
         simp [apply₁, BoolType.not]
         exact false_is_instance_of_ff
       case ff =>
-        rcases (instance_of_ff_is_false h₇) with h₈
+        have h₈ := instance_of_ff_is_false h₇
         subst h₈
         simp [apply₁, BoolType.not]
         exact true_is_instance_of_tt
@@ -95,7 +95,7 @@ theorem type_of_neg_inversion {x₁ : Expr} {c₁ c₂ : Capabilities} {env : En
   simp [typeOf] at h₁
   cases h₂ : typeOf x₁ c₁ env <;> simp [h₂] at h₁
   case ok res =>
-    rcases res with ⟨ty₁, c₁'⟩
+    have ⟨ty₁, c₁'⟩ := res
     simp [typeOfUnaryApp] at h₁
     split at h₁ <;> try contradiction
     simp [ok] at h₁
@@ -109,24 +109,24 @@ theorem type_of_neg_is_sound {x₁ : Expr} {c₁ c₂ : Capabilities} {env : Env
   GuardedCapabilitiesInvariant (Expr.unaryApp .neg x₁) c₂ request entities ∧
   ∃ v, EvaluatesTo (Expr.unaryApp .neg x₁) request entities v ∧ InstanceOfType v ty
 := by
-  rcases (type_of_neg_inversion h₃) with ⟨h₅, h₆, c₁', h₄⟩
+  have ⟨h₅, h₆, c₁', h₄⟩ := type_of_neg_inversion h₃
   subst h₅; subst h₆
   apply And.intro
   case left => exact empty_guarded_capabilities_invariant
   case right =>
-    rcases (ih h₁ h₂ h₄) with ⟨_, v₁, h₆, h₇⟩ -- IH
+    have ⟨_, v₁, h₆, h₇⟩ := ih h₁ h₂ h₄ -- IH
     simp [EvaluatesTo] at h₆
     simp [EvaluatesTo, evaluate]
     rcases h₆ with h₆ | h₆ | h₆ | h₆ <;> simp [h₆]
-    case intro.intro.intro.inr.inr.inr =>
-      rcases (instance_of_int_is_int h₇) with ⟨i, h₈⟩
+    case inr.inr.inr =>
+      have ⟨i, h₈⟩ := instance_of_int_is_int h₇
       subst h₈
       simp [apply₁, intOrErr]
       cases h₉ : i.neg?
-      case intro.none =>
+      case none =>
         simp only [or_false, or_true, true_and]
         exact type_is_inhabited CedarType.int
-      case intro.some i' =>
+      case some i' =>
         simp only [Except.ok.injEq, false_or, exists_eq_left']
         apply InstanceOfType.instance_of_int
     all_goals {
@@ -142,7 +142,7 @@ theorem type_of_mulBy_inversion {x₁ : Expr} {k : Int64} {c₁ c₂ : Capabilit
   simp [typeOf] at h₁
   cases h₂ : typeOf x₁ c₁ env <;> simp [h₂] at h₁
   case ok res =>
-    rcases res with ⟨ty₁, c₁'⟩
+    have ⟨ty₁, c₁'⟩ := res
     simp [typeOfUnaryApp] at h₁
     split at h₁ <;> try contradiction
     simp [ok] at h₁
@@ -156,24 +156,24 @@ theorem type_of_mulBy_is_sound {x₁ : Expr} {k : Int64} {c₁ c₂ : Capabiliti
   GuardedCapabilitiesInvariant (Expr.unaryApp (.mulBy k) x₁) c₂ request entities ∧
   ∃ v, EvaluatesTo (Expr.unaryApp (.mulBy k) x₁) request entities v ∧ InstanceOfType v ty
 := by
-  rcases (type_of_mulBy_inversion h₃) with ⟨h₅, h₆, c₁', h₄⟩
+  have ⟨h₅, h₆, c₁', h₄⟩ := type_of_mulBy_inversion h₃
   subst h₅; subst h₆
   apply And.intro
   case left => exact empty_guarded_capabilities_invariant
   case right =>
-    rcases (ih h₁ h₂ h₄) with ⟨_, v₁, h₆, h₇⟩ -- IH
+    have ⟨_, v₁, h₆, h₇⟩ := ih h₁ h₂ h₄ -- IH
     simp [EvaluatesTo] at h₆
     simp [EvaluatesTo, evaluate]
     rcases h₆ with h₆ | h₆ | h₆ | h₆ <;> simp [h₆]
-    case intro.intro.intro.inr.inr.inr =>
-      rcases (instance_of_int_is_int h₇) with ⟨i, h₈⟩
+    case inr.inr.inr =>
+      have ⟨i, h₈⟩ := instance_of_int_is_int h₇
       subst h₈
       simp [apply₁, intOrErr]
       cases h₉ : k.mul? i
-      case intro.none =>
+      case none =>
         simp only [or_false, or_true, true_and]
         exact type_is_inhabited CedarType.int
-      case intro.some i' =>
+      case some i' =>
         simp only [Except.ok.injEq, false_or, exists_eq_left']
         apply InstanceOfType.instance_of_int
     all_goals {
@@ -189,7 +189,7 @@ theorem type_of_like_inversion {x₁ : Expr} {p : Pattern} {c₁ c₂ : Capabili
   simp [typeOf] at h₁
   cases h₂ : typeOf x₁ c₁ env <;> simp [h₂] at h₁
   case ok res =>
-    rcases res with ⟨ty₁, c₁'⟩
+    have ⟨ty₁, c₁'⟩ := res
     simp [typeOfUnaryApp] at h₁
     split at h₁ <;> try contradiction
     simp [ok] at h₁
@@ -203,17 +203,17 @@ theorem type_of_like_is_sound {x₁ : Expr} {p : Pattern} {c₁ c₂ : Capabilit
   GuardedCapabilitiesInvariant (Expr.unaryApp (.like p) x₁) c₂ request entities ∧
   ∃ v, EvaluatesTo (Expr.unaryApp (.like p) x₁) request entities v ∧ InstanceOfType v ty
 := by
-  rcases (type_of_like_inversion h₃) with ⟨h₅, h₆, c₁', h₄⟩
+  have ⟨h₅, h₆, c₁', h₄⟩ := type_of_like_inversion h₃
   subst h₅; subst h₆
   apply And.intro
   case left => exact empty_guarded_capabilities_invariant
   case right =>
-    rcases (ih h₁ h₂ h₄) with ⟨_, v₁, h₆, h₇⟩ -- IH
+    have ⟨_, v₁, h₆, h₇⟩ := ih h₁ h₂ h₄ -- IH
     simp [EvaluatesTo] at h₆
     simp [EvaluatesTo, evaluate]
     rcases h₆ with h₆ | h₆ | h₆ | h₆ <;> simp [h₆]
-    case intro.intro.intro.inr.inr.inr =>
-      rcases (instance_of_string_is_string h₇) with ⟨s, h₈⟩
+    case inr.inr.inr =>
+      have ⟨s, h₈⟩ := instance_of_string_is_string h₇
       subst h₈
       simp [apply₁]
       exact bool_is_instance_of_anyBool (wildcardMatch s p)
@@ -231,10 +231,10 @@ theorem type_of_is_inversion {x₁ : Expr} {ety : EntityType} {c₁ c₂ : Capab
   simp [typeOf] at h₁
   cases h₂ : typeOf x₁ c₁ env <;> simp [h₂] at h₁
   case ok res =>
-    rcases res with ⟨ty₁, c₁'⟩
+    have ⟨ty₁, c₁'⟩ := res
     simp [typeOfUnaryApp] at h₁
     split at h₁ <;> try contradiction
-    case mk.h_5 _ _ ety' h₃ =>
+    case h_5 _ _ ety' h₃ =>
       simp only [UnaryOp.is.injEq] at h₃
       subst h₃
       simp [ok] at h₁
@@ -252,23 +252,23 @@ theorem type_of_is_is_sound {x₁ : Expr} {ety : EntityType} {c₁ c₂ : Capabi
   GuardedCapabilitiesInvariant (Expr.unaryApp (.is ety) x₁) c₂ request entities ∧
   ∃ v, EvaluatesTo (Expr.unaryApp (.is ety) x₁) request entities v ∧ InstanceOfType v ty
 := by
-  rcases (type_of_is_inversion h₃) with ⟨h₅, ety', c₁', h₆, h₄⟩
+  have ⟨h₅, ety', c₁', h₆, h₄⟩ := type_of_is_inversion h₃
   subst h₅; subst h₆
   apply And.intro
   case left => exact empty_guarded_capabilities_invariant
   case right =>
-    rcases (ih h₁ h₂ h₄) with ⟨_, v₁, h₆, h₇⟩ -- IH
+    have ⟨_, v₁, h₆, h₇⟩ := ih h₁ h₂ h₄ -- IH
     simp [EvaluatesTo] at h₆
     simp [EvaluatesTo, evaluate]
     rcases h₆ with h₆ | h₆ | h₆ | h₆ <;> simp [h₆]
-    case intro.intro.intro.inr.inr.inr =>
-      rcases (instance_of_entity_type_is_entity h₇) with ⟨uid, h₈, h₉⟩
+    case inr.inr.inr =>
+      have ⟨uid, h₈, h₉⟩ := instance_of_entity_type_is_entity h₇
       simp [apply₁, h₉, h₈]
       cases h₁₀ : ety == ety' <;>
       simp at h₁₀ <;>
       simp [h₁₀]
-      case intro.intro.false => exact false_is_instance_of_ff
-      case intro.intro.true => exact true_is_instance_of_tt
+      case false => exact false_is_instance_of_ff
+      case true => exact true_is_instance_of_tt
     all_goals {
       apply type_is_inhabited
     }


### PR DESCRIPTION
This PR is pure refactoring, no functional change.

Replaces (almost) all of our use of `rcases` with a trivial pattern (no destructuring, or just destructuring a conjunction) with an equivalent `have`.

Some side effects:
* Affects case names subsequent to the replacement.  This is a beneficial side effect; the new names are simpler but equally informative.
* Some behavior is different when we use `rcases`/`have` to shadow a previous binding, as in `have ⟨_, h₁⟩ := h₁`.  I believe the shadowed (but still present) binding is put in a different order by `rcases` vs `have`, which may affect any subsequent renaming operations.  I've made the necessary adjustments in this PR; they are minor.  In many of these cases I just removed the shadowing for clarity.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
