### PR TITLE
customizable error comparison in DRT

### DIFF
--- a/cedar-drt/fuzz/src/lib.rs
+++ b/cedar-drt/fuzz/src/lib.rs
@@ -23,15 +23,16 @@ pub use prt::*;
 use cedar_drt::{
     time_function, CedarTestImplementation, ErrorComparisonMode, RUST_AUTH_MSG, RUST_VALIDATION_MSG,
 };
-use cedar_policy::frontend::is_authorized::InterfaceResponse;
+use cedar_policy::{frontend::is_authorized::InterfaceResponse, PolicyId};
 use cedar_policy_core::ast;
-use cedar_policy_core::authorizer::{AuthorizationError, Authorizer, Diagnostics, Response};
+use cedar_policy_core::authorizer::{AuthorizationError, Authorizer, Response};
 use cedar_policy_core::entities::{Entities, NoEntitiesSchema, TCComputation};
 use cedar_policy_core::evaluator::{EvaluationErrorKind, Evaluator};
 use cedar_policy_core::extensions::Extensions;
 pub use cedar_policy_validator::{ValidationErrorKind, ValidationMode, Validator, ValidatorSchema};
 use libfuzzer_sys::arbitrary::{self, Unstructured};
 use log::info;
+use std::collections::HashSet;
 
 /// Compare the behavior of the evaluator in `cedar-policy` against a custom Cedar
 /// implementation. Panics if the two do not agree. `expr` is the expression to
@@ -121,35 +122,41 @@ pub fn run_auth_test(
             }
         }
         Ok(definitional_res) => {
-            let rust_res_for_comparison: cedar_policy::Response = match custom_impl
-                .error_comparison_mode()
-            {
-                ErrorComparisonMode::Ignore => Response {
-                    diagnostics: Diagnostics {
-                        errors: Vec::new(),
-                        reason: rust_res.diagnostics.reason.clone(),
-                    },
-                    ..rust_res
-                }
-                .into(),
-                ErrorComparisonMode::PolicyIds => Response {
-                    diagnostics: Diagnostics {
-                        errors: rust_res.diagnostics.errors.map(|err| match err {
-                            AuthorizationError::PolicyEvaluationError { id, .. } => format!("{id}"),
-                        }),
-                        reason: rust_res.diagnostics.reason.clone(),
-                    },
-                    ..rust_res
-                },
-                ErrorComparisonMode::Full => rust_res.clone(),
-            }
-            .into();
+            let rust_res_for_comparison: InterfaceResponse = {
+                let errors = match custom_impl.error_comparison_mode() {
+                    ErrorComparisonMode::Ignore => HashSet::new(),
+                    ErrorComparisonMode::PolicyIds => rust_res
+                        .diagnostics
+                        .errors
+                        .iter()
+                        .map(|err| match err {
+                            AuthorizationError::PolicyEvaluationError { id, .. } => {
+                                format!("{id}")
+                            }
+                        })
+                        .collect(),
+                    ErrorComparisonMode::Full => rust_res
+                        .diagnostics
+                        .errors
+                        .iter()
+                        .map(ToString::to_string)
+                        .collect(),
+                };
+                InterfaceResponse::new(
+                    rust_res.decision,
+                    rust_res
+                        .diagnostics
+                        .reason
+                        .iter()
+                        .map(|id| PolicyId::new(id.clone()))
+                        .collect(),
+                    errors,
+                )
+            };
             assert_eq!(
-                InterfaceResponse::from(rust_res_for_comparison),
-                definitional_res,
+                rust_res_for_comparison, definitional_res,
                 "Mismatch for {request}\nPolicies:\n{}\nEntities:\n{}",
-                &policies,
-                &entities
+                &policies, &entities
             );
             rust_res
         }

--- a/cedar-drt/fuzz/src/lib.rs
+++ b/cedar-drt/fuzz/src/lib.rs
@@ -25,7 +25,7 @@ use cedar_drt::{
 };
 use cedar_policy::frontend::is_authorized::InterfaceResponse;
 use cedar_policy_core::ast;
-use cedar_policy_core::authorizer::{Authorizer, AuthorizationError, Diagnostics, Response};
+use cedar_policy_core::authorizer::{AuthorizationError, Authorizer, Diagnostics, Response};
 use cedar_policy_core::entities::{Entities, NoEntitiesSchema, TCComputation};
 use cedar_policy_core::evaluator::{EvaluationErrorKind, Evaluator};
 use cedar_policy_core::extensions::Extensions;
@@ -142,7 +142,8 @@ pub fn run_auth_test(
                     ..rust_res
                 },
                 ErrorComparisonMode::Full => rust_res.clone(),
-            }.into();
+            }
+            .into();
             assert_eq!(
                 InterfaceResponse::from(rust_res_for_comparison),
                 definitional_res,

--- a/cedar-drt/src/cedar_test_impl.rs
+++ b/cedar-drt/src/cedar_test_impl.rs
@@ -74,4 +74,27 @@ pub trait CedarTestImplementation {
         policies: &PolicySet,
         mode: ValidationMode,
     ) -> InterfaceResult<InterfaceValidationResult>;
+
+    /// `ErrorComparisonMode` that should be used for this `CedarTestImplementation`
+    fn error_comparison_mode(&self) -> ErrorComparisonMode;
+}
+
+/// Specifies how errors coming from a `CedarTestImplementation` should be
+/// compared against errors coming from the Rust implementation.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum ErrorComparisonMode {
+    /// Don't compare errors at all; the `CedarTestImplementation` is not
+    /// expected to produce errors matching the Rust implementation's errors in
+    /// any way.
+    /// In fact, the `CedarTestImplementation` will be expected to never report
+    /// errors.
+    Ignore,
+    /// The `CedarTestImplementation` is expected to produce "error messages" that
+    /// are actually just the id of the erroring policy. This will be compared to
+    /// ensure that the `CedarTestImplementation` agrees with the Rust
+    /// implementation on which policies produce errors.
+    PolicyIds,
+    /// The `CedarTestImplementation` is expected to produce error messages that
+    /// exactly match the Rust implementation's error messages' `Display` text.
+    Full,
 }

--- a/cedar-drt/src/dafny_java_impl.rs
+++ b/cedar-drt/src/dafny_java_impl.rs
@@ -414,6 +414,10 @@ impl<'j> CedarTestImplementation for JavaDefinitionalEngine<'j> {
     ) -> InterfaceResult<InterfaceValidationResult> {
         Ok(self.validate(schema, policies, mode))
     }
+
+    fn error_comparison_mode(&self) -> ErrorComparisonMode {
+        ErrorComparisonMode::Ignore
+    }
 }
 
 /// Implementation of the trait used for integration testing.

--- a/cedar-drt/src/lean_impl.rs
+++ b/cedar-drt/src/lean_impl.rs
@@ -324,6 +324,10 @@ impl CedarTestImplementation for LeanDefinitionalEngine {
         );
         self.validate(schema, policies)
     }
+
+    fn error_comparison_mode(&self) -> ErrorComparisonMode {
+        ErrorComparisonMode::PolicyIds
+    }
 }
 
 /// Implementation of the trait used for integration testing. The integration


### PR DESCRIPTION
Following #206, the Lean engine actually returns errors (or at least, the ids of erroring policies).  DRT should properly compare this against the errors produced by the Rust.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
