### PR TITLE
Add basic EST round-trip testing

### DIFF
--- a/cedar-drt/README.md
+++ b/cedar-drt/README.md
@@ -13,9 +13,9 @@ The table below lists all available fuzz targets, including which component of t
 | [`abac`](fuzz/fuzz_targets/abac.rs) | Evaluator | DRT | Diff test evaluator on ABAC policies |
 | [`formatter`](fuzz/fuzz_targets/formatter.rs) | Policy formatter, Pretty printer, Parser | PBT | Test round trip property: parse ∘ format ∘ pretty-print == id for ASTs |
 | [`partial-eval`](fuzz/fuzz_targets/partial-eval.rs) | Partial evaluator | PBT | Test that residual policies with unknowns substituted are equivalent to original policies with unknowns replaced |
-| [`pp`](fuzz/fuzz_targets/pp.rs) | Pretty printer, Parser, Conversion to JSON | PBT | Test round trip property: parse ∘ pretty-print == id for ASTs |
 | [`rbac-authorizer`](fuzz/fuzz_targets/rbac-authorizer.rs) | Authorizer | PBT + DRT | Test for correct authorization responses over a set of simple policies |
 | [`rbac`](fuzz/fuzz_targets/rbac.rs) | Authorizer | DRT | Diff test authorizer on sets of RBAC policies, including template instantiations |
+| [`roundtrip`](fuzz/fuzz_targets/roundtrip.rs) | Pretty printer, Parser, Conversion to JSON | PBT | Test round trip property: parse ∘ pretty-print == deserialize ∘ serialize == id for ASTs |
 | [`simple-parser`](fuzz/fuzz_targets/simple-parser.rs) |  Parser | PBT | Test that parsing doesn't crash with random input strings |
 | [`strict-validation-drt-type-directed`](fuzz/fuzz_targets/strict-validation-drt-type-directed.rs) | Validator | DRT | Diff test strict validation using (mostly) well-typed inputs |
 | [`validation-drt-type-directed`](fuzz/fuzz_targets/validation-drt-type-directed.rs) | Validator | DRT | Diff test permissive validation using (mostly) well-typed inputs |

--- a/cedar-drt/README.md
+++ b/cedar-drt/README.md
@@ -13,7 +13,7 @@ The table below lists all available fuzz targets, including which component of t
 | [`abac`](fuzz/fuzz_targets/abac.rs) | Evaluator | DRT | Diff test evaluator on ABAC policies |
 | [`formatter`](fuzz/fuzz_targets/formatter.rs) | Policy formatter, Pretty printer, Parser | PBT | Test round trip property: parse ∘ format ∘ pretty-print == id for ASTs |
 | [`partial-eval`](fuzz/fuzz_targets/partial-eval.rs) | Partial evaluator | PBT | Test that residual policies with unknowns substituted are equivalent to original policies with unknowns replaced |
-| [`pp`](fuzz/fuzz_targets/pp.rs) | Pretty printer, Parser | PBT | Test round trip property: parse ∘ pretty-print == id for ASTs |
+| [`pp`](fuzz/fuzz_targets/pp.rs) | Pretty printer, Parser, Conversion to JSON | PBT | Test round trip property: parse ∘ pretty-print == id for ASTs |
 | [`rbac-authorizer`](fuzz/fuzz_targets/rbac-authorizer.rs) | Authorizer | PBT + DRT | Test for correct authorization responses over a set of simple policies |
 | [`rbac`](fuzz/fuzz_targets/rbac.rs) | Authorizer | DRT | Diff test authorizer on sets of RBAC policies, including template instantiations |
 | [`simple-parser`](fuzz/fuzz_targets/simple-parser.rs) |  Parser | PBT | Test that parsing doesn't crash with random input strings |
@@ -22,7 +22,6 @@ The table below lists all available fuzz targets, including which component of t
 | [`validation-drt`](fuzz/fuzz_targets/validation-drt.rs) | Validator | DRT | Diff test permissive validation |
 | [`validation-pbt`](fuzz/fuzz_targets/validation-pbt.rs) | Validator | PBT | Test that validated policies do not result in type errors |
 | [`wildcard-matching`](fuzz/fuzz_targets/wildcard-matching.rs) | String matching algorithm used for the `like` operator | DRT | Diff test wildcard matching using a regex-based implementation |
-
 
 ## Logging
 
@@ -34,6 +33,7 @@ The sampling rate can be controlled by the `RATE` environment variable, which de
 When using the `abac` or `abac-type-directed` targets, you can set `DUMP_TEST_DIR` and `DUMP_TEST_NAME` to have the fuzzer write out inputs in the format used by our [integration tests](https://github.com/cedar-policy/cedar/tree/main/cedar-integration-tests).
 The `create_corpus.sh` script will run the fuzzer for a set amount of time and then write the (minimized) corpus inputs into a folder using the integration test format.
 You can adjust the script's behavior using the following environment variables:
+
 * `FUZZ_TARGET`: `abac` or `abac-type-directed` (default = `abac`)
 * `TIMEOUT`: how long to run (default = 15m)
 * `JOBS`: number of jobs (default = 4)
@@ -42,6 +42,7 @@ You can adjust the script's behavior using the following environment variables:
 ## Debugging build failures
 
 If you run into weird build issues,
+
 1. Make sure you have run `source set_env_vars.sh`, which sets all the environment variables needed to run the Dafny and Lean definitional code.
 2. Try a `cargo clean` and rebuild.
 3. If the steps above don't help, then file [an issue](https://github.com/cedar-policy/cedar-spec/issues).

--- a/cedar-drt/fuzz/Cargo.toml
+++ b/cedar-drt/fuzz/Cargo.toml
@@ -92,8 +92,8 @@ test = false
 doc = false
 
 [[bin]]
-name = "pp"
-path = "fuzz_targets/pp.rs"
+name = "roundtrip"
+path = "fuzz_targets/roundtrip.rs"
 test = false
 doc = false
 

--- a/cedar-drt/fuzz/fuzz_targets/roundtrip.rs
+++ b/cedar-drt/fuzz/fuzz_targets/roundtrip.rs
@@ -38,7 +38,7 @@ struct FuzzTargetInput {
 // settings for this fuzz target
 // copy-pasted from abac.rs
 const SETTINGS: ABACSettings = ABACSettings {
-    match_types: true,
+    match_types: false,
     enable_extensions: true,
     max_depth: 7,
     max_width: 7,

--- a/cedar-drt/fuzz/fuzz_targets/roundtrip.rs
+++ b/cedar-drt/fuzz/fuzz_targets/roundtrip.rs
@@ -97,16 +97,16 @@ fn round_trip_json(p: StaticPolicy) -> StaticPolicy {
 // Check that round-tripping preserves syntactic equivalence.
 // Panic if the two policies are not the same, ignoring ids.
 fn check_policy_equivalence(p1: &StaticPolicy, p2: &StaticPolicy) {
-    let (t, _) = Template::link_static_policy(p1.clone());
+    let (t1, _) = Template::link_static_policy(p1.clone());
     assert!(
-        t.slots().collect::<Vec<_>>().is_empty(),
+        t1.slots().collect::<Vec<_>>().is_empty(),
         "\nold template slots should be empty\n"
     );
     // just dump to standard hashmaps to check equality without order
     let old_anno = p2
         .annotations()
         .collect::<std::collections::HashMap<_, _>>();
-    let new_anno = t.annotations().collect::<std::collections::HashMap<_, _>>();
+    let new_anno = t1.annotations().collect::<std::collections::HashMap<_, _>>();
     assert_eq!(
         old_anno, new_anno,
         "\nannotations should be the same, found:\nold: {:?}\nnew: {:?}\n",
@@ -114,37 +114,37 @@ fn check_policy_equivalence(p1: &StaticPolicy, p2: &StaticPolicy) {
     );
     assert_eq!(
         p2.effect(),
-        t.effect(),
+        t1.effect(),
         "\nnew effect: {:?}\nold effect: {:?}\n",
         p2.effect(),
-        t.effect()
+        t1.effect()
     );
     assert_eq!(
         p2.principal_constraint(),
-        t.principal_constraint(),
+        t1.principal_constraint(),
         "\nnew principal constraint: {:?}\nold principal constraint: {:?}\n",
         p2.principal_constraint(),
-        t.principal_constraint()
+        t1.principal_constraint()
     );
     assert_eq!(
         p2.action_constraint(),
-        t.action_constraint(),
+        t1.action_constraint(),
         "\nnew action constraint: {:?}\nold action constraint: {:?}\n",
         p2.action_constraint(),
-        t.action_constraint()
+        t1.action_constraint()
     );
     assert_eq!(
         p2.resource_constraint(),
-        t.resource_constraint(),
+        t1.resource_constraint(),
         "\nnew resource constraint: {:?}\nold resource constraint: {:?}\n",
         p2.resource_constraint(),
-        t.resource_constraint()
+        t1.resource_constraint()
     );
     assert!(
-        p2.non_head_constraints().eq_shape(t.non_head_constraints()),
+        p2.non_head_constraints().eq_shape(t1.non_head_constraints()),
         "\nnew policy condition: {:?}\nold policy condition: {:?}\n",
         p2.non_head_constraints(),
-        t.non_head_constraints()
+        t1.non_head_constraints()
     );
 }
 
@@ -166,7 +166,7 @@ fuzz_target!(|input: FuzzTargetInput| {
             check_policy_equivalence(&p, &np);
         }
         Err(err) => panic!(
-            "\nInvalid AST captured: {:?}\n pp form: {}\n, parsing error: {:?}\n",
+            "\nFailed to round-trip AST: {:?}\nPretty printed form: {}\nParse error: {:?}\n",
             p, p, err
         ),
     }

--- a/cedar-drt/fuzz/fuzz_targets/roundtrip.rs
+++ b/cedar-drt/fuzz/fuzz_targets/roundtrip.rs
@@ -18,8 +18,7 @@
 
 use cedar_drt::initialize_log;
 use cedar_drt_inner::fuzz_target;
-use cedar_policy_core::ast;
-use cedar_policy_core::ast::{EntityType, ExprKind, Literal, StaticPolicy, Template};
+use cedar_policy_core::ast::{self, EntityType, ExprKind, Literal, StaticPolicy, Template};
 use cedar_policy_core::est;
 use cedar_policy_core::parser::{self, parse_policy};
 use cedar_policy_generators::{
@@ -39,7 +38,7 @@ struct FuzzTargetInput {
 // settings for this fuzz target
 // copy-pasted from abac.rs
 const SETTINGS: ABACSettings = ABACSettings {
-    match_types: false,
+    match_types: true,
     enable_extensions: true,
     max_depth: 7,
     max_width: 7,
@@ -73,13 +72,37 @@ fn contains_unspecified_entities(p: &StaticPolicy) -> bool {
     p.condition().subexpressions().any(|e| matches!(e.expr_kind(), ExprKind::Lit(Literal::EntityUID(euid)) if matches!(*euid.entity_type(), EntityType::Unspecified)))
 }
 
-// Round-tripping using the display trait: print a policy to string and parse it back.
-fn round_trip(p: &StaticPolicy) -> Result<StaticPolicy, parser::err::ParseErrors> {
-    parse_policy(None, &p.to_string())
+// Print a policy to a string and parse it back using the standard AST parser.
+// Panics if parsing fails.
+fn round_trip_ast(p: &StaticPolicy) -> StaticPolicy {
+    parse_policy(None, &p.to_string()).unwrap_or_else(|err| {
+        panic!(
+            "Failed to round-trip AST: {:?}\nPretty printed form: {}\nParse error: {:?}\n",
+            p, p, err
+        )
+    })
 }
 
-// Round-tripping using the JSON (EST) format: print a policy to a JSON string
-// and parse it back. Panics if any step fails.
+// Print a policy to a string, parse it back using the EST parser, and convert to JSON.
+// Panics if any step fails. The resulting policy may be different from the input
+// (since the roundtrip is lossy), so this function only checks that the round-trip
+// succeeds without error.
+fn round_trip_est(p: &StaticPolicy) {
+    let est = parser::parse_policy_or_template_to_est(&p.to_string()).unwrap_or_else(|err| {
+        panic!(
+            "Failed to round-trip EST: {:?}\nPretty printed form: {}\nParse error: {:?}\n",
+            p, p, err
+        )
+    });
+    serde_json::to_value(est).unwrap_or_else(|err| {
+        panic!(
+            "Failed to convert EST to JSON: {:?}\nParse error: {:?}\n",
+            p, err
+        )
+    });
+}
+
+// Print a policy to a JSON string and parse it back. Panics if any step fails.
 fn round_trip_json(p: StaticPolicy) -> StaticPolicy {
     // convert to json
     let est = est::Policy::from(ast::Policy::from(p));
@@ -106,7 +129,9 @@ fn check_policy_equivalence(p1: &StaticPolicy, p2: &StaticPolicy) {
     let old_anno = p2
         .annotations()
         .collect::<std::collections::HashMap<_, _>>();
-    let new_anno = t1.annotations().collect::<std::collections::HashMap<_, _>>();
+    let new_anno = t1
+        .annotations()
+        .collect::<std::collections::HashMap<_, _>>();
     assert_eq!(
         old_anno, new_anno,
         "\nannotations should be the same, found:\nold: {:?}\nnew: {:?}\n",
@@ -141,7 +166,8 @@ fn check_policy_equivalence(p1: &StaticPolicy, p2: &StaticPolicy) {
         t1.resource_constraint()
     );
     assert!(
-        p2.non_head_constraints().eq_shape(t1.non_head_constraints()),
+        p2.non_head_constraints()
+            .eq_shape(t1.non_head_constraints()),
         "\nnew policy condition: {:?}\nold policy condition: {:?}\n",
         p2.non_head_constraints(),
         t1.non_head_constraints()
@@ -160,16 +186,16 @@ fuzz_target!(|input: FuzzTargetInput| {
         return;
     }
 
-    debug!("Starting policy: {:?}", p);
-    match round_trip(&p) {
-        Ok(np) => {
-            check_policy_equivalence(&p, &np);
-        }
-        Err(err) => panic!(
-            "\nFailed to round-trip AST: {:?}\nPretty printed form: {}\nParse error: {:?}\n",
-            p, p, err
-        ),
-    }
+    debug!("Running on policy: {:?}", p);
+
+    // round-trip AST & check the returned policy
+    let np = round_trip_ast(&p);
+    check_policy_equivalence(&p, &np);
+
+    // round-trip EST & check for failures
+    round_trip_est(&p);
+
+    // round-trip EST (via JSON) & check the returned policy
     let np = round_trip_json(p.clone());
     check_policy_equivalence(&p, &np);
 });


### PR DESCRIPTION
*Issue #, if available:*

#204 

*Description of changes:*

This PR renames the `pp` target to `roundtrip` and adds two additional checks per policy:
1. Check that parsing a displayed policy using `parser::parse_policy_or_template_to_est` and converting to JSON produces no errors.
2. Check that converting a policy to JSON and back preserves the policy structure.

To test, I reverted [cedar#601](https://github.com/cedar-policy/cedar/pull/601) and confirmed that the underlying bug was found quickly by check 1. Check 2 didn't turn up any bugs during an overnight run, but it seems useful(?)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
