### PR TITLE
Re-enable `like` operator

### DIFF
--- a/cedar-drt/fuzz/fuzz_targets/abac_shared.rs
+++ b/cedar-drt/fuzz/fuzz_targets/abac_shared.rs
@@ -55,7 +55,7 @@ const SETTINGS: ABACSettings = ABACSettings {
     max_depth: 3,
     max_width: 7,
     enable_additional_attributes: false,
-    enable_like: false,
+    enable_like: true,
     // ABAC fuzzing restricts the use of action because it is used to generate
     // the corpus tests which will be run on Cedar and CedarCLI.
     // These packages only expose the restricted action behavior.

--- a/cedar-drt/fuzz/fuzz_targets/abac_type_directed_shared.rs
+++ b/cedar-drt/fuzz/fuzz_targets/abac_type_directed_shared.rs
@@ -56,7 +56,7 @@ const SETTINGS: ABACSettings = ABACSettings {
     max_depth: 3,
     max_width: 3,
     enable_additional_attributes: false,
-    enable_like: false,
+    enable_like: true,
     enable_action_groups_and_attrs: true,
     enable_arbitrary_func_call: true,
     enable_unknowns: false,

--- a/cedar-drt/fuzz/fuzz_targets/eval_type_directed_shared.rs
+++ b/cedar-drt/fuzz/fuzz_targets/eval_type_directed_shared.rs
@@ -54,7 +54,7 @@ const SETTINGS: ABACSettings = ABACSettings {
     max_depth: 3,
     max_width: 3,
     enable_additional_attributes: false,
-    enable_like: false,
+    enable_like: true,
     enable_action_groups_and_attrs: true,
     enable_arbitrary_func_call: true,
     enable_unknowns: false,


### PR DESCRIPTION
*Issue #, if available:*

Resolves #185

*Description of changes:*

Now that the Lean implementation of wildcard matching has been fixed (#213), we can re-enable the `like` operator in our generators.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
