### PR TITLE
simplify simps

### DIFF
--- a/cedar-lean/Cedar/Data/LT.lean
+++ b/cedar-lean/Cedar/Data/LT.lean
@@ -200,8 +200,8 @@ instance Bool.strictLT : StrictLT Bool where
     split <;> simp
   connected  a b   := by
     simp [LT.lt, Bool.lt]
-    split <;> simp
-    split <;> simp
+    split <;> simp only [not_false_eq_true, _root_.or_false, imp_self]
+    split <;> simp only [not_false_eq_true, _root_.or_true, imp_self]
     cases a <;> cases b <;> simp at *
 
 instance Nat.strictLT : StrictLT Nat where

--- a/cedar-lean/Cedar/Thm/Authorization.lean
+++ b/cedar-lean/Cedar/Thm/Authorization.lean
@@ -60,7 +60,7 @@ theorem allowed_if_explicitly_permitted (request : Request) (entities : Entities
   unfold isAuthorized
   generalize (satisfiedPolicies forbid policies request entities) = forbids
   generalize hp : (satisfiedPolicies permit policies request entities) = permits
-  simp
+  simp only [Bool.and_eq_true, Bool.not_eq_true']
   cases forbids.isEmpty <;> simp
   cases h0 : permits.isEmpty <;> simp
   unfold IsExplicitlyPermitted

--- a/cedar-lean/Cedar/Thm/Authorization/Evaluator.lean
+++ b/cedar-lean/Cedar/Thm/Authorization/Evaluator.lean
@@ -113,8 +113,8 @@ theorem ways_and_can_error {e₁ e₂ : Expr} {request : Request} {entities : En
       case bool b =>
         cases b with
         | true =>
-          simp
-          simp [h_e₁] at h₁
+          simp only [true_and]
+          simp only [h_e₁] at h₁
           cases h_e₂ : (evaluate e₂ request entities) with
           | ok val =>
             cases val <;>

--- a/cedar-lean/Cedar/Thm/Data/List.lean
+++ b/cedar-lean/Cedar/Thm/Data/List.lean
@@ -102,7 +102,7 @@ theorem map_equiv (f : α → β) (xs ys : List α) :
   intro p h <;>
   exists p <;>
   rw [List.subset_def] at a b <;>
-  simp
+  simp only [and_true]
   exact a h
   exact b h
 
@@ -228,7 +228,7 @@ theorem sortedBy_equiv_implies_eq [LT β] [StrictLT β] (f : α → β) {xs ys :
       rw [←List.subset_nil]
       exact h₃.left
     case cons yhd ytl =>
-      simp
+      simp only [cons.injEq]
       have h₅ := sortedBy_equiv_implies_head_eq f h₁ h₂ h₃
       simp only [h₅, true_and]
       subst h₅
@@ -287,7 +287,7 @@ theorem insertCanonical_not_nil [DecidableEq β] [LT β] [DecidableLT β] (f : �
   cases xs with
   | nil => simp
   | cons hd tl =>
-    simp
+    simp only [gt_iff_lt, ne_eq]
     intro h
     split at h <;> try trivial
     split at h <;> trivial
@@ -346,7 +346,8 @@ theorem insertCanonical_cases [LT β] [DecidableLT β] (f : α → β) (x y : α
   (¬ f x < f y ∧ ¬ f x > f y ∧ insertCanonical f x (y :: ys) = x :: ys)
 := by
   generalize h₁ : insertCanonical f x ys = xys
-  unfold insertCanonical; simp
+  unfold insertCanonical
+  simp only [gt_iff_lt, ite_eq_left_iff]
   by_cases (f x < f y)
   case pos _ _ h₂ => simp [h₂]
   case neg _ _ h₂ =>
@@ -362,7 +363,7 @@ theorem insertCanonical_equiv [LT α] [StrictLT α] [DecidableLT α] (x : α) (x
   induction xs
   case nil => simp; exact Equiv.refl
   case cons _ _ hd tl ih =>
-    simp
+    simp only [id_eq, gt_iff_lt]
     split
     case inl => exact Equiv.refl
     case inr _ _ h₁ =>

--- a/cedar-lean/Cedar/Thm/Data/Map.lean
+++ b/cedar-lean/Cedar/Thm/Data/Map.lean
@@ -38,7 +38,7 @@ theorem in_list_in_map {α : Type u} (k : α) (v : β) (m : Map α β) :
   (k, v) ∈ m.kvs → k ∈ m
 := by
   intro h₀
-  have h₁ : k ∈ (List.map Prod.fst m.kvs) := by simp ; exists (k, v)
+  have h₁ : k ∈ (List.map Prod.fst m.kvs) := by simp only [List.mem_map] ; exists (k, v)
   apply h₁
 
 theorem contains_iff_some_find? {α β} [BEq α] {m : Map α β} {k : α} :

--- a/cedar-lean/Cedar/Thm/Data/Set.lean
+++ b/cedar-lean/Cedar/Thm/Data/Set.lean
@@ -119,7 +119,7 @@ theorem make_make_eqv [LT α] [DecidableLT α] [StrictLT α] {xs ys : List α} :
     have h₃ := List.Equiv.symm h₂; clear h₂
     exact List.Equiv.trans (a := xs) (b := List.canonicalize (fun x => x) xs) (c := ys) h₁ h₃
   case mpr =>
-    intro h; unfold make; simp
+    intro h; unfold make; simp only [mk.injEq]
     apply List.equiv_implies_canonical_eq _ _ h
 
 theorem elts_make_equiv [LT α] [DecidableLT α] [StrictLT α] {xs : List α} :

--- a/cedar-lean/Cedar/Thm/Validation/Typechecker/BinaryApp.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Typechecker/BinaryApp.lean
@@ -572,7 +572,7 @@ theorem entity_set_type_implies_set_of_entities {vs : List Value} {ety : EntityT
     simp [Set.mem_cons_self] at h₂
     replace ⟨heuid, hdty, h₂⟩ := instance_of_entity_type_is_entity h₂
     subst h₂
-    rw [Value.asEntityUID] ; simp
+    rw [Value.asEntityUID] ; simp only [Except.bind_ok]
     rw [List.mapM'_eq_mapM]
     have h₃ : InstanceOfType (Value.set (Set.mk tl)) (CedarType.set (CedarType.entity ety)) := by
       apply InstanceOfType.instance_of_set

--- a/cedar-lean/Cedar/Thm/Validation/Typechecker/GetAttr.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Typechecker/GetAttr.lean
@@ -51,10 +51,12 @@ theorem type_of_getAttr_inversion {x₁ : Expr} {a : Attr} {c₁ c₂ : Capabili
     simp [typeOfGetAttr] at h₁
     split at h₁ <;> try contradiction
     case h_1 =>
-      simp
+      simp only [List.empty_eq, Except.ok.injEq, Prod.mk.injEq, false_and, exists_const,
+        CedarType.record.injEq, exists_and_right, exists_eq', true_and, false_or, and_true]
       apply getAttrInRecord_has_empty_capabilities h₁
     case h_2 =>
-      simp
+      simp only [List.empty_eq, Except.ok.injEq, Prod.mk.injEq, CedarType.entity.injEq,
+        exists_and_right, exists_eq', true_and, false_and, exists_const, or_false, and_true]
       split at h₁ <;> try simp [err] at h₁
       apply getAttrInRecord_has_empty_capabilities h₁
 
@@ -126,8 +128,8 @@ theorem type_of_getAttr_is_sound_for_entities {x₁ : Expr} {a : Attr} {c₁ c�
     simp only [Except.bind_ok]
     cases h₉ : Map.find? d.attrs a
     case none =>
-      simp
-      simp [typeOf, h₄, typeOfGetAttr, getAttrInRecord] at h₃
+      simp only [Except.error.injEq, or_self, false_and, exists_const]
+      simp only [typeOf._eq_9, h₄, typeOfGetAttr, getAttrInRecord, List.empty_eq, Except.bind_ok] at h₃
       split at h₃ <;> simp [ok, err] at h₃
       split at h₃ <;> try simp at h₃
       case h_1.h_1 _ _ h₁₀ _ _ h₁₁ =>

--- a/cedar-lean/Cedar/Thm/Validation/Typechecker/LUB.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Typechecker/LUB.lean
@@ -330,7 +330,7 @@ theorem lubRecordType_trans {rty₁ rty₂ rty₃ : List (Attr × QualifiedType)
   unfold lubRecordType
   intro h₁ h₂
   cases rty₁ <;> cases rty₃ <;>
-  simp
+  simp only
   case cons.cons hd₁ tl₁ hd₃ tl₃ =>
     cases rty₂ <;> simp at h₁ h₂
     rename_i hd₂ tl₂
@@ -727,7 +727,7 @@ theorem lub_assoc (ty₁ ty₂ ty₃ : CedarType) :
 := by
   cases h₁ : (ty₁ ⊔ ty₂) <;>
   cases h₂ : (ty₂ ⊔ ty₃) <;>
-  simp
+  simp only [Option.bind_none_fun, Option.bind_some_fun]
   case none.some ty₄ =>
     rw [eq_comm]
     exact lub_assoc_none_some h₁ h₂


### PR DESCRIPTION
*Description of changes:*
Simplify usages of `simp` tactic in the middle of proofs. Using `simp` (as opposed to `simp only`), makes proofs more likely to break as adding the "simp" attribute to new theorems can break the proof. This is not the case at the end of a proof / case; we can freely use `simp` there.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
