### PR TITLE
Print the correct LHS and RHS in schema roundtrip

### DIFF
--- a/cedar-drt/fuzz/fuzz_targets/schema-roundtrip.rs
+++ b/cedar-drt/fuzz/fuzz_targets/schema-roundtrip.rs
@@ -69,10 +69,10 @@ impl<'a> Arbitrary<'a> for Input {
 fuzz_target!(|i: Input| {
     let src = i.schema.as_natural_schema().unwrap();
     let (parsed, _) = SchemaFragment::from_str_natural(&src).unwrap();
-    if let Err(msg) = equivalence_check(i.schema.clone(), parsed) {
+    if let Err(msg) = equivalence_check(i.schema.clone(), parsed.clone()) {
         println!("Schema: {src}");
         println!("LHS:\n{:?}", i.schema);
-        println!("RHS:\n{:?}", i.schema);
+        println!("RHS:\n{:?}", parsed);
         panic!("{msg}");
     }
 });


### PR DESCRIPTION
*Issue #, if available:*
N/A
*Description of changes:*
The `schema-roundtrip` target used to print LHS for both the LHS and RHS output.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
