### PR TITLE
Fix bug where hierarchy generator could loop infinitely

### DIFF
--- a/cedar-policy-generators/src/hierarchy.rs
+++ b/cedar-policy-generators/src/hierarchy.rs
@@ -457,6 +457,11 @@ impl<'a, 'u> HierarchyGenerator<'a, 'u> {
                         let num_entities_per_type = num_entities / entity_types.len();
                         let mut uids = HashSet::new();
                         while uids.len() < num_entities_per_type {
+                            // If we run out of bytes in `u`, then `uid` will be the same on every
+                            // subsequent iteration, so the size of `uids` won't increase.
+                            if self.u.is_empty() {
+                                return Err(Error::NotEnoughData);
+                            }
                             let uid =
                                 generate_uid_with_type(name.clone(), &self.uid_gen_mode, self.u)?;
                             uids.insert(uid);


### PR DESCRIPTION
If it ran out of bytes while generating uids, it would get stuck in a loop adding the same uid to a set on every iteration without ever adding a _new_ element to the set. It looks like `NumEntities::Exactly` was only ever used by the CLI in `cedar-policy-generators`, so this shouldn't effect any fuzz targets. 

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
