### PR TITLE
Update integration test CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
         run: |
               wget https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh
               bash elan-init.sh -y
-      - name: rustup
+      - name: Prepare Rust build
         run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
       - name: cargo fmt (cedar-policy-generators)
         working-directory: ./cedar-policy-generators
@@ -64,22 +64,9 @@ jobs:
       - name: cargo test (cedar-policy-generators)
         working-directory: ./cedar-policy-generators
         run: cargo test --verbose
-      - name: build.sh
+      - name: Run build.sh script
         shell: bash
         run: source ~/.profile && ./build.sh
-      - name: Delete old integration tests
-        working-directory: ./cedar
-        run: rm -rf cedar-integration-tests
-      - name: Download new integration tests
-        uses: actions/checkout@v4
-        with:
-          repository: cedar-policy/cedar-integration-tests
-          ref: main
-          path: ./cedar/cedar-integration-tests
-      - name: Unpack corpus tests
-        working-directory: ./cedar/cedar-integration-tests
-        run: tar xzf corpus-tests.tar.gz
-      - name: Run integration tests
-        working-directory: ./cedar-drt
-        run: source ~/.profile && source set_env_vars.sh && cargo test --features "integration-testing" -- --nocapture
 
+  run-integration-tests:
+    uses: ./.github/workflows/run_integration_tests_reusable.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
       - name: cargo test (cedar-policy-generators)
         working-directory: ./cedar-policy-generators
         run: cargo test --verbose
-      - name: Build & test cedar-drt/
+      - name: Build Lean libraries, and build & test cedar-drt/
         shell: bash
         run: source ~/.profile && ./build.sh
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,11 @@
-name: Build cedar-spec
+name: Build and test cedar-spec
 
 on:
   pull_request:
 
 jobs:
   build_and_test_lean:
-    name: Build and Test Lean
+    name: Build and test Lean
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -31,7 +31,7 @@ jobs:
         run: source ~/.profile && lake exe CedarUnitTests
 
   build_and_test_drt:
-    name: Build and Test DRT
+    name: Build and test DRT
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,9 +64,11 @@ jobs:
       - name: cargo test (cedar-policy-generators)
         working-directory: ./cedar-policy-generators
         run: cargo test --verbose
-      - name: Run build.sh script
+      - name: Build & test cedar-drt/
         shell: bash
         run: source ~/.profile && ./build.sh
 
   run-integration-tests:
     uses: ./.github/workflows/run_integration_tests_reusable.yml
+    with:
+      cedar_spec_ref: ${{ github.ref }}

--- a/.github/workflows/run_integration_tests_reusable.yml
+++ b/.github/workflows/run_integration_tests_reusable.yml
@@ -1,0 +1,50 @@
+name: Run Integration Tests
+
+on:
+  workflow_call:
+
+jobs:
+  run_integration_tests:
+    name: Run integration tests
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        toolchain:
+          - stable
+
+    steps:
+      - name: Checkout cedar-spec
+        uses: actions/checkout@v4
+        with:
+          repository: cedar-policy/cedar-spec
+          ref: main
+          path: ./cedar-spec
+          submodules: recursive
+      - name: Delete old integration tests
+        working-directory: ./cedar-spec/cedar
+        run: rm -rf cedar-integration-tests # blast the current content
+      - name: Checkout cedar-integration-tests
+        uses: actions/checkout@v4
+        with:
+          repository: cedar-policy/cedar-integration-tests
+          ref: main
+          path: ./cedar-spec/cedar/cedar-integration-tests
+      - name: Decompress corpus tests
+        working-directory: ./cedar-spec/cedar/cedar-integration-tests
+        run: tar xzf corpus-tests.tar.gz
+      - name: Install Lean
+        shell: bash
+        run: |
+             wget https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh
+             bash elan-init.sh -y
+      - name: Prepare Rust build
+        run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
+      - name: Run build.sh script
+        working-directory: ./cedar-spec
+        shell: bash
+        run: source ~/.profile && ./build.sh
+      - name: Run integration tests
+        working-directory: ./cedar-spec/cedar-drt
+        shell: bash
+        run: source ~/.profile && source set_env_vars.sh && cargo test --features "integration-testing" -- --nocapture
+

--- a/.github/workflows/run_integration_tests_reusable.yml
+++ b/.github/workflows/run_integration_tests_reusable.yml
@@ -2,6 +2,15 @@ name: Run Integration Tests
 
 on:
   workflow_call:
+    inputs:
+    cedar_integration_tests_ref:
+      required: false
+      default: "main"
+      type: string
+    cedar_spec_ref:
+        required: false
+        default: "main"
+        type: string
 
 jobs:
   run_integration_tests:
@@ -17,7 +26,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: cedar-policy/cedar-spec
-          ref: main
+          ref: ${{ inputs.cedar_spec_ref }}
           path: ./cedar-spec
           submodules: recursive
       - name: Delete old integration tests
@@ -27,7 +36,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: cedar-policy/cedar-integration-tests
-          ref: main
+          ref: ${{ inputs.cedar_integration_tests_ref }}
           path: ./cedar-spec/cedar/cedar-integration-tests
       - name: Decompress corpus tests
         working-directory: ./cedar-spec/cedar/cedar-integration-tests
@@ -39,10 +48,10 @@ jobs:
              bash elan-init.sh -y
       - name: Prepare Rust build
         run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
-      - name: Run build.sh script
-        working-directory: ./cedar-spec
+      - name: Build Lean libraries
+        working-directory: ./cedar-spec/cedar-lean
         shell: bash
-        run: source ~/.profile && ./build.sh
+        run: lake build Cedar:static DiffTest:static Std:static
       - name: Run integration tests
         working-directory: ./cedar-spec/cedar-drt
         shell: bash

--- a/.github/workflows/run_integration_tests_reusable.yml
+++ b/.github/workflows/run_integration_tests_reusable.yml
@@ -3,14 +3,14 @@ name: Run Integration Tests
 on:
   workflow_call:
     inputs:
-    cedar_integration_tests_ref:
-      required: false
-      default: "main"
-      type: string
-    cedar_spec_ref:
+      cedar_integration_tests_ref:
         required: false
         default: "main"
         type: string
+      cedar_spec_ref:
+          required: false
+          default: "main"
+          type: string
 
 jobs:
   run_integration_tests:

--- a/.github/workflows/run_integration_tests_reusable.yml
+++ b/.github/workflows/run_integration_tests_reusable.yml
@@ -49,9 +49,9 @@ jobs:
       - name: Prepare Rust build
         run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
       - name: Build Lean libraries
-        working-directory: ./cedar-spec/cedar-lean
+        working-directory: ./cedar-spec
         shell: bash
-        run: lake build Cedar:static DiffTest:static Std:static
+        run: source ~/.profile && ./build.sh
       - name: Run integration tests
         working-directory: ./cedar-spec/cedar-drt
         shell: bash

--- a/cedar-drt/set_env_vars.sh
+++ b/cedar-drt/set_env_vars.sh
@@ -8,7 +8,7 @@ else
     export LD_LIBRARY_PATH=${LD_LIBRARY_PATH+$LD_LIBRARY_PATH:}$(lean --print-libdir)
     export DYLD_LIBRARY_PATH=${DYLD_LIBRARY_PATH+$DYLD_LIBRARY_PATH:}$(lean --print-libdir)
 
-    # if the version of GLIBC is too old (< 2.27), then use the verison of libm.so packaged with Lean
+    # if the version of GLIBC is too old (< 2.27), then use the version of libm.so packaged with Lean
     GLIBC_VERSION=`ldd --version | awk '/ldd/{print $NF}'`
     if awk "BEGIN {exit !($GLIBC_VERSION < 2.27)}"; then
         export LD_PRELOAD=${LD_PRELOAD+$LD_PRELOAD:}$(lean --print-prefix)/lib/glibc/libm.so


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Updates to CI to enable running the integration tests from the `cedar-integration-tests` repository.

(Same idea as [cedar#746](https://github.com/cedar-policy/cedar/pull/746).)

