### PR TITLE
Update generation of unspecified entities

### DIFF
--- a/cedar-drt/fuzz/src/dump.rs
+++ b/cedar-drt/fuzz/src/dump.rs
@@ -19,11 +19,15 @@ use cedar_policy_core::ast::{
     Context, EntityType, EntityUID, EntityUIDEntry, PolicySet, Request, RestrictedExpr,
 };
 use cedar_policy_core::authorizer::Response;
+use cedar_policy_core::entities;
 use cedar_policy_core::entities::{Entities, TypeAndId};
+use cedar_policy_core::extensions::Extensions;
 use cedar_policy_core::jsonvalue::JsonValueWithNoDuplicateKeys;
+use cedar_policy_core::parser;
 use cedar_policy_generators::collections::HashMap;
 use cedar_policy_validator::{SchemaFragment, ValidationMode, Validator, ValidatorSchema};
-use cedar_testing::integration_testing::{JsonRequest, JsonTest};
+use cedar_testing::cedar_test_impl::RustEngine;
+use cedar_testing::integration_testing::{perform_integration_test, JsonRequest, JsonTest};
 use std::io::Write;
 use std::path::Path;
 use std::str::FromStr;
@@ -64,7 +68,8 @@ pub fn dump(
         .append(false)
         .truncate(true)
         .open(&schema_filename)?;
-    writeln!(schema_file, "{}", schema.as_natural_schema().unwrap())?;
+    let schema_text = schema.as_natural_schema().unwrap();
+    writeln!(schema_file, "{schema_text}")?;
 
     let mut policies_file = std::fs::OpenOptions::new()
         .create(true)
@@ -76,7 +81,8 @@ pub fn dump(
         .static_policies()
         .map(ToString::to_string)
         .collect();
-    writeln!(policies_file, "{}", static_policies.join("\n"))?;
+    let policy_text = static_policies.join("\n");
+    writeln!(policies_file, "{policy_text}")?;
 
     let entities_file = std::fs::OpenOptions::new()
         .create(true)
@@ -86,50 +92,103 @@ pub fn dump(
         .open(&entities_filename)?;
     entities.write_to_json(entities_file).unwrap();
 
+    let requests: Vec<JsonRequest> = requests
+        .into_iter()
+        .enumerate()
+        .map(|(i, (q, a))| JsonRequest {
+            desc: format!("Request {i}"),
+            principal: dump_request_var(q.principal()),
+            action: dump_request_var(q.action()),
+            resource: dump_request_var(q.resource()),
+            context: dump_context(
+                q.context()
+                    .expect("`dump` does not support requests missing context"),
+            ),
+            enable_request_validation: true,
+            decision: a.decision,
+            reason: cedar_policy::Response::from(a.clone())
+                .diagnostics()
+                .reason()
+                .cloned()
+                .collect(),
+            errors: cedar_policy::Response::from(a)
+                .diagnostics()
+                .errors()
+                .map(AuthorizationError::id)
+                .cloned()
+                .collect(),
+        })
+        .collect();
+
+    let should_validate = passes_validation(schema.clone(), policies);
+
+    let testcase = JsonTest {
+        schema: schema_filename.display().to_string(),
+        policies: policies_filename.display().to_string(),
+        entities: entities_filename.display().to_string(),
+        should_validate,
+        requests: requests.clone(),
+    };
+
     let testcase_file = std::fs::OpenOptions::new()
         .create(true)
         .write(true)
         .append(false)
         .truncate(true)
         .open(testcase_filename)?;
-    serde_json::to_writer_pretty(
-        testcase_file,
-        &JsonTest {
-            schema: schema_filename.display().to_string(),
-            policies: policies_filename.display().to_string(),
-            entities: entities_filename.display().to_string(),
-            should_validate: passes_validation(schema.clone(), policies),
-            requests: requests
-                .into_iter()
-                .enumerate()
-                .map(|(i, (q, a))| JsonRequest {
-                    desc: format!("Request {i}"),
-                    principal: dump_request_var(q.principal()),
-                    action: dump_request_var(q.action()),
-                    resource: dump_request_var(q.resource()),
-                    context: dump_context(
-                        q.context()
-                            .expect("`dump` does not support requests missing context"),
-                    ),
-                    enable_request_validation: true,
-                    decision: a.decision,
-                    reason: cedar_policy::Response::from(a.clone())
-                        .diagnostics()
-                        .reason()
-                        .cloned()
-                        .collect(),
-                    errors: cedar_policy::Response::from(a)
-                        .diagnostics()
-                        .errors()
-                        .map(AuthorizationError::id)
-                        .cloned()
-                        .collect(),
-                })
-                .collect(),
-        },
-    )?;
+    serde_json::to_writer_pretty(testcase_file, &testcase)?;
+
+    // The generated test case should successfully run
+    check_test(
+        policy_text,
+        schema_text,
+        entities,
+        should_validate,
+        requests,
+        testcasename,
+    );
 
     Ok(())
+}
+
+// Check that the generated test passes the `perform_integration_test` function
+fn check_test(
+    formatted_policies: String,
+    formatted_schema: String,
+    entities: &Entities,
+    should_validate: bool,
+    requests: Vec<JsonRequest>,
+    test_name: &str,
+) {
+    let parsed_policies = parser::parse_policyset(&formatted_policies)
+        .unwrap_or_else(|e| panic!("error re-parsing policy file: {e}"));
+
+    let parsed_schema =
+        ValidatorSchema::from_str_natural(&formatted_schema, Extensions::all_available())
+            .unwrap_or_else(|e| panic!("error re-parsing schema: {e}"))
+            .0;
+
+    let core_schema = cedar_policy_validator::CoreSchema::new(&parsed_schema);
+    let eparser = entities::EntityJsonParser::new(
+        Some(&core_schema),
+        Extensions::all_available(),
+        entities::TCComputation::ComputeNow,
+    );
+    let parsed_entities = eparser
+        .from_json_value(entities.to_json_value().unwrap())
+        .unwrap_or_else(|e| panic!("error re-parsing entities: {e}"));
+
+    let rust_impl = RustEngine::new();
+
+    perform_integration_test(
+        parsed_policies,
+        parsed_entities,
+        parsed_schema,
+        should_validate,
+        requests,
+        test_name,
+        &rust_impl,
+    );
 }
 
 /// Check whether a policy set can be successfully parsed

--- a/cedar-policy-generators/src/expr.rs
+++ b/cedar-policy-generators/src/expr.rs
@@ -1,10 +1,12 @@
 use crate::abac::{AttrValue, AvailableExtensionFunctions, ConstantPool, Type, UnknownPool};
 use crate::collections::HashMap;
 use crate::err::{while_doing, Error, Result};
-use crate::hierarchy::{generate_uid_with_type, EntityUIDGenMode, Hierarchy};
+use crate::hierarchy::{
+    arbitrary_specified_uid, generate_uid_with_type, EntityUIDGenMode, Hierarchy,
+};
 use crate::schema::{
-    arbitrary_specified_uid_without_schema, attrs_from_attrs_or_context,
-    build_qualified_entity_type_name, entity_type_name_to_schema_type, uid_for_action_name, Schema,
+    attrs_from_attrs_or_context, build_qualified_entity_type_name, entity_type_name_to_schema_type,
+    uid_for_action_name, Schema,
 };
 use crate::settings::ABACSettings;
 use crate::size_hint_utils::{size_hint_for_choose, size_hint_for_range, size_hint_for_ratio};
@@ -953,7 +955,7 @@ impl<'a> ExprGenerator<'a> {
                         11 => Ok(ast::Expr::val(self.generate_uid(u)?)),
                         // UID literal, that doesn't exist
                         2 => Ok(ast::Expr::val(
-                            arbitrary_specified_uid_without_schema(u)?,
+                            arbitrary_specified_uid(u)?,
                         )),
                         // `principal`
                         6 => Ok(ast::Expr::var(ast::Var::Principal)),
@@ -1462,7 +1464,7 @@ impl<'a> ExprGenerator<'a> {
                 3 => Ok(ast::Expr::val(self.generate_uid(u)?)),
                 // UID literal, that doesn't exist
                 1 => Ok(ast::Expr::val(
-                    arbitrary_specified_uid_without_schema(u)?,
+                    arbitrary_specified_uid(u)?,
                 )))
             }
             Type::IPAddr | Type::Decimal => {
@@ -2060,7 +2062,7 @@ impl<'a> ExprGenerator<'a> {
         )),
         20 => Ok(ast::Expr::val(self.generate_uid(u)?)),
         4 => Ok(ast::Expr::val(
-            arbitrary_specified_uid_without_schema(u)?,
+            arbitrary_specified_uid(u)?,
         )))
     }
 

--- a/cedar-policy-generators/src/hierarchy.rs
+++ b/cedar-policy-generators/src/hierarchy.rs
@@ -95,7 +95,7 @@ impl Hierarchy {
         }
     }
 
-    /// Generate an arbitrary uid based on the hierarchy. If `unspecified_location`
+    /// Generate an arbitrary uid based on the hierarchy. If `request_field`
     /// is `Some(var)` then the generated uid may be unspecified with eid `var`.
     /// Otherwise, the uid is guaranteed to be specified.
     pub fn arbitrary_uid(

--- a/cedar-policy-generators/src/hierarchy.rs
+++ b/cedar-policy-generators/src/hierarchy.rs
@@ -95,8 +95,14 @@ impl Hierarchy {
         }
     }
 
-    /// generate an arbitrary uid based on the hierarchy
-    pub fn arbitrary_uid(&self, u: &mut Unstructured<'_>) -> Result<EntityUID> {
+    /// Generate an arbitrary uid based on the hierarchy. If `unspecified_location`
+    /// is `Some(var)` then the generated uid may be unspecified with eid `var`.
+    /// Otherwise, the uid is guaranteed to be specified.
+    pub fn arbitrary_uid(
+        &self,
+        u: &mut Unstructured<'_>,
+        request_field: Option<ast::Var>,
+    ) -> Result<EntityUID> {
         // UID that exists or doesn't. 90% of the time pick one that exists
         if u.ratio::<u8>(9, 10)? {
             let uid = u
@@ -104,8 +110,19 @@ impl Hierarchy {
                 .map_err(|e| while_doing("getting an arbitrary uid".into(), e))?;
             Ok(uid.clone())
         } else {
-            // Note: may generate an unspecified entity
-            u.arbitrary().map_err(Into::into)
+            match request_field {
+                Some(var) => {
+                    // generate an arbitrary uid, but replace the eid if it's unspecified
+                    let uid: EntityUID = u.arbitrary()?;
+                    match uid.entity_type() {
+                        ast::EntityType::Specified(_) => Ok(uid),
+                        ast::EntityType::Unspecified => Ok(ast::EntityUID::unspecified_from_eid(
+                            ast::Eid::new(var.to_string()),
+                        )),
+                    }
+                }
+                None => arbitrary_specified_uid(u).map_err(Into::into),
+            }
         }
     }
     /// size hint for arbitrary_uid()
@@ -115,7 +132,7 @@ impl Hierarchy {
             arbitrary::size_hint::or(
                 // exists case
                 size_hint_for_choose(None),
-                // not-exists case
+                // not-exists case; both branches should lead to a similar cost
                 <EntityUID as Arbitrary>::size_hint(depth),
             ),
         )
@@ -380,6 +397,15 @@ pub enum AttributesMode {
     // schema-based mode.
 }
 
+/// Helper function to generate an arbitrary UID (but not Unspecified), without
+/// regard to an existing schema or hierarchy
+pub(crate) fn arbitrary_specified_uid(u: &mut Unstructured<'_>) -> Result<ast::EntityUID> {
+    Ok(ast::EntityUID::from_components(
+        u.arbitrary::<ast::Name>()?,
+        u.arbitrary::<ast::Eid>()?,
+    ))
+}
+
 /// Helper function that generates a new UID with the given type.
 /// Unlike `Hierarchy::arbitrary_uid_with_type()`, this doesn't take a
 /// `Hierarchy` parameter and doesn't make any effort to generate a UID that
@@ -530,7 +556,7 @@ impl<'a, 'u> HierarchyGenerator<'a, 'u> {
                                 // `uids_for_type` only prevent cycles resulting from self-loops in the entity types graph
                                 // It should be very unlikely where loops involving multiple entity types occur in the schemas
                                 hierarchy_no_attrs
-                                    .uids_for_type(&allowed_parent_typename, &uid)
+                                    .uids_for_type(&allowed_parent_typename, uid)
                             {
                                 if self.u.ratio::<u8>(1, 2)? {
                                     parents.insert(possible_parent_uid.clone());
@@ -555,7 +581,7 @@ impl<'a, 'u> HierarchyGenerator<'a, 'u> {
                             }
                         }
                         // assert there is no self-edge
-                        assert!(!parents.contains(&uid));
+                        assert!(!parents.contains(uid));
                     }
                 }
                 // generate appropriate attributes for this entity

--- a/cedar-policy-generators/src/policy.rs
+++ b/cedar-policy-generators/src/policy.rs
@@ -127,15 +127,7 @@ impl GeneratedPolicy {
 fn convert_annotations(annotations: HashMap<AnyId, SmolStr>) -> Annotations {
     annotations
         .into_iter()
-        .map(|(k, v)| {
-            (
-                k,
-                Annotation {
-                    val: v.into(),
-                    loc: None,
-                },
-            )
-        })
+        .map(|(k, v)| (k, Annotation { val: v, loc: None }))
         .collect()
 }
 
@@ -299,7 +291,7 @@ impl PrincipalOrResourceConstraint {
                 )
             } else {
                 // 32% Eq, 16% In, 16% Is, 16% IsIn
-                let uid = hierarchy.arbitrary_uid(u)?;
+                let uid = hierarchy.arbitrary_uid(u, None)?;
                 gen!(u,
                     2 => Ok(Self::Eq(uid)),
                     1 => Ok(Self::In(uid)),
@@ -396,13 +388,13 @@ impl ActionConstraint {
         if u.ratio(1, 10)? {
             Ok(Self::NoConstraint)
         } else if u.ratio(1, 3)? {
-            Ok(Self::Eq(hierarchy.arbitrary_uid(u)?))
+            Ok(Self::Eq(hierarchy.arbitrary_uid(u, None)?))
         } else if u.ratio(1, 2)? {
-            Ok(Self::In(hierarchy.arbitrary_uid(u)?))
+            Ok(Self::In(hierarchy.arbitrary_uid(u, None)?))
         } else {
             let mut uids = vec![];
             u.arbitrary_loop(Some(0), max_list_length, |u| {
-                uids.push(hierarchy.arbitrary_uid(u)?);
+                uids.push(hierarchy.arbitrary_uid(u, None)?);
                 Ok(std::ops::ControlFlow::Continue(()))
             })?;
             Ok(Self::InList(uids))
@@ -457,7 +449,7 @@ impl GeneratedLinkedPolicy {
         u: &mut Unstructured<'_>,
     ) -> Result<Option<EntityUID>> {
         if prc.has_slot() {
-            Ok(Some(hierarchy.arbitrary_uid(u)?))
+            Ok(Some(hierarchy.arbitrary_uid(u, None)?))
         } else {
             Ok(None)
         }

--- a/cedar-policy-generators/src/request.rs
+++ b/cedar-policy-generators/src/request.rs
@@ -28,9 +28,9 @@ impl Request {
         u: &mut Unstructured<'_>,
     ) -> arbitrary::Result<Self> {
         Ok(Self {
-            principal: hierarchy.arbitrary_uid(u)?,
-            action: hierarchy.arbitrary_uid(u)?,
-            resource: hierarchy.arbitrary_uid(u)?,
+            principal: hierarchy.arbitrary_uid(u, Some(ast::Var::Principal))?,
+            action: hierarchy.arbitrary_uid(u, Some(ast::Var::Action))?,
+            resource: hierarchy.arbitrary_uid(u, Some(ast::Var::Resource))?,
             context: ast::Context::from_pairs(context, Extensions::all_available())
                 .map_err(Error::ContextError)?,
         })

--- a/cedar-policy-generators/src/schema.rs
+++ b/cedar-policy-generators/src/schema.rs
@@ -311,17 +311,6 @@ fn schematype_to_type(
     }
 }
 
-/// Get a totally arbitrary UID (but not Unspecified), with no regards to
-/// existing schema or hierarchy
-pub(crate) fn arbitrary_specified_uid_without_schema(
-    u: &mut Unstructured<'_>,
-) -> Result<ast::EntityUID> {
-    Ok(ast::EntityUID::from_components(
-        u.arbitrary::<ast::Name>()?,
-        u.arbitrary::<ast::Eid>()?,
-    ))
-}
-
 /// Get an arbitrary namespace for a schema. The namespace may be absent.
 fn arbitrary_namespace(u: &mut Unstructured<'_>) -> Result<Option<ast::Name>> {
     u.arbitrary()
@@ -409,7 +398,7 @@ fn attrs_in_schematype(
                         .iter()
                         .flat_map(|(_, v)| attrs_in_schematype(schema, v))
                         .collect::<Vec<_>>();
-                    Box::new(toplevel.into_iter().chain(recursed.into_iter()))
+                    Box::new(toplevel.into_iter().chain(recursed))
                 }
             }
         }
@@ -761,9 +750,7 @@ impl Schema {
             entity_types: entity_types.into_iter().collect(),
             actions: actions.into_iter().collect(),
         };
-        let attrsorcontexts /* : impl Iterator<Item = &AttributesOrContext> */ = nsdef.entity_types
-            .iter()
-            .map(|(_, et)| attrs_from_attrs_or_context(&nsdef, &et.shape))
+        let attrsorcontexts /* : impl Iterator<Item = &AttributesOrContext> */ = nsdef.entity_types.values().map(|et| attrs_from_attrs_or_context(&nsdef, &et.shape))
             .chain(nsdef.actions.iter().filter_map(|(_, action)| action.applies_to.as_ref()).map(|a| attrs_from_attrs_or_context(&nsdef, &a.context)));
         let attributes: Vec<(SmolStr, cedar_policy_validator::SchemaType)> = attrsorcontexts
             .flat_map(|attributes| {
@@ -775,15 +762,12 @@ impl Schema {
                 })
             })
             .collect();
-        let attributes_by_type = build_attributes_by_type(
-            &nsdef,
-            nsdef.entity_types.iter().map(|(a, b)| (a, b)),
-            namespace.as_ref(),
-        );
+        let attributes_by_type =
+            build_attributes_by_type(&nsdef, nsdef.entity_types.iter(), namespace.as_ref());
         let actions_eids = nsdef
             .actions
-            .iter()
-            .map(|(name, _)| ast::Eid::new(name.clone()))
+            .keys()
+            .map(|name| ast::Eid::new(name.clone()))
             .collect();
         Ok(Schema {
             schema: nsdef,
@@ -850,6 +834,7 @@ impl Schema {
         &self,
         ty_name: Option<ast::Id>, // REVIEW: should we allow `ast::Name` here?
         hierarchy: Option<&Hierarchy>,
+        request_field: ast::Var,
         u: &mut Unstructured<'_>,
     ) -> Result<ast::EntityUID> {
         let ty = build_qualified_entity_type(self.namespace().cloned(), ty_name);
@@ -858,7 +843,7 @@ impl Schema {
                 .exprgenerator(hierarchy)
                 .arbitrary_uid_with_type(&ty, u),
             ast::EntityType::Unspecified => Ok(ast::EntityUID::unspecified_from_eid(
-                ast::Eid::new("Unspecified"),
+                ast::Eid::new(request_field.to_string()),
             )),
         }
     }
@@ -1160,7 +1145,12 @@ impl Schema {
                 .as_ref()
                 .and_then(|at| at.principal_types.as_ref())
             {
-                None => self.arbitrary_uid_with_optional_type(None, Some(hierarchy), u)?, // unspecified principal
+                None => self.arbitrary_uid_with_optional_type(
+                    None,
+                    Some(hierarchy),
+                    ast::Var::Principal,
+                    u,
+                )?, // unspecified principal
                 Some(types) => {
                     // Assert that these are vec, so it's safe to draw from directly
                     let types: &Vec<_> = types;
@@ -1173,6 +1163,7 @@ impl Schema {
                                 .unwrap_or_else(|e| panic!("invalid action name {ty:?}: {e}")),
                         ),
                         Some(hierarchy),
+                        ast::Var::Principal,
                         u,
                     )?
                 }
@@ -1183,7 +1174,12 @@ impl Schema {
                 .as_ref()
                 .and_then(|at| at.resource_types.as_ref())
             {
-                None => self.arbitrary_uid_with_optional_type(None, Some(hierarchy), u)?, // unspecified resource
+                None => self.arbitrary_uid_with_optional_type(
+                    None,
+                    Some(hierarchy),
+                    ast::Var::Resource,
+                    u,
+                )?, // unspecified resource
                 Some(types) => {
                     // Assert that these are vec, so it's safe to draw from directly
                     let types: &Vec<_> = types;
@@ -1196,6 +1192,7 @@ impl Schema {
                                 .unwrap_or_else(|e| panic!("invalid action type {ty:?}: {e}")),
                         ),
                         Some(hierarchy),
+                        ast::Var::Resource,
                         u,
                     )?
                 }
@@ -1255,18 +1252,15 @@ impl Schema {
 impl From<Schema> for SchemaFragment {
     fn from(schema: Schema) -> SchemaFragment {
         SchemaFragment(
-            HashMap::from_iter(
-                [(
-                    schema
-                        .namespace
-                        .as_ref()
-                        .map(ToString::to_string)
-                        .map(SmolStr::new)
-                        .unwrap_or_default(),
-                    schema.schema,
-                )]
-                .into_iter(),
-            )
+            HashMap::from_iter([(
+                schema
+                    .namespace
+                    .as_ref()
+                    .map(ToString::to_string)
+                    .map(SmolStr::new)
+                    .unwrap_or_default(),
+                schema.schema,
+            )])
             .into(),
         )
     }


### PR DESCRIPTION
## Issue #, if available

## Description of changes

### TLDR

* Only produce unspecified entities with eid "principal", "action", or "resource"
* Perform an extra check during corpus test generation
* Bonus: auto-applied some clippy lints

Requires [cedar#752](https://github.com/cedar-policy/cedar/pull/752) to be merged first.

### Full description

The generators currently allow generation of unspecified entities with arbitrary eids, while the actual `cedar-policy` implementation can only produce unspecified entities with eid "principal", "action", or "resource".

I ran into this issue when re-generating corpus tests for [cedar-integration-tests#3](https://github.com/cedar-policy/cedar-integration-tests/pull/3). A couple produced tests were failing, with a note that the request was supposed to result in an error, but it did not.

The issue turned out to be a policy with a subexpression like `principal == resource && //error`. The generator had assigned both `principal` and `resource` to an unspecified entity with eid "Unspecified", so the equality was satisfied and the error was reached. But when writing out the test case, these unspecified entities were serialized as `None` (the eid was lost). When reading back the test case and running the input through `cedar-policy`, the entities were given eids "principal" and "resource" so the equality was not satisfied and short-circuiting prevented the error from being reached.

This was a little irritating to debug, since the issue was due to a loss of information when serializing the test case. To detect errors like this in the future, I added code to `dump.rs` that will try to run the test on generation. This adds some extra overhead to corpus test generation, but I don't think that's a big issue. Lmk if you disagree.
