### PR TITLE
Fix upstream CI

### DIFF
--- a/.github/workflows/build_and_test_drt_reusable.yml
+++ b/.github/workflows/build_and_test_drt_reusable.yml
@@ -24,12 +24,14 @@ jobs:
       - name: Checkout cedar-spec
         uses: actions/checkout@v4
         with:
+          repository: cedar-policy/cedar-spec
           ref: ${{ inputs.cedar_spec_ref }}
+          path: ./cedar-spec
       - name: checkout cedar
         uses: actions/checkout@v4
         with:
           repository: cedar-policy/cedar
-          path: ./cedar
+          path: ./cedar-spec/cedar
           ref: ${{ inputs.cedar_policy_ref }}
       - name: Install Lean
         shell: bash
@@ -39,32 +41,32 @@ jobs:
       - name: Prepare Rust build
         run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
       - name: cargo fmt (cedar-policy-generators)
-        working-directory: ./cedar-policy-generators
+        working-directory: ./cedar-spec/cedar-policy-generators
         run: cargo fmt --all --check
       - name: cargo fmt (cedar-drt)
-        working-directory: ./cedar-drt
+        working-directory: ./cedar-spec/cedar-drt
         run: cargo fmt --all --check
       - name: cargo fmt (cedar-drt/fuzz/)
-        working-directory: ./cedar-drt/fuzz
+        working-directory: ./cedar-spec/cedar-drt/fuzz
         run: cargo fmt --all --check
       - name: cargo build (cedar-policy-generators)
-        working-directory: ./cedar-policy-generators
+        working-directory: ./cedar-spec/cedar-policy-generators
         run: RUSTFLAGS="-D warnings -F unsafe-code" cargo build --verbose
       - name: cargo test (cedar-policy-generators)
-        working-directory: ./cedar-policy-generators
+        working-directory: ./cedar-spec/cedar-policy-generators
         run: cargo test --verbose
       - name: Build Lean libraries
-        working-directory: ./cedar-lean
+        working-directory: ./cedar-spec/cedar-lean
         run: source ~/.profile && lake build Cedar:static DiffTest:static Std:static
       - name: cargo build (cedar-drt/)
         shell: bash
-        working-directory: ./cedar-drt
+        working-directory: ./cedar-spec/cedar-drt
         run: source ~/.profile && source set_env_vars.sh && cargo build
       - name: cargo build (cedar-drt/fuzz/)
-        working-directory: ./cedar-drt/fuzz
+        working-directory: ./cedar-spec/cedar-drt/fuzz
         run: source ~/.profile && source ../set_env_vars.sh && RUSTFLAGS="--cfg=fuzzing" cargo build
       - name: cargo test (cedar-drt/fuzz/)
-        working-directory: ./cedar-drt/fuzz
+        working-directory: ./cedar-spec/cedar-drt/fuzz
         run: source ~/.profile && source ../set_env_vars.sh && cargo test
 
   run-integration-tests:

--- a/.github/workflows/build_and_test_drt_reusable.yml
+++ b/.github/workflows/build_and_test_drt_reusable.yml
@@ -67,7 +67,7 @@ jobs:
         run: source ~/.profile && source ../set_env_vars.sh && RUSTFLAGS="--cfg=fuzzing" cargo build
       - name: cargo test (cedar-drt/fuzz/)
         working-directory: ./cedar-spec/cedar-drt/fuzz
-        run: source ~/.profile && source ../set_env_vars.sh && cargo test
+        run: source ~/.profile && source ../set_env_vars.sh && cargo test -- --nocapture
 
   run-integration-tests:
     uses: ./.github/workflows/run_integration_tests_reusable.yml

--- a/cedar-drt/README.md
+++ b/cedar-drt/README.md
@@ -56,14 +56,16 @@ If everything builds, but the integration tests are failing, then it may be help
 ## Running integration tests
 
 The integration tests are run by default in CI (e.g., as a part of each pull request), but you can also run them locally.
-In order to do this, you need to have the [`cedar-integration-tests`](https://github.com/cedar-policy/cedar-integration-tests) repository cloned in the `cedar` directory (`../cedar`).
+In order to do this, you need to have the [`cedar`](https://github.com/cedar-policy/cedar) and [`cedar-integration-tests`](https://github.com/cedar-policy/cedar-integration-tests) repositories cloned locally.
+`cedar` should be in the toplevel directory (so `../cedar`) and `cedar-integration-tests` should be in the `cedar` directory (so `../cedar/cedar-integration-tests`).
 Then, run `cargo test --features "integration-testing"`.
 
 ```bash
 # starting in the top-level directory (..)
+git clone --depth 1 https://github.com/cedar-policy/cedar
 cd cedar
 rm -rf cedar-integration-tests
-git clone https://github.com/cedar-policy/cedar-integration-tests
+git clone --depth 1 https://github.com/cedar-policy/cedar-integration-tests
 cd cedar-integration-tests
 tar xzf corpus-tests.tar.gz
 cd ../../cedar-drt

--- a/cedar-drt/tests/integration_tests.rs
+++ b/cedar-drt/tests/integration_tests.rs
@@ -74,12 +74,7 @@ pub fn get_corpus_tests() -> impl Iterator<Item = PathBuf> {
 
 fn run_tests(custom_impl: &impl CedarTestImplementation, tests: impl Iterator<Item = PathBuf>) {
     for test_json in tests {
-        // These messages are for progress reporting and so that if the
-        // `#[test]` fails, the user can know which test case failed by looking
-        // for the last "Running integration test" message before the failure.
-        println!("Running integration test: {:?}", test_json);
         perform_integration_test_from_json_custom(&test_json, custom_impl);
-        println!("Integration test succeeded: {:?}", test_json);
     }
 }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Followup to #269. The upstream CI on [cedar#771](https://github.com/cedar-policy/cedar/pull/771) failed because I didn't have the paths set up correctly (it should still fail -- but due to a breaking change, not broken CI).

