### PR TITLE
Update guide and set default target

### DIFF
--- a/cedar-lean/GUIDE.md
+++ b/cedar-lean/GUIDE.md
@@ -60,3 +60,12 @@ To break up implications across multiple lines:
 ## Comments
 
 Main theorems should have a docstring comment `/-- ... -/` explaining what is proven. See [here](https://leanprover-community.github.io/contribute/doc.html) for more information on the Mathlib documentation style.
+
+
+## Proof stability
+To make version upgrades easier, strive to follow these guidelines:
+
+- Use `simp only` instead of `simp`. It's okay to use `simp` to close a goal.
+- Use `have` to deconstruct values. Use `rcases` only to split disjunctions.
+- Use `exact` instead of `apply` whenever possible.
+- Fully spell out types in function and theorem declarations.

--- a/cedar-lean/lakefile.lean
+++ b/cedar-lean/lakefile.lean
@@ -22,6 +22,7 @@ require std from git
 
 package Cedar
 
+@[default_target]
 lean_lib Cedar where
   defaultFacets := #[LeanLib.staticFacet]
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Update Lean style guide and set Cedar as the default target.

