### PR TITLE
A few followups to #281

### DIFF
--- a/cedar-lean/Cedar/Partial/Expr.lean
+++ b/cedar-lean/Cedar/Partial/Expr.lean
@@ -17,7 +17,7 @@
 import Cedar.Data
 import Cedar.Spec.Expr
 
-/-! This file defines abstract syntax for Cedar expressions. -/
+/-! This file defines abstract syntax for Cedar partial expressions. -/
 
 namespace Cedar.Partial
 
@@ -125,8 +125,8 @@ def Value.asPartialExpr : Spec.Value → Partial.Expr
   | .prim p => .lit p
   | .set (Set.mk elts) => .set (elts.map₁ λ ⟨v, _⟩ => v.asPartialExpr)
   | .record m => .record (m.kvs.attach₃.map λ ⟨(k, v), _⟩ => (k, v.asPartialExpr))
-  | .ext (.decimal d) => .call ExtFun.decimal [Partial.Expr.lit (.string d.unParse)]
-  | .ext (.ipaddr ip) => .call ExtFun.ip [Partial.Expr.lit (.string (Spec.Ext.IPAddr.unParse ip))]
+  | .ext (.decimal d) => .call ExtFun.decimal [Partial.Expr.lit (.string (toString d))]
+  | .ext (.ipaddr ip) => .call ExtFun.ip [Partial.Expr.lit (.string (toString ip))]
 
 def Expr.asPartialExpr : Spec.Expr → Partial.Expr
   | .lit p => .lit p

--- a/cedar-lean/Cedar/Spec/Ext/Decimal.lean
+++ b/cedar-lean/Cedar/Spec/Ext/Decimal.lean
@@ -58,18 +58,19 @@ def parse (str : String) : Option Decimal :=
     else .none
   | _ => .none
 
-def unParse (d : Decimal) : String :=
-  let neg   := if d < (0 : Int) then "-" else ""
-  let d     := d.natAbs
-  let left  := d / (Nat.pow 10 DECIMAL_DIGITS)
-  let right := d % (Nat.pow 10 DECIMAL_DIGITS)
-  let right :=
-    -- this is not generalized for arbitrary DECIMAL_DIGITS
-    if right < 10 then s!".000{right}"
-    else if right < 100 then s!".00{right}"
-    else if right < 1000 then s!".0{right}"
-    else s!".{right}"
-  s!"{neg}{left}{right}"
+instance : ToString Decimal where
+  toString (d : Decimal) : String :=
+    let neg   := if d < (0 : Int) then "-" else ""
+    let d     := d.natAbs
+    let left  := d / (Nat.pow 10 DECIMAL_DIGITS)
+    let right := d % (Nat.pow 10 DECIMAL_DIGITS)
+    let right :=
+      -- this is not generalized for arbitrary DECIMAL_DIGITS
+      if right < 10 then s!".000{right}"
+      else if right < 100 then s!".00{right}"
+      else if right < 1000 then s!".0{right}"
+      else s!".{right}"
+    s!"{neg}{left}{right}"
 
 abbrev decimal := parse
 

--- a/cedar-lean/Cedar/Spec/Ext/IPAddr.lean
+++ b/cedar-lean/Cedar/Spec/Ext/IPAddr.lean
@@ -254,8 +254,8 @@ def toHex (n : Nat) : String :=
   let a3 := hexDigitRepr ((n % 0x10) / 0x1)
   s!"{a0}{a1}{a2}{a3}"
 
-def unParse (ip : IPNet) : String :=
-  match ip with
+instance : ToString IPNet where
+  toString : IPNet → String
   | .V4 v p =>
     let a0 := (v >>> 24) &&& 0xFF
     let a1 := (v >>> 16) &&& 0xFF

--- a/cedar-lean/UnitTest/Decimal.lean
+++ b/cedar-lean/UnitTest/Decimal.lean
@@ -23,14 +23,14 @@ namespace UnitTest.Decimal
 
 open Cedar.Spec.Ext.Decimal
 
-theorem test1 : unParse ((parse "3.14").get!) = "3.1400" := by decide
-theorem test2 : unParse ((parse "11.0003").get!) = "11.0003" := by decide
-theorem test3 : unParse ((parse "11.003").get!) = "11.0030" := by decide
-theorem test4 : unParse ((parse "11.3000").get!) = "11.3000" := by decide
-theorem test5 : unParse ((parse "123.0").get!) = "123.0000" := by decide
-theorem test6 : unParse ((parse "-123.0").get!) = "-123.0000" := by decide
-theorem test7 : unParse ((parse "-3.14").get!) = "-3.1400" := by decide
-theorem test8 : unParse ((parse "-11.0003").get!) = "-11.0003" := by decide
+theorem test1 : toString ((parse "3.14").get!) = "3.1400" := by decide
+theorem test2 : toString ((parse "11.0003").get!) = "11.0003" := by decide
+theorem test3 : toString ((parse "11.003").get!) = "11.0030" := by decide
+theorem test4 : toString ((parse "11.3000").get!) = "11.3000" := by decide
+theorem test5 : toString ((parse "123.0").get!) = "123.0000" := by decide
+theorem test6 : toString ((parse "-123.0").get!) = "-123.0000" := by decide
+theorem test7 : toString ((parse "-3.14").get!) = "-3.1400" := by decide
+theorem test8 : toString ((parse "-11.0003").get!) = "-11.0003" := by decide
 
 private def testValid (str : String) (rep : Int) : TestCase IO :=
   test str ⟨λ _ => checkEq (parse str) (decimal? rep)⟩

--- a/cedar-lean/UnitTest/IPAddr.lean
+++ b/cedar-lean/UnitTest/IPAddr.lean
@@ -23,14 +23,14 @@ namespace UnitTest.IPAddr
 
 open Cedar.Spec.Ext.IPAddr
 
-theorem test1 : unParse ((parse "192.168.0.1/32").get!) = "192.168.0.1/32" := by decide
-theorem test2 : unParse ((parse "0.0.0.0/1").get!) = "0.0.0.0/1" := by decide
-theorem test3 : unParse ((parse "8.8.8.8/24").get!) = "8.8.8.8/24" := by decide
-theorem test4 : unParse ((parse "1:2:3:4:a:b:c:d/128").get!) = "0001:0002:0003:0004:000a:000b:000c:000d/128" := by decide
-theorem test5 : unParse ((parse "1:22:333:4444:a:bb:ccc:dddd/128").get!) = "0001:0022:0333:4444:000a:00bb:0ccc:dddd/128" := by decide
-theorem test6 : unParse ((parse "7:70:700:7000::a00/128").get!) = "0007:0070:0700:7000:0000:0000:0000:0a00/128" := by decide
-theorem test7 : unParse ((parse "::ffff/128").get!) = "0000:0000:0000:0000:0000:0000:0000:ffff/128" := by decide
-theorem test8 : unParse ((parse "ffff::/4").get!) = "ffff:0000:0000:0000:0000:0000:0000:0000/4" := by decide
+theorem test1 : toString ((parse "192.168.0.1/32").get!) = "192.168.0.1/32" := by decide
+theorem test2 : toString ((parse "0.0.0.0/1").get!) = "0.0.0.0/1" := by decide
+theorem test3 : toString ((parse "8.8.8.8/24").get!) = "8.8.8.8/24" := by decide
+theorem test4 : toString ((parse "1:2:3:4:a:b:c:d/128").get!) = "0001:0002:0003:0004:000a:000b:000c:000d/128" := by decide
+theorem test5 : toString ((parse "1:22:333:4444:a:bb:ccc:dddd/128").get!) = "0001:0022:0333:4444:000a:00bb:0ccc:dddd/128" := by decide
+theorem test6 : toString ((parse "7:70:700:7000::a00/128").get!) = "0007:0070:0700:7000:0000:0000:0000:0a00/128" := by decide
+theorem test7 : toString ((parse "::ffff/128").get!) = "0000:0000:0000:0000:0000:0000:0000:ffff/128" := by decide
+theorem test8 : toString ((parse "ffff::/4").get!) = "ffff:0000:0000:0000:0000:0000:0000:0000/4" := by decide
 
 private def ipv4 (a₀ a₁ a₂ a₃ : UInt8) (pre : Nat) : IPNet :=
   IPNet.V4 (IPv4Addr.mk a₀ a₁ a₂ a₃) (Fin.ofNat pre)


### PR DESCRIPTION
A few followups to #281 suggested in comments there.

- Better comments in Partial/Evaluator.lean
- Comment fixed in Partial/Expr.lean
- `ToString` instance instead of `unParse`

Not included in this PR is splitting the partial evaluator into a function for each `Partial.Expr` case.  I'll do that in a separate followup.


