### PR TITLE
Tweak build scripts to hopefully avoid commmon confusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,6 @@ See the README in each directory for more information.
 * `source ../cedar-drt/set_env_vars.sh`
 * `lake build Cedar`
 
-(It's important to source `set_env_vars.sh` from inside the `cedar-lean` lake project so that the right version of Lean is used.)
-
 ### DRT framework
 
 The simplest way to build our DRT framework is to use the included Dockerfile:

--- a/cedar-drt/build.rs
+++ b/cedar-drt/build.rs
@@ -17,7 +17,7 @@
 use std::env;
 fn main() {
     let lean_dir = env::var("LEAN_LIB_DIR").expect(
-        "`LEAN_LIB_DIR` environment variable is not set! Try running `source set-env-vars.sh`",
+        "`LEAN_LIB_DIR` environment variable is not set! Try running `source set_env_vars.sh`",
     );
     println!("cargo:rustc-link-search=native=../cedar-lean/.lake/build/lib");
     println!("cargo:rustc-link-search=native={lean_dir}");

--- a/cedar-drt/build.rs
+++ b/cedar-drt/build.rs
@@ -22,4 +22,5 @@ fn main() {
     println!("cargo:rustc-link-search=native=../cedar-lean/.lake/build/lib");
     println!("cargo:rustc-link-search=native={lean_dir}");
     println!("cargo:rustc-link-search=native=../cedar-lean/.lake/packages/std/.lake/build/lib");
+    println!("cargo:rerun-if-changed==../cedar-lean/.lake/build/lib");
 }

--- a/cedar-drt/build.rs
+++ b/cedar-drt/build.rs
@@ -16,7 +16,9 @@
 
 use std::env;
 fn main() {
-    let lean_dir = env::var("LEAN_LIB_DIR").unwrap();
+    let lean_dir = env::var("LEAN_LIB_DIR").expect(
+        "`LEAN_LIB_DIR` environment variable is not set! Try running `source set-env-vars.sh`",
+    );
     println!("cargo:rustc-link-search=native=../cedar-lean/.lake/build/lib");
     println!("cargo:rustc-link-search=native={lean_dir}");
     println!("cargo:rustc-link-search=native=../cedar-lean/.lake/packages/std/.lake/build/lib");

--- a/cedar-drt/fuzz/build.rs
+++ b/cedar-drt/fuzz/build.rs
@@ -17,7 +17,7 @@
 use std::env;
 fn main() {
     let lean_dir = env::var("LEAN_LIB_DIR").expect(
-        "`LEAN_LIB_DIR` environment variable is not set! Try running `source set-env-vars.sh`",
+        "`LEAN_LIB_DIR` environment variable is not set! Try running `source set_env_vars.sh`",
     );
     println!("cargo:rustc-link-search=native=../../cedar-lean/.lake/build/lib");
     println!("cargo:rustc-link-search=native={lean_dir}");

--- a/cedar-drt/fuzz/build.rs
+++ b/cedar-drt/fuzz/build.rs
@@ -16,7 +16,9 @@
 
 use std::env;
 fn main() {
-    let lean_dir = env::var("LEAN_LIB_DIR").unwrap();
+    let lean_dir = env::var("LEAN_LIB_DIR").expect(
+        "`LEAN_LIB_DIR` environment variable is not set! Try running `source set-env-vars.sh`",
+    );
     println!("cargo:rustc-link-search=native=../../cedar-lean/.lake/build/lib");
     println!("cargo:rustc-link-search=native={lean_dir}");
     println!("cargo:rustc-link-search=native=../../cedar-lean/.lake/packages/std/.lake/build/lib");

--- a/cedar-drt/lean-toolchain
+++ b/cedar-drt/lean-toolchain
@@ -1,1 +1,0 @@
-../cedar-lean/lean-toolchain

--- a/cedar-drt/tests/integration_tests.rs
+++ b/cedar-drt/tests/integration_tests.rs
@@ -59,7 +59,7 @@ pub fn get_corpus_tests() -> impl Iterator<Item = PathBuf> {
     WalkDir::new(&tests_folder)
         .into_iter()
         .map(|e| {
-            e.expect("failed to access file in corpus_tests")
+            e.expect("failed to access file in corpus_tests. Maybe you haven't unpacked `corpus-tests.tar.gz`")
                 .into_path()
         })
         .filter(|p| {

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,0 +1,1 @@
+cedar-lean/lean-toolchain


### PR DESCRIPTION
* Use `expect` instead of `unwrap` for better errors from `build.rs` when you forget to `source set-env-vars.sh`
* Move `lean-toolchain` symlink from `cedar-drt` to the repository root. With this change `lean --print-libdir` detects the correct toolchain when run in root or any subdirectory of the repository, hopefully avoiding the issue mentioned in the readme update here https://github.com/cedar-policy/cedar-spec/pull/277
* Add check to rebuild DRT if lean build dir has changed. Without this a changing and recompiling the lean did not reflect if cargo didn't have to recompile for some other reason.