### PR TITLE
Fix rerun-if-changed in build.rs

### DIFF
--- a/cedar-drt/build.rs
+++ b/cedar-drt/build.rs
@@ -22,5 +22,5 @@ fn main() {
     println!("cargo:rustc-link-search=native=../cedar-lean/.lake/build/lib");
     println!("cargo:rustc-link-search=native={lean_dir}");
     println!("cargo:rustc-link-search=native=../cedar-lean/.lake/packages/std/.lake/build/lib");
-    println!("cargo:rerun-if-changed==../cedar-lean/.lake/build/lib");
+    println!("cargo:rerun-if-changed=../cedar-lean/.lake/build/lib");
 }


### PR DESCRIPTION
*Issue #, if available:*

Typo in #301 meant `cargo-build` always had to recompile `cedar-drt` 

*Description of changes:*


