### PR TITLE
more data structure lemmas

### DIFF
--- a/cedar-lean/Cedar/Data/LT.lean
+++ b/cedar-lean/Cedar/Data/LT.lean
@@ -170,12 +170,10 @@ theorem List.lt_conn [LT α] [StrictLT α] {xs ys : List α} :
         have h₆ := StrictLT.if_not_lt_gt_then_eq xhd yhd h₄ h₅
         subst h₆
         simp at h₁
-        cases (List.lt_conn h₁)
-        case inl _ _ h₆ =>
-          have h₇ := List.cons_lt_cons xhd xtl ytl h₆
+        cases (List.lt_conn h₁) <;> rename_i h₆
+        · have h₇ := List.cons_lt_cons xhd xtl ytl h₆
           contradiction
-        case inr _ _ h₆ =>
-          have h₇ := List.cons_lt_cons xhd ytl xtl h₆
+        · have h₇ := List.cons_lt_cons xhd ytl xtl h₆
           contradiction
 
 instance List.strictLT (α) [LT α] [StrictLT α] : StrictLT (List α) where

--- a/cedar-lean/Cedar/Data/Map.lean
+++ b/cedar-lean/Cedar/Data/Map.lean
@@ -91,6 +91,14 @@ def mapOnValues {α β γ} [LT α] [DecidableLT α] (f : β → γ) (m : Map α 
 def mapOnKeys {α β γ} [LT γ] [DecidableLT γ] (f : α → γ) (m : Map α β) : Map γ β :=
   Map.make (m.kvs.map (λ (k, v) => (f k, v)))
 
+def mapMOnValues {α β γ} [LT α] [DecidableLT α] [Monad m] (f : β → m γ) (map : Map α β) : m (Map α γ) := do
+  let kvs ← map.kvs.mapM (λ (k, v) => f v >>= λ v' => pure (k, v'))
+  pure (Map.mk kvs)
+
+def mapMOnKeys {α β γ} [LT γ] [DecidableLT γ] [Monad m] (f : α → m γ) (map : Map α β) : m (Map γ β) := do
+  let kvs ← map.kvs.mapM (λ (k, v) => f k >>= λ k' => pure (k', v))
+  pure (Map.make kvs)
+
 ----- Instances -----
 
 instance [LT (Prod α β)] : LT (Map α β) where

--- a/cedar-lean/Cedar/Thm/Authorization/Authorizer.lean
+++ b/cedar-lean/Cedar/Thm/Authorization/Authorizer.lean
@@ -145,13 +145,12 @@ theorem sound_policy_slice_is_equierror (request : Request) (entities : Entities
   simp [List.mem_filter] <;>
   intro h₄ h₅ <;>
   apply And.intro
-  case left.left => exact h₁ h₄
-  case left.right => exact h₅
-  case right.left =>
-    by_contra h₆
+  · exact h₁ h₄
+  · exact h₅
+  · by_contra h₆
     specialize h₂ policy h₄ h₆
     exact h₂.right h₅
-  case right.right => exact h₅
+  · exact h₅
 
 /--
   an alternate, proved-equivalent, definition of errorPolicies that's easier to prove things about
@@ -170,24 +169,21 @@ theorem alternate_errorPolicies_equiv_errorPolicies {policies : Policies} {reque
     intro pid p h₁ h₂
     exists p
     unfold errored hasError at h₂
-    split at h₂
-    case inl h₃ =>
-      unfold hasError
+    split at h₂ <;> rename_i h₃
+    · unfold hasError
       apply And.intro
-      case left => simp [h₃, h₁, List.mem_filter]
-      case right => simp at h₂; exact h₂
-    case inr => contradiction
+      · simp [h₃, h₁, List.mem_filter]
+      · simp at h₂; exact h₂
+    · contradiction
   case right =>
     intro p h₁
     exists p
     simp [List.mem_filter] at h₁
-    apply And.intro
-    case left => exact h₁.left
-    case right =>
-      unfold errored
-      split
-      case inl => rfl
-      case inr h₃ => simp [h₃] at h₁
+    apply And.intro h₁.left
+    unfold errored
+    split <;> rename_i h₃
+    · rfl
+    · simp [h₃] at h₁
 
 theorem errorPolicies_eq_for_sound_policy_slice (request : Request) (entities : Entities) (slice policies : Policies) :
   IsSoundPolicySlice request entities slice policies →
@@ -357,12 +353,10 @@ theorem mapOrErr_value_asEntityUID_on_uids_produces_set {list : List EntityUID} 
     repeat rw [List.subset_def] at *
     constructor <;> intro a h₃ <;>
     replace h₃ := List.mem_map_of_mem (Value.prim ∘ Prim.entityUID) h₃
-    case left =>
-      specialize h₁ h₃
+    · specialize h₁ h₃
       simp at h₁
       exact h₁
-    case right =>
-      specialize h₂ h₃
+    · specialize h₂ h₃
       simp at h₂
       exact h₂
   case h_2 err h =>
@@ -459,8 +453,8 @@ theorem produces_boolean_means_not_non_boolean {e : Expr} {request : Request} {e
   unfold producesNonBool at h₂
   generalize (evaluate e request entities) = res at h₁ h₂
   split at h₁
-  case h_1 => simp at h₂
-  case h_2 => split at h₂ <;> simp at h₁
+  · simp at h₂
+  · split at h₂ <;> simp at h₁
 
 theorem principal_scope_does_not_throw {policy : Policy} {request : Request} {entities : Entities} {err : Error} :
   ¬ (evaluate policy.principalScope.toExpr request entities = .error err)

--- a/cedar-lean/Cedar/Thm/Data/LT.lean
+++ b/cedar-lean/Cedar/Thm/Data/LT.lean
@@ -175,17 +175,13 @@ theorem EntityUID.lt_asymm {a b : EntityUID} :
   have h₃ := Name.strictLT.asymmetric a.ty b.ty
   simp [LT.lt] at h₃
   rcases h₁ with h₁ | h₁ <;> rcases h₂ with h₂ | h₂
-  case inl.inl =>
-    simp only [h₁, h₂, forall_const] at h₃
-  case inl.inr =>
-    have ⟨h₂, _⟩ := h₂
+  · simp only [h₁, h₂, forall_const] at h₃
+  · have ⟨h₂, _⟩ := h₂
     rw [h₂] at h₁ h₃
     simp [h₁] at h₃
-  case inr.inl =>
-    have h₄ := StrictLT.not_eq b.ty a.ty h₂
+  · have h₄ := StrictLT.not_eq b.ty a.ty h₂
     simp [h₁] at h₄
-  case inr.inr =>
-    have h₄ := String.strictLT.asymmetric a.eid b.eid
+  · have h₄ := String.strictLT.asymmetric a.eid b.eid
     simp [LT.lt, h₁, h₂] at h₄
 
 theorem EntityUID.lt_trans {a b c : EntityUID} :
@@ -194,20 +190,16 @@ theorem EntityUID.lt_trans {a b c : EntityUID} :
   simp [LT.lt, EntityUID.lt]
   intro h₁ h₂
   rcases h₁ with h₁ | h₁ <;> rcases h₂ with h₂ | h₂
-  case inl.inl =>
-    have h₃ := Name.strictLT.transitive a.ty b.ty c.ty h₁ h₂
+  · have h₃ := Name.strictLT.transitive a.ty b.ty c.ty h₁ h₂
     simp only [LT.lt] at h₃
     simp [h₃]
-  case inl.inr =>
-    have ⟨h₂, _⟩ := h₂
+  · have ⟨h₂, _⟩ := h₂
     simp [h₂] at h₁
     simp [h₁]
-  case inr.inl =>
-    have ⟨h₁, _⟩ := h₁
+  · have ⟨h₁, _⟩ := h₁
     simp [←h₁] at h₂
     simp [h₂]
-  case inr.inr =>
-    have ⟨hl₁, hr₁⟩ := h₁
+  · have ⟨hl₁, hr₁⟩ := h₁
     have ⟨hl₂, hr₂⟩ := h₂
     simp [hl₁] at * ; simp [hl₂] at *
     have h₃ := String.strictLT.transitive a.eid b.eid c.eid hr₁ hr₂
@@ -297,11 +289,9 @@ theorem Values.lt_irrefl (vs : List Value) :
   cases vs ; simp [Values.lt] ; rename_i hd tl ; simp [Values.lt]
   by_contra h₁
   rcases h₁ with h₁ | h₁
-  case inl =>
-    have h₂ := Value.lt_irrefl hd
+  · have h₂ := Value.lt_irrefl hd
     simp [h₁] at h₂
-  case inr =>
-    have h₂ := Values.lt_irrefl tl
+  · have h₂ := Values.lt_irrefl tl
     simp [h₁] at h₂
 
 theorem ValueAttrs.lt_irrefl (vs : List (Attr × Value)) :
@@ -311,16 +301,12 @@ theorem ValueAttrs.lt_irrefl (vs : List (Attr × Value)) :
   cases hd ; rename_i a v ; simp [ValueAttrs.lt]
   by_contra h₁
   rcases h₁ with h₁ | h₁
-  case inl =>
-    rcases h₁ with h₁ | h₁
-    case inl =>
-      have h₂ := StrictLT.irreflexive a
+  · rcases h₁ with h₁ | h₁
+    · have h₂ := StrictLT.irreflexive a
       contradiction
-    case inr =>
-      have h₂ := Value.lt_irrefl v
+    · have h₂ := Value.lt_irrefl v
       contradiction
-  case inr =>
-    have h₂ := ValueAttrs.lt_irrefl tl
+  · have h₂ := ValueAttrs.lt_irrefl tl
     contradiction
 
 end
@@ -360,13 +346,11 @@ theorem Values.lt_asym {vs₁ vs₂: List Value} :
   cases vs₁ <;> cases vs₂ <;> simp [Values.lt]
   rename_i hd₁ tl₁ hd₂ tl₂
   intro h₁ ; rcases h₁ with h₁ | h₁
-  case inl =>
-    have h₂ := Value.lt_asymm h₁
+  · have h₂ := Value.lt_asymm h₁
     simp [LT.lt] at h₂
     simp [h₂] ; intro h₃ ; subst h₃
     simp [h₁] at h₂
-  case inr =>
-    have ⟨hl₁, h₂⟩ := h₁
+  · have ⟨hl₁, h₂⟩ := h₁
     subst hl₁ ; simp only [true_and]
     have h₂ := Values.lt_asym h₂
     simp [h₂, Value.lt_irrefl hd₁]
@@ -435,17 +419,13 @@ theorem Values.lt_trans {vs₁ vs₂ vs₃: List Value}
   cases vs₁ <;> cases vs₂ <;> cases vs₃ <;> simp [Values.lt] at *
   rename_i hd₁ tl₁ hd₂ tl₂ hd₃ tl₃
   rcases h₁ with h₁ | h₁ <;> rcases h₂ with h₂ | h₂
-  case inl.inl =>
-    have h₃ := Value.lt_trans h₁ h₂
+  · have h₃ := Value.lt_trans h₁ h₂
     simp [LT.lt] at h₃ ; simp [h₃]
-  case inl.inr =>
-    have ⟨h₂, _⟩ := h₂
+  · have ⟨h₂, _⟩ := h₂
     subst h₂ ; simp [h₁]
-  case inr.inl =>
-    have ⟨h₁, _⟩ := h₁
+  · have ⟨h₁, _⟩ := h₁
     subst h₁ ; simp [h₂]
-  case inr.inr =>
-    have ⟨hl₁, h₃⟩ := h₁ ; subst hl₁
+  · have ⟨hl₁, h₃⟩ := h₁ ; subst hl₁
     have ⟨hl₂, h₄⟩ := h₂ ; subst hl₂
     have h₃ := Values.lt_trans h₃ h₄
     simp [h₃]
@@ -462,17 +442,12 @@ theorem ValueAttrs.lt_trans {vs₁ vs₂ vs₃: List (Attr × Value)}
   rcases h₁ with h₁ | h₁ <;> rcases h₂ with h₂ | h₂
   case inl.inl =>
     rcases h₁ with h₁ | h₁ <;> rcases h₂ with h₂ | h₂
-    case inl.inl =>
-      have h₃ := String.strictLT.transitive a₁ a₂ a₃ h₁ h₂
-      simp [h₃]
-    case inl.inr =>
-      have ⟨h₂, _⟩ := h₂ ; subst h₂ ; simp [h₁]
-    case inr.inl =>
-      have ⟨h₁, _⟩ := h₁ ; subst h₁ ; simp [h₂]
-    case inr.inr =>
-      have ⟨hl₁, h₃⟩ := h₁ ; subst hl₁
-      have ⟨hl₂, h₄⟩ := h₂ ; subst hl₂
-      have h₃ := Value.lt_trans h₃ h₄
+    · simp [String.strictLT.transitive a₁ a₂ a₃ h₁ h₂]
+    · replace ⟨h₂, _⟩ := h₂ ; subst h₂ ; simp [h₁]
+    · replace ⟨h₁, _⟩ := h₁ ; subst h₁ ; simp [h₂]
+    · replace ⟨h₁', h₁⟩ := h₁ ; subst h₁'
+      replace ⟨h₂', h₂⟩ := h₂ ; subst h₂'
+      have h₃ := Value.lt_trans h₁ h₂
       simp [LT.lt] at h₃ ; simp [h₃]
   case inl.inr =>
     have ⟨⟨hl₂, hr₂⟩, _⟩ := h₂

--- a/cedar-lean/Cedar/Thm/Data/List.lean
+++ b/cedar-lean/Cedar/Thm/Data/List.lean
@@ -41,7 +41,7 @@ infix:50 " ≡ " => Equiv
 
 theorem Equiv.refl {a : List α} :
   a ≡ a
-:= by unfold List.Equiv; simp
+:= by unfold List.Equiv; simp only [Subset.refl, and_self]
 
 theorem Equiv.symm {a b : List α} :
   a ≡ b → b ≡ a
@@ -268,7 +268,7 @@ theorem map_eq_implies_sortedBy [LT β] [StrictLT β] {f : α → β} {g : γ �
         case cons xhd' xtl =>
           rw [← h₃.left]
           apply sortedBy_implies_head_lt_tail h₂
-          simp
+          simp only [mem_cons, true_or]
   case mpr =>
     intro h₂
     cases xs <;> cases ys <;> simp only [map_nil, map_cons, cons.injEq] at h₁
@@ -286,7 +286,7 @@ theorem map_eq_implies_sortedBy [LT β] [StrictLT β] {f : α → β} {g : γ �
         case cons yhd' ytl =>
           rw [h₃.left]
           apply sortedBy_implies_head_lt_tail h₂
-          simp
+          simp only [mem_cons, true_or]
 
 theorem filter_sortedBy [LT β] [StrictLT β] [DecidableLT β] {f : α → β} (p : α → Bool) {xs : List α} :
   SortedBy f xs → SortedBy f (xs.filter p)
@@ -349,7 +349,7 @@ theorem insertCanonical_not_nil [DecidableEq β] [LT β] [DecidableLT β] (f : �
 := by
   unfold insertCanonical
   cases xs
-  case nil => simp
+  case nil => simp only [ne_eq, not_false_eq_true]
   case cons hd tl =>
     simp only [gt_iff_lt, ne_eq]
     intro h
@@ -477,7 +477,8 @@ theorem insertCanonical_equiv [LT α] [StrictLT α] [DecidableLT α] (x : α) (x
               have h₆ := StrictLT.if_not_lt_gt_then_eq x hd' h₃ h₄
               subst h₆
               unfold List.Equiv
-              simp
+              simp only [cons_subset, mem_cons, true_or, or_true, Subset.refl, and_self,
+                subset_cons]
             case inl _ _ _ h₃ =>
               replace ⟨h₃, h₄, h₅⟩ := h₃
               simp only [h₅]
@@ -579,7 +580,7 @@ theorem canonicalize_not_nil [DecidableEq β] [LT β] [DecidableLT β] (f : α �
   case mpr =>
     unfold canonicalize
     intro h₀
-    cases xs <;> simp only [ne_eq, not_true_eq_false] at h₀; simp
+    cases xs <;> simp only [ne_eq, not_true_eq_false, not_false_eq_true] at *
 
 theorem canonicalize_cons [LT β] [DecidableLT β] (f : α → β) (xs : List α) (a : α) :
   canonicalize f xs = canonicalize f ys → canonicalize f (a :: xs) = canonicalize f (a :: ys)
@@ -619,7 +620,7 @@ theorem canonicalize_subseteq [LT β] [StrictLT β] [DecidableLT β] (f : α →
     apply Subset.trans h
     simp only [cons_subset, mem_cons, true_or, true_and]
     apply Subset.trans ih
-    simp
+    simp only [subset_cons]
 
 /-- Corollary of `canonicalize_subseteq` -/
 theorem in_canonicalize_in_list [LT β] [StrictLT β] [DecidableLT β] {f : α → β} {x : α} {xs : List α} :
@@ -931,7 +932,7 @@ theorem mapM_pure {α β} [Monad m] [LawfulMonad m] {f : α → β} {xs : List �
   xs.mapM ((λ a => pure (f a)) : α → m β) = pure (xs.map f)
 := by
   induction xs
-  case nil => simp
+  case nil => simp only [mapM_nil, map_nil]
   case cons hd tl ih => simp [ih]
 
 theorem mapM_some {xs : List α} :
@@ -940,14 +941,14 @@ theorem mapM_some {xs : List α} :
   -- Probably could be proved as a corollary of `mapM_pure`, but I couldn't
   -- easily get that to work, and the direct inductive proof is very short
   induction xs
-  case nil => simp
+  case nil => simp only [mapM_nil, Option.pure_def]
   case cons hd tl ih => simp [ih]
 
 theorem mapM_map {α β γ} [Monad m] [LawfulMonad m] {f : α → β} {g : β → m γ} {xs : List α} :
   List.mapM g (xs.map f) = xs.mapM λ x => g (f x)
 := by
   induction xs
-  case nil => simp
+  case nil => simp only [map_nil, mapM_nil]
   case cons hd tl ih => simp [ih]
 
 theorem mapM_pmap_subtype [Monad m] [LawfulMonad m]
@@ -1406,7 +1407,7 @@ theorem find?_pair_map {α β γ} [BEq α] (f : β → γ) (xs : List (α × β)
   List.find? (λ x => x.fst == k) (List.map (λ x => (x.fst, f x.snd)) xs)
 := by
   induction xs
-  case nil => simp
+  case nil => simp only [find?_nil, Option.map_none', map_nil]
   case cons hd tl ih =>
     cases h₁ : hd.fst == k <;> simp only [map_cons]
     case false =>
@@ -1513,7 +1514,8 @@ theorem filterMap_empty_iff_all_none {f : α → Option β} {xs : List α} :
   constructor
   case mp =>
     induction xs
-    case nil => simp
+    case nil =>
+      simp only [filterMap_nil, not_mem_nil, false_implies, implies_true, imp_self]
     case cons hd tl ih =>
       intro h₁ a h₂
       simp only [List.filterMap_cons] at h₁
@@ -1525,7 +1527,7 @@ theorem filterMap_empty_iff_all_none {f : α → Option β} {xs : List α} :
   case mpr =>
     intro h₁
     induction xs
-    case nil => simp
+    case nil => simp only [filterMap_nil]
     case cons hd tl ih =>
       simp only [List.filterMap_cons]
       split

--- a/cedar-lean/Cedar/Thm/Data/List.lean
+++ b/cedar-lean/Cedar/Thm/Data/List.lean
@@ -17,6 +17,7 @@
 import Cedar.Data.List
 import Cedar.Data.LT
 import Cedar.Thm.Data.Control
+import Std.Logic
 
 /-!
 
@@ -44,7 +45,7 @@ theorem Equiv.refl {a : List α} :
 
 theorem Equiv.symm {a b : List α} :
   a ≡ b → b ≡ a
-:= by unfold List.Equiv; simp; intro h₁ h₂; simp [h₁, h₂]
+:= by unfold List.Equiv; simp only [and_imp]; intro h₁ h₂; simp [h₁, h₂]
 
 theorem Equiv.trans {a b c : List α} :
   a ≡ b → b ≡ c → a ≡ c
@@ -86,8 +87,7 @@ theorem filter_equiv (f : α → Bool) (xs ys : List α) :
   intros h₁ h₂
   apply And.intro <;>
   intro a h₃ <;>
-  simp only [mem_filter] <;>
-  rw [List.mem_filter] at h₃
+  rw [mem_filter] <;> rw [mem_filter] at h₃
   exact And.intro (h₁ h₃.left) h₃.right
   exact And.intro (h₂ h₃.left) h₃.right
 
@@ -103,8 +103,8 @@ theorem map_equiv (f : α → β) (xs ys : List α) :
   exists p <;>
   rw [List.subset_def] at a b <;>
   simp only [and_true]
-  exact a h
-  exact b h
+  case left  => exact a h
+  case right => exact b h
 
 theorem filterMap_equiv (f : α → Option β) (xs ys : List α) :
   xs ≡ ys → xs.filterMap f ≡ ys.filterMap f
@@ -114,70 +114,9 @@ theorem filterMap_equiv (f : α → Option β) (xs ys : List α) :
   apply And.intro <;>
   intro b a h₃ h₄ <;>
   exists a <;>
-  simp [h₄]
-  exact h₁ h₃
-  exact h₂ h₃
-
-theorem filterMap_empty_iff_f_returns_none {f : α → Option β} {xs : List α} :
-  xs.filterMap f = [] ↔ ∀ x ∈ xs, f x = none
-:= by
-  constructor
-  case mp =>
-    induction xs
-    case nil => simp
-    case cons x xs h_ind =>
-      intro h₁ a h₂
-      simp only [List.filterMap_cons] at h₁
-      split at h₁ <;> try simp at h₁
-      case h_1 h₃ =>
-        rcases (List.mem_cons.mp h₂) with h₄ | h₄
-        case inl => subst h₄ ; assumption
-        case inr => apply h_ind h₁ a ; assumption
-  case mpr =>
-    intro h₁
-    induction xs
-    case nil => simp
-    case cons x xs h_ind =>
-      simp only [List.filterMap_cons]
-      split
-      case h_1 =>
-        apply h_ind ; clear h_ind
-        intro a h₂
-        apply h₁ a
-        exact List.mem_cons_of_mem x h₂
-      case h_2 b h₂ =>
-        exfalso
-        specialize h₁ x
-        simp at h₁
-        simp [h₁] at h₂
-
-theorem filterMap_nonempty_iff_exists_f_returns_some {f : α → Option β} {xs : List α} :
-  xs.filterMap f ≠ [] ↔ ∃ x ∈ xs, (f x).isSome
-:= by
-  constructor
-  case mp =>
-    intro h₁
-    replace ⟨b, h₁⟩ := List.exists_mem_of_ne_nil (xs.filterMap f) h₁
-    replace ⟨x, h₁⟩ := (List.mem_filterMap f xs).mp h₁
-    exists x
-    simp [h₁, Option.isSome]
-  case mpr =>
-    intro h₁ h₂
-    rw [filterMap_empty_iff_f_returns_none] at h₂
-    replace ⟨x, h₁, h₃⟩ := h₁
-    specialize h₂ x h₁
-    simp [h₂, Option.isSome] at h₃
-
-theorem f_implies_g_then_subset {f g : α → Option β} {xs : List α} :
-  (∀ a b, f a = some b → g a = some b) →
-  xs.filterMap f ⊆ xs.filterMap g
-:= by
-  intro h₁
-  simp [List.subset_def]
-  intro b a h₂ h₃
-  exists a
-  apply And.intro h₂
-  exact h₁ a b h₃
+  simp only [h₄, and_true]
+  case left  => exact h₁ h₃
+  case right => exact h₂ h₃
 
 /-! ### Sorted -/
 
@@ -204,7 +143,7 @@ theorem sortedBy_implies_head_lt_tail [LT β] [StrictLT β] {f : α → β} {x :
   intro h₁ y h₂
   induction xs generalizing y
   case nil => contradiction
-  case cons _ _ hd tl ih =>
+  case cons hd tl ih =>
     cases h₂
     case head => cases h₁; assumption
     case tail h₂ =>
@@ -227,10 +166,8 @@ theorem sortedBy_equiv_implies_head_eq [LT β] [StrictLT β] (f : α → β) {x 
 := by
   intro h₁ h₂
   unfold List.Equiv; intro h₃
-  replace ⟨h₃, h₄⟩ := h₃
-  simp at h₃; simp at h₄
-  replace ⟨h₃, _⟩ := h₃
-  replace ⟨h₄, _⟩ := h₄
+  simp only [cons_subset, mem_cons] at h₃
+  replace ⟨⟨h₃, _⟩, ⟨h₄, _⟩⟩ := h₃
   cases h₃ <;> cases h₄ <;> try { assumption }
   case _ _ h₅ => simp [h₅]
   case _ h₅ h₆ =>
@@ -246,10 +183,10 @@ theorem sortedBy_equiv_implies_tail_subset [LT β] [StrictLT β] (f : α → β)
   xs ⊆ ys
 := by
   intro h₁ h₂ h₃
-  simp at h₃
-  simp [List.subset_def]
+  simp only [cons_subset, mem_cons, true_or, true_and] at h₃
+  simp only [subset_def]
+  simp only [subset_def, mem_cons] at h₃
   intro y h₄
-  simp [List.subset_def] at h₃
   specialize h₃ h₄
   cases h₃
   case inr => assumption
@@ -310,6 +247,49 @@ theorem sortedBy_cons [LT β] [StrictLT β] {f : α → β} {x : α} {ys : List 
     apply SortedBy.cons_cons _ h₁
     apply h₂
     simp only [mem_cons, true_or]
+
+theorem map_eq_implies_sortedBy [LT β] [StrictLT β] {f : α → β} {g : γ → β} {xs : List α} {ys : List γ} :
+  xs.map f = ys.map g →
+  (SortedBy f xs ↔ SortedBy g ys)
+:= by
+  intro h₁
+  constructor
+  case mp =>
+    intro h₂
+    cases xs <;> cases ys <;> simp only [map_nil, map_cons, cons.injEq] at h₁
+    case nil.nil => exact SortedBy.nil
+    case cons.cons xhd xtl yhd ytl =>
+      replace ⟨h₁, h₃⟩ := h₁
+      have ih := map_eq_implies_sortedBy h₃
+      cases ytl <;> simp only [map_nil, map_cons, map_eq_nil] at *
+      case nil => exact SortedBy.cons_nil
+      case cons yhd' ytl =>
+        simp only [tail_sortedBy h₂, true_iff] at ih
+        apply SortedBy.cons_cons _ ih
+        rw [← h₁]
+        cases xtl <;> simp only [map_nil, map_cons, cons.injEq] at h₃
+        case cons xhd' xtl =>
+          rw [← h₃.left]
+          apply sortedBy_implies_head_lt_tail h₂
+          simp
+  case mpr =>
+    intro h₂
+    cases xs <;> cases ys <;> simp only [map_nil, map_cons, cons.injEq] at h₁
+    case nil.nil => exact SortedBy.nil
+    case cons.cons xhd xtl yhd ytl =>
+      replace ⟨h₁, h₃⟩ := h₁
+      have ih := map_eq_implies_sortedBy h₃
+      cases xtl <;> simp only [map_nil, map_cons, map_eq_nil] at *
+      case nil => exact SortedBy.cons_nil
+      case cons xhd' xtl =>
+        simp only [tail_sortedBy h₂, iff_true] at ih
+        apply SortedBy.cons_cons _ ih
+        rw [h₁]
+        cases ytl <;> simp only [map_nil, map_cons, cons.injEq] at h₃
+        case cons yhd' ytl =>
+          rw [h₃.left]
+          apply sortedBy_implies_head_lt_tail h₂
+          simp
 
 theorem filter_sortedBy [LT β] [StrictLT β] [DecidableLT β] {f : α → β} (p : α → Bool) {xs : List α} :
   SortedBy f xs → SortedBy f (xs.filter p)
@@ -388,7 +368,7 @@ theorem insertCanonical_sortedBy [LT β] [StrictLT β] [DecidableLT β] {f : α 
   induction xs
   case nil => simp [insertCanonical, SortedBy.cons_nil]
   case cons hd tl ih =>
-    simp [insertCanonical]
+    simp only [insertCanonical, gt_iff_lt]
     split
     case inl h₂ =>
       apply SortedBy.cons_cons h₂ h₁
@@ -401,7 +381,7 @@ theorem insertCanonical_sortedBy [LT β] [StrictLT β] [DecidableLT β] {f : α 
           apply SortedBy.cons_nil
         case cons_cons y ys h₄ h₅ =>
           specialize ih h₄
-          simp [insertCanonical]
+          simp only [insertCanonical, gt_iff_lt]
           split
           case inl h₆ =>
             apply SortedBy.cons_cons h₃
@@ -410,23 +390,21 @@ theorem insertCanonical_sortedBy [LT β] [StrictLT β] [DecidableLT β] {f : α 
             split
             case inl h₇ =>
               apply SortedBy.cons_cons h₅
-              simp [insertCanonical, h₆, h₇] at ih
+              simp only [insertCanonical, h₆, ↓reduceIte, gt_iff_lt, h₇] at ih
               exact ih
             case inr h₇ =>
               have h₈ := StrictLT.if_not_lt_gt_then_eq (f x) (f y) h₆ h₇
               apply SortedBy.cons_cons h₃
               cases h₄
-              case cons_nil =>
-                exact SortedBy.cons_nil
+              case cons_nil => exact SortedBy.cons_nil
               case cons_cons z zs h₉ h₁₀ =>
                 apply SortedBy.cons_cons (by simp [h₈, h₁₀]) h₉
       case inr h₃ =>
         have h₄ := StrictLT.if_not_lt_gt_then_eq (f x) (f hd) h₂ h₃
         cases h₁
-        case cons_nil =>
-          exact SortedBy.cons_nil
+        case cons_nil => exact SortedBy.cons_nil
         case cons_cons h₅ h₆ =>
-          apply SortedBy.cons_cons (by simp only [h₄, h₆]) h₅
+          exact SortedBy.cons_cons (by simp only [h₄, h₆]) h₅
 
 theorem insertCanonical_cases [LT β] [DecidableLT β] (f : α → β) (x y : α) (ys : List α) :
   (f x < f y ∧ insertCanonical f x (y :: ys) = x :: y :: ys) ∨
@@ -439,11 +417,11 @@ theorem insertCanonical_cases [LT β] [DecidableLT β] (f : α → β) (x y : α
   by_cases (f x < f y)
   case pos _ _ h₂ => simp [h₂]
   case neg _ _ h₂ =>
-    simp [h₂]
+    simp only [h₂, not_false_eq_true, forall_const, false_and, ↓reduceIte, true_and,
+      ite_eq_right_iff, cons.injEq, false_or]
     by_cases (f x > f y)
     case pos _ _ h₃ => simp [h₃, h₁]
     case neg _ _ h₃ => simp [h₃]
-
 
 theorem insertCanonical_subset [LT β] [DecidableLT β] (f : α → β) (x : α) (xs : List α) :
   insertCanonical f x xs ⊆ x :: xs
@@ -451,17 +429,15 @@ theorem insertCanonical_subset [LT β] [DecidableLT β] (f : α → β) (x : α)
   induction xs
   case nil => simp only [insertCanonical, Subset.refl]
   case cons hd tl ih =>
-    have h₁ := insertCanonical_cases f x hd tl
-    rcases h₁ with h₁ | h₁ | h₁
-    case inl =>
-      simp only [h₁, Subset.refl]
+    rcases (insertCanonical_cases f x hd tl) with h₁ | h₁ | h₁
+    case inl => simp only [h₁, Subset.refl]
     case inr.inl =>
-      simp [h₁]
+      simp only [h₁, cons_subset, mem_cons, true_or, or_true, true_and]
       apply Subset.trans ih
       simp only [cons_subset, mem_cons, true_or, true_and]
       exact Subset.trans (List.subset_cons hd tl) (List.subset_cons x (hd :: tl))
     case inr.inr =>
-      simp [h₁]
+      simp only [h₁, cons_subset, mem_cons, true_or, true_and]
       exact Subset.trans (List.subset_cons hd tl) (List.subset_cons x (hd :: tl))
 
 theorem insertCanonical_equiv [LT α] [StrictLT α] [DecidableLT α] (x : α) (xs : List α) :
@@ -469,8 +445,8 @@ theorem insertCanonical_equiv [LT α] [StrictLT α] [DecidableLT α] (x : α) (x
 := by
   unfold insertCanonical
   induction xs
-  case nil => simp; exact Equiv.refl
-  case cons _ _ hd tl ih =>
+  case nil => simp only ; exact Equiv.refl
+  case cons hd tl ih =>
     simp only [id_eq, gt_iff_lt]
     split
     case inl => exact Equiv.refl
@@ -483,37 +459,37 @@ theorem insertCanonical_equiv [LT α] [StrictLT α] [DecidableLT α] (x : α) (x
       case inl _ _ h₂ =>
         cases tl
         case nil =>
-          have h₃ := insertCanonical_singleton id x
-          simp [h₃]
+          simp only [insertCanonical_singleton id x]
           apply swap_cons_cons_equiv
-        case cons _ _ _ hd' tl' =>
-          simp at ih
+        case cons hd' tl' =>
+          simp only [id_eq, gt_iff_lt] at ih
           have h₃ := insertCanonical_cases id x hd' tl'
           simp only [id_eq] at h₃
           cases h₃
           case inl _ _ _ h₃ =>
-            simp [h₃]
+            simp only [h₃]
             unfold List.Equiv
             simp only [cons_subset, mem_cons, true_or, or_true, true_and]
             apply And.intro
             all_goals {
-              simp [List.subset_def]
-              intro a h₄; simp [h₄]
+              simp only [subset_def, mem_cons]
+              intro a h₄
+              simp [h₄]
             }
           case inr _ _ _ h₃ =>
             cases h₃
             case inr _ _ _ h₃ =>
               replace ⟨h₃, h₄, h₅⟩ := h₃
-              simp [h₅]
+              simp only [h₅]
               unfold GT.gt at h₄
               have h₆ := StrictLT.if_not_lt_gt_then_eq x hd' h₃ h₄
               subst h₆
               unfold List.Equiv
-              simp only [cons_subset, mem_cons, true_or, or_true, Subset.refl, and_self, subset_cons]
+              simp
             case inl _ _ _ h₃ =>
               replace ⟨h₃, h₄, h₅⟩ := h₃
-              simp [h₅]
-              simp [h₃, h₄] at ih
+              simp only [h₅]
+              simp only [h₃, h₄] at ih
               have h₆ := swap_cons_cons_equiv x hd (hd' :: tl')
               apply Equiv.trans h₆
               apply cons_equiv_cons
@@ -525,30 +501,30 @@ theorem insertCanonical_preserves_forallᵥ {α β γ} [LT α] [StrictLT α] [De
   (h₂ : Forallᵥ p kvs₁ kvs₂) :
   Forallᵥ p (insertCanonical Prod.fst kv₁ kvs₁) (insertCanonical Prod.fst kv₂ kvs₂)
 := by
-  simp [Forallᵥ] at *
+  simp only [Forallᵥ] at *
   cases h₂
   case nil =>
     simp only [insertCanonical_singleton, forall₂_cons, Forall₂.nil, and_true]
     apply h₁
   case cons hd₁ hd₂ tl₁ tl₂ h₃ h₄ =>
-    simp [insertCanonical]
+    simp only [insertCanonical, gt_iff_lt]
     split <;> split
     case inl.inl =>
       apply Forall₂.cons (by exact h₁)
       apply Forall₂.cons (by exact h₃) (by exact h₄)
     case inl.inr h₅ h₆ =>
-      simp [h₁, h₃] at h₅
+      simp only [h₁, h₃] at h₅
       have _ := StrictLT.asymmetric kv₂.fst hd₂.fst h₅
       split <;> contradiction
     case inr.inl h₅ h₆ =>
-      simp [h₁, h₃] at h₅ h₆
+      simp only [h₁, h₃] at h₅ h₆
       split
       case inl => contradiction
       case inr =>
         apply Forall₂.cons (by exact h₃)
         apply insertCanonical_preserves_forallᵥ h₁ h₄
     case inr.inr h₅ h₆ =>
-      simp [h₁, h₃] at h₅ h₆
+      simp only [h₁, h₃] at h₅ h₆
       split
       case inl => contradiction
       case inr => apply Forall₂.cons (by exact h₁) (by exact h₄)
@@ -559,13 +535,16 @@ theorem insertCanonical_map_fst {α β γ} [LT α] [StrictLT α] [DecidableLT α
 := by
   induction xs generalizing x
   case nil => simp [insertCanonical, canonicalize, Prod.map]
-  case cons ih =>
-    simp [insertCanonical, Prod.map]
+  case cons hd tl ih =>
+    simp only [insertCanonical, Prod.map, id_eq, map_cons, gt_iff_lt]
     split
     case inl => simp [Prod.map]
     case inr =>
       split
-      case inl => specialize ih x ; simp [Prod.map] at ih ; simp [ih, Prod.map]
+      case inl =>
+        specialize ih x
+        simp only [Prod.map, id_eq] at ih
+        simp [ih, Prod.map]
       case inr => simp [Prod.map]
 
 theorem insertCanonical_map_fst_canonicalize {α β γ} [LT α] [StrictLT α] [DecidableLT α] (xs : List (α × β)) (f : β → γ) (x : α × β) :
@@ -573,10 +552,9 @@ theorem insertCanonical_map_fst_canonicalize {α β γ} [LT α] [StrictLT α] [D
   map (Prod.map id f) (insertCanonical Prod.fst x (canonicalize Prod.fst xs))
 := by
   induction xs generalizing x
-  case nil =>
-    simp [insertCanonical, canonicalize, Prod.map]
+  case nil => simp [insertCanonical, canonicalize, Prod.map]
   case cons hd tl ih =>
-    simp [canonicalize, ih hd]
+    simp only [canonicalize, ih hd]
     apply insertCanonical_map_fst (insertCanonical Prod.fst hd (canonicalize Prod.fst tl))
 
 /-! ## canonicalize -/
@@ -597,7 +575,7 @@ theorem canonicalize_nil' [DecidableEq β] [LT β] [DecidableLT β] (f : α → 
     cases xs with
     | nil => trivial
     | cons x xs =>
-      simp
+      exfalso
       unfold canonicalize at h₁
       apply insertCanonical_not_nil f x (canonicalize f xs)
       exact h₁
@@ -616,14 +594,21 @@ theorem canonicalize_not_nil [DecidableEq β] [LT β] [DecidableLT β] (f : α �
   case mpr =>
     unfold canonicalize
     intro h₀
-    cases xs <;> simp at h₀; simp
+    cases xs <;> simp only [ne_eq, not_true_eq_false] at h₀; simp
+
+theorem canonicalize_cons [LT β] [DecidableLT β] (f : α → β) (xs : List α) (a : α) :
+  canonicalize f xs = canonicalize f ys → canonicalize f (a :: xs) = canonicalize f (a :: ys)
+:= by
+  intro h₁
+  unfold canonicalize
+  simp [h₁]
 
 theorem canonicalize_sortedBy [LT β] [StrictLT β] [DecidableLT β] (f : α → β) (xs : List α) :
   SortedBy f (canonicalize f xs)
 := by
   induction xs
   case nil => simp [canonicalize_nil, SortedBy.nil]
-  case cons _ _ hd tl ih =>
+  case cons hd tl ih =>
     unfold canonicalize
     apply insertCanonical_sortedBy
     exact ih
@@ -632,10 +617,8 @@ theorem sortedBy_implies_canonicalize_eq [LT β] [StrictLT β] [DecidableLT β] 
   SortedBy f xs → (canonicalize f xs) = xs
 := by
   intro h₁
-  induction xs
-  case nil => simp [canonicalize]
+  induction xs <;> simp only [canonicalize]
   case cons hd tl ih =>
-    simp [canonicalize]
     cases h₁
     case cons_nil => simp [canonicalize, insertCanonical]
     case cons_cons h₁ h₂ =>
@@ -645,15 +628,13 @@ theorem sortedBy_implies_canonicalize_eq [LT β] [StrictLT β] [DecidableLT β] 
 theorem canonicalize_subseteq [LT β] [StrictLT β] [DecidableLT β] (f : α → β) (xs : List α) :
   xs.canonicalize f ⊆ xs
 := by
-  induction xs
-  case nil => simp only [canonicalize, Subset.refl]
+  induction xs <;> simp only [canonicalize, Subset.refl]
   case cons hd tl ih =>
-    simp [canonicalize]
     have h := insertCanonical_subset f hd (canonicalize f tl)
     apply Subset.trans h
     simp only [cons_subset, mem_cons, true_or, true_and]
     apply Subset.trans ih
-    simp only [subset_cons]
+    simp
 
 /-
 Note that `canonicalize_equiv` does not hold for all functions `f`.
@@ -665,15 +646,19 @@ theorem canonicalize_equiv [LT α] [StrictLT α] [DecidableLT α] (xs : List α)
 := by
   induction xs
   case nil => simp [canonicalize_nil, Equiv.refl]
-  case cons _ _ hd tl ih =>
+  case cons hd tl ih =>
     unfold canonicalize
     generalize h₁ : canonicalize id tl = ys
-    simp [h₁] at ih
+    simp only [h₁] at ih
     have h₂ := insertCanonical_equiv hd ys
     apply Equiv.trans _ h₂
     apply cons_equiv_cons
     exact ih
 
+/-
+Open problem: does `equiv_implies_canonical_eq` hold for functions other than `id`?
+In particular, for `Prod.fst`?
+-/
 theorem equiv_implies_canonical_eq [LT α] [StrictLT α] [DecidableLT α] (xs ys : List α) :
   xs ≡ ys → (canonicalize id xs) = (canonicalize id ys)
 := by
@@ -719,12 +704,12 @@ theorem canonicalize_preserves_forallᵥ {α β γ} [LT α] [StrictLT α] [Decid
   List.Forallᵥ p kvs₁ kvs₂ →
   List.Forallᵥ p (List.canonicalize Prod.fst kvs₁) (List.canonicalize Prod.fst kvs₂)
 := by
-  simp [Forallᵥ]
+  simp only [Forallᵥ]
   intro h₁
   cases h₁
   case nil => simp [canonicalize_nil]
   case cons hd₁ hd₂ tl₁ tl₂ h₂ h₃ =>
-    simp [canonicalize]
+    simp only [canonicalize]
     have h₄ := canonicalize_preserves_forallᵥ p tl₁ tl₂ h₃
     apply insertCanonical_preserves_forallᵥ h₂ h₄
 
@@ -735,7 +720,7 @@ theorem canonicalize_of_map_fst {α β γ} [LT α] [StrictLT α] [DecidableLT α
   cases xs
   case nil => simp [canonicalize]
   case cons hd tl =>
-    simp [canonicalize]
+    simp only [canonicalize]
     exact insertCanonical_map_fst_canonicalize tl f hd
 
 /-! ### any -/
@@ -745,60 +730,149 @@ theorem any_of_mem {f : α → Bool} {x : α} {xs : List α}
   (h₂ : f x) :
   any xs f = true
 := by
-  cases xs <;> simp at h₁
+  cases xs <;> simp only [mem_cons, not_mem_nil] at h₁
   case cons hd tl =>
-    simp [List.any_cons]
+    simp only [any_cons, Bool.or_eq_true, any_eq_true]
     rcases h₁ with h₁ | h₁
-    subst h₁ ; simp [h₂]
-    apply Or.inr ; exists x
+    subst h₁
+    simp only [h₂, true_or]
+    apply Or.inr
+    exists x
 
-/-! ### mapM and mapM₁ -/
+/-! ### all -/
 
-theorem mapM_pmap_subtype [Monad m] [LawfulMonad m]
+/--
+  Copied from Mathlib. We can delete this if it gets added to Std.
+-/
+theorem all_pmap_subtype
   {p : α → Prop}
-  (f : α → m β)
+  (f : α → Bool)
   (as : List α)
   (h : ∀ a, a ∈ as → p a)
-  : List.mapM (fun x : { a : α // p a } => f x.val) (List.pmap Subtype.mk as h)
+  : List.all (List.pmap Subtype.mk as h) (λ x : { a : α // p a } => f x.val)
     =
-    List.mapM f as
+    List.all as f
 := by
-  rw [←List.mapM'_eq_mapM]
   induction as <;> simp [*]
 
-theorem mapM₁_eq_mapM [Monad m] [LawfulMonad m]
-  (f : α → m β)
-  (as : List α) :
-  List.mapM₁ as (fun x : { x // x ∈ as } => f x.val) =
-  List.mapM f as
-:= by
-  simp [mapM₁, attach, mapM_pmap_subtype]
+/-! ### map and map₁ -/
 
-theorem mapM_implies_nil {f : α → Except β γ} {as : List α}
-  (h₁ : List.mapM f as = Except.ok []) :
-  as = []
-:= by
-  rw [←List.mapM'_eq_mapM] at h₁
-  cases as
-  case nil => rfl
-  case cons hd tl =>
-    simp [List.mapM'] at h₁
-    cases h₂ : f hd <;> simp [h₂] at h₁
-    cases h₃ : List.mapM' f tl <;>
-    simp [h₃, pure, Except.pure] at h₁
+/--
+  Copied from Mathlib. We can delete this if it gets added to Std.
+-/
+theorem map_congr {f g : α → β} : ∀ {l : List α},
+  (∀ x ∈ l, f x = g x) → map f l = map g l
+  | [], _ => rfl
+  | a :: l, h => by
+    let ⟨h₁, h₂⟩ := forall_mem_cons.1 h
+    rw [map, map, h₁, map_congr h₂]
 
-theorem mapM_head_tail {α β γ} {f : α → Except β γ} {x : α} {xs : List α} {y : γ} {ys : List γ} :
-  (List.mapM f (x :: xs)) = Except.ok (y :: ys) →
-  (List.mapM f xs) = Except.ok ys
+/--
+  Copied from Mathlib. We can delete this if it gets added to Std.
+-/
+theorem map_pmap_subtype
+  {p : α → Prop}
+  (f : α → β)
+  (as : List α)
+  (h : ∀ a, a ∈ as → p a)
+  : List.map (λ x : { a : α // p a } => f x.val) (List.pmap Subtype.mk as h)
+    =
+    List.map f as
 := by
-  simp [←List.mapM'_eq_mapM]
-  cases h₁ : f x <;>
-  simp [h₁]
-  cases h₂ : mapM' f xs <;>
-  simp [h₂, pure, Except.pure]
+  induction as <;> simp [*]
+
+/--
+  Not actually a special case of `map_pmap_subtype` -- you can use this in
+  places you can't use `map_pmap_subtype` because the LHS function (being
+  mapped) doesn't fit the `map_pmap_subtype` form but does fit this form (where
+  the application of `f` is not the outermost AST node of the function,
+  basically)
+-/
+theorem map_pmap_subtype_snd
+  {p : (α × β) → Prop}
+  (f : β → γ)
+  (xs : List (α × β))
+  (h : ∀ pair ∈ xs, p pair)
+  : List.map (λ x : { pair : (α × β) // p pair } => (x.val.fst, f x.val.snd)) (List.pmap Subtype.mk xs h)
+    =
+    xs.map λ pair => (pair.fst, f pair.snd)
+:= by
+  induction xs <;> simp [*]
+
+theorem map₁_eq_map (f : α → β) (as : List α) :
+  as.map₁ (λ x : {x // x ∈ as} => f x.val) =
+  as.map f
+:= by
+  simp [map₁, attach, map_pmap_subtype]
+
+theorem map_attach₂ {α : Type u} {β : Type v} [SizeOf α] [SizeOf β] {xs : List (α × β)} (f : (α × β) → γ) :
+  xs.attach₂.map (λ x : { x : α × β // sizeOf x.snd < 1 + sizeOf xs } => f x.1) =
+  xs.map f
+:= by
+  simp [attach₂, map_pmap_subtype]
+
+/--
+  Not actually a special case of `map_attach₂` -- you can use this in places you
+  can't use `map_attach₂` because the LHS function (being mapped) doesn't fit
+  the `map_attach₂` form but does fit this form (where the application of `f` is
+  not the outermost AST node of the function, basically)
+-/
+theorem map_attach₂_snd {α : Type u} {β : Type v} [SizeOf α] [SizeOf β] {xs : List (α × β)} (f : β → γ) :
+  xs.attach₂.map (λ x : {x : α × β // sizeOf x.snd < 1 + sizeOf xs } => match x with | ⟨(a, b), _⟩ => (a, f b)) =
+  xs.map λ (a, b) => (a, f b)
+:= by
+  simp [attach₂, map_pmap_subtype_snd]
 
 /-! ### Forall₂ -/
 
+/--
+  Copied from Mathlib
+-/
+theorem forall₂_nil_left_iff {l} : Forall₂ R nil l ↔ l = nil :=
+  ⟨fun H => by cases H; rfl, by rintro rfl; exact Forall₂.nil⟩
+
+/--
+  Copied from Mathlib
+-/
+theorem forall₂_nil_right_iff {l} : Forall₂ R l nil ↔ l = nil :=
+  ⟨fun H => by cases H; rfl, by rintro rfl; exact Forall₂.nil⟩
+
+/--
+  Copied from Mathlib
+-/
+theorem Forall₂.imp (H : ∀ a b, R a b → S a b) {l₁ l₂} (h : Forall₂ R l₁ l₂) : Forall₂ S l₁ l₂ := by
+  induction h <;> constructor <;> solve_by_elim
+
+/--
+  Copied from Mathlib
+-/
+theorem forall₂_cons_left_iff {a l u} :
+    Forall₂ R (a :: l) u ↔ ∃ b u', R a b ∧ Forall₂ R l u' ∧ u = b :: u' :=
+  Iff.intro
+    (fun h =>
+      match u, h with
+      | b :: u', Forall₂.cons h₁ h₂ => ⟨b, u', h₁, h₂, rfl⟩)
+    fun h =>
+    match u, h with
+    | _, ⟨_, _, h₁, h₂, rfl⟩ => Forall₂.cons h₁ h₂
+
+/--
+  Copied from Mathlib
+-/
+theorem forall₂_cons_right_iff {b l u} :
+    Forall₂ R u (b :: l) ↔ ∃ a u', R a b ∧ Forall₂ R u' l ∧ u = a :: u' :=
+  Iff.intro
+    (fun h =>
+      match u, h with
+      | b :: u', Forall₂.cons h₁ h₂ => ⟨b, u', h₁, h₂, rfl⟩)
+    fun h =>
+    match u, h with
+    | _, ⟨_, _, h₁, h₂, rfl⟩ => Forall₂.cons h₁ h₂
+
+/--
+  Note the converse is not true:
+  counterexample `R` is `=`, `xs` is `[1]`, `ys` is `[1, 2]`
+-/
 theorem forall₂_implies_all_left {α β} {R : α → β → Prop} {xs : List α} {ys : List β} :
   List.Forall₂ R xs ys →
   ∀ x ∈ xs, ∃ y ∈ ys, R x y
@@ -841,73 +915,323 @@ theorem forall₂_implies_all_right {α β} {R : α → β → Prop} {xs : List 
       exists x
       simp only [mem_cons, ih, or_true, and_self]
 
-/-! ### mapM' -/
+/-! ### mapM, mapM', and mapM₁ -/
 
-theorem mapM'_ok_implies_forall₂ {α β γ} {f : α → Except γ β} {xs : List α} {ys : List β} :
-  List.mapM' f xs = .ok ys →
+/--
+  `mapM` with a function that always produces `pure`
+-/
+theorem mapM_pure {α β} [Monad m] [LawfulMonad m] {f : α → β} {xs : List α} :
+  xs.mapM ((λ a => pure (f a)) : α → m β) = pure (xs.map f)
+:= by
+  induction xs
+  case nil => simp
+  case cons hd tl ih => simp [ih]
+
+theorem mapM_some {xs : List α} :
+  xs.mapM some = some xs
+:= by
+  -- Probably could be proved as a corollary of `mapM_pure`, but I couldn't
+  -- easily get that to work, and the direct inductive proof is very short
+  induction xs
+  case nil => simp
+  case cons hd tl ih => simp [ih]
+
+theorem mapM_map {α β γ} [Monad m] [LawfulMonad m] {f : α → β} {g : β → m γ} {xs : List α} :
+  List.mapM g (xs.map f) = xs.mapM λ x => g (f x)
+:= by
+  induction xs
+  case nil => simp
+  case cons hd tl ih => simp [ih]
+
+theorem mapM_pmap_subtype [Monad m] [LawfulMonad m]
+  {p : α → Prop}
+  (f : α → m β)
+  (as : List α)
+  (h : ∀ a, a ∈ as → p a)
+  : List.mapM (λ x : { a : α // p a } => f x.val) (List.pmap Subtype.mk as h)
+    =
+    List.mapM f as
+:= by
+  rw [←List.mapM'_eq_mapM]
+  induction as <;> simp [*]
+
+theorem mapM₁_eq_mapM [Monad m] [LawfulMonad m]
+  (f : α → m β)
+  (as : List α) :
+  List.mapM₁ as (λ x : { x // x ∈ as } => f x.val) =
+  List.mapM f as
+:= by
+  simp [mapM₁, attach, mapM_pmap_subtype]
+
+theorem mapM_implies_nil {f : α → Except β γ} {as : List α}
+  (h₁ : List.mapM f as = Except.ok []) :
+  as = []
+:= by
+  rw [←List.mapM'_eq_mapM] at h₁
+  cases as
+  case nil => rfl
+  case cons hd tl =>
+    simp only [List.mapM'] at h₁
+    cases h₂ : f hd <;> simp only [h₂, Except.bind_err, Except.bind_ok] at h₁
+    cases h₃ : List.mapM' f tl <;>
+    simp [h₃, pure, Except.pure] at h₁
+
+theorem mapM_head_tail {α β γ} {f : α → Except β γ} {x : α} {xs : List α} {y : γ} {ys : List γ} :
+  (List.mapM f (x :: xs)) = Except.ok (y :: ys) →
+  (List.mapM f xs) = Except.ok ys
+:= by
+  simp only [← mapM'_eq_mapM, mapM'_cons]
+  cases h₁ : f x <;>
+  simp only [h₁, Except.bind_ok, Except.bind_err, false_implies]
+  cases h₂ : mapM' f xs <;>
+  simp [h₂, pure, Except.pure]
+
+theorem mapM'_ok_iff_forall₂ {α β γ} {f : α → Except γ β} {xs : List α} {ys : List β} :
+  List.mapM' f xs = .ok ys ↔
   List.Forall₂ (λ x y => f x = .ok y) xs ys
 := by
-  intro h₁
-  induction xs generalizing ys
-  case nil =>
-    simp only [mapM'_nil, pure, Except.pure, Except.ok.injEq] at h₁
-    subst h₁
-    exact List.Forall₂.nil
-  case cons xhd xtl ih =>
-    simp only [mapM'_cons, pure, Except.pure] at h₁
-    cases h₂ : f xhd <;>
-    simp only [h₂, Except.bind_err, Except.bind_ok] at h₁
-    rename_i yhd
-    cases h₃ : mapM' f xtl <;>
-    simp only [h₃, Except.bind_err, Except.bind_ok] at h₁
-    rename_i ytl
-    simp only [Except.ok.injEq] at h₁
-    subst h₁
-    exact List.Forall₂.cons h₂ (ih h₃)
+  constructor
+  case mp =>
+    intro h₁
+    induction xs generalizing ys
+    case nil =>
+      simp only [mapM'_nil, pure, Except.pure, Except.ok.injEq] at h₁
+      subst h₁
+      exact List.Forall₂.nil
+    case cons xhd xtl ih =>
+      simp only [mapM'_cons, pure, Except.pure] at h₁
+      cases h₂ : f xhd <;>
+      simp only [h₂, Except.bind_err, Except.bind_ok] at h₁
+      rename_i yhd
+      cases h₃ : mapM' f xtl <;>
+      simp only [h₃, Except.bind_err, Except.bind_ok] at h₁
+      rename_i ytl
+      simp only [Except.ok.injEq] at h₁
+      subst h₁
+      exact List.Forall₂.cons h₂ (ih h₃)
+  case mpr =>
+    intro h₁
+    induction xs generalizing ys
+    case nil =>
+      simp only [forall₂_nil_left_iff] at h₁
+      simp only [mapM'_nil, pure, Except.pure, h₁]
+    case cons xhd xtl ih =>
+      simp only [mapM'_cons, pure, Except.pure]
+      replace ⟨yhd, ytl, h₁, h₃, h₄⟩ := forall₂_cons_left_iff.mp h₁
+      subst ys
+      cases h₂ : f xhd
+      case error e => simp [h₁] at h₂
+      case ok y' =>
+        simp only [h₁, Except.ok.injEq] at h₂
+        subst y'
+        specialize @ih ytl h₃
+        simp only [ih, Except.bind_err, Except.bind_ok]
 
+theorem mapM_ok_iff_forall₂ {α β γ} {f : α → Except γ β} {xs : List α} {ys : List β} :
+  List.mapM f xs = .ok ys ↔
+  List.Forall₂ (λ x y => f x = .ok y) xs ys
+:= by
+  rw [← List.mapM'_eq_mapM]
+  exact mapM'_ok_iff_forall₂
+
+/--
+  Note that the converse is not true:
+  counterexample `xs` is `[1]`, `ys` is `[1, 2]`, `f` is `Except.ok`
+
+  But for a limited converse, see `all_ok_implies_mapM'_ok`
+-/
 theorem mapM'_ok_implies_all_ok {α β γ} {f : α → Except γ β} {xs : List α} {ys : List β} :
   List.mapM' f xs = .ok ys →
   ∀ x ∈ xs, ∃ y ∈ ys, f x = .ok y
 := by
   intro h
-  exact forall₂_implies_all_left (mapM'_ok_implies_forall₂ h)
+  exact forall₂_implies_all_left (mapM'_ok_iff_forall₂.mp h)
 
+theorem mapM_ok_implies_all_ok {α β γ} {f : α → Except γ β} {xs : List α} {ys : List β} :
+  List.mapM f xs = .ok ys →
+  ∀ x ∈ xs, ∃ y ∈ ys, f x = .ok y
+:= by
+  rw [← List.mapM'_eq_mapM]
+  exact mapM'_ok_implies_all_ok
+
+theorem all_ok_implies_mapM'_ok {α β γ} {f : α → Except γ β} {xs : List α} :
+  (∀ x ∈ xs, ∃ y, f x = .ok y) →
+  ∃ ys, List.mapM' f xs = .ok ys
+:= by
+  intro h₁
+  induction xs
+  case nil => exists []
+  case cons xhd xtl ih =>
+    simp only [mem_cons, forall_eq_or_imp] at h₁
+    replace ⟨⟨yhd, h₁⟩, h₂⟩ := h₁
+    replace ⟨ytl, ih⟩ := ih h₂
+    exists yhd :: ytl
+    simp [h₁, ih, pure, Except.pure]
+
+theorem all_ok_implies_mapM_ok {α β γ} {f : α → Except γ β} {xs : List α} :
+  (∀ x ∈ xs, ∃ y, f x = .ok y) →
+  ∃ ys, List.mapM f xs = .ok ys
+:= by
+  rw [← List.mapM'_eq_mapM]
+  exact all_ok_implies_mapM'_ok
+
+/--
+  Note that the converse is not true:
+  counterexample `ys` is `[1]`, `xs` is `[1, 2]`, `f` is `Except.ok`
+
+  But for a limited converse, see `all_from_ok_implies_mapM'_ok`
+-/
 theorem mapM'_ok_implies_all_from_ok {α β γ} {f : α → Except γ β} {xs : List α} {ys : List β} :
   List.mapM' f xs = .ok ys →
   ∀ y ∈ ys, ∃ x ∈ xs, f x = .ok y
 := by
   intro h
-  exact forall₂_implies_all_right (mapM'_ok_implies_forall₂ h)
+  exact forall₂_implies_all_right (mapM'_ok_iff_forall₂.mp h)
 
-theorem mapM'_some_implies_forall₂ {α β} {f : α → Option β} {xs : List α} {ys : List β} :
-  List.mapM' f xs = .some ys →
-  List.Forall₂ (λ x y => f x = .some y) xs ys
+theorem mapM_ok_implies_all_from_ok {α β γ} {f : α → Except γ β} {xs : List α} {ys : List β} :
+  List.mapM f xs = .ok ys →
+  ∀ y ∈ ys, ∃ x ∈ xs, f x = .ok y
+:= by
+  rw [← List.mapM'_eq_mapM]
+  exact mapM'_ok_implies_all_from_ok
+
+theorem all_from_ok_implies_mapM'_ok {α β γ} {f : α → Except γ β} {ys : List β} :
+  (∀ y ∈ ys, ∃ x, f x = .ok y) →
+  ∃ xs, List.mapM' f xs = .ok ys
 := by
   intro h₁
-  induction xs generalizing ys
-  case nil =>
-    simp only [mapM'_nil, pure, Option.some.injEq] at h₁
-    subst h₁
-    exact List.Forall₂.nil
-  case cons xhd xtl ih =>
-    simp only [mapM'_cons, pure, Option.bind_eq_bind, Option.bind_eq_some, Option.some.injEq] at h₁
-    replace ⟨yhd, h₁, ytl, h₂, h₃⟩ := h₁
-    subst h₃
-    exact List.Forall₂.cons h₁ (ih h₂)
+  induction ys
+  case nil => exists []
+  case cons yhd ytl ih =>
+    simp only [mem_cons, forall_eq_or_imp] at h₁
+    replace ⟨⟨xhd, h₁⟩, h₂⟩ := h₁
+    replace ⟨xtl, ih⟩ := ih h₂
+    exists xhd :: xtl
+    simp [h₁, ih, pure, Except.pure]
 
+theorem all_from_ok_implies_mapM_ok {α β γ} {f : α → Except γ β} {ys : List β} :
+  (∀ y ∈ ys, ∃ x, f x = .ok y) →
+  ∃ xs, List.mapM f xs = .ok ys
+:= by
+  intro h
+  have ⟨xs, h₂⟩ := all_from_ok_implies_mapM'_ok h
+  rw [List.mapM'_eq_mapM] at h₂
+  exists xs
+
+theorem mapM'_some_iff_forall₂ {α β} {f : α → Option β} {xs : List α} {ys : List β} :
+  List.mapM' f xs = .some ys ↔
+  List.Forall₂ (λ x y => f x = .some y) xs ys
+:= by
+  constructor
+  case mp =>
+    intro h₁
+    induction xs generalizing ys
+    case nil =>
+      simp only [mapM'_nil, pure, Option.some.injEq] at h₁
+      subst h₁
+      exact List.Forall₂.nil
+    case cons xhd xtl ih =>
+      simp only [mapM'_cons, pure, Option.bind_eq_bind, Option.bind_eq_some, Option.some.injEq] at h₁
+      replace ⟨yhd, h₁, ytl, h₂, h₃⟩ := h₁
+      subst h₃
+      exact List.Forall₂.cons h₁ (ih h₂)
+  case mpr =>
+    intro h₁
+    induction xs generalizing ys
+    case nil =>
+      simp only [forall₂_nil_left_iff] at h₁
+      simp only [mapM'_nil, pure, Except.pure, h₁]
+    case cons xhd xtl ih =>
+      simp only [mapM'_cons, pure, Except.pure]
+      replace ⟨yhd, ytl, h₁, h₃, h₄⟩ := forall₂_cons_left_iff.mp h₁
+      subst ys
+      cases h₂ : f xhd
+      case none => simp [h₁] at h₂
+      case some y' =>
+        simp only [h₁, Option.some.injEq] at h₂
+        subst y'
+        simp [@ih ytl h₃]
+
+theorem mapM_some_iff_forall₂ {α β} {f : α → Option β} {xs : List α} {ys : List β} :
+  List.mapM f xs = .some ys ↔
+  List.Forall₂ (λ x y => f x = .some y) xs ys
+:= by
+  rw [← List.mapM'_eq_mapM]
+  exact mapM'_some_iff_forall₂
+
+/--
+  Note that the converse is not true:
+  counterexample `xs` is `[1]`, `ys` is `[1, 2]`, `f` is `Option.some`
+-/
 theorem mapM'_some_implies_all_some {α β} {f : α → Option β} {xs : List α} {ys : List β} :
   List.mapM' f xs = .some ys →
   ∀ x ∈ xs, ∃ y ∈ ys, f x = .some y
 := by
   intro h
-  exact forall₂_implies_all_left (mapM'_some_implies_forall₂ h)
+  exact forall₂_implies_all_left (mapM'_some_iff_forall₂.mp h)
 
+theorem mapM_some_implies_all_some {α β} {f : α → Option β} {xs : List α} {ys : List β} :
+  List.mapM f xs = .some ys →
+  ∀ x ∈ xs, ∃ y ∈ ys, f x = .some y
+:= by
+  rw [← List.mapM'_eq_mapM]
+  exact mapM'_some_implies_all_some
+
+/--
+  Note that the converse is not true:
+  counterexample `ys` is `[1]`, `xs` is `[1, 2]`, `f` is `Option.some`
+-/
 theorem mapM'_some_implies_all_from_some {α β} {f : α → Option β} {xs : List α} {ys : List β} :
   List.mapM' f xs = .some ys →
   ∀ y ∈ ys, ∃ x ∈ xs, f x = .some y
 := by
   intro h
-  exact forall₂_implies_all_right (mapM'_some_implies_forall₂ h)
+  exact forall₂_implies_all_right (mapM'_some_iff_forall₂.mp h)
+
+theorem mapM_some_implies_all_from_some {α β} {f : α → Option β} {xs : List α} {ys : List β} :
+  List.mapM f xs = .some ys →
+  ∀ y ∈ ys, ∃ x ∈ xs, f x = .some y
+:= by
+  rw [← List.mapM'_eq_mapM]
+  exact mapM'_some_implies_all_from_some
+
+theorem mapM'_none_iff_exists {α β} {f : α → Option β} {xs : List α} :
+  List.mapM' f xs = none ↔ ∃ x ∈ xs, f x = none
+:= by
+  constructor
+  case mp =>
+    intro h₁
+    cases xs
+    case nil => simp at h₁
+    case cons xhd xtl =>
+      cases h₂ : f xhd <;> simp only [h₂, mem_cons, exists_eq_or_imp, true_or, false_or]
+      case some yhd =>
+        simp only [mapM'_cons, h₂, Option.pure_def, Option.bind_eq_bind, Option.bind_some_fun,
+          Option.bind_eq_none] at h₁
+        apply mapM'_none_iff_exists.mp
+        by_contra h₃
+        rw [← ne_eq] at h₃
+        replace ⟨ytl, h₃⟩ := Option.ne_none_iff_exists'.mp h₃
+        exact h₁ ytl h₃
+  case mpr =>
+    intro h₁
+    replace ⟨x, h₁, h₂⟩ := h₁
+    cases xs <;> simp only [mem_cons, not_mem_nil] at h₁
+    case cons xhd xtl =>
+      simp only [mapM'_cons, Option.pure_def, Option.bind_eq_bind, Option.bind_eq_none]
+      intro yhd h₃ ytl h₄
+      rcases h₁ with h₁ | h₁
+      case inl => subst h₁ ; simp [h₂] at h₃
+      case inr =>
+        replace h₄ := mapM'_some_implies_all_some h₄
+        replace ⟨y, _, h₅⟩ := h₄ x h₁
+        simp [h₂] at h₅
+
+theorem mapM_none_iff_exists {α β} {f : α → Option β} {xs : List α} :
+  List.mapM f xs = none ↔ ∃ x ∈ xs, f x = none
+:= by
+  rw [← List.mapM'_eq_mapM]
+  exact mapM'_none_iff_exists
 
 theorem mapM'_some_eq_filterMap {α β} {f : α → Option β} {xs : List α} {ys : List β} :
   List.mapM' f xs = .some ys →
@@ -927,6 +1251,13 @@ theorem mapM'_some_eq_filterMap {α β} {f : α → Option β} {xs : List α} {y
     simp only [h, cons.injEq, true_and]
     exact ih hm
 
+theorem mapM_some_eq_filterMap {α β} {f : α → Option β} {xs : List α} {ys : List β} :
+  List.mapM f xs = .some ys →
+  List.filterMap f xs = ys
+:= by
+  rw [← List.mapM'_eq_mapM]
+  exact mapM'_some_eq_filterMap
+
 /-! ### foldlM -/
 
 theorem foldlM_of_assoc_some (f : α → α → Option α) (x₀ x₁ x₂ x₃ : α) (xs : List α)
@@ -939,29 +1270,29 @@ theorem foldlM_of_assoc_some (f : α → α → Option α) (x₀ x₁ x₂ x₃ 
 := by
   cases xs
   case nil =>
-    simp [List.foldlM, pure] at *
+    simp only [Option.bind_eq_bind, List.foldlM, pure, Option.some.injEq, Option.bind_some_fun] at *
     subst h₃; exact h₂
   case cons hd tl =>
-    simp [List.foldlM] at *
-    cases h₄ : f x₂ hd <;> simp [h₄] at h₃
-    rename_i x₄
+    simp only [Option.bind_eq_bind, List.foldlM, Option.bind_eq_some] at *
+    cases h₄ : f x₂ hd <;> simp only [h₄, false_and, exists_false, Option.some.injEq, exists_eq_left'] at h₃
+    case some x₄ =>
     have h₅ := h₁ x₀ x₁ hd
-    simp [h₂, h₄] at h₅
-    cases h₆ : f x₁ hd <;> simp [h₆] at h₅
-    rename_i x₅
+    simp only [h₂, h₄, Option.some_bind] at h₅
+    cases h₆ : f x₁ hd <;> simp only [h₆, Option.some_bind, Option.none_bind] at h₅
+    case some x₅ =>
     have h₇ := List.foldlM_of_assoc_some f x₂ hd x₄ x₃ tl h₁ h₄ h₃
-    cases h₈ : List.foldlM f hd tl <;> simp [h₈] at h₇
-    rename_i x₆
+    cases h₈ : List.foldlM f hd tl <;> simp only [h₈, Option.bind_some_fun, Option.bind_none_fun] at h₇
+    case some x₆ =>
     rw [eq_comm] at h₅
-    cases h₉ : List.foldlM f x₅ tl <;> simp [h₉]
+    cases h₉ : List.foldlM f x₅ tl <;> simp only [h₉, Option.some.injEq, exists_eq_left', false_and, exists_false]
     case none =>
       have h₁₀ := List.foldlM_of_assoc_some f x₀ x₅ x₄ x₃ tl h₁ h₅ h₃
       simp [h₉] at h₁₀
     case some x₇ =>
       have h₁₀ := List.foldlM_of_assoc_some f x₁ hd x₅ x₇ tl h₁ h₆ h₉
-      simp [h₈] at h₁₀
+      simp only [h₈, Option.bind_some_fun] at h₁₀
       specialize h₁ x₀ x₁ x₆
-      simp [h₂, h₁₀] at h₁
+      simp only [h₂, h₁₀, Option.some_bind] at h₁
       simp [←h₁, h₇]
 
 theorem foldlM_of_assoc_none' (f : α → α → Option α) (x₀ x₁ x₂ : α) (xs : List α)
@@ -974,16 +1305,16 @@ theorem foldlM_of_assoc_none' (f : α → α → Option α) (x₀ x₁ x₂ : α
 := by
   cases xs
   case nil =>
-    simp [pure] at h₃ ; subst h₃; exact h₂
+    simp only [foldlM_nil, pure, Option.some.injEq] at h₃ ; subst h₃; exact h₂
   case cons hd tl =>
-    simp [List.foldlM] at h₃
-    cases h₄ : f x₁ hd <;> simp [h₄] at h₃
-    rename_i x₃
+    simp only [List.foldlM, Option.bind_eq_bind, Option.bind_eq_some] at h₃
+    cases h₄ : f x₁ hd <;> simp only [h₄, false_and, exists_false, Option.some.injEq, exists_eq_left'] at h₃
+    case some x₃ =>
     have h₅ := List.foldlM_of_assoc_some f x₁ hd x₃ x₂ tl h₁ h₄ h₃
-    cases h₆ : List.foldlM f hd tl <;> simp [h₆] at h₅
-    rename_i x₄
+    cases h₆ : List.foldlM f hd tl <;> simp only [h₆, Option.bind_some_fun, Option.bind_none_fun] at h₅
+    case some x₄ =>
     specialize h₁ x₀ x₁ x₄
-    simp [h₂, h₅] at h₁
+    simp only [h₂, h₅, Option.bind_none_fun, Option.bind_some_fun] at h₁
     simp [h₁]
 
 theorem foldlM_of_assoc_none (f : α → α → Option α) (x₀ x₁ x₂ : α) (xs : List α)
@@ -995,29 +1326,29 @@ theorem foldlM_of_assoc_none (f : α → α → Option α) (x₀ x₁ x₂ : α)
   (do let y ← List.foldlM f x₁ xs ; f x₀ y) = none
 := by
   cases xs
-  case nil =>
-    simp [List.foldlM] at h₃
+  case nil => simp [List.foldlM] at h₃
   case cons hd tl =>
-    simp [List.foldlM]
-    cases h₄ : f x₁ hd <;> simp [h₄]
-    rename_i x₃
-    cases h₅ : List.foldlM f x₃ tl <;> simp [h₅]
-    rename_i x₄
+    simp only [List.foldlM, Option.bind_eq_bind, Option.bind_eq_none, Option.bind_eq_some,
+      forall_exists_index, and_imp]
+    cases h₄ : f x₁ hd <;> simp only [false_implies, implies_true, Option.some.injEq, forall_eq']
+    case some x₃ =>
+    cases h₅ : List.foldlM f x₃ tl <;> simp only [false_implies, implies_true, Option.some.injEq, forall_eq']
+    case some x₄ =>
     have h₆ := List.foldlM_of_assoc_some f x₁ hd x₃ x₄ tl h₁ h₄ h₅
-    cases h₇ : List.foldlM f hd tl <;> simp [h₇] at h₆
-    rename_i x₅
-    simp [List.foldlM] at h₃
-    cases h₈ : f x₂ hd <;> simp [h₈] at h₃
+    cases h₇ : List.foldlM f hd tl <;> simp only [h₇, Option.bind_some_fun, Option.bind_none_fun] at h₆
+    case some x₅ =>
+    simp only [List.foldlM, Option.bind_eq_bind, Option.bind_eq_none] at h₃
+    cases h₈ : f x₂ hd <;> simp only [h₈, false_implies, implies_true, Option.some.injEq, forall_eq'] at h₃
     case none =>
       have h₉ := List.foldlM_of_assoc_none' f x₂ hd x₅ tl h₁ h₈ h₇
       have h₁₀ := h₁ x₀ x₁ x₅
-      simp [h₂, h₆] at h₁₀
+      simp only [h₂, h₆, Option.bind_some_fun] at h₁₀
       simp [←h₁₀, h₉]
     case some x₆ =>
       have h₉ := List.foldlM_of_assoc_none f x₂ hd x₆ tl h₁ h₈ h₃
-      simp [h₇] at h₉
+      simp only [h₇, Option.bind_some_fun] at h₉
       have h₁₀ := h₁ x₀ x₁ x₅
-      simp [h₂, h₆] at h₁₀
+      simp only [h₂, h₆, Option.bind_some_fun] at h₁₀
       simp [←h₁₀, h₉]
 
 theorem foldlM_of_assoc (f : α → α → Option α) (x₀ x₁ : α) (xs : List α)
@@ -1027,19 +1358,18 @@ theorem foldlM_of_assoc (f : α → α → Option α) (x₀ x₁ : α) (xs : Lis
   List.foldlM f x₀ (x₁ :: xs) =
   (do let y ← List.foldlM f x₁ xs ; f x₀ y)
 := by
-  simp [List.foldlM]
-  cases h₂ : f x₀ x₁ <;> simp [h₂]
+  simp only [List.foldlM, Option.bind_eq_bind]
+  cases h₂ : f x₀ x₁ <;> simp only [Option.some_bind, Option.none_bind]
   case none =>
     induction xs generalizing x₁
     case nil => simp [h₂]
     case cons hd tl ih =>
-      simp [List.foldlM]
-      cases h₃ : f x₁ hd <;> simp [h₃]
-      rename_i x₂
+      simp only [List.foldlM, Option.bind_eq_bind]
+      cases h₃ : f x₁ hd <;> simp only [Option.some_bind, Option.none_bind]
+      case some x₂ =>
+      apply ih x₂
       specialize h₁ x₀ x₁ hd
-      simp [h₂, h₃] at h₁
-      specialize ih x₂
-      apply ih
+      simp only [h₂, h₃, Option.bind_some_fun, Option.bind_none_fun] at h₁
       rw [eq_comm] at h₁ ; exact h₁
   case some x₂ =>
     rw [eq_comm]
@@ -1056,8 +1386,7 @@ theorem find?_pair_map {α β γ} [BEq α] (f : β → γ) (xs : List (α × β)
   List.find? (λ x => x.fst == k) (List.map (λ x => (x.fst, f x.snd)) xs)
 := by
   induction xs
-  case nil =>
-    simp only [find?_nil, Option.map_none', map_nil]
+  case nil => simp
   case cons hd tl ih =>
     cases h₁ : hd.fst == k <;> simp only [map_cons]
     case false =>
@@ -1066,27 +1395,26 @@ theorem find?_pair_map {α β γ} [BEq α] (f : β → γ) (xs : List (α × β)
         (λ (x : α × β) => x.fst == k) hd tl h₁
       have h₃ := @List.find?_cons_of_neg _
         (λ (x : α × γ) => x.fst == k) (hd.fst, f hd.snd)
-        (map (fun x => (x.fst, f x.snd)) tl)
-      simp [h₁] at h₃
-      simp [h₂, h₃]
+        (map (λ x => (x.fst, f x.snd)) tl)
+      simp only [h₁, not_false_eq_true, forall_const] at h₃
+      simp only [h₂, h₃]
       exact ih
     case true =>
       have h₂ := @List.find?_cons_of_pos _
         (λ (x : α × β) => x.fst == k) hd tl h₁
       have h₃ := @List.find?_cons_of_pos _
         (λ (x : α × γ) => x.fst == k) (hd.fst, f hd.snd)
-        (map (fun x => (x.fst, f x.snd)) tl)
-      simp [h₁] at h₃
+        (map (λ x => (x.fst, f x.snd)) tl)
+      simp only [h₁, forall_const] at h₃
       simp [h₂, h₃]
 
 theorem find?_fst_map_implies_find? {α β γ} [BEq α] {f : β → γ} {xs : List (α × β)} {k : α} {fx : α × γ}:
-  List.find? (fun x => x.fst == k) (List.map (Prod.map id f) xs) = .some fx  →
-  ∃ x, xs.find? (fun x => x.fst == k) = .some x ∧ fx = Prod.map id f x
+  List.find? (λ x => x.fst == k) (List.map (Prod.map id f) xs) = .some fx  →
+  ∃ x, xs.find? (λ x => x.fst == k) = .some x ∧ fx = Prod.map id f x
 := by
   intro h
   induction xs
-  case nil =>
-    simp only [map_nil, find?_nil] at h
+  case nil => simp at h
   case cons hd tl ih =>
     simp only [map_cons, find?_cons] at h
     split at h
@@ -1100,7 +1428,7 @@ theorem find?_fst_map_implies_find? {α β γ} [BEq α] {f : β → γ} {xs : Li
       replace ⟨x, ih⟩ := ih h
       exists x
       simp only [Prod.map, id_eq] at heq
-      simp only [find?_cons, heq, ih, and_self]
+      simp [find?_cons, heq, ih]
 
 theorem mem_of_sortedBy_implies_find? {α β} [LT β] [StrictLT β] [DecidableLT β] [DecidableEq β]
   {f : α → β} {x : α} {xs : List α} :
@@ -1158,40 +1486,7 @@ theorem mem_of_sortedBy_unique {α β} [LT β] [StrictLT β] [DecidableLT β] [D
       specialize hlt x hx
       simp only [hf, StrictLT.irreflexive] at hlt
 
-/-! ### map -/
-
-/-
-These are copied from Mathlib. We can delete them if they get added to Std.
--/
-
-theorem map_pmap_subtype
-  {p : α → Prop}
-  (f : α → β)
-  (as : List α)
-  (h : ∀ a, a ∈ as → p a)
-  : List.map (fun x : { a : α // p a } => f x.val) (List.pmap Subtype.mk as h)
-    =
-    List.map f as
-:= by
-  induction as <;> simp [*]
-
-theorem all_pmap_subtype
-  {p : α → Prop}
-  (f : α → Bool)
-  (as : List α)
-  (h : ∀ a, a ∈ as → p a)
-  : List.all (List.pmap Subtype.mk as h) (fun x : { a : α // p a } => f x.val)
-    =
-    List.all as f
-:= by
-  induction as <;> simp [*]
-
-theorem map_congr {f g : α → β} : ∀ {l : List α},
-  (∀ x ∈ l, f x = g x) → map f l = map g l
-  | [], _ => rfl
-  | a :: l, h => by
-    let ⟨h₁, h₂⟩ := forall_mem_cons.1 h
-    rw [map, map, h₁, map_congr h₂]
+/-! ### filterMap -/
 
 /--
   our own variant of map_congr, for filterMap
@@ -1202,5 +1497,66 @@ theorem filterMap_congr {f g : α → Option β} : ∀ {l : List α},
   | a :: l, h => by
     let ⟨h₁, h₂⟩ := forall_mem_cons.1 h
     rw [filterMap, filterMap, h₁, filterMap_congr h₂]
+
+theorem filterMap_empty_iff_all_none {f : α → Option β} {xs : List α} :
+  xs.filterMap f = [] ↔ ∀ x ∈ xs, f x = none
+:= by
+  constructor
+  case mp =>
+    induction xs
+    case nil => simp
+    case cons hd tl ih =>
+      intro h₁ a h₂
+      simp only [List.filterMap_cons] at h₁
+      split at h₁ <;> try simp only at h₁
+      case h_1 h₃ =>
+        rcases (List.mem_cons.mp h₂) with h₄ | h₄
+        case inl => subst h₄ ; assumption
+        case inr => apply ih h₁ a ; assumption
+  case mpr =>
+    intro h₁
+    induction xs
+    case nil => simp
+    case cons hd tl ih =>
+      simp only [List.filterMap_cons]
+      split
+      case h_1 =>
+        apply ih ; clear ih
+        intro a h₂
+        apply h₁ a
+        exact List.mem_cons_of_mem hd h₂
+      case h_2 b h₂ =>
+        exfalso
+        specialize h₁ hd
+        simp only [mem_cons, true_or, forall_const] at h₁
+        simp [h₁] at h₂
+
+theorem filterMap_nonempty_iff_exists {f : α → Option β} {xs : List α} :
+  xs.filterMap f ≠ [] ↔ ∃ x ∈ xs, (f x).isSome
+:= by
+  constructor
+  case mp =>
+    intro h₁
+    replace ⟨b, h₁⟩ := List.exists_mem_of_ne_nil (xs.filterMap f) h₁
+    replace ⟨x, h₁⟩ := (List.mem_filterMap f xs).mp h₁
+    exists x
+    simp [h₁, Option.isSome]
+  case mpr =>
+    intro h₁ h₂
+    rw [filterMap_empty_iff_all_none] at h₂
+    replace ⟨x, h₁, h₃⟩ := h₁
+    specialize h₂ x h₁
+    simp [h₂, Option.isSome] at h₃
+
+theorem f_implies_g_then_subset {f g : α → Option β} {xs : List α} :
+  (∀ a b, f a = some b → g a = some b) →
+  xs.filterMap f ⊆ xs.filterMap g
+:= by
+  intro h₁
+  simp only [subset_def, mem_filterMap, forall_exists_index, and_imp]
+  intro b a h₂ h₃
+  exists a
+  apply And.intro h₂
+  exact h₁ a b h₃
 
 end List

--- a/cedar-lean/Cedar/Thm/Data/List.lean
+++ b/cedar-lean/Cedar/Thm/Data/List.lean
@@ -636,6 +636,15 @@ theorem canonicalize_subseteq [LT β] [StrictLT β] [DecidableLT β] (f : α →
     apply Subset.trans ih
     simp
 
+/-- Corollary of `canonicalize_subseteq` -/
+theorem in_canonicalize_in_list [LT β] [StrictLT β] [DecidableLT β] {f : α → β} {x : α} {xs : List α} :
+  x ∈ xs.canonicalize f → x ∈ xs
+:= by
+  intro h₁
+  have h₂ := canonicalize_subseteq f xs
+  simp [List.subset_def] at h₂
+  exact h₂ h₁
+
 /-
 Note that `canonicalize_equiv` does not hold for all functions `f`.
 To see why, consider xs = [(1, false), (1, true)], f = Prod.fst.
@@ -656,8 +665,8 @@ theorem canonicalize_equiv [LT α] [StrictLT α] [DecidableLT α] (xs : List α)
     exact ih
 
 /-
-Open problem: does `equiv_implies_canonical_eq` hold for functions other than `id`?
-In particular, for `Prod.fst`?
+Note that `equiv_implies_canonical_eq` does not hold for all functions `f`.
+To see why, consider the `example` immediately below this.
 -/
 theorem equiv_implies_canonical_eq [LT α] [StrictLT α] [DecidableLT α] (xs ys : List α) :
   xs ≡ ys → (canonicalize id xs) = (canonicalize id ys)
@@ -673,6 +682,23 @@ theorem equiv_implies_canonical_eq [LT α] [StrictLT α] [DecidableLT α] (xs ys
   apply Equiv.trans h₃
   apply Equiv.symm
   exact h₁
+
+/--
+  Illustration that `equiv_implies_canonical_eq` does not hold for
+  all functions `f` -- in particular, does not hold for `Prod.fst`.
+
+  (One `canonicalize` produces `[(1, false)]`, and the other
+  produces `[(1, true)]`.)
+-/
+example :
+  xs = [(1, false), (1, true)] →
+  ys = [(1, true), (1, false)] →
+  xs ≡ ys ∧ (canonicalize Prod.fst xs) ≠ (canonicalize Prod.fst ys)
+:= by
+  intro h₁ h₂
+  subst h₁ h₂
+  simp [List.Equiv]
+  decide
 
 theorem canonicalize_idempotent {α β} [LT β] [StrictLT β] [DecidableLT β] (f : α → β) (xs : List α) :
   canonicalize f (canonicalize f xs) = canonicalize f xs

--- a/cedar-lean/Cedar/Thm/Data/List.lean
+++ b/cedar-lean/Cedar/Thm/Data/List.lean
@@ -1221,7 +1221,7 @@ theorem mapM_some_implies_all_from_some {α β} {f : α → Option β} {xs : Lis
   rw [← List.mapM'_eq_mapM]
   exact mapM'_some_implies_all_from_some
 
-theorem mapM'_none_iff_exists {α β} {f : α → Option β} {xs : List α} :
+theorem mapM'_none_iff_exists_none {α β} {f : α → Option β} {xs : List α} :
   List.mapM' f xs = none ↔ ∃ x ∈ xs, f x = none
 := by
   constructor
@@ -1234,7 +1234,7 @@ theorem mapM'_none_iff_exists {α β} {f : α → Option β} {xs : List α} :
       case some yhd =>
         simp only [mapM'_cons, h₂, Option.pure_def, Option.bind_eq_bind, Option.bind_some_fun,
           Option.bind_eq_none] at h₁
-        apply mapM'_none_iff_exists.mp
+        apply mapM'_none_iff_exists_none.mp
         by_contra h₃
         rw [← ne_eq] at h₃
         replace ⟨ytl, h₃⟩ := Option.ne_none_iff_exists'.mp h₃
@@ -1253,11 +1253,11 @@ theorem mapM'_none_iff_exists {α β} {f : α → Option β} {xs : List α} :
         replace ⟨y, _, h₅⟩ := h₄ x h₁
         simp [h₂] at h₅
 
-theorem mapM_none_iff_exists {α β} {f : α → Option β} {xs : List α} :
+theorem mapM_none_iff_exists_none {α β} {f : α → Option β} {xs : List α} :
   List.mapM f xs = none ↔ ∃ x ∈ xs, f x = none
 := by
   rw [← List.mapM'_eq_mapM]
-  exact mapM'_none_iff_exists
+  exact mapM'_none_iff_exists_none
 
 theorem mapM'_some_eq_filterMap {α β} {f : α → Option β} {xs : List α} {ys : List β} :
   List.mapM' f xs = .some ys →
@@ -1557,7 +1557,7 @@ theorem filterMap_empty_iff_all_none {f : α → Option β} {xs : List α} :
         simp only [mem_cons, true_or, forall_const] at h₁
         simp [h₁] at h₂
 
-theorem filterMap_nonempty_iff_exists {f : α → Option β} {xs : List α} :
+theorem filterMap_nonempty_iff_exists_some {f : α → Option β} {xs : List α} :
   xs.filterMap f ≠ [] ↔ ∃ x ∈ xs, (f x).isSome
 := by
   constructor

--- a/cedar-lean/Cedar/Thm/Data/List.lean
+++ b/cedar-lean/Cedar/Thm/Data/List.lean
@@ -103,8 +103,8 @@ theorem map_equiv (f : α → β) (xs ys : List α) :
   exists p <;>
   rw [List.subset_def] at a b <;>
   simp only [and_true]
-  case left  => exact a h
-  case right => exact b h
+  · exact a h
+  · exact b h
 
 theorem filterMap_equiv (f : α → Option β) (xs ys : List α) :
   xs ≡ ys → xs.filterMap f ≡ ys.filterMap f
@@ -115,8 +115,8 @@ theorem filterMap_equiv (f : α → Option β) (xs ys : List α) :
   intro b a h₃ h₄ <;>
   exists a <;>
   simp only [h₄, and_true]
-  case left  => exact h₁ h₃
-  case right => exact h₂ h₃
+  · exact h₁ h₃
+  · exact h₂ h₃
 
 /-! ### Sorted -/
 
@@ -147,16 +147,14 @@ theorem sortedBy_implies_head_lt_tail [LT β] [StrictLT β] {f : α → β} {x :
     cases h₂
     case head => cases h₁; assumption
     case tail h₂ =>
-      apply ih
-      case _ =>
-        cases h₁
-        case cons_cons h₃ h₄ =>
-          cases h₄
-          case _ => exact SortedBy.cons_nil
-          case cons_cons _ _ hd' tl' h₅ h₆ =>
-            apply SortedBy.cons_cons _ h₅
-            apply StrictLT.transitive (f x) (f hd) (f hd') h₃ h₆
-      case _ => assumption
+      apply ih _ _ h₂
+      cases h₁
+      case cons_cons h₃ h₄ =>
+        cases h₄
+        case _ => exact SortedBy.cons_nil
+        case cons_cons _ _ hd' tl' h₅ h₆ =>
+          apply SortedBy.cons_cons _ h₅
+          exact StrictLT.transitive (f x) (f hd) (f hd') h₃ h₆
 
 theorem sortedBy_equiv_implies_head_eq [LT β] [StrictLT β] (f : α → β) {x y : α} {xs ys : List α} :
   SortedBy f (x :: xs) →
@@ -189,12 +187,11 @@ theorem sortedBy_equiv_implies_tail_subset [LT β] [StrictLT β] (f : α → β)
   intro y h₄
   specialize h₃ h₄
   cases h₃
-  case inr => assumption
-  case inl _ h₅ =>
-    subst h₅
-    have h₆ := sortedBy_implies_head_lt_tail h₁ y h₄
-    have h₇ := StrictLT.irreflexive (f y)
+  · rename_i h₃ ; subst h₃
+    have h₅ := sortedBy_implies_head_lt_tail h₁ y h₄
+    have h₆ := StrictLT.irreflexive (f y)
     contradiction
+  · assumption
 
 theorem sortedBy_equiv_implies_tail_equiv [LT β] [StrictLT β] (f : α → β) {x : α} {xs ys : List α} :
   SortedBy f (x :: xs) →
@@ -301,13 +298,12 @@ theorem filter_sortedBy [LT β] [StrictLT β] [DecidableLT β] {f : α → β} (
     simp only [filter_cons]
     specialize ih (tail_sortedBy h₁)
     split
-    case inl =>
-      apply sortedBy_cons ih
+    · apply sortedBy_cons ih
       intro y h₂
       apply sortedBy_implies_head_lt_tail h₁
       rw [List.mem_filter] at h₂
       exact h₂.left
-    case inr => exact ih
+    · exact ih
 
 theorem filterMap_sortedBy [LT β] [StrictLT β] [DecidableLT β] {f : α → β} {g : α → Option γ} {f' : γ → β} {xs : List α} :
   (∀ x y, g x = some y → f x = f' y) →
@@ -352,9 +348,9 @@ theorem insertCanonical_not_nil [DecidableEq β] [LT β] [DecidableLT β] (f : �
   insertCanonical f x xs ≠ []
 := by
   unfold insertCanonical
-  cases xs with
-  | nil => simp
-  | cons hd tl =>
+  cases xs
+  case nil => simp
+  case cons hd tl =>
     simp only [gt_iff_lt, ne_eq]
     intro h
     split at h <;> try trivial
@@ -369,11 +365,9 @@ theorem insertCanonical_sortedBy [LT β] [StrictLT β] [DecidableLT β] {f : α 
   case nil => simp [insertCanonical, SortedBy.cons_nil]
   case cons hd tl ih =>
     simp only [insertCanonical, gt_iff_lt]
-    split
-    case inl h₂ =>
-      apply SortedBy.cons_cons h₂ h₁
-    case inr h₂ =>
-      split
+    split <;> rename_i h₂
+    · exact SortedBy.cons_cons h₂ h₁
+    · split
       case inl h₃ =>
         cases h₁
         case cons_nil =>
@@ -385,7 +379,7 @@ theorem insertCanonical_sortedBy [LT β] [StrictLT β] [DecidableLT β] {f : α 
           split
           case inl h₆ =>
             apply SortedBy.cons_cons h₃
-            apply SortedBy.cons_cons h₆ h₄
+            exact SortedBy.cons_cons h₆ h₄
           case inr h₆ =>
             split
             case inl h₇ =>
@@ -398,7 +392,7 @@ theorem insertCanonical_sortedBy [LT β] [StrictLT β] [DecidableLT β] {f : α 
               cases h₄
               case cons_nil => exact SortedBy.cons_nil
               case cons_cons z zs h₉ h₁₀ =>
-                apply SortedBy.cons_cons (by simp [h₈, h₁₀]) h₉
+                exact SortedBy.cons_cons (by simp [h₈, h₁₀]) h₉
       case inr h₃ =>
         have h₄ := StrictLT.if_not_lt_gt_then_eq (f x) (f hd) h₂ h₃
         cases h₁
@@ -430,14 +424,12 @@ theorem insertCanonical_subset [LT β] [DecidableLT β] (f : α → β) (x : α)
   case nil => simp only [insertCanonical, Subset.refl]
   case cons hd tl ih =>
     rcases (insertCanonical_cases f x hd tl) with h₁ | h₁ | h₁
-    case inl => simp only [h₁, Subset.refl]
-    case inr.inl =>
-      simp only [h₁, cons_subset, mem_cons, true_or, or_true, true_and]
+    · simp only [h₁, Subset.refl]
+    · simp only [h₁, cons_subset, mem_cons, true_or, or_true, true_and]
       apply Subset.trans ih
       simp only [cons_subset, mem_cons, true_or, true_and]
       exact Subset.trans (List.subset_cons hd tl) (List.subset_cons x (hd :: tl))
-    case inr.inr =>
-      simp only [h₁, cons_subset, mem_cons, true_or, true_and]
+    · simp only [h₁, cons_subset, mem_cons, true_or, true_and]
       exact Subset.trans (List.subset_cons hd tl) (List.subset_cons x (hd :: tl))
 
 theorem insertCanonical_equiv [LT α] [StrictLT α] [DecidableLT α] (x : α) (xs : List α) :
@@ -508,26 +500,21 @@ theorem insertCanonical_preserves_forallᵥ {α β γ} [LT α] [StrictLT α] [De
     apply h₁
   case cons hd₁ hd₂ tl₁ tl₂ h₃ h₄ =>
     simp only [insertCanonical, gt_iff_lt]
-    split <;> split
-    case inl.inl =>
-      apply Forall₂.cons (by exact h₁)
-      apply Forall₂.cons (by exact h₃) (by exact h₄)
-    case inl.inr h₅ h₆ =>
-      simp only [h₁, h₃] at h₅
+    split <;> split <;> rename_i h₅ h₆
+    · apply Forall₂.cons (by exact h₁)
+      exact Forall₂.cons (by exact h₃) (by exact h₄)
+    · simp only [h₁, h₃] at h₅
       have _ := StrictLT.asymmetric kv₂.fst hd₂.fst h₅
       split <;> contradiction
-    case inr.inl h₅ h₆ =>
-      simp only [h₁, h₃] at h₅ h₆
+    · simp only [h₁, h₃] at h₅ h₆
       split
-      case inl => contradiction
-      case inr =>
-        apply Forall₂.cons (by exact h₃)
-        apply insertCanonical_preserves_forallᵥ h₁ h₄
-    case inr.inr h₅ h₆ =>
-      simp only [h₁, h₃] at h₅ h₆
+      · contradiction
+      · apply Forall₂.cons (by exact h₃)
+        exact insertCanonical_preserves_forallᵥ h₁ h₄
+    · simp only [h₁, h₃] at h₅ h₆
       split
-      case inl => contradiction
-      case inr => apply Forall₂.cons (by exact h₁) (by exact h₄)
+      · contradiction
+      · exact Forall₂.cons (by exact h₁) (by exact h₄)
 
 theorem insertCanonical_map_fst {α β γ} [LT α] [StrictLT α] [DecidableLT α] (xs : List (α × β)) (f : β → γ) (x : α × β) :
   insertCanonical Prod.fst (Prod.map id f x) (map (Prod.map id f) xs) =
@@ -538,14 +525,12 @@ theorem insertCanonical_map_fst {α β γ} [LT α] [StrictLT α] [DecidableLT α
   case cons hd tl ih =>
     simp only [insertCanonical, Prod.map, id_eq, map_cons, gt_iff_lt]
     split
-    case inl => simp [Prod.map]
-    case inr =>
-      split
-      case inl =>
-        specialize ih x
+    · simp [Prod.map]
+    · split
+      · specialize ih x
         simp only [Prod.map, id_eq] at ih
         simp [ih, Prod.map]
-      case inr => simp [Prod.map]
+      · simp [Prod.map]
 
 theorem insertCanonical_map_fst_canonicalize {α β γ} [LT α] [StrictLT α] [DecidableLT α] (xs : List (α × β)) (f : β → γ) (x : α × β) :
   insertCanonical Prod.fst (Prod.map id f x) (canonicalize Prod.fst (map (Prod.map id f) xs)) =
@@ -911,12 +896,10 @@ theorem forall₂_implies_all_left {α β} {R : α → β → Prop} {xs : List �
     intro x hx
     simp only [mem_cons] at hx
     rcases hx with hx | hx
-    case inl =>
-      subst hx
+    · subst hx
       exists yhd
       simp only [mem_cons, true_or, hhd, and_self]
-    case inr =>
-      have ⟨y, ih⟩ := ih x hx
+    · have ⟨y, ih⟩ := ih x hx
       exists y
       simp only [mem_cons, ih, or_true, and_self]
 
@@ -932,12 +915,10 @@ theorem forall₂_implies_all_right {α β} {R : α → β → Prop} {xs : List 
     intro y hy
     simp only [mem_cons] at hy
     rcases hy with hy | hy
-    case inl =>
-      subst hy
+    · subst hy
       exists xhd
       simp only [mem_cons, true_or, hhd, and_self]
-    case inr =>
-      have ⟨x, ih⟩ := ih y hy
+    · have ⟨x, ih⟩ := ih y hy
       exists x
       simp only [mem_cons, ih, or_true, and_self]
 
@@ -1261,9 +1242,8 @@ theorem mapM'_none_iff_exists_none {α β} {f : α → Option β} {xs : List α}
       simp only [mapM'_cons, Option.pure_def, Option.bind_eq_bind, Option.bind_eq_none]
       intro yhd h₃ ytl h₄
       rcases h₁ with h₁ | h₁
-      case inl => subst h₁ ; simp [h₂] at h₃
-      case inr =>
-        replace h₄ := mapM'_some_implies_all_some h₄
+      · subst h₁ ; simp [h₂] at h₃
+      · replace h₄ := mapM'_some_implies_all_some h₄
         replace ⟨y, _, h₅⟩ := h₄ x h₁
         simp [h₂] at h₅
 
@@ -1457,15 +1437,13 @@ theorem find?_fst_map_implies_find? {α β γ} [BEq α] {f : β → γ} {xs : Li
   case nil => simp at h
   case cons hd tl ih =>
     simp only [map_cons, find?_cons] at h
-    split at h
-    case h_1 heq =>
-      exists hd
+    split at h <;> rename_i heq
+    · exists hd
       simp only [Option.some.injEq] at h
       simp only [h, and_true]
       simp only [Prod.map, id_eq] at heq
       simp only [find?_cons, heq]
-    case h_2 heq =>
-      replace ⟨x, ih⟩ := ih h
+    · replace ⟨x, ih⟩ := ih h
       exists x
       simp only [Prod.map, id_eq] at heq
       simp [find?_cons, heq, ih]
@@ -1482,23 +1460,17 @@ theorem mem_of_sortedBy_implies_find? {α β} [LT β] [StrictLT β] [DecidableLT
   case cons hd tl ih =>
     simp only [mem_cons] at h₁
     simp only [find?_cons]
-    split
-    case h_1 heq =>
-      simp only [beq_iff_eq] at heq
+    split <;> rename_i heq
+    · simp only [beq_iff_eq] at heq
       simp only [Option.some.injEq]
       rcases h₁ with h₁ | h₁
-      case inl => simp only [h₁]
-      case inr =>
-        have h₃ := sortedBy_implies_head_lt_tail h₂
-        specialize h₃ x h₁
+      · simp only [h₁]
+      · have h₃ := sortedBy_implies_head_lt_tail h₂ x h₁
         simp only [heq, StrictLT.irreflexive] at h₃
-    case h_2 heq =>
-      simp only [beq_eq_false_iff_ne, ne_eq] at heq
+    · simp only [beq_eq_false_iff_ne, ne_eq] at heq
       rcases h₁ with h₁ | h₁
-      case inl =>
-        simp only [h₁, not_true_eq_false] at heq
-      case inr =>
-        exact ih h₁ (tail_sortedBy h₂)
+      · simp only [h₁, not_true_eq_false] at heq
+      · exact ih h₁ (tail_sortedBy h₂)
 
 theorem mem_of_sortedBy_unique {α β} [LT β] [StrictLT β] [DecidableLT β] [DecidableEq β]
   {f : α → β} {x y : α} {xs : List α} :
@@ -1513,18 +1485,15 @@ theorem mem_of_sortedBy_unique {α β} [LT β] [StrictLT β] [DecidableLT β] [D
     simp only [mem_cons] at hx hy
     specialize ih (tail_sortedBy hsrt)
     have hlt := sortedBy_implies_head_lt_tail hsrt
-    rcases hx with hx | hx <;>
-    rcases hy with hy | hy
-    case inl.inl => simp only [hx, hy]
-    case inr.inr => exact ih hx hy
-    case inl.inr =>
-      subst hx
+    rcases hx with hx | hx <;> rcases hy with hy | hy
+    · simp only [hx, hy]
+    · subst hx
       specialize hlt y hy
       simp only [hf, StrictLT.irreflexive] at hlt
-    case inr.inl =>
-      subst hy
+    · subst hy
       specialize hlt x hx
       simp only [hf, StrictLT.irreflexive] at hlt
+    · exact ih hx hy
 
 /-! ### filterMap -/
 
@@ -1548,11 +1517,11 @@ theorem filterMap_empty_iff_all_none {f : α → Option β} {xs : List α} :
     case cons hd tl ih =>
       intro h₁ a h₂
       simp only [List.filterMap_cons] at h₁
-      split at h₁ <;> try simp only at h₁
-      case h_1 h₃ =>
-        rcases (List.mem_cons.mp h₂) with h₄ | h₄
-        case inl => subst h₄ ; assumption
-        case inr => apply ih h₁ a ; assumption
+      split at h₁ <;> rename_i h₃
+      · rcases (List.mem_cons.mp h₂) with h₄ | h₄
+        · subst h₄ ; assumption
+        · apply ih h₁ a ; assumption
+      · simp only at h₁
   case mpr =>
     intro h₁
     induction xs

--- a/cedar-lean/Cedar/Thm/Data/List.lean
+++ b/cedar-lean/Cedar/Thm/Data/List.lean
@@ -1053,6 +1053,13 @@ theorem mapM'_ok_iff_forall₂ {α β γ} {f : α → Except γ β} {xs : List �
         specialize @ih ytl h₃
         simp only [ih, Except.bind_err, Except.bind_ok]
 
+/-- Deprecated alias for the forward direction of `mapM'_ok_iff_forall₂` -/
+@[deprecated]
+theorem mapM'_ok_implies_forall₂ {α β γ} {f : α → Except γ β} {xs : List α} {ys : List β} :
+  List.mapM' f xs = .ok ys →
+  List.Forall₂ (λ x y => f x = .ok y) xs ys
+:= mapM'_ok_iff_forall₂.mp
+
 theorem mapM_ok_iff_forall₂ {α β γ} {f : α → Except γ β} {xs : List α} {ys : List β} :
   List.mapM f xs = .ok ys ↔
   List.Forall₂ (λ x y => f x = .ok y) xs ys
@@ -1177,6 +1184,13 @@ theorem mapM'_some_iff_forall₂ {α β} {f : α → Option β} {xs : List α} {
         simp only [h₁, Option.some.injEq] at h₂
         subst y'
         simp [@ih ytl h₃]
+
+/-- Deprecated alias for the forward direction of `mapM'_some_iff_forall₂` -/
+@[deprecated]
+theorem mapM'_some_implies_forall₂ {α β} {f : α → Option β} {xs : List α} {ys : List β} :
+  List.mapM' f xs = .some ys →
+  List.Forall₂ (λ x y => f x = .some y) xs ys
+:= mapM'_some_iff_forall₂.mp
 
 theorem mapM_some_iff_forall₂ {α β} {f : α → Option β} {xs : List α} {ys : List β} :
   List.mapM f xs = .some ys ↔

--- a/cedar-lean/Cedar/Thm/Data/Map.lean
+++ b/cedar-lean/Cedar/Thm/Data/Map.lean
@@ -363,9 +363,9 @@ theorem mapOnValues_contains {α β γ} [LT α] [DecidableLT α] [DecidableEq α
   Map.contains m k = Map.contains (Map.mapOnValues f m) k
 := by
   simp only [contains, Option.isSome]
-  split
-  case h_1 h => simp [find?_mapOnValues_some f h]
-  case h_2 h => simp [find?_mapOnValues_none f h]
+  split <;> rename_i h
+  · simp [find?_mapOnValues_some f h]
+  · simp [find?_mapOnValues_none f h]
 
 theorem values_mapOnValues [LT α] [StrictLT α] [DecidableLT α] [DecidableEq α] {f : β → γ} {m : Map α β} :
   (m.mapOnValues f).values = m.values.map f
@@ -657,9 +657,8 @@ theorem mapMOnValues_none_iff_exists_none {α : Type 0} [LT α] [DecidableLT α]
       simp only [mapMOnValues_cons h₃, Option.pure_def, Option.bind_eq_bind, Option.bind_eq_none]
       intro yhd h₄ ytl h₅
       rcases h₁ with h₁ | h₁
-      case inl => subst h₁ ; simp [h₂] at h₄
-      case inr =>
-        replace h₅ := mapMOnValues_some_implies_all_some h₅
+      · subst h₁ ; simp [h₂] at h₄
+      · replace h₅ := mapMOnValues_some_implies_all_some h₅
         replace ⟨k', h₁⟩ := in_values_exists_key h₁
         replace ⟨y, _, h₅⟩ := h₅ (k', v) h₁
         simp [h₂] at h₅

--- a/cedar-lean/Cedar/Thm/Data/Map.lean
+++ b/cedar-lean/Cedar/Thm/Data/Map.lean
@@ -277,7 +277,7 @@ theorem find?_mem_toList {α β} [LT α] [DecidableLT α] [DecidableEq α] {m : 
   The `mpr` direction of this does not need the `wf` precondition and, in fact,
   is available separately as `find?_mem_toList` above
 -/
-theorem in_list_some_find? [DecidableEq α] [LT α] [DecidableLT α] [StrictLT α] {k : α} {v : β} {m : Map α β}
+theorem in_list_iff_find?_some [DecidableEq α] [LT α] [DecidableLT α] [StrictLT α] {k : α} {v : β} {m : Map α β}
   (wf : m.WellFormed) :
   (k, v) ∈ m.kvs ↔ m.find? k = some v
 := by
@@ -407,12 +407,12 @@ theorem in_values_iff_findOrErr_ok [LT α] [DecidableLT α] [StrictLT α] [Decid
     simp only at h₂
     subst v'
     exists k
-    simp [h₁, ← in_list_some_find? wf]
+    simp [h₁, ← in_list_iff_find?_some wf]
   case mpr =>
     intro h₁
     replace ⟨k, h₁⟩ := h₁
     exists (k, v)
-    simp [h₁, in_list_some_find? wf, and_true]
+    simp [h₁, in_list_iff_find?_some wf, and_true]
 
 theorem in_kvs_in_mapOnValues [LT α] [DecidableLT α] [DecidableEq α] {f : β → γ} {m : Map α β} {k : α} {v : β} :
   (k, v) ∈ m.kvs → (k, f v) ∈ (m.mapOnValues f).kvs

--- a/cedar-lean/Cedar/Thm/Data/Map.lean
+++ b/cedar-lean/Cedar/Thm/Data/Map.lean
@@ -285,7 +285,7 @@ theorem in_list_iff_find?_some [DecidableEq α] [LT α] [DecidableLT α] [Strict
       exfalso
       rw [List.find?_eq_none] at h₂
       apply h₂ (k, v) h₁ ; clear h₂
-      simp
+      simp only [beq_self_eq_true]
     case some kv =>
       simp only [Option.some.injEq]
       have h₃ := List.find?_some h₂
@@ -314,7 +314,7 @@ theorem find?_mapOnValues {α β γ} [LT α] [DecidableLT α] [DecidableEq α] (
   (m.find? k).map f = (m.mapOnValues f).find? k
 := by
   simp only [find?, kvs, mapOnValues, ← List.find?_pair_map]
-  cases m.1.find? (λ x => x.fst == k) <;> simp
+  cases m.1.find? (λ x => x.fst == k) <;> simp only [Option.map_none', Option.map_some']
 
 theorem find?_mapOnValues_some {α β γ} [LT α] [DecidableLT α] [DecidableEq α] (f : β → γ) {m : Map α β} {k : α} {v : β} :
   m.find? k = .some v →
@@ -372,7 +372,7 @@ theorem values_mapOnValues [LT α] [StrictLT α] [DecidableLT α] [DecidableEq �
 := by
   unfold mapOnValues values kvs
   induction m.1
-  case nil => simp
+  case nil => simp only [List.map_nil]
   case cons hd tl ih =>
     simp only [List.map_cons, List.cons.injEq, true_and]
     trivial
@@ -388,7 +388,7 @@ theorem findOrErr_ok_iff_find?_some [LT α] [DecidableLT α] [DecidableEq α] {m
   m.findOrErr k e = .ok v ↔ m.find? k = some v
 := by
   unfold findOrErr
-  cases m.find? k <;> simp
+  cases m.find? k <;> simp only [Except.ok.injEq, Option.some.injEq]
 
 theorem in_values_iff_findOrErr_ok [LT α] [DecidableLT α] [StrictLT α] [DecidableEq α] {m : Map α β} {v : β} {e : Error}
   (wf : m.WellFormed) :
@@ -634,7 +634,7 @@ theorem mapMOnValues_none_iff_exists_none {α : Type 0} [LT α] [DecidableLT α]
       simp only [mapMOnValues_cons h₂, Option.pure_def, Option.bind_eq_bind,
         Option.bind_eq_none] at h₁
       cases h₃ : f vhd
-      case none => simp
+      case none => simp only [true_or]
       case some yhd =>
         right
         specialize h₁ yhd h₃

--- a/cedar-lean/Cedar/Thm/Data/Map.lean
+++ b/cedar-lean/Cedar/Thm/Data/Map.lean
@@ -467,6 +467,30 @@ theorem mapMOnValues_wf [LT α] [DecidableLT α] [StrictLT α] {f : β → Optio
   have h₂ := mapMOnValues_preserves_keys h₁
   exact (List.map_eq_implies_sortedBy h₂).mp wf
 
+/--
+  Alternate proof of `mapMOnValues_wf`, that relies on
+  `List.mapM_some_eq_filterMap` instead of `mapMOnValues_preserves_keys`. Which do
+  we prefer?
+-/
+theorem mapMOnValues_wf_alt_proof [LT α] [DecidableLT α] [StrictLT α] {f : β → Option γ} {m₁ : Map α β} {m₂ : Map α γ} :
+  m₁.WellFormed →
+  (m₁.mapMOnValues f = some m₂) →
+  m₂.WellFormed
+:= by
+  simp only [wf_iff_sorted, toList]
+  intro wf h₁
+  simp [mapMOnValues] at h₁
+  replace ⟨xs, h₁, h₂⟩ := h₁
+  subst h₂
+  simp [kvs]
+  replace h₁ := List.mapM_some_eq_filterMap h₁
+  subst h₁
+  apply List.filterMap_sortedBy _ wf
+  intro (k, v) (k', v') h₁
+  simp only at *
+  cases h₂ : f v <;> simp [h₂, Option.bind] at h₁
+  exact h₁.left
+
 theorem mapMOnValues_nil [LT α] [DecidableLT α] {f : β → Option γ} :
   (Map.empty : Map α β).mapMOnValues f = some Map.empty
 := by

--- a/cedar-lean/Cedar/Thm/Data/Map.lean
+++ b/cedar-lean/Cedar/Thm/Data/Map.lean
@@ -623,7 +623,7 @@ theorem mapMOnValues_some_implies_all_from_some_alt_proof [LT α] [DecidableLT �
     subst a'
     exists b
 
-theorem mapMOnValues_none_iff_exists {α : Type 0} [LT α] [DecidableLT α] {f : β → Option γ} {m : Map α β} :
+theorem mapMOnValues_none_iff_exists_none {α : Type 0} [LT α] [DecidableLT α] {f : β → Option γ} {m : Map α β} :
   m.mapMOnValues f = none ↔ ∃ v ∈ m.values, f v = none
 := by
   constructor
@@ -644,7 +644,7 @@ theorem mapMOnValues_none_iff_exists {α : Type 0} [LT α] [DecidableLT α] {f :
         right
         specialize h₁ yhd h₃
         have := sizeOf_lt_of_tl h₂ -- required for Lean to allow the following recursive call
-        apply mapMOnValues_none_iff_exists.mp
+        apply mapMOnValues_none_iff_exists_none.mp
         by_contra h₄
         rw [← ne_eq] at h₄
         replace ⟨ytl, h₄⟩ := Option.ne_none_iff_exists'.mp h₄

--- a/cedar-lean/Cedar/Thm/Data/Map.lean
+++ b/cedar-lean/Cedar/Thm/Data/Map.lean
@@ -27,6 +27,43 @@ This file proves useful properties of canonical list-based maps defined in
 
 namespace Cedar.Data.Map
 
+/-! ### sizeOf -/
+
+theorem sizeOf_lt_of_value [SizeOf α] [SizeOf β] {m : Map α β} {k : α} {v : β}
+  (h : (k, v) ∈ m.1) :
+  sizeOf v < sizeOf m
+:= by
+  simp only [Membership.mem] at h
+  replace h := List.sizeOf_lt_of_mem h
+  have v_lt_kv : sizeOf v < sizeOf (k, v) := by
+    simp only [sizeOf, Prod._sizeOf_1]
+    omega
+  have m1_lt_m : sizeOf m.1 < sizeOf m := by
+    simp only [sizeOf, _sizeOf_1]
+    omega
+  let a := sizeOf v
+  let c := sizeOf m.1
+  let d := sizeOf m
+  have v_lt_m1 : a < c := by apply Nat.lt_trans v_lt_kv h
+  have v_lt_m : a < d := by apply Nat.lt_trans v_lt_m1 m1_lt_m
+  have ha : a = sizeOf v := by simp
+  have hd : d = sizeOf m := by simp
+  rw [ha, hd] at v_lt_m
+  exact v_lt_m
+
+theorem sizeOf_lt_of_tl [SizeOf α] [SizeOf β] {m : Map α β} {tl : List (α × β)}
+  (h : m.kvs = (k, v) :: tl) :
+  1 + sizeOf tl < sizeOf m
+:= by
+  conv => rhs ; unfold sizeOf _sizeOf_inst _sizeOf_1
+  simp only
+  unfold kvs at h
+  simp only [h, List.cons.sizeOf_spec, Prod.mk.sizeOf_spec]
+  generalize sizeOf k = kn
+  generalize sizeOf v = vn
+  generalize sizeOf tl = tn
+  omega
+
 /-! ### Well-formed maps -/
 
 def WellFormed {α β} [LT α] [DecidableLT α] (m : Map α β) :=
@@ -47,7 +84,85 @@ theorem wf_iff_sorted {α β} [LT α] [DecidableLT α] [StrictLT α] {m : Map α
     replace h := List.sortedBy_implies_canonicalize_eq h
     rw [WellFormed, toList, kvs, make, h]
 
-/-! ### contains and mem -/
+theorem if_wf_then_exists_make [LT α] [DecidableLT α] (m : Map α β) :
+  m.WellFormed → ∃ list, m = Map.make list
+:= by
+  intro h₁
+  exists m.kvs
+
+/--
+  In well-formed maps, if there are two pairs with the same key, then they have
+  the same value
+-/
+theorem key_maps_to_one_value [DecidableEq α] [LT α] [DecidableLT α] [StrictLT α] (k : α) (v₁ v₂ : β) (m : Map α β) :
+  m.WellFormed →
+  (k, v₁) ∈ m.kvs →
+  (k, v₂) ∈ m.kvs →
+  v₁ = v₂
+:= by
+  simp only [wf_iff_sorted, toList]
+  intro wf h₁ h₂
+  have h₃ := List.mem_of_sortedBy_unique wf h₁ h₂ (by simp)
+  injection h₃
+
+/--
+  `make` on equivalent lists of (k,v) pairs produces equal maps
+
+  (Organizationally belongs in the `make` section, but is needed before that)
+-/
+theorem make_eqv [LT α] [DecidableLT α] {xs ys : List (α × β)}:
+  xs ≡ ys →
+  Map.make xs = Map.make ys
+:= by
+  intro h; unfold make; simp
+  sorry
+
+/--
+  (Organizationally belongs in the `make` section, but is needed before that)
+-/
+theorem make_of_make_is_id [LT α] [DecidableLT α] [StrictLT α] (xs : List (α × β)) :
+  Map.make (Map.kvs (Map.make xs)) = Map.make xs
+:= by
+  simp only [make, mk.injEq]
+  have h₁ := List.canonicalize_idempotent Prod.fst xs
+  unfold id at h₁
+  exact h₁
+
+/--
+  If two well-formed maps have equivalent (k,v) sets, then the maps are actually
+  equal
+-/
+theorem eq_iff_kvs_equiv [LT α] [DecidableLT α] [StrictLT α] {m₁ m₂ : Map α β}
+  (wf₁ : m₁.WellFormed)
+  (wf₂ : m₂.WellFormed) :
+  m₁.kvs ≡ m₂.kvs ↔ m₁ = m₂
+:= by
+  constructor
+  case mp =>
+    intro h₁
+    replace ⟨kvs₁, wf₁⟩ := if_wf_then_exists_make m₁ wf₁
+    subst wf₁
+    replace ⟨kvs₂, wf₂⟩ := if_wf_then_exists_make m₂ wf₂
+    subst wf₂
+    replace h₁ := make_eqv h₁
+    simp only [make_of_make_is_id] at h₁
+    exact h₁
+  case mpr =>
+    intro h₁
+    subst h₁
+    exact List.Equiv.refl
+
+/-! ### contains, mem, kvs, values -/
+
+theorem kvs_nil_iff_empty {m : Map α β} :
+  m.kvs = [] ↔ m = Map.empty
+:= by
+  unfold kvs empty
+  constructor <;> intro h
+  case mp => match m with
+    | mk [] => trivial
+    | mk ((k, v) :: kvs) => trivial
+  case mpr => simp [h]
 
 theorem in_list_in_map {α : Type u} (k : α) (v : β) (m : Map α β) :
   (k, v) ∈ m.kvs → k ∈ m
@@ -55,6 +170,30 @@ theorem in_list_in_map {α : Type u} (k : α) (v : β) (m : Map α β) :
   intro h₀
   have h₁ : k ∈ (List.map Prod.fst m.kvs) := by simp only [List.mem_map] ; exists (k, v)
   apply h₁
+
+theorem in_list_in_values {k : α} {v : β} {m : Map α β} :
+  (k, v) ∈ m.kvs → v ∈ m.values
+:= by
+  simp only [values, List.mem_map]
+  intro h₁
+  exists (k, v)
+
+/-- kinda the converse of `in_list_in_values` -/
+theorem in_values_exists_key {m : Map α β} {v : β} :
+  v ∈ m.values → ∃ k, (k, v) ∈ m.kvs
+:= by
+  simp only [values, List.mem_map, forall_exists_index, and_imp]
+  intro kv h₁ h₂
+  subst h₂
+  exists kv.fst
+
+theorem values_cons {m : Map α β} :
+  m.kvs = (k, v) :: tl →
+  m.values = v :: (mk tl).values
+:= by
+  unfold values kvs
+  intro h₁
+  simp [h₁]
 
 theorem contains_iff_some_find? {α β} [BEq α] {m : Map α β} {k : α} :
   m.contains k ↔ ∃ v, m.find? k = .some v
@@ -85,28 +224,109 @@ theorem make_mem_list_mem [LT α] [StrictLT α] [DecidableLT α] {xs : List (α 
   simp only [kvs, make]
   intro h₁
   have h₂ := List.canonicalize_subseteq Prod.fst xs
-  simp [List.subset_def] at h₂
+  simp only [List.subset_def] at h₂
   exact h₂ h₁
+
+/--
+  Very similar to `make_mem_list_mem` above
+-/
+theorem mem_values_make [LT α] [StrictLT α] [DecidableLT α] {xs : List (α × β)} :
+  v ∈ (Map.make xs).values → v ∈ xs.map Prod.snd
+:= by
+  -- despite the similarity to `make_mem_list_mem`, the proof does not currently
+  -- use `make_mem_list_mem`
+  simp only [values, make]
+  simp only [List.mem_map, forall_exists_index, and_imp]
+  intro (k, v) h₁ h₂
+  exists (k, v)
+  subst h₂
+  simp only [and_true]
+  have h₂ := List.canonicalize_subseteq Prod.fst xs
+  simp only [List.subset_def] at h₂
+  exact @h₂ (k, v) h₁
 
 theorem make_nil_is_empty {α β} [LT α] [DecidableLT α] :
   (Map.make [] : Map α β) = Map.empty
 := by simp [make, empty, List.canonicalize_nil]
 
+/--
+  Note that the converse of this is not true:
+  counterexample `xs = [(1, false)]`, `ys = []`, `ab = (1, false)`.
+-/
+theorem make_cons [LT α] [DecidableLT α] {xs ys : List (α × β)} {ab : α × β} :
+  make xs = make ys → make (ab :: xs) = make (ab :: ys)
+:= by
+  simp only [make, mk.injEq]
+  apply List.canonicalize_cons
+
 /-! ### find? and mapOnValues -/
+
+theorem find?_mem_toList {α β} [LT α] [DecidableLT α] [DecidableEq α] {m : Map α β} {k : α} {v : β}
+  (h₁ : m.find? k = .some v) :
+  (k, v) ∈ m.toList
+:= by
+  unfold toList kvs find? at *
+  split at h₁ <;> simp only [Option.some.injEq] at h₁
+  subst h₁
+  rename_i h₂
+  have h₃ := List.find?_some h₂
+  simp only [beq_iff_eq] at h₃ ; subst h₃
+  exact List.mem_of_find?_eq_some h₂
+
+/--
+  The `mpr` direction of this does not need the `wf` precondition and, in fact,
+  is available separately as `find?_mem_toList` above
+-/
+theorem in_list_some_find? [DecidableEq α] [LT α] [DecidableLT α] [StrictLT α] {k : α} {v : β} {m : Map α β}
+  (wf : m.WellFormed) :
+  (k, v) ∈ m.kvs ↔ m.find? k = some v
+:= by
+  unfold find?
+  constructor
+  case mp =>
+    intro h₁
+    cases h₂ : m.kvs.find? λ x => match x with | (k', _) => k' == k
+    case none =>
+      exfalso
+      rw [List.find?_eq_none] at h₂
+      apply h₂ (k, v) h₁ ; clear h₂
+      simp
+    case some kv =>
+      simp only [Option.some.injEq]
+      have h₃ := List.find?_some h₂
+      simp only [beq_iff_eq] at h₃
+      subst h₃
+      replace h₃ := List.mem_of_find?_eq_some h₂
+      apply (key_maps_to_one_value kv.fst v kv.snd m wf h₁ _).symm
+      trivial
+  case mpr => exact find?_mem_toList
+
+theorem mapOnValues_wf [DecidableEq α] [LT α] [DecidableLT α] [StrictLT α] {f : β → γ} {m : Map α β} :
+  m.WellFormed ↔ (m.mapOnValues f).WellFormed
+:= by
+  simp only [wf_iff_sorted, toList]
+  apply List.map_eq_implies_sortedBy
+  simp only [kvs, mapOnValues, List.map_map]
+  apply List.map_congr
+  simp
+
+theorem mapOnValues_empty {α β γ} [LT α] [DecidableLT α] [DecidableEq α] {f : β → γ} :
+  (empty : Map α β).mapOnValues f = empty
+:= by
+  simp [mapOnValues, empty]
 
 theorem find?_mapOnValues {α β γ} [LT α] [DecidableLT α] [DecidableEq α] (f : β → γ) (m : Map α β) (k : α)  :
   (m.find? k).map f = (m.mapOnValues f).find? k
 := by
-  simp [Map.find?, Map.mapOnValues, Map.kvs, ←List.find?_pair_map]
-  cases __ : List.find? (fun x => x.fst == k) m.1 <;>
-  simp only [Option.map_none', Option.map_some']
+  simp only [find?, kvs, mapOnValues, ← List.find?_pair_map]
+  cases m.1.find? (λ x => x.fst == k) <;> simp
 
 theorem find?_mapOnValues_some {α β γ} [LT α] [DecidableLT α] [DecidableEq α] (f : β → γ) {m : Map α β} {k : α} {v : β} :
   m.find? k = .some v →
   (m.mapOnValues f).find? k = .some (f v)
 := by
   intro h₁
-  rw [← find?_mapOnValues f m k]
+  rw [← find?_mapOnValues]
   simp [Option.map, h₁]
 
 theorem find?_mapOnValues_none {α β γ} [LT α] [DecidableLT α] [DecidableEq α] (f : β → γ) {m : Map α β} {k : α} :
@@ -114,30 +334,18 @@ theorem find?_mapOnValues_none {α β γ} [LT α] [DecidableLT α] [DecidableEq 
   (m.mapOnValues f).find? k = .none
 := by
   intro h₁
-  rw [← find?_mapOnValues f m k]
+  rw [← find?_mapOnValues]
   simp [Option.map, h₁]
 
 theorem mapOnValues_eq_make_map {α β γ} [LT α] [StrictLT α] [DecidableLT α] (f : β → γ) {m : Map α β}
-  (h₁ : m.WellFormed) :
+  (wf : m.WellFormed) :
   m.mapOnValues f = Map.make (m.toList.map λ kv => (kv.fst, f kv.snd))
 := by
-  simp [Map.WellFormed] at h₁
-  simp [Map.mapOnValues, Map.toList, Map.kvs, Map.make] at *
-  rw [h₁] ; simp only ; rw [eq_comm]
-  have h₂ : Prod.map id f = (fun (x : α × β) => (x.fst, f x.snd)) := by unfold Prod.map ; simp only [id_eq]
-  simp only [← h₂, ← List.canonicalize_of_map_fst, List.canonicalize_idempotent]
-
-theorem find?_mem_toList {α β} [LT α] [DecidableLT α] [DecidableEq α] {m : Map α β} {k : α} {v : β}
-  (h₁ : m.find? k = .some v) :
-  (k, v) ∈ m.toList
-:= by
-  simp [Map.toList, Map.kvs, Map.find?] at *
-  split at h₁ <;> simp at h₁
-  subst h₁
-  rename_i h₂
-  have h₃ := List.find?_some h₂
-  simp at h₃ ; subst h₃
-  exact List.mem_of_find?_eq_some h₂
+  unfold WellFormed at wf
+  simp only [make, toList, kvs, mapOnValues, mk.injEq] at *
+  rw [wf] ; simp only ; rw [eq_comm]
+  have h₁ : Prod.map id f = (λ (x : α × β) => (x.fst, f x.snd)) := by unfold Prod.map ; simp only [id_eq]
+  simp only [← h₁, ← List.canonicalize_of_map_fst, List.canonicalize_idempotent]
 
 theorem mem_toList_find? {α β} [LT α] [DecidableLT α] [StrictLT α] [DecidableEq α] {m : Map α β} {k : α} {v : β}
   (h₁ : m.WellFormed)
@@ -164,31 +372,279 @@ theorem mapOnValues_contains {α β γ} [LT α] [DecidableLT α] [DecidableEq α
   case h_1 h => simp [find?_mapOnValues_some f h]
   case h_2 h => simp [find?_mapOnValues_none f h]
 
-
-/-! ### sizeOf -/
-
-theorem sizeOf_lt_of_value [SizeOf α] [SizeOf β] {m : Map α β} {k : α} {v : β}
-  (h : (k, v) ∈ m.1) :
-  sizeOf v < sizeOf m
+theorem values_mapOnValues [LT α] [StrictLT α] [DecidableLT α] [DecidableEq α] {f : β → γ} {m : Map α β} :
+  (m.mapOnValues f).values = m.values.map f
 := by
-  simp only [Membership.mem] at h
-  replace h := List.sizeOf_lt_of_mem h
-  have _ : sizeOf v < sizeOf (k, v) := by
-    simp only [sizeOf, Prod._sizeOf_1]
-    omega
-  have _ : sizeOf m.1 < sizeOf m := by
-    simp only [sizeOf, _sizeOf_1]
-    omega
-  rename_i v_lt_kv m1_lt_m
-  let a := sizeOf v
-  let c := sizeOf m.1
-  let d := sizeOf m
-  have v_lt_m1 : a < c := by apply Nat.lt_trans v_lt_kv h
-  have v_lt_m : a < d := by apply Nat.lt_trans v_lt_m1 m1_lt_m
-  have ha : a = sizeOf v := by simp
-  have hd : d = sizeOf m := by simp
-  rw [ha, hd] at v_lt_m
-  exact v_lt_m
+  unfold mapOnValues values kvs
+  induction m.1
+  case nil => simp
+  case cons hd tl ih =>
+    simp only [List.map_cons, List.cons.injEq, true_and]
+    trivial
+
+theorem findOrErr_mapOnValues [LT α] [DecidableLT α] [DecidableEq α] {f : β → γ} {m : Map α β} {k : α} {e : Error} :
+  (m.mapOnValues f).findOrErr k e = (m.findOrErr k e).map f
+:= by
+  unfold findOrErr
+  rw [← find?_mapOnValues]
+  cases m.find? k <;> simp [Except.map]
+
+theorem findOrErr_ok_iff_find?_some [LT α] [DecidableLT α] [DecidableEq α] {m : Map α β} {k : α} {v : β} {e : Error} :
+  m.findOrErr k e = .ok v ↔ m.find? k = some v
+:= by
+  unfold findOrErr
+  cases m.find? k <;> simp
+
+theorem in_values_iff_findOrErr_ok [LT α] [DecidableLT α] [StrictLT α] [DecidableEq α] {m : Map α β} {v : β} {e : Error}
+  (wf : m.WellFormed) :
+  v ∈ m.values ↔ ∃ k, m.findOrErr k e = .ok v
+:= by
+  simp only [values, List.mem_map, findOrErr_ok_iff_find?_some]
+  constructor
+  case mp =>
+    intro h₁
+    replace ⟨⟨k, v'⟩, ⟨h₁, h₂⟩⟩ := h₁
+    simp only at h₂
+    subst v'
+    exists k
+    simp [h₁, ← in_list_some_find? wf]
+  case mpr =>
+    intro h₁
+    replace ⟨k, h₁⟩ := h₁
+    exists (k, v)
+    simp [h₁, in_list_some_find? wf, and_true]
+
+theorem in_kvs_in_mapOnValues [LT α] [DecidableLT α] [DecidableEq α] {f : β → γ} {m : Map α β} {k : α} {v : β} :
+  (k, v) ∈ m.kvs → (k, f v) ∈ (m.mapOnValues f).kvs
+:= by
+  unfold mapOnValues
+  intro h₁
+  simp only [kvs, List.mem_map, Prod.mk.injEq]
+  exists (k, v)
+
+/-! ### mapMOnValues -/
+
+/--
+  This is not stated in terms of `Map.keys` because `Map.keys` produces a `Set`,
+  and we want the even stronger property that it not only preserves the key-set,
+  but also the key-order. (We'll use this to prove `mapMOnValues_wf`.)
+-/
+theorem mapMOnValues_preserves_keys [LT α] [DecidableLT α] [StrictLT α] {f : β → Option γ} {m₁ : Map α β} {m₂ : Map α γ} :
+  m₁.mapMOnValues f = some m₂ →
+  m₁.kvs.map Prod.fst = m₂.kvs.map Prod.fst
+:= by
+  intro h₁
+  simp only [mapMOnValues, Option.pure_def, Option.bind_eq_bind, Option.bind_eq_some,
+    Option.some.injEq] at h₁
+  replace ⟨xs, h₁, h₂⟩ := h₁
+  subst h₂
+  cases h₂ : m₁.kvs <;> simp only [h₂, List.mapM_nil, List.mapM_cons, Option.pure_def,
+    Option.bind_eq_bind, Option.bind_eq_some, Option.some.injEq] at h₁
+  <;> unfold kvs at *
+  case nil =>
+    subst h₁
+    simp [h₂]
+  case cons kv tl =>
+    have (k, v) := kv ; clear kv
+    replace ⟨(k', y), ⟨y', h₁, h₃⟩, ⟨tl', h₄, h₅⟩⟩ := h₁
+    subst h₅
+    simp only [Prod.mk.injEq, List.map_cons, List.cons.injEq] at *
+    replace ⟨h₃, h₃'⟩ := h₃
+    subst k' y'
+    have ih := mapMOnValues_preserves_keys (m₁ := mk tl) (m₂ := mk tl') (f := f)
+    simp only [mapMOnValues, kvs, Option.pure_def, Option.bind_eq_bind,
+      Option.bind_eq_some, Option.some.injEq, mk.injEq, exists_eq_right] at ih
+    specialize ih h₄
+    simp [ih, h₂]
+
+theorem mapMOnValues_wf [LT α] [DecidableLT α] [StrictLT α] {f : β → Option γ} {m₁ : Map α β} {m₂ : Map α γ} :
+  m₁.WellFormed →
+  (m₁.mapMOnValues f = some m₂) →
+  m₂.WellFormed
+:= by
+  simp only [wf_iff_sorted, toList]
+  intro wf h₁
+  have h₂ := mapMOnValues_preserves_keys h₁
+  exact (List.map_eq_implies_sortedBy h₂).mp wf
+
+theorem mapMOnValues_nil [LT α] [DecidableLT α] {f : β → Option γ} :
+  (Map.empty : Map α β).mapMOnValues f = some Map.empty
+:= by
+  simp [mapMOnValues, empty, kvs, List.mapM_nil]
+
+theorem mapMOnValues_cons {α : Type 0} [LT α] [DecidableLT α] {f : β → Option γ} {m : Map α β} {k : α} {v : β} {tl : List (α × β)}:
+  m.kvs = (k, v) :: tl →
+  (m.mapMOnValues f = do
+    let v' ← f v
+    let tl' ← (mk tl).mapMOnValues f
+    return mk ((k, v') :: tl'.kvs))
+:= by
+  intro h₁
+  cases h₂ : f v <;> simp only [Option.pure_def, Option.bind_eq_bind, Option.bind_none_fun, Option.bind_some_fun]
+  case none => unfold mapMOnValues ; simp [h₁, h₂]
+  case some v' =>
+    cases h₃ : (mk tl).mapMOnValues f <;> simp only [Option.none_bind, Option.some_bind]
+    <;> unfold mapMOnValues at *
+    case none =>
+      simp only [h₁, Option.pure_def, Option.bind_eq_bind, List.mapM_cons, Option.bind_eq_none,
+        Option.bind_eq_some, Option.some.injEq, forall_exists_index, and_imp,
+        forall_apply_eq_imp_iff₂]
+      intro kvs' v'' h₄ tl' h₅ h₆
+      simp only [h₂, Option.some.injEq] at h₄
+      subst v'' kvs'
+      cases (tl.mapM λ x => match x with | (k, v) => do let v' ← f v ; pure (k, v'))
+      <;> simp only [Option.pure_def, Option.bind_eq_bind, Option.bind_eq_none] at h₃
+      <;> exact h₃ tl' h₅
+    case some mtl' =>
+      simp only [h₁, Option.pure_def, Option.bind_eq_bind, Option.bind_eq_some, Option.some.injEq,
+        List.mapM_cons, mk.injEq, exists_eq_right, List.cons.injEq, exists_eq_right_right,
+        Prod.mk.injEq, true_and] at *
+      apply And.intro h₂
+      replace ⟨tl', h₃, h₄⟩ := h₃
+      subst mtl'
+      simp [h₃]
+
+theorem mapMOnValues_some_implies_forall₂ [LT α] [DecidableLT α] {f : β → Option γ} {m₁ : Map α β} {m₂ : Map α γ} :
+  m₁.mapMOnValues f = some m₂ →
+  List.Forall₂ (λ kv₁ kv₂ => kv₁.fst = kv₂.fst ∧ f kv₁.snd = some kv₂.snd) m₁.kvs m₂.kvs
+:= by
+  unfold mapMOnValues kvs
+  intro h₁
+  simp only [Option.pure_def, Option.bind_eq_bind, Option.bind_eq_some, Option.some.injEq] at h₁
+  replace ⟨x, h₁, h₂⟩ := h₁
+  subst h₂
+  replace h₁ := List.mapM_some_iff_forall₂.mp h₁
+  simp only
+  apply List.Forall₂.imp _ h₁
+  intro (k, v) (k', v') h₂
+  simp only [Option.bind_eq_some, Option.some.injEq, Prod.mk.injEq, exists_eq_right_right] at h₂
+  replace ⟨h₂, h₂'⟩ := h₂
+  subst k'
+  simp only [true_and]
+  exact h₂
+
+theorem mapMOnValues_some_implies_all_some {α : Type 0} [LT α] [DecidableLT α] {f : β → Option γ} {m₁ : Map α β} {m₂ : Map α γ} :
+  m₁.mapMOnValues f = some m₂ →
+  ∀ kv ∈ m₁.kvs, ∃ v, (kv.fst, v) ∈ m₂.kvs ∧ f kv.snd = some v
+:= by
+  intro h₁
+  replace h₁ := List.forall₂_implies_all_left (mapMOnValues_some_implies_forall₂ h₁)
+  intro (k, v) h₂
+  replace ⟨(k', v'), h₁, h₃, h₄⟩ := h₁ (k, v) h₂
+  simp only at *
+  subst k'
+  exists v'
+
+/--
+  alternate proof of `mapMOnValues_some_implies_all_some`, which instead of
+  relying on `mapMOnValues_some_implies_forall₂`, relies on
+  `List.mapM_some_implies_all_some`.  Which do we prefer?
+-/
+theorem mapMOnValues_some_implies_all_some_alt_proof [LT α] [DecidableLT α] {f : β → Option γ} {m₁ : Map α β} {m₂ : Map α γ} :
+  m₁.mapMOnValues f = some m₂ →
+  ∀ kv ∈ m₁.kvs, ∃ v, (kv.fst, v) ∈ m₂.kvs ∧ f kv.snd = some v
+:= by
+  unfold mapMOnValues
+  intro h₁ kv h₂
+  cases h₃ : m₁.kvs.mapM (λ x => match x with | (k, v) => do let v' ← f v ; pure (k, v'))
+  <;> rw [h₃] at h₁
+  <;> simp only [Option.pure_def, Option.bind_some_fun, Option.bind_none_fun, Option.some.injEq] at h₁
+  case some ags =>
+    subst h₁
+    have (a, b) := kv ; clear kv
+    simp only
+    replace h₃ := List.mapM_some_implies_all_some h₃
+    replace ⟨(a', g), h₃, h₄⟩ := h₃ (a, b) h₂
+    simp only [Option.pure_def, Option.bind_eq_bind, Option.bind_eq_some, Option.some.injEq,
+      Prod.mk.injEq, exists_eq_right_right] at h₄
+    replace ⟨h₄, h₄'⟩ := h₄
+    subst a'
+    exists g
+
+theorem mapMOnValues_some_implies_all_from_some [LT α] [DecidableLT α] {f : β → Option γ} {m₁ : Map α β} {m₂ : Map α γ} :
+  m₁.mapMOnValues f = some m₂ →
+  ∀ kv ∈ m₂.kvs, ∃ v, (kv.fst, v) ∈ m₁.kvs ∧ f v = kv.snd
+:= by
+  intro h₁
+  replace h₁ := List.forall₂_implies_all_right (mapMOnValues_some_implies_forall₂ h₁)
+  intro (k, v) h₂
+  replace ⟨(k', v'), h₁, h₃, h₄⟩ := h₁ (k, v) h₂
+  simp only at *
+  subst k'
+  exists v'
+
+/--
+  alternate proof of `mapMOnValues_some_implies_all_from_some`, which instead of
+  relying on `mapMOnValues_some_implies_forall₂`, relies on
+  `List.mapM_some_implies_all_from_some`. Which do we prefer?
+-/
+theorem mapMOnValues_some_implies_all_from_some_alt_proof [LT α] [DecidableLT α] {f : β → Option γ} {m₁ : Map α β} {m₂ : Map α γ} :
+  m₁.mapMOnValues f = some m₂ →
+  ∀ kv ∈ m₂.kvs, ∃ v, (kv.fst, v) ∈ m₁.kvs ∧ f v = kv.snd
+:= by
+  unfold mapMOnValues
+  intro h₁ kv h₂
+  cases h₃ : m₁.kvs.mapM (λ x => match x with | (k, v) => do let v' ← f v ; pure (k, v'))
+  <;> rw [h₃] at h₁
+  <;> simp only [Option.pure_def, Option.bind_some_fun, Option.bind_none_fun, Option.some.injEq] at h₁
+  case some ags =>
+    subst h₁
+    have (a, g) := kv ; clear kv
+    simp only
+    replace h₃ := List.mapM_some_implies_all_from_some h₃
+    replace ⟨(a', b), h₃, h₄⟩ := h₃ (a, g) h₂
+    simp only [Option.pure_def, Option.bind_eq_bind, Option.bind_eq_some, Option.some.injEq,
+      Prod.mk.injEq, exists_eq_right_right] at h₄
+    replace ⟨h₄, h₄'⟩ := h₄
+    subst a'
+    exists b
+
+theorem mapMOnValues_none_iff_exists {α : Type 0} [LT α] [DecidableLT α] {f : β → Option γ} {m : Map α β} :
+  m.mapMOnValues f = none ↔ ∃ v ∈ m.values, f v = none
+:= by
+  constructor
+  case mp =>
+    intro h₁
+    cases h₂ : m.kvs <;> simp only at h₁
+    case nil =>
+      rw [kvs_nil_iff_empty] at h₂ ; subst h₂
+      simp [mapMOnValues_nil] at h₁
+    case cons hd tl =>
+      have (khd, vhd) := hd ; clear hd
+      simp only [values_cons h₂, List.mem_cons, exists_eq_or_imp]
+      simp only [mapMOnValues_cons h₂, Option.pure_def, Option.bind_eq_bind,
+        Option.bind_eq_none] at h₁
+      cases h₃ : f vhd
+      case none => simp
+      case some yhd =>
+        right
+        specialize h₁ yhd h₃
+        have := sizeOf_lt_of_tl h₂ -- required for Lean to allow the following recursive call
+        apply mapMOnValues_none_iff_exists.mp
+        by_contra h₄
+        rw [← ne_eq] at h₄
+        replace ⟨ytl, h₄⟩ := Option.ne_none_iff_exists'.mp h₄
+        exact h₁ ytl h₄
+  case mpr =>
+    intro h₁
+    replace ⟨v, h₁, h₂⟩ := h₁
+    cases h₃ : m.kvs
+    case nil =>
+      rw [kvs_nil_iff_empty] at h₃ ; subst h₃
+      simp [values, kvs, empty] at h₁
+    case cons hd tl =>
+      have (khd, vhd) := hd ; clear hd
+      simp only [values_cons h₃, List.mem_cons] at h₁
+      simp only [mapMOnValues_cons h₃, Option.pure_def, Option.bind_eq_bind, Option.bind_eq_none]
+      intro yhd h₄ ytl h₅
+      rcases h₁ with h₁ | h₁
+      case inl => subst h₁ ; simp [h₂] at h₄
+      case inr =>
+        replace h₅ := mapMOnValues_some_implies_all_some h₅
+        replace ⟨k', h₁⟩ := in_values_exists_key h₁
+        replace ⟨y, _, h₅⟩ := h₅ (k', v) h₁
+        simp [h₂] at h₅
+termination_by m
 
 
 end Cedar.Data.Map

--- a/cedar-lean/Cedar/Thm/Data/Set.lean
+++ b/cedar-lean/Cedar/Thm/Data/Set.lean
@@ -163,8 +163,8 @@ theorem empty_iff_not_exists [DecidableEq α] (s : Set α) :
     apply List.not_mem_nil
   case mpr =>
     intro h₁
-    cases s
-    case mk xs =>
+    match s with
+    | mk xs =>
       rw [mk.injEq]
       rw [List.eq_nil_iff_forall_not_mem]
       intro x
@@ -187,8 +187,8 @@ theorem make_mem [LT α] [DecidableLT α] [StrictLT α] (x : α) (xs : List α) 
   simp only [List.Equiv, List.subset_def] at h₁
   have ⟨h₁, h₂⟩ := h₁
   constructor <;> intro h₃
-  case mp => apply h₁ h₃
-  case mpr => apply h₂ h₃
+  case mp => exact h₁ h₃
+  case mpr => exact h₂ h₃
 
 theorem make_mk_eqv [LT α] [DecidableLT α] [StrictLT α] {xs ys : List α} :
   Set.make xs = Set.mk ys → xs ≡ ys
@@ -219,11 +219,9 @@ theorem elts_make_equiv [LT α] [DecidableLT α] [StrictLT α] {xs : List α} :
 := by
   simp only [List.Equiv, List.subset_def]
   constructor <;> intro a h₁
-  case left =>
-    rw [make_mem, ← in_list_iff_in_set]
+  · rw [make_mem, ← in_list_iff_in_set]
     exact h₁
-  case right =>
-    rw [in_list_iff_in_set, ← make_mem]
+  · rw [in_list_iff_in_set, ← make_mem]
     exact h₁
 
 theorem elts_make_nil [LT α] [DecidableLT α] [StrictLT α] :

--- a/cedar-lean/Cedar/Thm/Validation/Typechecker/And.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Typechecker/And.lean
@@ -68,9 +68,9 @@ theorem type_of_and_inversion {x₁ x₂ : Expr} {c c' : Capabilities} {env : En
       exists BoolType.anyBool, res₂.snd
       cases bty₂ <;> simp at *
       simp [←hty₂, hc₁, lubBool]
-      split
-      case inl h₆ => simp [h₆]
-      case inr => rfl
+      split <;> rename_i h₆
+      · simp [h₆]
+      · rfl
 
 theorem type_of_and_is_sound {x₁ x₂ : Expr} {c₁ c₂ : Capabilities} {env : Environment} {ty : CedarType} {request : Request} {entities : Entities}
   (h₁ : CapabilitiesInvariant c₁ request entities)
@@ -91,43 +91,39 @@ theorem type_of_and_is_sound {x₁ x₂ : Expr} {c₁ c₂ : Capabilities} {env 
     subst h₆
     have ⟨hty, hc⟩ := h₅
     subst hty hc
-    apply And.intro
-    case left => exact empty_guarded_capabilities_invariant
-    case right =>
-      have h₇ := instance_of_ff_is_false ih₁₃
-      simp at h₇ ; subst h₇
-      simp [EvaluatesTo] at ih₁₂
-      rcases ih₁₂ with ih₁₂ | ih₁₂ | ih₁₂ | ih₁₂ <;>
-      simp [EvaluatesTo, evaluate, Result.as, ih₁₂, Coe.coe, Value.asBool] <;>
-      try exact type_is_inhabited (CedarType.bool BoolType.ff)
-      exact false_is_instance_of_ff
+    apply And.intro empty_guarded_capabilities_invariant
+    have h₇ := instance_of_ff_is_false ih₁₃
+    simp at h₇ ; subst h₇
+    simp [EvaluatesTo] at ih₁₂
+    rcases ih₁₂ with ih₁₂ | ih₁₂ | ih₁₂ | ih₁₂ <;>
+    simp [EvaluatesTo, evaluate, Result.as, ih₁₂, Coe.coe, Value.asBool] <;>
+    try exact type_is_inhabited (CedarType.bool BoolType.ff)
+    exact false_is_instance_of_ff
   case inr h₆ =>
     have ⟨bty₂, rc₂, hₜ, h₇⟩ := h₅
     split at h₇ <;> have ⟨hty, hc⟩ := h₇ <;> subst hty hc
     case inl h₈ =>
       subst h₈
-      apply And.intro
-      case left => exact empty_guarded_capabilities_invariant
-      case right =>
-        exists false ; simp [false_is_instance_of_ff]
-        cases b₁
-        case false =>
-          rcases ih₁₂ with ih₁₂ | ih₁₂ | ih₁₂ | ih₁₂ <;>
-          simp [EvaluatesTo, evaluate, Result.as, ih₁₂, Coe.coe, Value.asBool]
-        case true =>
-          rcases ih₁₂ with ih₁₂ | ih₁₂ | ih₁₂ | ih₁₂ <;>
-          simp [EvaluatesTo, evaluate, Result.as, ih₁₂, Coe.coe, Value.asBool]
-          simp [GuardedCapabilitiesInvariant] at ih₁₁
-          specialize ih₁₁ ih₁₂
-          have h₇ := capability_union_invariant h₁ ih₁₁
-          specialize ih₂ h₇ h₂ hₜ
-          have ⟨_, v₂, ih₂₂, ih₂₃⟩ := ih₂
-          simp [EvaluatesTo] at ih₂₂
-          rcases ih₂₂ with ih₂₂ | ih₂₂ | ih₂₂ | ih₂₂ <;>
-          simp [Result.as, ih₂₂, Coe.coe, Value.asBool, Lean.Internal.coeM, pure, Except.pure]
-          have h₈ := instance_of_ff_is_false ih₂₃
-          subst h₈
-          simp [CoeT.coe, CoeHTCT.coe, CoeHTC.coe, CoeOTC.coe, CoeTC.coe, Coe.coe]
+      apply And.intro empty_guarded_capabilities_invariant
+      exists false ; simp [false_is_instance_of_ff]
+      cases b₁
+      case false =>
+        rcases ih₁₂ with ih₁₂ | ih₁₂ | ih₁₂ | ih₁₂ <;>
+        simp [EvaluatesTo, evaluate, Result.as, ih₁₂, Coe.coe, Value.asBool]
+      case true =>
+        rcases ih₁₂ with ih₁₂ | ih₁₂ | ih₁₂ | ih₁₂ <;>
+        simp [EvaluatesTo, evaluate, Result.as, ih₁₂, Coe.coe, Value.asBool]
+        simp [GuardedCapabilitiesInvariant] at ih₁₁
+        specialize ih₁₁ ih₁₂
+        have h₇ := capability_union_invariant h₁ ih₁₁
+        specialize ih₂ h₇ h₂ hₜ
+        have ⟨_, v₂, ih₂₂, ih₂₃⟩ := ih₂
+        simp [EvaluatesTo] at ih₂₂
+        rcases ih₂₂ with ih₂₂ | ih₂₂ | ih₂₂ | ih₂₂ <;>
+        simp [Result.as, ih₂₂, Coe.coe, Value.asBool, Lean.Internal.coeM, pure, Except.pure]
+        have h₈ := instance_of_ff_is_false ih₂₃
+        subst h₈
+        simp [CoeT.coe, CoeHTCT.coe, CoeHTC.coe, CoeOTC.coe, CoeTC.coe, Coe.coe]
     case inr h₈ =>
       cases b₁
       case false =>
@@ -156,11 +152,9 @@ theorem type_of_and_is_sound {x₁ x₂ : Expr} {c₁ c₂ : Capabilities} {env 
           apply instance_of_lubBool ; simp [ih₂₃]
         case true =>
           apply And.intro
-          case left =>
-            simp [GuardedCapabilitiesInvariant] at ih₂₁
+          · simp [GuardedCapabilitiesInvariant] at ih₂₁
             specialize ih₂₁ ih₂₂
             exact capability_union_invariant ih₁₁ ih₂₁
-          case right =>
-            apply instance_of_lubBool ; simp [ih₁₃]
+          · apply instance_of_lubBool ; simp [ih₁₃]
 
 end Cedar.Thm

--- a/cedar-lean/Cedar/Thm/Validation/Typechecker/BinaryApp.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Typechecker/BinaryApp.lean
@@ -62,12 +62,11 @@ theorem type_of_eq_inversion {x₁ x₂ : Expr} {c c' : Capabilities} {env : Env
       case h_2 =>
         exists tc₁.fst
         constructor
-        case left  => exists tc₁.snd
-        case right =>
-          exists tc₂.fst
+        · exists tc₁.snd
+        · exists tc₂.fst
           constructor
-          case left  => exists tc₂.snd
-          case right => simp [h₅]
+          · exists tc₂.snd
+          · simp [h₅]
     case h_2 h₅ =>
       split at h₁ <;> simp at h₁ ; simp [h₁]
       split
@@ -76,16 +75,14 @@ theorem type_of_eq_inversion {x₁ x₂ : Expr} {c c' : Capabilities} {env : Env
       case h_2 ety₁ ety₂ _ true_is_instance_of_tt _ _ _ _ =>
         exists tc₁.fst
         constructor
-        case left  => exists tc₁.snd
-        case right =>
-          exists tc₂.fst
+        · exists tc₁.snd
+        · exists tc₂.fst
           constructor
-          case left  => exists tc₂.snd
-          case right =>
-            simp [h₅]
+          · exists tc₂.snd
+          · simp [h₅]
             constructor
-            case left  => exists ety₁
-            case right => exists ety₂
+            · exists ety₁
+            · exists ety₂
 
 theorem no_entity_type_lub_implies_not_eq {v₁ v₂ : Value} {ety₁ ety₂ : EntityType}
   (h₁ : InstanceOfType v₁ (CedarType.entity ety₁))
@@ -113,46 +110,44 @@ theorem type_of_eq_is_sound {x₁ x₂ : Expr} {c₁ c₂ : Capabilities} {env :
 := by
   have ⟨hc, hty⟩ := type_of_eq_inversion h₃
   subst hc
-  constructor
-  case left => exact empty_guarded_capabilities_invariant
-  case right =>
+  apply And.intro empty_guarded_capabilities_invariant
+  split at hty
+  case h_1 =>
+    split at hty <;> subst hty
+    case inl heq _ _ =>
+      subst heq
+      simp [EvaluatesTo, evaluate, apply₂]
+      exact true_is_instance_of_tt
+    case inr p₁ p₂ heq _ _ =>
+      simp [EvaluatesTo, evaluate, apply₂]
+      cases h₃ : Value.prim p₁ == Value.prim p₂ <;>
+      simp only [beq_iff_eq, beq_eq_false_iff_ne, ne_eq, Value.prim.injEq] at h₃
+      case false => exact false_is_instance_of_ff
+      case true  => contradiction
+  case h_2 =>
+    replace ⟨ty₁, c₁', ty₂, c₂', ht₁, ht₂, hty⟩ := hty
+    specialize ih₁ h₁ h₂ ht₁ ; replace ⟨_, v₁, ih₁⟩ := ih₁
+    specialize ih₂ h₁ h₂ ht₂ ; replace ⟨_, v₂, ih₂⟩ := ih₂
+    simp [EvaluatesTo, evaluate] at *
+    cases h₄ : evaluate x₁ request entities <;> simp [h₄] at * <;>
+    cases h₅ : evaluate x₂ request entities <;> simp [h₅] at * <;>
+    try { simp [ih₁, ih₂] ; apply type_is_inhabited }
+    replace ⟨ihl₁, ih₃⟩ := ih₁
+    replace ⟨ihl₂, ih₄⟩ := ih₂
+    rw [eq_comm] at ihl₁ ihl₂; subst ihl₁ ihl₂
+    simp [apply₂]
     split at hty
     case h_1 =>
-      split at hty <;> subst hty
-      case inl heq _ _ =>
-        subst heq
-        simp [EvaluatesTo, evaluate, apply₂]
-        exact true_is_instance_of_tt
-      case inr p₁ p₂ heq _ _ =>
-        simp [EvaluatesTo, evaluate, apply₂]
-        cases h₃ : Value.prim p₁ == Value.prim p₂ <;>
-        simp only [beq_iff_eq, beq_eq_false_iff_ne, ne_eq, Value.prim.injEq] at h₃
-        case false => exact false_is_instance_of_ff
-        case true  => contradiction
-    case h_2 =>
-      replace ⟨ty₁, c₁', ty₂, c₂', ht₁, ht₂, hty⟩ := hty
-      specialize ih₁ h₁ h₂ ht₁ ; replace ⟨_, v₁, ih₁⟩ := ih₁
-      specialize ih₂ h₁ h₂ ht₂ ; replace ⟨_, v₂, ih₂⟩ := ih₂
-      simp [EvaluatesTo, evaluate] at *
-      cases h₄ : evaluate x₁ request entities <;> simp [h₄] at * <;>
-      cases h₅ : evaluate x₂ request entities <;> simp [h₅] at * <;>
-      try { simp [ih₁, ih₂] ; apply type_is_inhabited }
-      replace ⟨ihl₁, ih₃⟩ := ih₁
-      replace ⟨ihl₂, ih₄⟩ := ih₂
-      rw [eq_comm] at ihl₁ ihl₂; subst ihl₁ ihl₂
-      simp [apply₂]
-      split at hty
-      case h_1 =>
-        rw [hty]
-        apply bool_is_instance_of_anyBool
-      case h_2 heq =>
-        have ⟨hty₀, ⟨ety₁, hty₁⟩, ⟨ety₂, hty₂⟩⟩ := hty ; clear hty
-        subst hty₀ hty₁ hty₂
-        have h₆ := no_entity_type_lub_implies_not_eq ih₃ ih₄ heq
-        cases h₇ : v₁ == v₂ <;>
-        simp only [beq_iff_eq, beq_eq_false_iff_ne, ne_eq, Value.prim.injEq] at h₇
-        case false => exact false_is_instance_of_ff
-        case true  => contradiction
+      rw [hty]
+      apply bool_is_instance_of_anyBool
+    case h_2 heq =>
+      have ⟨hty₀, ⟨ety₁, hty₁⟩, ⟨ety₂, hty₂⟩⟩ := hty ; clear hty
+      subst hty₀ hty₁ hty₂
+      have h₆ := no_entity_type_lub_implies_not_eq ih₃ ih₄ heq
+      cases h₇ : v₁ == v₂ <;>
+      simp only [beq_iff_eq, beq_eq_false_iff_ne, ne_eq, Value.prim.injEq] at h₇
+      case false => exact false_is_instance_of_ff
+      case true  => contradiction
 
 theorem type_of_int_cmp_inversion {op₂ : BinaryOp} {x₁ x₂ : Expr} {c c' : Capabilities} {env : Environment} {ty : CedarType}
   (h₁ : op₂ = .less ∨ op₂ = .lessEq)
@@ -173,8 +168,8 @@ theorem type_of_int_cmp_inversion {op₂ : BinaryOp} {x₁ x₂ : Expr} {c c' : 
     simp at h₂ ; simp [h₂]
     rename_i tc₁ tc₂ _ _ _ _ h₅ h₆
     constructor
-    case left  => exists tc₁.snd ; simp [←h₅]
-    case right => exists tc₂.snd ; simp [←h₆]
+    · exists tc₁.snd ; simp [←h₅]
+    · exists tc₂.snd ; simp [←h₆]
   }
 
 theorem type_of_int_cmp_is_sound {op₂ : BinaryOp} {x₁ x₂ : Expr} {c₁ c₂ : Capabilities} {env : Environment} {ty : CedarType} {request : Request} {entities : Entities}
@@ -189,29 +184,27 @@ theorem type_of_int_cmp_is_sound {op₂ : BinaryOp} {x₁ x₂ : Expr} {c₁ c�
 := by
   have ⟨hc, hty, ht₁, ht₂⟩ := type_of_int_cmp_inversion h₀ h₃
   subst hc hty
-  constructor
-  case left => exact empty_guarded_capabilities_invariant
-  case right =>
-    replace ⟨c₁', ht₁⟩ := ht₁
-    replace ⟨c₂', ht₂⟩ := ht₂
-    specialize ih₁ h₁ h₂ ht₁ ; replace ⟨_, v₁, ih₁⟩ := ih₁
-    specialize ih₂ h₁ h₂ ht₂ ; replace ⟨_, v₂, ih₂⟩ := ih₂
-    simp [EvaluatesTo, evaluate] at *
-    cases h₄ : evaluate x₁ request entities <;> simp [h₄] at * <;>
-    cases h₅ : evaluate x₂ request entities <;> simp [h₅] at * <;>
-    try { simp [ih₁, ih₂] ; exact type_is_inhabited (.bool .anyBool) }
-    replace ⟨ihl₁, ih₃⟩ := ih₁
-    replace ⟨ihl₂, ih₄⟩ := ih₂
-    rw [eq_comm] at ihl₁ ihl₂; subst ihl₁ ihl₂
-    have ⟨i₁, ih₁⟩ := instance_of_int_is_int ih₃
-    have ⟨i₂, ih₂⟩ := instance_of_int_is_int ih₄
-    subst ih₁ ih₂
-    rcases h₀ with h₀ | h₀
-    all_goals {
-      subst h₀
-      simp [apply₂]
-      apply bool_is_instance_of_anyBool
-    }
+  apply And.intro empty_guarded_capabilities_invariant
+  replace ⟨c₁', ht₁⟩ := ht₁
+  replace ⟨c₂', ht₂⟩ := ht₂
+  specialize ih₁ h₁ h₂ ht₁ ; replace ⟨_, v₁, ih₁⟩ := ih₁
+  specialize ih₂ h₁ h₂ ht₂ ; replace ⟨_, v₂, ih₂⟩ := ih₂
+  simp [EvaluatesTo, evaluate] at *
+  cases h₄ : evaluate x₁ request entities <;> simp [h₄] at * <;>
+  cases h₅ : evaluate x₂ request entities <;> simp [h₅] at * <;>
+  try { simp [ih₁, ih₂] ; exact type_is_inhabited (.bool .anyBool) }
+  replace ⟨ihl₁, ih₃⟩ := ih₁
+  replace ⟨ihl₂, ih₄⟩ := ih₂
+  rw [eq_comm] at ihl₁ ihl₂; subst ihl₁ ihl₂
+  have ⟨i₁, ih₁⟩ := instance_of_int_is_int ih₃
+  have ⟨i₂, ih₂⟩ := instance_of_int_is_int ih₄
+  subst ih₁ ih₂
+  rcases h₀ with h₀ | h₀
+  all_goals {
+    subst h₀
+    simp [apply₂]
+    apply bool_is_instance_of_anyBool
+  }
 
 theorem type_of_int_arith_inversion {op₂ : BinaryOp} {x₁ x₂ : Expr} {c c' : Capabilities} {env : Environment} {ty : CedarType}
   (h₁ : op₂ = .add ∨ op₂ = .sub ∨ op₂ = .mul)
@@ -233,8 +226,8 @@ theorem type_of_int_arith_inversion {op₂ : BinaryOp} {x₁ x₂ : Expr} {c c' 
     rename_i tc₁ tc₂ _ _ _ _ h₅ h₆
     replace ⟨h₂, _⟩ := h₂
     constructor
-    case left  => exists tc₁.snd ; simp [←h₂, ←h₅]
-    case right => exists tc₂.snd ; simp [←h₂, ←h₆]
+    · exists tc₁.snd ; simp [←h₂, ←h₅]
+    · exists tc₂.snd ; simp [←h₂, ←h₆]
   }
 
 theorem type_of_int_arith_is_sound {op₂ : BinaryOp} {x₁ x₂ : Expr} {c₁ c₂ : Capabilities} {env : Environment} {ty : CedarType} {request : Request} {entities : Entities}
@@ -249,36 +242,34 @@ theorem type_of_int_arith_is_sound {op₂ : BinaryOp} {x₁ x₂ : Expr} {c₁ c
 := by
   have ⟨hc, hty, ht₁, ht₂⟩ := type_of_int_arith_inversion h₀ h₃
   subst hc hty
-  constructor
-  case left => exact empty_guarded_capabilities_invariant
-  case right =>
-    replace ⟨c₁', ht₁⟩ := ht₁
-    replace ⟨c₂', ht₂⟩ := ht₂
-    specialize ih₁ h₁ h₂ ht₁ ; replace ⟨_, v₁, ih₁⟩ := ih₁
-    specialize ih₂ h₁ h₂ ht₂ ; replace ⟨_, v₂, ih₂⟩ := ih₂
-    simp [EvaluatesTo, evaluate] at *
-    cases h₄ : evaluate x₁ request entities <;> simp [h₄] at * <;>
-    cases h₅ : evaluate x₂ request entities <;> simp [h₅] at * <;>
-    try { simp [ih₁, ih₂] ; exact type_is_inhabited .int }
-    replace ⟨ihl₁, ih₃⟩ := ih₁
-    replace ⟨ihl₂, ih₄⟩ := ih₂
-    rw [eq_comm] at ihl₁ ihl₂; subst ihl₁ ihl₂
-    have ⟨i₁, ih₁⟩ := instance_of_int_is_int ih₃
-    have ⟨i₂, ih₂⟩ := instance_of_int_is_int ih₄
-    subst ih₁ ih₂
-    rcases h₀ with h₀ | h₀ | h₀ <;> subst h₀ <;> simp [apply₂, intOrErr]
-    case inl =>
-      cases h₄ : Int64.add? i₁ i₂ <;> simp [h₄]
-      case none => exact type_is_inhabited CedarType.int
-      case some => simp [InstanceOfType.instance_of_int]
-    case inr.inl =>
-      cases h₄ : Int64.sub? i₁ i₂ <;> simp [h₄]
-      case none => exact type_is_inhabited CedarType.int
-      case some => simp [InstanceOfType.instance_of_int]
-    case inr.inr =>
-      cases h₄ : Int64.mul? i₁ i₂ <;> simp [h₄]
-      case none => exact type_is_inhabited CedarType.int
-      case some => simp [InstanceOfType.instance_of_int]
+  apply And.intro empty_guarded_capabilities_invariant
+  replace ⟨c₁', ht₁⟩ := ht₁
+  replace ⟨c₂', ht₂⟩ := ht₂
+  specialize ih₁ h₁ h₂ ht₁ ; replace ⟨_, v₁, ih₁⟩ := ih₁
+  specialize ih₂ h₁ h₂ ht₂ ; replace ⟨_, v₂, ih₂⟩ := ih₂
+  simp [EvaluatesTo, evaluate] at *
+  cases h₄ : evaluate x₁ request entities <;> simp [h₄] at * <;>
+  cases h₅ : evaluate x₂ request entities <;> simp [h₅] at * <;>
+  try { simp [ih₁, ih₂] ; exact type_is_inhabited .int }
+  replace ⟨ihl₁, ih₃⟩ := ih₁
+  replace ⟨ihl₂, ih₄⟩ := ih₂
+  rw [eq_comm] at ihl₁ ihl₂; subst ihl₁ ihl₂
+  have ⟨i₁, ih₁⟩ := instance_of_int_is_int ih₃
+  have ⟨i₂, ih₂⟩ := instance_of_int_is_int ih₄
+  subst ih₁ ih₂
+  rcases h₀ with h₀ | h₀ | h₀ <;> subst h₀ <;> simp [apply₂, intOrErr]
+  case inl =>
+    cases h₄ : Int64.add? i₁ i₂ <;> simp [h₄]
+    case none => exact type_is_inhabited CedarType.int
+    case some => simp [InstanceOfType.instance_of_int]
+  case inr.inl =>
+    cases h₄ : Int64.sub? i₁ i₂ <;> simp [h₄]
+    case none => exact type_is_inhabited CedarType.int
+    case some => simp [InstanceOfType.instance_of_int]
+  case inr.inr =>
+    cases h₄ : Int64.mul? i₁ i₂ <;> simp [h₄]
+    case none => exact type_is_inhabited CedarType.int
+    case some => simp [InstanceOfType.instance_of_int]
 
 theorem type_of_contains_inversion {x₁ x₂ : Expr} {c c' : Capabilities} {env : Environment} {ty : CedarType}
   (h₁ : typeOf (Expr.binaryApp .contains x₁ x₂) c env = Except.ok (ty, c')) :
@@ -302,8 +293,8 @@ theorem type_of_contains_inversion {x₁ x₂ : Expr} {c c' : Capabilities} {env
   rw [lub_comm] at h₅
   simp [h₅, ←h₄]
   constructor
-  case left  => exists tc₁.snd
-  case right => exists tc₂.snd
+  · exists tc₁.snd
+  · exists tc₂.snd
 
 theorem type_of_contains_is_sound {x₁ x₂ : Expr} {c₁ c₂ : Capabilities} {env : Environment} {ty : CedarType} {request : Request} {entities : Entities}
   (h₁ : CapabilitiesInvariant c₁ request entities)
@@ -316,24 +307,22 @@ theorem type_of_contains_is_sound {x₁ x₂ : Expr} {c₁ c₂ : Capabilities} 
 := by
   have ⟨hc, hty, ty₁, ty₂, _, ht₁, ht₂⟩ := type_of_contains_inversion h₃
   subst hc hty
-  constructor
-  case left => exact empty_guarded_capabilities_invariant
-  case right =>
-    replace ⟨c₁', ht₁⟩ := ht₁
-    replace ⟨c₂', ht₂⟩ := ht₂
-    specialize ih₁ h₁ h₂ ht₁ ; replace ⟨_, v₁, ih₁⟩ := ih₁
-    specialize ih₂ h₁ h₂ ht₂ ; replace ⟨_, v₂, ih₂⟩ := ih₂
-    simp [EvaluatesTo, evaluate] at *
-    cases h₄ : evaluate x₁ request entities <;> simp [h₄] at * <;>
-    cases h₅ : evaluate x₂ request entities <;> simp [h₅] at * <;>
-    try { simp [ih₁, ih₂] ; apply type_is_inhabited }
-    replace ⟨ihl₁, ih₃⟩ := ih₁
-    replace ⟨ihl₂, ih₄⟩ := ih₂
-    rw [eq_comm] at ihl₁ ihl₂; subst ihl₁ ihl₂
-    have ⟨s₁, ih₁⟩ := instance_of_set_type_is_set ih₃
-    subst ih₁
-    simp [apply₂]
-    apply bool_is_instance_of_anyBool
+  apply And.intro empty_guarded_capabilities_invariant
+  replace ⟨c₁', ht₁⟩ := ht₁
+  replace ⟨c₂', ht₂⟩ := ht₂
+  specialize ih₁ h₁ h₂ ht₁ ; replace ⟨_, v₁, ih₁⟩ := ih₁
+  specialize ih₂ h₁ h₂ ht₂ ; replace ⟨_, v₂, ih₂⟩ := ih₂
+  simp [EvaluatesTo, evaluate] at *
+  cases h₄ : evaluate x₁ request entities <;> simp [h₄] at * <;>
+  cases h₅ : evaluate x₂ request entities <;> simp [h₅] at * <;>
+  try { simp [ih₁, ih₂] ; apply type_is_inhabited }
+  replace ⟨ihl₁, ih₃⟩ := ih₁
+  replace ⟨ihl₂, ih₄⟩ := ih₂
+  rw [eq_comm] at ihl₁ ihl₂; subst ihl₁ ihl₂
+  have ⟨s₁, ih₁⟩ := instance_of_set_type_is_set ih₃
+  subst ih₁
+  simp [apply₂]
+  apply bool_is_instance_of_anyBool
 
 theorem type_of_containsA_inversion {op₂ : BinaryOp} {x₁ x₂ : Expr} {c c' : Capabilities} {env : Environment} {ty : CedarType}
   (h₁ : op₂ = .containsAll ∨ op₂ = .containsAny)
@@ -360,8 +349,8 @@ theorem type_of_containsA_inversion {op₂ : BinaryOp} {x₁ x₂ : Expr} {c c' 
     exists ty₁, ty₂
     simp [h₇]
     constructor
-    case left  => exists tc₁.snd ; simp [←h₅]
-    case right => exists tc₂.snd ; simp [←h₆]
+    · exists tc₁.snd ; simp [←h₅]
+    · exists tc₂.snd ; simp [←h₆]
   }
 
 
@@ -377,29 +366,27 @@ theorem type_of_containsA_is_sound {op₂ : BinaryOp} {x₁ x₂ : Expr} {c₁ c
 := by
   have ⟨hc, hty, ty₁, ty₂, _, ht₁, ht₂⟩ := type_of_containsA_inversion h₀ h₃
   subst hc hty
-  constructor
-  case left => exact empty_guarded_capabilities_invariant
-  case right =>
-    replace ⟨c₁', ht₁⟩ := ht₁
-    replace ⟨c₂', ht₂⟩ := ht₂
-    specialize ih₁ h₁ h₂ ht₁ ; replace ⟨_, v₁, ih₁⟩ := ih₁
-    specialize ih₂ h₁ h₂ ht₂ ; replace ⟨_, v₂, ih₂⟩ := ih₂
-    simp [EvaluatesTo, evaluate] at *
-    cases h₄ : evaluate x₁ request entities <;> simp [h₄] at * <;>
-    cases h₅ : evaluate x₂ request entities <;> simp [h₅] at * <;>
-    try { simp [ih₁, ih₂] ; apply type_is_inhabited }
-    replace ⟨ihl₁, ih₃⟩ := ih₁
-    replace ⟨ihl₂, ih₄⟩ := ih₂
-    rw [eq_comm] at ihl₁ ihl₂; subst ihl₁ ihl₂
-    have ⟨s₁, ih₁⟩ := instance_of_set_type_is_set ih₃
-    have ⟨s₂, ih₂⟩ := instance_of_set_type_is_set ih₄
-    subst ih₁ ih₂
-    rcases h₀ with h₀ | h₀
-    all_goals {
-      subst h₀
-      simp [apply₂]
-      apply bool_is_instance_of_anyBool
-    }
+  apply And.intro empty_guarded_capabilities_invariant
+  replace ⟨c₁', ht₁⟩ := ht₁
+  replace ⟨c₂', ht₂⟩ := ht₂
+  specialize ih₁ h₁ h₂ ht₁ ; replace ⟨_, v₁, ih₁⟩ := ih₁
+  specialize ih₂ h₁ h₂ ht₂ ; replace ⟨_, v₂, ih₂⟩ := ih₂
+  simp [EvaluatesTo, evaluate] at *
+  cases h₄ : evaluate x₁ request entities <;> simp [h₄] at * <;>
+  cases h₅ : evaluate x₂ request entities <;> simp [h₅] at * <;>
+  try { simp [ih₁, ih₂] ; apply type_is_inhabited }
+  replace ⟨ihl₁, ih₃⟩ := ih₁
+  replace ⟨ihl₂, ih₄⟩ := ih₂
+  rw [eq_comm] at ihl₁ ihl₂; subst ihl₁ ihl₂
+  have ⟨s₁, ih₁⟩ := instance_of_set_type_is_set ih₃
+  have ⟨s₂, ih₂⟩ := instance_of_set_type_is_set ih₄
+  subst ih₁ ih₂
+  rcases h₀ with h₀ | h₀
+  all_goals {
+    subst h₀
+    simp [apply₂]
+    apply bool_is_instance_of_anyBool
+  }
 
 theorem type_of_mem_inversion {x₁ x₂ : Expr} {c c' : Capabilities} {env : Environment} {ty : CedarType}
   (h₁ : typeOf (Expr.binaryApp .mem x₁ x₂) c env = Except.ok (ty, c')) :
@@ -423,8 +410,8 @@ theorem type_of_mem_inversion {x₁ x₂ : Expr} {c c' : Capabilities} {env : En
     rename_i tc₁ tc₂ _ _ _ ety₁ ety₂ _ h₄ h₅
     exists ety₁
     constructor
-    case left  => exists tc₁.snd ; simp [←h₄]
-    case right => exists ety₂, tc₂.snd ; simp [←h₅, h₁]
+    · exists tc₁.snd ; simp [←h₄]
+    · exists ety₂, tc₂.snd ; simp [←h₅, h₁]
   }
 
 theorem entityUID?_some_implies_entity_lit {x : Expr} {euid : EntityUID}
@@ -640,8 +627,8 @@ theorem mapM'_eval_lits_eq_prims {ps : List Prim} {vs : List Value} {request : R
     simp [pure, Except.pure] at h₁ ; subst h₁
     simp [List.map]
     constructor
-    case left  => simp [evaluate] at h₂ ; simp [h₂]
-    case right => apply mapM'_eval_lits_eq_prims h₃
+    · simp [evaluate] at h₂ ; simp [h₂]
+    · exact mapM'_eval_lits_eq_prims h₃
 
 theorem mapM'_asEntityUID_eq_entities {vs : List Value} {euids : List EntityUID}
   (h₁ : List.mapM' Value.asEntityUID vs = Except.ok euids) :
@@ -660,13 +647,11 @@ theorem mapM'_asEntityUID_eq_entities {vs : List Value} {euids : List EntityUID}
     simp [pure, Except.pure] at h₁ ; subst h₁
     simp [List.map]
     constructor
-    case left  =>
-      simp [Value.asEntityUID] at h₂
+    · simp [Value.asEntityUID] at h₂
       split at h₂ <;> simp at h₂
       rw [eq_comm] at h₂ ; subst h₂
       rfl
-    case right =>
-      apply mapM'_asEntityUID_eq_entities h₃
+    · exact mapM'_asEntityUID_eq_entities h₃
 
 theorem evaluate_entity_set_eqv {vs : List Value} {euids euids' : List EntityUID} {request : Request} {entities : Entities}
   (h₁ : evaluate (Expr.set (List.map (Expr.lit ∘ Prim.entityUID) euids')) request entities =
@@ -688,8 +673,8 @@ theorem evaluate_entity_set_eqv {vs : List Value} {euids euids' : List EntityUID
   simp [List.Equiv, List.subset_def] at *
   have ⟨hl₁, hr₁⟩ := h₁
   constructor
-  case left  => apply hr₁
-  case right => apply hl₁
+  · apply hr₁
+  · apply hl₁
 
 theorem action_type_in_eq_action_inₛ {auid : EntityUID} {euids euids' : List EntityUID} {env : Environment} {entities : Entities}
   (h₁ : InstanceOfActionSchema entities env.acts)
@@ -818,14 +803,10 @@ theorem type_of_mem_is_sound {x₁ x₂ : Expr} {c₁ c₂ : Capabilities} {env 
 := by
   have ⟨hc, ety₁, ety₂, ⟨c₁', h₄⟩ , c₂', h₅⟩ := type_of_mem_inversion h₃
   subst hc
-  constructor
-  case left => exact empty_guarded_capabilities_invariant
-  case right =>
-    rcases h₅ with ⟨h₅, h₆⟩ | ⟨h₅, h₆⟩ <;> subst h₆
-    case inl =>
-      apply type_of_mem_is_soundₑ h₁ h₂ h₄ h₅ ih₁ ih₂
-    case inr =>
-      apply type_of_mem_is_soundₛ h₁ h₂ h₄ h₅ ih₁ ih₂
+  apply And.intro empty_guarded_capabilities_invariant
+  rcases h₅ with ⟨h₅, h₆⟩ | ⟨h₅, h₆⟩ <;> subst h₆
+  · exact type_of_mem_is_soundₑ h₁ h₂ h₄ h₅ ih₁ ih₂
+  · exact type_of_mem_is_soundₛ h₁ h₂ h₄ h₅ ih₁ ih₂
 
 theorem type_of_binaryApp_is_sound {op₂ : BinaryOp} {x₁ x₂ : Expr} {c₁ c₂ : Capabilities} {env : Environment} {ty : CedarType} {request : Request} {entities : Entities}
   (h₁ : CapabilitiesInvariant c₁ request entities)

--- a/cedar-lean/Cedar/Thm/Validation/Typechecker/Call.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Typechecker/Call.lean
@@ -53,18 +53,14 @@ theorem type_of_call_decimal_is_sound {xs : List Expr} {c₁ c₂ : Capabilities
 := by
   have ⟨h₂, h₃, s, h₄, h₅⟩ := type_of_call_decimal_inversion h₁
   subst h₂ h₃ h₄
-  apply And.intro
-  case left => exact empty_guarded_capabilities_invariant
-  case right =>
-    rw [Option.isSome_iff_exists] at h₅
-    have ⟨d, h₅⟩ := h₅
-    exists .ext d
-    apply And.intro
-    case left =>
-      simp [EvaluatesTo, evaluate, List.mapM₁, List.mapM, List.mapM.loop, call, res, h₅, Coe.coe]
-    case right =>
-      apply InstanceOfType.instance_of_ext
-      simp [InstanceOfExtType]
+  apply And.intro empty_guarded_capabilities_invariant
+  rw [Option.isSome_iff_exists] at h₅
+  have ⟨d, h₅⟩ := h₅
+  exists .ext d
+  constructor
+  · simp [EvaluatesTo, evaluate, List.mapM₁, List.mapM, List.mapM.loop, call, res, h₅, Coe.coe]
+  · apply InstanceOfType.instance_of_ext
+    simp [InstanceOfExtType]
 
 theorem type_of_call_ip_inversion {xs : List Expr} {c c' : Capabilities} {env : Environment} {ty : CedarType}
   (h₁ : typeOf (Expr.call .ip xs) c env = Except.ok (ty, c')) :
@@ -93,18 +89,14 @@ theorem type_of_call_ip_is_sound {xs : List Expr} {c₁ c₂ : Capabilities} {en
 := by
   have ⟨h₂, h₃, s, h₄, h₅⟩ := type_of_call_ip_inversion h₁
   subst h₂ h₃ h₄
-  apply And.intro
-  case left => exact empty_guarded_capabilities_invariant
-  case right =>
-    rw [Option.isSome_iff_exists] at h₅
-    have ⟨ip, h₅⟩ := h₅
-    exists .ext ip
-    apply And.intro
-    case left =>
-      simp [EvaluatesTo, evaluate, List.mapM₁, List.mapM, List.mapM.loop, call, res, h₅, Coe.coe]
-    case right =>
-      apply InstanceOfType.instance_of_ext
-      simp [InstanceOfExtType]
+  apply And.intro empty_guarded_capabilities_invariant
+  rw [Option.isSome_iff_exists] at h₅
+  have ⟨ip, h₅⟩ := h₅
+  exists .ext ip
+  constructor
+  · simp [EvaluatesTo, evaluate, List.mapM₁, List.mapM, List.mapM.loop, call, res, h₅, Coe.coe]
+  · apply InstanceOfType.instance_of_ext
+    simp [InstanceOfExtType]
 
 theorem typeOf_of_binary_call_inversion {xs : List Expr} {c : Capabilities} {env : Environment} {ty₁ ty₂ : CedarType}
   (h₁ : (xs.mapM₁ fun x => justType (typeOf x.val c env)) = Except.ok [ty₁, ty₂]) :
@@ -196,31 +188,29 @@ theorem type_of_call_decimal_comparator_is_sound {xfn : ExtFun} {xs : List Expr}
 := by
   have ⟨h₄, h₅, x₁, x₂, c₁', c₂', h₆, h₇, h₈⟩ := type_of_call_decimal_comparator_inversion h₀ h₃
   subst h₄ h₅ h₆
-  apply And.intro
-  case left => exact empty_guarded_capabilities_invariant
-  case right =>
-    simp [EvaluatesTo, evaluate, List.mapM₁, List.attach]
-    have ih₁ := ih x₁
-    have ih₂ := ih x₂
-    simp [TypeOfIsSound] at ih₁ ih₂
-    have ⟨_, v₁, hl₁, hr₁⟩ := ih₁ h₁ h₂ h₇
-    have ⟨_, v₂, hl₂, hr₂⟩ := ih₂ h₁ h₂ h₈
-    simp [EvaluatesTo] at hl₁
-    rcases hl₁ with hl₁ | hl₁ | hl₁ | hl₁ <;>
-    simp [hl₁] <;>
-    try { exact type_is_inhabited (CedarType.bool BoolType.anyBool)}
-    rcases hl₂ with hl₂ | hl₂ | hl₂ | hl₂ <;>
-    simp [hl₂] <;>
-    try { exact type_is_inhabited (CedarType.bool BoolType.anyBool)}
-    have ⟨d₁, hr₁⟩ := instance_of_decimal_type_is_decimal hr₁
-    have ⟨d₂, hr₂⟩ := instance_of_decimal_type_is_decimal hr₂
-    subst hr₁ hr₂
-    simp [IsDecimalComparator] at h₀
-    split at h₀ <;>
-    simp [call] <;> try { contradiction }
-    all_goals {
-      apply bool_is_instance_of_anyBool
-    }
+  apply And.intro empty_guarded_capabilities_invariant
+  simp [EvaluatesTo, evaluate, List.mapM₁, List.attach]
+  have ih₁ := ih x₁
+  have ih₂ := ih x₂
+  simp [TypeOfIsSound] at ih₁ ih₂
+  have ⟨_, v₁, hl₁, hr₁⟩ := ih₁ h₁ h₂ h₇
+  have ⟨_, v₂, hl₂, hr₂⟩ := ih₂ h₁ h₂ h₈
+  simp [EvaluatesTo] at hl₁
+  rcases hl₁ with hl₁ | hl₁ | hl₁ | hl₁ <;>
+  simp [hl₁] <;>
+  try { exact type_is_inhabited (CedarType.bool BoolType.anyBool)}
+  rcases hl₂ with hl₂ | hl₂ | hl₂ | hl₂ <;>
+  simp [hl₂] <;>
+  try { exact type_is_inhabited (CedarType.bool BoolType.anyBool)}
+  have ⟨d₁, hr₁⟩ := instance_of_decimal_type_is_decimal hr₁
+  have ⟨d₂, hr₂⟩ := instance_of_decimal_type_is_decimal hr₂
+  subst hr₁ hr₂
+  simp [IsDecimalComparator] at h₀
+  split at h₀ <;>
+  simp [call] <;> try { contradiction }
+  all_goals {
+    apply bool_is_instance_of_anyBool
+  }
 
 theorem type_of_call_isInRange_inversion {xs : List Expr} {c c' : Capabilities} {env : Environment} {ty : CedarType}
   (h₁ : typeOf (Expr.call .isInRange xs) c env = Except.ok (ty, c')) :
@@ -253,27 +243,25 @@ theorem type_of_call_isInRange_comparator_is_sound {xs : List Expr} {c₁ c₂ :
 := by
   have ⟨h₄, h₅, x₁, x₂, c₁', c₂', h₆, h₇, h₈⟩ := type_of_call_isInRange_inversion h₃
   subst h₄ h₅ h₆
-  apply And.intro
-  case left => exact empty_guarded_capabilities_invariant
-  case right =>
-    simp [EvaluatesTo, evaluate, List.mapM₁, List.attach]
-    have ih₁ := ih x₁
-    have ih₂ := ih x₂
-    simp [TypeOfIsSound] at ih₁ ih₂
-    have ⟨_, v₁, hl₁, hr₁⟩ := ih₁ h₁ h₂ h₇
-    have ⟨_, v₂, hl₂, hr₂⟩ := ih₂ h₁ h₂ h₈
-    simp [EvaluatesTo] at hl₁
-    rcases hl₁ with hl₁ | hl₁ | hl₁ | hl₁ <;>
-    simp [hl₁] <;>
-    try { exact type_is_inhabited (CedarType.bool BoolType.anyBool)}
-    rcases hl₂ with hl₂ | hl₂ | hl₂ | hl₂ <;>
-    simp [hl₂] <;>
-    try { exact type_is_inhabited (CedarType.bool BoolType.anyBool)}
-    have ⟨d₁, hr₁⟩ := instance_of_ipAddr_type_is_ipAddr hr₁
-    have ⟨d₂, hr₂⟩ := instance_of_ipAddr_type_is_ipAddr hr₂
-    subst hr₁ hr₂
-    simp [call]
-    apply bool_is_instance_of_anyBool
+  apply And.intro empty_guarded_capabilities_invariant
+  simp [EvaluatesTo, evaluate, List.mapM₁, List.attach]
+  have ih₁ := ih x₁
+  have ih₂ := ih x₂
+  simp [TypeOfIsSound] at ih₁ ih₂
+  have ⟨_, v₁, hl₁, hr₁⟩ := ih₁ h₁ h₂ h₇
+  have ⟨_, v₂, hl₂, hr₂⟩ := ih₂ h₁ h₂ h₈
+  simp [EvaluatesTo] at hl₁
+  rcases hl₁ with hl₁ | hl₁ | hl₁ | hl₁ <;>
+  simp [hl₁] <;>
+  try { exact type_is_inhabited (CedarType.bool BoolType.anyBool)}
+  rcases hl₂ with hl₂ | hl₂ | hl₂ | hl₂ <;>
+  simp [hl₂] <;>
+  try { exact type_is_inhabited (CedarType.bool BoolType.anyBool)}
+  have ⟨d₁, hr₁⟩ := instance_of_ipAddr_type_is_ipAddr hr₁
+  have ⟨d₂, hr₂⟩ := instance_of_ipAddr_type_is_ipAddr hr₂
+  subst hr₁ hr₂
+  simp [call]
+  apply bool_is_instance_of_anyBool
 
 def IsIpAddrRecognizer : ExtFun → Prop
   | .isIpv4
@@ -353,25 +341,23 @@ theorem type_of_call_ipAddr_recognizer_is_sound {xfn : ExtFun} {xs : List Expr} 
 := by
   have ⟨h₄, h₅, x₁, c₁', h₆, h₇⟩ := type_of_call_ipAddr_recognizer_inversion h₀ h₃
   subst h₄ h₅ h₆
-  apply And.intro
-  case left => exact empty_guarded_capabilities_invariant
-  case right =>
-    simp [EvaluatesTo, evaluate, List.mapM₁, List.attach]
-    have ih₁ := ih x₁
-    simp [TypeOfIsSound] at ih₁
-    have ⟨_, v₁, hl₁, hr₁⟩ := ih₁ h₁ h₂ h₇
-    simp [EvaluatesTo] at hl₁
-    rcases hl₁ with hl₁ | hl₁ | hl₁ | hl₁ <;>
-    simp [hl₁] <;>
-    try { exact type_is_inhabited (CedarType.bool BoolType.anyBool)}
-    have ⟨ip₁, hr₁⟩ := instance_of_ipAddr_type_is_ipAddr hr₁
-    subst hr₁
-    simp [IsIpAddrRecognizer] at h₀
-    split at h₀ <;>
-    simp [call] <;> try { contradiction }
-    all_goals {
-      apply bool_is_instance_of_anyBool
-    }
+  apply And.intro exact empty_guarded_capabilities_invariant
+  simp [EvaluatesTo, evaluate, List.mapM₁, List.attach]
+  have ih₁ := ih x₁
+  simp [TypeOfIsSound] at ih₁
+  have ⟨_, v₁, hl₁, hr₁⟩ := ih₁ h₁ h₂ h₇
+  simp [EvaluatesTo] at hl₁
+  rcases hl₁ with hl₁ | hl₁ | hl₁ | hl₁ <;>
+  simp [hl₁] <;>
+  try { exact type_is_inhabited (CedarType.bool BoolType.anyBool)}
+  have ⟨ip₁, hr₁⟩ := instance_of_ipAddr_type_is_ipAddr hr₁
+  subst hr₁
+  simp [IsIpAddrRecognizer] at h₀
+  split at h₀ <;>
+  simp [call] <;> try { contradiction }
+  all_goals {
+    apply bool_is_instance_of_anyBool
+  }
 
 theorem type_of_call_is_sound {xfn : ExtFun} {xs : List Expr} {c₁ c₂ : Capabilities} {env : Environment} {ty : CedarType} {request : Request} {entities : Entities}
   (h₁ : CapabilitiesInvariant c₁ request entities)

--- a/cedar-lean/Cedar/Thm/Validation/Typechecker/Call.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Typechecker/Call.lean
@@ -341,7 +341,7 @@ theorem type_of_call_ipAddr_recognizer_is_sound {xfn : ExtFun} {xs : List Expr} 
 := by
   have ⟨h₄, h₅, x₁, c₁', h₆, h₇⟩ := type_of_call_ipAddr_recognizer_inversion h₀ h₃
   subst h₄ h₅ h₆
-  apply And.intro exact empty_guarded_capabilities_invariant
+  apply And.intro empty_guarded_capabilities_invariant
   simp [EvaluatesTo, evaluate, List.mapM₁, List.attach]
   have ih₁ := ih x₁
   simp [TypeOfIsSound] at ih₁

--- a/cedar-lean/Cedar/Thm/Validation/Typechecker/GetAttr.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Typechecker/GetAttr.lean
@@ -50,12 +50,10 @@ theorem type_of_getAttr_inversion {x₁ : Expr} {a : Attr} {c₁ c₂ : Capabili
     have ⟨ty₁, c₁'⟩ := res
     simp [typeOfGetAttr] at h₁
     split at h₁ <;> try contradiction
-    case h_1 =>
-      simp only [List.empty_eq, Except.ok.injEq, Prod.mk.injEq, false_and, exists_const,
+    · simp only [List.empty_eq, Except.ok.injEq, Prod.mk.injEq, false_and, exists_const,
         CedarType.record.injEq, exists_and_right, exists_eq', true_and, false_or, and_true]
       apply getAttrInRecord_has_empty_capabilities h₁
-    case h_2 =>
-      simp only [List.empty_eq, Except.ok.injEq, Prod.mk.injEq, CedarType.entity.injEq,
+    · simp only [List.empty_eq, Except.ok.injEq, Prod.mk.injEq, CedarType.entity.injEq,
         exists_and_right, exists_eq', true_and, false_and, exists_const, or_false, and_true]
       split at h₁ <;> try simp [err] at h₁
       apply getAttrInRecord_has_empty_capabilities h₁
@@ -167,21 +165,15 @@ theorem type_of_getAttr_is_sound {x₁ : Expr} {a : Attr} {c₁ c₂ : Capabilit
 := by
   have ⟨h₅, c₁', h₄⟩ := type_of_getAttr_inversion h₃
   subst h₅
-  apply And.intro
-  case left => exact empty_guarded_capabilities_invariant
-  case right =>
-    rcases h₄ with ⟨ety, h₄⟩ | ⟨rty, h₄⟩ <;>
-    have ⟨_, v₁, h₆, h₇⟩ := ih h₁ h₂ h₄ <;>
-    simp [EvaluatesTo] at h₆ <;>
-    simp [EvaluatesTo, evaluate] <;>
-    rcases h₆ with h₆ | h₆ | h₆ | h₆ <;> simp [h₆]
-    case inl.intro.inr.inr.inr =>
-      exact type_of_getAttr_is_sound_for_entities h₁ h₂ h₃ h₄ h₆ h₇
-    case inr.intro.inr.inr.inr =>
-      exact type_of_getAttr_is_sound_for_records h₁ h₃ h₄ h₆ h₇
-    all_goals {
-      exact type_is_inhabited ty
-    }
+  apply And.intro empty_guarded_capabilities_invariant
+  rcases h₄ with ⟨ety, h₄⟩ | ⟨rty, h₄⟩ <;>
+  have ⟨_, v₁, h₆, h₇⟩ := ih h₁ h₂ h₄ <;>
+  simp [EvaluatesTo] at h₆ <;>
+  simp [EvaluatesTo, evaluate] <;>
+  rcases h₆ with h₆ | h₆ | h₆ | h₆ <;> simp [h₆]
+  <;> try exact type_is_inhabited ty
+  · exact type_of_getAttr_is_sound_for_entities h₁ h₂ h₃ h₄ h₆ h₇
+  · exact type_of_getAttr_is_sound_for_records h₁ h₃ h₄ h₆ h₇
 
 
 end Cedar.Thm

--- a/cedar-lean/Cedar/Thm/Validation/Typechecker/HasAttr.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Typechecker/HasAttr.lean
@@ -38,19 +38,15 @@ theorem type_of_hasAttr_inversion {x₁ : Expr} {a : Attr} {c₁ c₂ : Capabili
   case ok res =>
     have ⟨ty₁, c₁'⟩ := res
     simp at h₁
-    split at h₁ <;> try simp [err, ok, hasAttrInRecord] at h₁
-    case h_1 _ _ =>
-      split at h₁ <;> try split at h₁
-      all_goals {
-        simp [ok] at h₁
-        simp [h₁]
-      }
-    case h_2 _ _ =>
-      split at h₁ <;> split at h₁ <;> try split at h₁
-      all_goals {
-        simp [ok] at h₁
-        try simp [h₁]
-      }
+    split at h₁
+    <;> simp [err, ok, hasAttrInRecord] at h₁
+    <;> split at h₁
+    <;> try split at h₁
+    <;> try split at h₁
+    all_goals {
+      simp [ok] at h₁
+      try simp [h₁]
+    }
 
 theorem type_of_hasAttr_is_sound_for_records {x₁ : Expr} {a : Attr} {c₁ c₁' : Capabilities} {env : Environment} {rty : RecordType} {request : Request} {entities : Entities} {v₁ : Value}
   (h₁ : CapabilitiesInvariant c₁ request entities)
@@ -186,12 +182,9 @@ theorem type_of_hasAttr_is_sound {x₁ : Expr} {a : Attr} {c₁ c₂ : Capabilit
     simp [EvaluatesTo] at h₆ <;>
     simp [EvaluatesTo, evaluate] <;>
     rcases h₆ with h₆ | h₆ | h₆ | h₆ <;> simp [h₆]
-    case inl.intro.inr.inr.inr =>
-      exact type_of_hasAttr_is_sound_for_entities h₁ h₂ h₃ h₄ h₆ h₇
-    case inr.intro.inr.inr.inr =>
-      exact type_of_hasAttr_is_sound_for_records h₁ h₃ h₄ h₆ h₇
-    all_goals {
-      exact type_is_inhabited ty
-    }
+    <;> try exact type_is_inhabited ty
+    · exact type_of_hasAttr_is_sound_for_entities h₁ h₂ h₃ h₄ h₆ h₇
+    · exact type_of_hasAttr_is_sound_for_records h₁ h₃ h₄ h₆ h₇
+
 
 end Cedar.Thm

--- a/cedar-lean/Cedar/Thm/Validation/Typechecker/IfThenElse.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Typechecker/IfThenElse.lean
@@ -153,10 +153,8 @@ theorem type_of_ite_is_sound {x₁ x₂ x₃ : Expr} {c₁ c₂ : Capabilities} 
     have ⟨ih₃₁, v₃, ih₃₂, ih₃₃⟩ := ih₃
     subst ht hc
     apply And.intro
-    case left =>
-      simp [GuardedCapabilitiesInvariant] at ih₃₁
+    · simp [GuardedCapabilitiesInvariant] at ih₃₁
       exact ih₃₁
-    case right =>
-      exists v₃
+    · exists v₃
 
 end Cedar.Thm

--- a/cedar-lean/Cedar/Thm/Validation/Typechecker/LUB.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Typechecker/LUB.lean
@@ -401,13 +401,7 @@ theorem lub_left_subty {ty₁ ty₂ ty₃ : CedarType} :
   split at h₁
   case h_1 bty₁ bty₂ =>
     simp [lubBool] at h₁
-    split at h₁
-    case inl h₂ =>
-      subst h₁
-      simp [lub?, lubBool]
-    case inr h₂ =>
-      subst h₁
-      simp [lub?, lubBool]
+    split at h₁ <;> subst h₁ <;> simp [lub?, lubBool]
   case h_2 sty₁ sty₂ =>
     cases h₂ : sty₁ ⊔ sty₂ <;> simp [h₂] at h₁
     rename_i sty₃

--- a/cedar-lean/Cedar/Thm/Validation/Typechecker/LitVar.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Typechecker/LitVar.lean
@@ -40,9 +40,8 @@ theorem type_of_lit_is_sound {l : Prim} {c₁ c₂ : Capabilities} {env : Enviro
   all_goals {
     have ⟨h₃, h₄⟩ := h₃
     rw [←h₃, ←h₄]
-    constructor
-    case left => exact empty_guarded_capabilities_invariant
-    case right => first |
+    apply And.intro empty_guarded_capabilities_invariant
+    first |
       exact true_is_instance_of_tt |
       exact false_is_instance_of_ff |
       apply InstanceOfType.instance_of_int |

--- a/cedar-lean/Cedar/Thm/Validation/Typechecker/Or.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Typechecker/Or.lean
@@ -101,16 +101,14 @@ theorem type_of_or_is_sound {x₁ x₂ : Expr} {c₁ c₂ : Capabilities} {env :
   case inl h₆ =>
     subst h₆
     have ⟨hty, hc⟩ := h₅ ; subst hty hc
-    apply And.intro
-    case left => exact empty_guarded_capabilities_invariant
-    case right =>
-      have h₇ := instance_of_tt_is_true ih₁₃
-      simp at h₇ ; subst h₇
-      simp [EvaluatesTo] at ih₁₂
-      rcases ih₁₂ with ih₁₂ | ih₁₂ | ih₁₂ | ih₁₂ <;>
-      simp [EvaluatesTo, evaluate, Result.as, ih₁₂, Coe.coe, Value.asBool] <;>
-      try exact type_is_inhabited (CedarType.bool BoolType.tt)
-      exact true_is_instance_of_tt
+    apply And.intro empty_guarded_capabilities_invariant
+    have h₇ := instance_of_tt_is_true ih₁₃
+    simp at h₇ ; subst h₇
+    simp [EvaluatesTo] at ih₁₂
+    rcases ih₁₂ with ih₁₂ | ih₁₂ | ih₁₂ | ih₁₂ <;>
+    simp [EvaluatesTo, evaluate, Result.as, ih₁₂, Coe.coe, Value.asBool] <;>
+    try exact type_is_inhabited (CedarType.bool BoolType.tt)
+    exact true_is_instance_of_tt
   case inr =>
     have ⟨bty₂, rc₂, h₅', h₇⟩ := h₅
     specialize ih₂ h₁ h₂ h₅'
@@ -147,15 +145,14 @@ theorem type_of_or_is_sound {x₁ x₂ : Expr} {c₁ c₂ : Capabilities} {env :
           simp [InstanceOfBoolType] at ih₂₃
         case anyBool.tt =>
           apply And.intro
-          case left => apply empty_capabilities_invariant
-          case right => apply true_is_instance_of_tt
+          · apply empty_capabilities_invariant
+          · exact true_is_instance_of_tt
         case anyBool.anyBool =>
           apply And.intro
-          case left =>
-            simp [GuardedCapabilitiesInvariant, ih₂₂] at ih₂₁
+          · simp [GuardedCapabilitiesInvariant, ih₂₂] at ih₂₁
             apply capability_intersection_invariant
             simp [ih₂₁]
-          case right => apply bool_is_instance_of_anyBool
+          · apply bool_is_instance_of_anyBool
         all_goals {
           simp [GuardedCapabilitiesInvariant, ih₂₂] at ih₂₁
           simp [ih₂₁]

--- a/cedar-lean/Cedar/Thm/Validation/Typechecker/Record.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Typechecker/Record.lean
@@ -271,18 +271,16 @@ theorem type_of_record_is_sound {axs : List (Attr × Expr)} {c₁ c₂ : Capabil
 := by
   have ⟨h₆, rty, h₅, h₄⟩ := type_of_record_inversion h₃
   subst h₅ h₆
-  apply And.intro
-  case left => exact empty_guarded_capabilities_invariant
-  case right =>
-    simp [EvaluatesTo, evaluate, List.mapM₂, List.attach₂]
-    let f := fun (x : Attr × Expr) => bindAttr x.fst (evaluate x.snd request entities)
-    simp [List.mapM_pmap_subtype f]
-    cases h₅ : (axs.mapM f) <;>
-    simp [h₅]
-    case error err =>
-      simp [type_is_inhabited]
-      exact type_of_record_is_sound_err ih h₁ h₂ h₄ h₅
-    case ok avs =>
-      exact type_of_record_is_sound_ok ih h₁ h₂ h₄ h₅
+  apply And.intro empty_guarded_capabilities_invariant
+  simp [EvaluatesTo, evaluate, List.mapM₂, List.attach₂]
+  let f := fun (x : Attr × Expr) => bindAttr x.fst (evaluate x.snd request entities)
+  simp [List.mapM_pmap_subtype f]
+  cases h₅ : (axs.mapM f) <;>
+  simp [h₅]
+  case error err =>
+    simp [type_is_inhabited]
+    exact type_of_record_is_sound_err ih h₁ h₂ h₄ h₅
+  case ok avs =>
+    exact type_of_record_is_sound_ok ih h₁ h₂ h₄ h₅
 
 end Cedar.Thm

--- a/cedar-lean/Cedar/Thm/Validation/Typechecker/Set.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Typechecker/Set.lean
@@ -147,11 +147,9 @@ theorem type_of_set_inversion {xs : List Expr} {c c' : Capabilities} {env : Envi
     rename_i res h₇
     exists hdty
     apply And.intro
-    case left =>
-      exists res.snd
+    · exists res.snd
       simp [←h₅, h₇]
-    case right =>
-      exact foldlM_of_lub_is_LUB h₃
+    · exact foldlM_of_lub_is_LUB h₃
   case tail xhd xtl h₄ =>
     have ⟨ty', h₅, h₆⟩ := type_of_set_tail h₂ h₃ h₄
     have h₇ := @type_of_set_inversion xtl c ∅ env (.set ty')
@@ -161,8 +159,8 @@ theorem type_of_set_inversion {xs : List Expr} {c c' : Capabilities} {env : Envi
     exists tyᵢ
     have ⟨cᵢ, h₇⟩ := h₇
     apply And.intro
-    case left  => exists cᵢ
-    case right => apply lub_lub_fixed h₈ h₆
+    · exists cᵢ
+    . exact lub_lub_fixed h₈ h₆
 
 theorem list_is_sound_implies_tail_is_sound {hd : Expr} {tl : List Expr}
   (h₁ : ∀ (xᵢ : Expr), xᵢ ∈ hd :: tl → TypeOfIsSound xᵢ) :
@@ -273,19 +271,17 @@ theorem type_of_set_is_sound {xs : List Expr} {c₁ c₂ : Capabilities} {env : 
 := by
   have ⟨h₆, ty, h₄, h₅⟩ := type_of_set_inversion h₃
   subst h₆ h₄
-  apply And.intro
-  case left => exact empty_guarded_capabilities_invariant
-  case right =>
-    simp [EvaluatesTo, evaluate, List.mapM₁, List.attach, List.mapM_pmap_subtype (evaluate · request entities)]
-    cases h₆ : xs.mapM fun x => evaluate x request entities <;>
-    simp [h₆]
-    case error err =>
-      simp [type_is_inhabited]
-      exact type_of_set_is_sound_err ih h₁ h₂ h₅ h₆
-    case ok vs =>
-      apply InstanceOfType.instance_of_set
-      intro v h₇
-      rw [←Set.make_mem] at h₇
-      exact type_of_set_is_sound_ok ih h₁ h₂ h₅ h₆ h₇
+  apply And.intro empty_guarded_capabilities_invariant
+  simp [EvaluatesTo, evaluate, List.mapM₁, List.attach, List.mapM_pmap_subtype (evaluate · request entities)]
+  cases h₆ : xs.mapM fun x => evaluate x request entities <;>
+  simp [h₆]
+  case error err =>
+    simp [type_is_inhabited]
+    exact type_of_set_is_sound_err ih h₁ h₂ h₅ h₆
+  case ok vs =>
+    apply InstanceOfType.instance_of_set
+    intro v h₇
+    rw [←Set.make_mem] at h₇
+    exact type_of_set_is_sound_ok ih h₁ h₂ h₅ h₆ h₇
 
 end Cedar.Thm

--- a/cedar-lean/Cedar/Thm/Validation/Typechecker/Types.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Typechecker/Types.lean
@@ -431,20 +431,17 @@ theorem instance_of_lubBool_left {v : Value} {bty₁ bty₂ : BoolType} :
   intro h₁ ; cases h₁
   simp [lubBool]
   split <;> rename_i b h₁ h₂
-  case inl =>
-    subst h₂
+  · subst h₂
     apply InstanceOfType.instance_of_bool b bty₁ h₁
-  case inr => try exact bool_is_instance_of_anyBool b
+  · exact bool_is_instance_of_anyBool b
 
 theorem instance_of_lubBool {v : Value} {bty₁ bty₂ : BoolType} :
   (InstanceOfType v (CedarType.bool bty₁) ∨ InstanceOfType v (CedarType.bool bty₂)) →
   InstanceOfType v (CedarType.bool (lubBool bty₁ bty₂))
 := by
-  intro h₁ ; cases h₁
-  case inl h₂ =>
-    exact instance_of_lubBool_left h₂
-  case inr h₂ =>
-    rw [lubBool_comm]
+  intro h₁ ; cases h₁ <;> rename_i h₂
+  · exact instance_of_lubBool_left h₂
+  · rw [lubBool_comm]
     exact instance_of_lubBool_left h₂
 
 theorem sizeOf_attr_type_lt_sizeOf_record_type {a : Attr} {qty : QualifiedType } {rty : List (Attr × Qualified CedarType) }
@@ -535,12 +532,10 @@ theorem instance_of_lub {v : Value} {ty ty₁ ty₂ : CedarType}
   (h₂ : InstanceOfType v ty₁ ∨ InstanceOfType v ty₂) :
   InstanceOfType v ty
 := by
-  cases h₂
-  case inl h₃ =>
-    apply instance_of_lub_left h₁ h₃
-  case inr h₃ =>
-    rw [lub_comm] at h₁
-    apply instance_of_lub_left h₁ h₃
+  cases h₂ <;> rename_i h₃
+  · exact instance_of_lub_left h₁ h₃
+  · rw [lub_comm] at h₁
+    exact instance_of_lub_left h₁ h₃
 
 
 end Cedar.Thm

--- a/cedar-lean/Cedar/Thm/Validation/Typechecker/UnaryApp.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Typechecker/UnaryApp.lean
@@ -42,9 +42,8 @@ theorem type_of_not_inversion {x₁ : Expr} {c₁ c₂ : Capabilities} {env : En
     case h_1 _ ty₁ bty _ =>
       simp [ok] at h₁
       apply And.intro
-      case left => simp [h₁]
-      case right =>
-        exists bty, c₁'
+      · simp [h₁]
+      · exists bty, c₁'
         simp only [and_true, h₁]
 
 theorem type_of_not_is_sound {x₁ : Expr} {c₁ c₂ : Capabilities} {env : Environment} {ty : CedarType} {request : Request} {entities : Entities}
@@ -57,34 +56,32 @@ theorem type_of_not_is_sound {x₁ : Expr} {c₁ c₂ : Capabilities} {env : Env
 := by
   have ⟨h₅, bty, c₁', h₆, h₄⟩ := type_of_not_inversion h₃
   subst h₅; subst h₆
-  apply And.intro
-  case left => exact empty_guarded_capabilities_invariant
-  case right =>
-    have ⟨_, v₁, h₆, h₇⟩ := ih h₁ h₂ h₄ -- IH
-    simp [EvaluatesTo] at h₆
-    simp [EvaluatesTo, evaluate]
-    rcases h₆ with h₆ | h₆ | h₆ | h₆ <;> simp [h₆]
-    case inr.inr.inr =>
-      cases bty
-      case anyBool =>
-        have ⟨b, h₈⟩ := instance_of_anyBool_is_bool h₇
-        cases b <;>
-        subst h₈ <;>
-        simp [apply₁] <;>
-        apply bool_is_instance_of_anyBool
-      case tt =>
-        have h₈ := instance_of_tt_is_true h₇
-        subst h₈
-        simp [apply₁, BoolType.not]
-        exact false_is_instance_of_ff
-      case ff =>
-        have h₈ := instance_of_ff_is_false h₇
-        subst h₈
-        simp [apply₁, BoolType.not]
-        exact true_is_instance_of_tt
-    all_goals {
-      exact type_is_inhabited (CedarType.bool (BoolType.not bty))
-    }
+  apply And.intro empty_guarded_capabilities_invariant
+  have ⟨_, v₁, h₆, h₇⟩ := ih h₁ h₂ h₄ -- IH
+  simp [EvaluatesTo] at h₆
+  simp [EvaluatesTo, evaluate]
+  rcases h₆ with h₆ | h₆ | h₆ | h₆ <;> simp [h₆]
+  case inr.inr.inr =>
+    cases bty
+    case anyBool =>
+      have ⟨b, h₈⟩ := instance_of_anyBool_is_bool h₇
+      cases b <;>
+      subst h₈ <;>
+      simp [apply₁] <;>
+      apply bool_is_instance_of_anyBool
+    case tt =>
+      have h₈ := instance_of_tt_is_true h₇
+      subst h₈
+      simp [apply₁, BoolType.not]
+      exact false_is_instance_of_ff
+    case ff =>
+      have h₈ := instance_of_ff_is_false h₇
+      subst h₈
+      simp [apply₁, BoolType.not]
+      exact true_is_instance_of_tt
+  all_goals {
+    exact type_is_inhabited (CedarType.bool (BoolType.not bty))
+  }
 
 theorem type_of_neg_inversion {x₁ : Expr} {c₁ c₂ : Capabilities} {env : Environment} {ty : CedarType}
   (h₁ : typeOf (Expr.unaryApp .neg x₁) c₁ env = Except.ok (ty, c₂)) :
@@ -111,27 +108,25 @@ theorem type_of_neg_is_sound {x₁ : Expr} {c₁ c₂ : Capabilities} {env : Env
 := by
   have ⟨h₅, h₆, c₁', h₄⟩ := type_of_neg_inversion h₃
   subst h₅; subst h₆
-  apply And.intro
-  case left => exact empty_guarded_capabilities_invariant
-  case right =>
-    have ⟨_, v₁, h₆, h₇⟩ := ih h₁ h₂ h₄ -- IH
-    simp [EvaluatesTo] at h₆
-    simp [EvaluatesTo, evaluate]
-    rcases h₆ with h₆ | h₆ | h₆ | h₆ <;> simp [h₆]
-    case inr.inr.inr =>
-      have ⟨i, h₈⟩ := instance_of_int_is_int h₇
-      subst h₈
-      simp [apply₁, intOrErr]
-      cases __ : i.neg?
-      case none =>
-        simp only [or_false, or_true, true_and]
-        exact type_is_inhabited CedarType.int
-      case some i' =>
-        simp only [Except.ok.injEq, false_or, exists_eq_left']
-        apply InstanceOfType.instance_of_int
-    all_goals {
+  apply And.intro empty_guarded_capabilities_invariant
+  have ⟨_, v₁, h₆, h₇⟩ := ih h₁ h₂ h₄ -- IH
+  simp [EvaluatesTo] at h₆
+  simp [EvaluatesTo, evaluate]
+  rcases h₆ with h₆ | h₆ | h₆ | h₆ <;> simp [h₆]
+  case inr.inr.inr =>
+    have ⟨i, h₈⟩ := instance_of_int_is_int h₇
+    subst h₈
+    simp [apply₁, intOrErr]
+    cases __ : i.neg?
+    case none =>
+      simp only [or_false, or_true, true_and]
       exact type_is_inhabited CedarType.int
-    }
+    case some i' =>
+      simp only [Except.ok.injEq, false_or, exists_eq_left']
+      apply InstanceOfType.instance_of_int
+  all_goals {
+    exact type_is_inhabited CedarType.int
+  }
 
 theorem type_of_like_inversion {x₁ : Expr} {p : Pattern} {c₁ c₂ : Capabilities} {env : Environment} {ty : CedarType}
   (h₁ : typeOf (Expr.unaryApp (.like p) x₁) c₁ env = Except.ok (ty, c₂)) :
@@ -158,21 +153,19 @@ theorem type_of_like_is_sound {x₁ : Expr} {p : Pattern} {c₁ c₂ : Capabilit
 := by
   have ⟨h₅, h₆, c₁', h₄⟩ := type_of_like_inversion h₃
   subst h₅; subst h₆
-  apply And.intro
-  case left => exact empty_guarded_capabilities_invariant
-  case right =>
-    have ⟨_, v₁, h₆, h₇⟩ := ih h₁ h₂ h₄ -- IH
-    simp [EvaluatesTo] at h₆
-    simp [EvaluatesTo, evaluate]
-    rcases h₆ with h₆ | h₆ | h₆ | h₆ <;> simp [h₆]
-    case inr.inr.inr =>
-      have ⟨s, h₈⟩ := instance_of_string_is_string h₇
-      subst h₈
-      simp [apply₁]
-      exact bool_is_instance_of_anyBool (wildcardMatch s p)
-    all_goals {
-      exact type_is_inhabited (.bool .anyBool)
-    }
+  apply And.intro empty_guarded_capabilities_invariant
+  have ⟨_, v₁, h₆, h₇⟩ := ih h₁ h₂ h₄ -- IH
+  simp [EvaluatesTo] at h₆
+  simp [EvaluatesTo, evaluate]
+  rcases h₆ with h₆ | h₆ | h₆ | h₆ <;> simp [h₆]
+  case inr.inr.inr =>
+    have ⟨s, h₈⟩ := instance_of_string_is_string h₇
+    subst h₈
+    simp [apply₁]
+    exact bool_is_instance_of_anyBool (wildcardMatch s p)
+  all_goals {
+    exact type_is_inhabited (.bool .anyBool)
+  }
 
 theorem type_of_is_inversion {x₁ : Expr} {ety : EntityType} {c₁ c₂ : Capabilities} {env : Environment} {ty : CedarType}
   (h₁ : typeOf (Expr.unaryApp (.is ety) x₁) c₁ env = Except.ok (ty, c₂)) :
@@ -192,9 +185,8 @@ theorem type_of_is_inversion {x₁ : Expr} {ety : EntityType} {c₁ c₂ : Capab
       subst h₃
       simp [ok] at h₁
       apply And.intro
-      case left => simp [h₁]
-      case right =>
-        exists ety', c₁'
+      · simp [h₁]
+      · exists ety', c₁'
         simp only [h₁, and_self]
 
 theorem type_of_is_is_sound {x₁ : Expr} {ety : EntityType} {c₁ c₂ : Capabilities} {env : Environment} {ty : CedarType} {request : Request} {entities : Entities}
@@ -207,24 +199,22 @@ theorem type_of_is_is_sound {x₁ : Expr} {ety : EntityType} {c₁ c₂ : Capabi
 := by
   have ⟨h₅, ety', c₁', h₆, h₄⟩ := type_of_is_inversion h₃
   subst h₅; subst h₆
-  apply And.intro
-  case left => exact empty_guarded_capabilities_invariant
-  case right =>
-    have ⟨_, v₁, h₆, h₇⟩ := ih h₁ h₂ h₄ -- IH
-    simp [EvaluatesTo] at h₆
-    simp [EvaluatesTo, evaluate]
-    rcases h₆ with h₆ | h₆ | h₆ | h₆ <;> simp [h₆]
-    case inr.inr.inr =>
-      have ⟨uid, h₈, h₉⟩ := instance_of_entity_type_is_entity h₇
-      simp [apply₁, h₉, h₈]
-      cases h₁₀ : ety == ety' <;>
-      simp at h₁₀ <;>
-      simp [h₁₀]
-      case false => exact false_is_instance_of_ff
-      case true => exact true_is_instance_of_tt
-    all_goals {
-      apply type_is_inhabited
-    }
+  apply And.intro empty_guarded_capabilities_invariant
+  have ⟨_, v₁, h₆, h₇⟩ := ih h₁ h₂ h₄ -- IH
+  simp [EvaluatesTo] at h₆
+  simp [EvaluatesTo, evaluate]
+  rcases h₆ with h₆ | h₆ | h₆ | h₆ <;> simp [h₆]
+  case inr.inr.inr =>
+    have ⟨uid, h₈, h₉⟩ := instance_of_entity_type_is_entity h₇
+    simp [apply₁, h₉, h₈]
+    cases h₁₀ : ety == ety' <;>
+    simp at h₁₀ <;>
+    simp [h₁₀]
+    case false => exact false_is_instance_of_ff
+    case true => exact true_is_instance_of_tt
+  all_goals {
+    apply type_is_inhabited
+  }
 
 theorem type_of_unaryApp_is_sound {op₁ : UnaryOp} {x₁ : Expr} {c₁ c₂ : Capabilities} {env : Environment} {ty : CedarType} {request : Request} {entities : Entities}
   (h₁ : CapabilitiesInvariant c₁ request entities)


### PR DESCRIPTION
A bunch more data structure lemmas.  These changes were split off #291, but without most of the breaking changes to the Cedar/Thm/Data files, and also taking advantage of the new lemmas in #297 when appropriate.  There are still a few breaking changes in this PR, but only to lemmas introduced in #297, as a compromise due to the simultaneous/duplicated work in #291 and #297.  Also, the changes are isolated to this PR rather than being included with #291.


