### PR TITLE
Add a target to PBT common type resolution

### DIFF
--- a/cedar-drt/fuzz/Cargo.toml
+++ b/cedar-drt/fuzz/Cargo.toml
@@ -134,3 +134,9 @@ name = "json-schema-roundtrip"
 path = "fuzz_targets/json-schema-roundtrip.rs"
 test = false
 doc = false
+
+[[bin]]
+name = "common-type-resolution"
+path = "fuzz_targets/common-type-resolution.rs"
+test = false
+doc = false

--- a/cedar-drt/fuzz/fuzz_targets/common-type-resolution.rs
+++ b/cedar-drt/fuzz/fuzz_targets/common-type-resolution.rs
@@ -1,0 +1,94 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#![no_main]
+use cedar_drt_inner::{schemas::validator_schema_entity_attr_equivalent, *};
+use cedar_policy_generators::{schema::Schema, settings::ABACSettings};
+use cedar_policy_validator::SchemaFragment;
+use libfuzzer_sys::arbitrary::{self, Arbitrary, Unstructured};
+use log::info;
+use serde::Serialize;
+use std::collections::HashMap;
+
+#[derive(Debug, Clone, Serialize)]
+struct Input {
+    pub schema: SchemaFragment,
+    pub schema_with_common_types: SchemaFragment,
+}
+
+/// settings for this fuzz target
+const SETTINGS: ABACSettings = ABACSettings {
+    match_types: false,
+    enable_extensions: true,
+    max_depth: 3,
+    max_width: 7,
+    enable_additional_attributes: false,
+    enable_like: true,
+    // ABAC fuzzing restricts the use of action because it is used to generate
+    // the corpus tests which will be run on Cedar and CedarCLI.
+    // These packages only expose the restricted action behavior.
+    enable_action_groups_and_attrs: false,
+    enable_arbitrary_func_call: true,
+    enable_unknowns: false,
+    enable_action_in_constraints: true,
+    enable_unspecified_apply_spec: true,
+};
+
+impl<'a> Arbitrary<'a> for Input {
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        let arb_schema = Schema::arbitrary(SETTINGS.clone(), u)?;
+        let namespace = &arb_schema.schema;
+        let name = &arb_schema.namespace;
+
+        let schema = SchemaFragment(HashMap::from([(name.clone(), namespace.clone())]));
+
+        let namespace_with_common_types = arb_schema.add_common_types(u)?;
+        let schema_with_common_types = SchemaFragment(HashMap::from_iter([(
+            name.clone(),
+            namespace_with_common_types,
+        )]));
+
+        Ok(Self {
+            schema,
+            schema_with_common_types,
+        })
+    }
+
+    fn size_hint(depth: usize) -> (usize, Option<usize>) {
+        Schema::arbitrary_size_hint(depth)
+    }
+}
+
+fuzz_target!(|i: Input| {
+    info!("schemas: {i:?}");
+    let validator_schema1: Result<cedar_policy_validator::ValidatorSchema, _> = i.schema.try_into();
+    let validator_schema2: Result<cedar_policy_validator::ValidatorSchema, _> =
+        i.schema_with_common_types.try_into();
+    match (validator_schema1, validator_schema2) {
+        (Ok(s1), Ok(s2)) => {
+            assert!(
+                validator_schema_entity_attr_equivalent(&s1, &s2),
+                "reduced to different validator schemas: {:?}\n{:?}\n",
+                s1,
+                s2
+            );
+        }
+        (Err(_), Err(_)) => {}
+        (Ok(s), Err(_)) | (Err(_), Ok(s)) => {
+            panic!("reduction results differ, got validator schema: {:?}\n", s);
+        }
+    }
+});

--- a/cedar-drt/fuzz/fuzz_targets/common-type-resolution.rs
+++ b/cedar-drt/fuzz/fuzz_targets/common-type-resolution.rs
@@ -15,7 +15,7 @@
  */
 
 #![no_main]
-use cedar_drt_inner::{schemas::validator_schema_entity_attr_equivalent, *};
+use cedar_drt_inner::{schemas::validator_schema_attr_types_equivalent, *};
 use cedar_policy_generators::{schema::Schema, settings::ABACSettings};
 use cedar_policy_validator::SchemaFragment;
 use libfuzzer_sys::arbitrary::{self, Arbitrary, Unstructured};
@@ -80,7 +80,7 @@ fuzz_target!(|i: Input| {
     match (validator_schema1, validator_schema2) {
         (Ok(s1), Ok(s2)) => {
             assert!(
-                validator_schema_entity_attr_equivalent(&s1, &s2),
+                validator_schema_attr_types_equivalent(&s1, &s2),
                 "reduced to different validator schemas: {:?}\n{:?}\n",
                 s1,
                 s2

--- a/cedar-drt/fuzz/src/schemas.rs
+++ b/cedar-drt/fuzz/src/schemas.rs
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+use std::collections::HashMap;
+
 use cedar_policy_validator::{ActionType, ApplySpec, NamespaceDefinition, SchemaFragment};
 
 /// Check if two schema fragments are equivalent, modulo empty apply specs.
@@ -111,4 +113,25 @@ fn both_unspecified(spec: &ApplySpec) -> bool {
 fn either_empty(spec: &ApplySpec) -> bool {
     matches!(spec.resource_types.as_ref(), Some(ts) if ts.is_empty())
         || matches!(spec.principal_types.as_ref(), Some(ts) if ts.is_empty())
+}
+
+/// Just compare entity attribute types are equivalent
+pub fn validator_schema_entity_attr_equivalent(
+    schema1: &cedar_policy_validator::ValidatorSchema,
+    schema2: &cedar_policy_validator::ValidatorSchema,
+) -> bool {
+    let attr_tys1: HashMap<
+        &cedar_drt::ast::Name,
+        HashMap<&smol_str::SmolStr, &cedar_policy_validator::types::AttributeType>,
+    > = HashMap::from_iter(
+        schema1
+            .entity_types()
+            .map(|(name, ty)| (name, HashMap::from_iter(ty.attributes()))),
+    );
+    let attr_tys2 = HashMap::from_iter(
+        schema2
+            .entity_types()
+            .map(|(name, ty)| (name, HashMap::from_iter(ty.attributes()))),
+    );
+    attr_tys1 == attr_tys2
 }

--- a/cedar-policy-generators/src/expr.rs
+++ b/cedar-policy-generators/src/expr.rs
@@ -1056,8 +1056,7 @@ impl<'a> ExprGenerator<'a> {
                             Type::IPAddr => "ipaddr".parse::<Id>().unwrap(),
                             Type::Decimal => "decimal".parse().unwrap(),
                             _ => unreachable!("target type is deemed to be an extension type!"),
-                        }
-                        .into();
+                        };
                         gen!(u,
                         // if-then-else expression, where both arms are extension types
                         2 => Ok(ast::Expr::ite(

--- a/cedar-policy-generators/src/schema.rs
+++ b/cedar-policy-generators/src/schema.rs
@@ -32,8 +32,8 @@ use arbitrary::{self, Arbitrary, Unstructured};
 use cedar_policy_core::ast::{self, Effect, Id, Name, PolicyID};
 use cedar_policy_core::extensions::Extensions;
 use cedar_policy_validator::{
-    ActionType, ApplySpec, AttributesOrContext, SchemaError, SchemaFragment, SchemaType,
-    TypeOfAttribute, ValidatorSchema,
+    ActionType, ApplySpec, AttributesOrContext, EntityType, SchemaError, SchemaFragment,
+    SchemaType, SchemaTypeVariant, TypeOfAttribute, ValidatorSchema,
 };
 use smol_str::SmolStr;
 use std::collections::BTreeMap;
@@ -177,7 +177,6 @@ pub fn arbitrary_schematype_with_bounded_depth(
     max_depth: usize,
     u: &mut Unstructured<'_>,
 ) -> Result<cedar_policy_validator::SchemaType> {
-    use cedar_policy_validator::SchemaTypeVariant;
     Ok(SchemaType::Type(uniform!(
         u,
         SchemaTypeVariant::String,
@@ -283,7 +282,6 @@ fn schematype_to_type(
     schema: &cedar_policy_validator::NamespaceDefinition,
     schematy: &cedar_policy_validator::SchemaType,
 ) -> Type {
-    use cedar_policy_validator::SchemaTypeVariant;
     match schematy {
         SchemaType::TypeDef { type_name } => schematype_to_type(
             schema,
@@ -341,7 +339,6 @@ pub(crate) fn attrs_from_attrs_or_context<'a>(
     schema: &'a cedar_policy_validator::NamespaceDefinition,
     attrsorctx: &'a AttributesOrContext,
 ) -> Attributes<'a> {
-    use cedar_policy_validator::SchemaTypeVariant;
     match &attrsorctx.0 {
         SchemaType::TypeDef { type_name } => match schema.common_types.get(&type_name.clone().try_into().unwrap()).unwrap_or_else(|| panic!("reference to undefined common type: {type_name}")) {
             SchemaType::TypeDef { .. } => panic!("common type `{type_name}` refers to another common type, which is not allowed as of this writing?"),
@@ -377,7 +374,6 @@ fn attrs_in_schematype(
 ) -> Box<dyn Iterator<Item = (SmolStr, cedar_policy_validator::SchemaType)>> {
     match schematype {
         cedar_policy_validator::SchemaType::Type(variant) => {
-            use cedar_policy_validator::SchemaTypeVariant;
             match variant {
                 SchemaTypeVariant::Boolean => Box::new(std::iter::empty()),
                 SchemaTypeVariant::Long => Box::new(std::iter::empty()),
@@ -437,7 +433,184 @@ fn build_attributes_by_type<'a>(
     hm
 }
 
+// Common type bindings
+#[derive(Debug)]
+struct Bindings {
+    // Bindings from `SchemaType` to a list of `Id`
+    // The `ids` field ensures that `Id`s are unique
+    // Note that `SchemaType`s should not contain any common type references
+    bindings: BTreeMap<SchemaType, Vec<Id>>,
+    // The set of `Id`s used in the bindings
+    ids: HashSet<Id>,
+}
+
+impl Bindings {
+    fn new() -> Self {
+        Self {
+            bindings: BTreeMap::new(),
+            ids: HashSet::new(),
+        }
+    }
+
+    // Add a `SchemaType` and `Id` binding
+    // Note that this function always succeeds even if the `Id` already exists
+    // Under that situation, we create a new `Id` based on the existing `Id`
+    fn add_binding(&mut self, binding: (SchemaType, Id)) {
+        let (ty, id) = binding;
+        // create a new id when the provided id has been used
+        let new_id = if self.ids.get(&id).is_some() {
+            format!("_{id}").parse().unwrap()
+        } else {
+            id
+        };
+        self.ids.insert(new_id.clone());
+        if let Some(binding_for_ty) = self.bindings.get_mut(&ty) {
+            binding_for_ty.push(new_id);
+        } else {
+            self.bindings.insert(ty, vec![new_id]);
+        }
+    }
+
+    // Replace types with common type references
+    // We only replace smaller types in composite types like sets and records
+    // to avoid circularity
+    // This function is a no-op for other types
+    fn rewrite_type(&self, u: &mut Unstructured<'_>, ty: &SchemaType) -> Result<SchemaType> {
+        match ty {
+            SchemaType::TypeDef { .. } => unreachable!("common type references shouldn't be here"),
+            SchemaType::Type(SchemaTypeVariant::Set { element }) => {
+                Ok(SchemaType::Type(SchemaTypeVariant::Set {
+                    element: Box::new(if let Some(ids) = self.bindings.get(element) {
+                        SchemaType::TypeDef {
+                            type_name: Name::unqualified_name(u.choose(ids)?.clone()),
+                        }
+                    } else {
+                        self.rewrite_type(u, element)?
+                    }),
+                }))
+            }
+            SchemaType::Type(SchemaTypeVariant::Record {
+                attributes,
+                additional_attributes,
+            }) => Ok(SchemaType::Type(SchemaTypeVariant::Record {
+                attributes: BTreeMap::from_iter(
+                    attributes
+                        .iter()
+                        .map(|(attr, attr_ty)| {
+                            Ok((
+                                attr.to_owned(),
+                                TypeOfAttribute {
+                                    ty: self.rewrite_type(u, &attr_ty.ty)?,
+                                    required: attr_ty.required.to_owned(),
+                                },
+                            ))
+                        })
+                        .collect::<Result<Vec<_>>>()?,
+                ),
+                additional_attributes: additional_attributes.to_owned(),
+            })),
+            _ => Ok(ty.clone()),
+        }
+    }
+
+    // Replace attribute types in an entity type with common types
+    fn rewrite_entity_type(&self, u: &mut Unstructured<'_>, et: &EntityType) -> Result<EntityType> {
+        let ty = &et.shape.0;
+        let new_ty = if let Some(ids) = self.bindings.get(ty) {
+            SchemaType::TypeDef {
+                type_name: Name::unqualified_name(u.choose(ids)?.clone()),
+            }
+        } else {
+            self.rewrite_type(u, ty)?
+        };
+        Ok(EntityType {
+            member_of_types: et.member_of_types.clone(),
+            shape: AttributesOrContext(new_ty),
+        })
+    }
+
+    // Generate common types based on the bindings
+    // For a binding `ty` to `[id_1, id_2, ..., id_n]`
+    // We create common types as follows
+    // ```
+    // type id_1 = id_2;
+    // type id_2 = id_3;
+    // ...
+    // type id_n = rewrite_type(ty)
+    // ```
+    fn to_common_types(&self, u: &mut Unstructured<'_>) -> Result<HashMap<Id, SchemaType>> {
+        let mut common_types = HashMap::new();
+        for (ty, ids) in &self.bindings {
+            if ids.len() == 1 {
+                common_types.insert(ids.first().unwrap().clone(), self.rewrite_type(u, ty)?);
+            } else if ids.len() > 1 {
+                // ids[0] -> ids[1] -> ... -> ids[n]
+                for i in 0..(ids.len() - 1) {
+                    common_types.insert(
+                        ids[i].clone(),
+                        SchemaType::TypeDef {
+                            type_name: Name::unqualified_name(ids[i + 1].clone()),
+                        },
+                    );
+                    common_types.insert(ids[ids.len() - 1].clone(), self.rewrite_type(u, ty)?);
+                }
+            }
+        }
+        Ok(common_types)
+    }
+}
+
+// Bind types to random ids recursively
+fn bind_type(ty: &SchemaType, u: &mut Unstructured<'_>, bindings: &mut Bindings) -> Result<()> {
+    // flip a coin to decide if we should create a binding for the top-level type
+    if u.ratio(1, 2)? {
+        bindings.add_binding((ty.clone(), u.arbitrary()?));
+    }
+    match ty {
+        SchemaType::Type(cedar_policy_validator::SchemaTypeVariant::Set { element }) => {
+            bind_type(element, u, bindings)?;
+        }
+        SchemaType::Type(cedar_policy_validator::SchemaTypeVariant::Record {
+            attributes,
+            additional_attributes: _,
+        }) => {
+            attributes
+                .iter()
+                .map(|(_, attr_ty)| bind_type(&attr_ty.ty, u, bindings))
+                .collect::<Result<Vec<()>>>()?;
+        }
+        SchemaType::TypeDef { .. } => unreachable!("common type references shouldn't exist here"),
+        _ => {}
+    };
+    Ok(())
+}
+
 impl Schema {
+    /// Add common types to the existing schema and return a new schema
+    pub fn add_common_types(
+        &self,
+        u: &mut Unstructured<'_>,
+    ) -> Result<cedar_policy_validator::NamespaceDefinition> {
+        let attribute_types = &self.attributes;
+        let mut bindings = Bindings::new();
+        for (_, ty) in attribute_types {
+            bind_type(ty, u, &mut bindings)?;
+        }
+        let common_types = bindings.to_common_types(u)?;
+        let entity_types: HashMap<Id, EntityType> = HashMap::from_iter(
+            self.schema
+                .entity_types
+                .iter()
+                .map(|(id, et)| Ok((id.clone(), bindings.rewrite_entity_type(u, et)?)))
+                .collect::<Result<Vec<_>>>()?,
+        );
+        let actions = self.schema.actions.clone();
+        Ok(cedar_policy_validator::NamespaceDefinition {
+            common_types: common_types.into(),
+            entity_types: entity_types.into(),
+            actions,
+        })
+    }
     /// Get a slice of all of the entity types in this schema
     pub fn entity_types(&self) -> &[ast::Name] {
         &self.entity_types
@@ -485,9 +658,9 @@ impl Schema {
                 .keys()
                 .map(|k| k.clone().into())
                 .collect(),
-            principal_types: principal_types.into_iter().map(|p| p.clone()).collect(),
+            principal_types: principal_types.into_iter().cloned().collect(),
             actions_eids: nsdef.actions.keys().cloned().map(ast::Eid::new).collect(),
-            resource_types: resource_types.into_iter().map(|r| r.clone()).collect(),
+            resource_types: resource_types.into_iter().cloned().collect(),
             attributes,
             attributes_by_type,
             schema: nsdef,
@@ -561,7 +734,7 @@ impl Schema {
             .filter(|id| settings.enable_action_groups_and_attrs || id.to_string() != "Action")
             .map(|id| {
                 Ok((
-                    id.clone().into(),
+                    id.clone(),
                     cedar_policy_validator::EntityType {
                         member_of_types: vec![],
                         shape: arbitrary_attrspec(&settings, &entity_type_names, u)?,
@@ -825,7 +998,6 @@ impl Schema {
         ty: &Type,
         u: &mut Unstructured<'_>,
     ) -> Result<Option<cedar_policy_validator::SchemaType>> {
-        use cedar_policy_validator::SchemaTypeVariant;
         Ok(match ty {
             Type::Bool => Some(SchemaTypeVariant::Boolean),
             Type::Long => Some(SchemaTypeVariant::Long),
@@ -1215,7 +1387,7 @@ impl Schema {
 
 impl From<Schema> for SchemaFragment {
     fn from(schema: Schema) -> SchemaFragment {
-        SchemaFragment(HashMap::from_iter([(schema.namespace, schema.schema)].into_iter()).into())
+        SchemaFragment(HashMap::from_iter([(schema.namespace, schema.schema)]).into())
     }
 }
 
@@ -1707,7 +1879,7 @@ mod tests {
             ValidatorSchema::try_from(schema).expect("failed to convert to ValidatorSchema");
         let coreschema = CoreSchema::new(&vschema);
         Entities::from_entities(
-            h.entities().into_iter().map(|e| e.clone()),
+            h.entities().cloned(),
             Some(&coreschema),
             cedar_policy_core::entities::TCComputation::ComputeNow,
             Extensions::all_available(),

--- a/cedar-policy-generators/src/schema.rs
+++ b/cedar-policy-generators/src/schema.rs
@@ -456,11 +456,10 @@ impl Bindings {
     fn add_binding(&mut self, binding: (SchemaType, Id)) {
         let (ty, id) = binding;
         // create a new id when the provided id has been used
-        let new_id = if self.ids.get(&id).is_some() {
-            format!("_{id}").parse().unwrap()
-        } else {
-            id
-        };
+        let mut new_id = id;
+        while self.ids.contains(&new_id) {
+            new_id = format!("_{new_id}").parse().unwrap();
+        }
         self.ids.insert(new_id.clone());
         if let Some(binding_for_ty) = self.bindings.get_mut(&ty) {
             binding_for_ty.push(new_id);
@@ -594,6 +593,7 @@ impl Schema {
         for (_, ty) in attribute_types {
             bind_type(ty, u, &mut bindings)?;
         }
+
         let common_types = bindings.to_common_types(u)?;
         let entity_types: HashMap<Id, EntityType> = HashMap::from_iter(
             self.schema

--- a/cedar-policy-generators/src/schema.rs
+++ b/cedar-policy-generators/src/schema.rs
@@ -373,27 +373,25 @@ fn attrs_in_schematype(
     schematype: &cedar_policy_validator::SchemaType,
 ) -> Box<dyn Iterator<Item = (SmolStr, cedar_policy_validator::SchemaType)>> {
     match schematype {
-        cedar_policy_validator::SchemaType::Type(variant) => {
-            match variant {
-                SchemaTypeVariant::Boolean => Box::new(std::iter::empty()),
-                SchemaTypeVariant::Long => Box::new(std::iter::empty()),
-                SchemaTypeVariant::String => Box::new(std::iter::empty()),
-                SchemaTypeVariant::Entity { .. } => Box::new(std::iter::empty()),
-                SchemaTypeVariant::Extension { .. } => Box::new(std::iter::empty()),
-                SchemaTypeVariant::Set { element } => attrs_in_schematype(schema, element),
-                SchemaTypeVariant::Record { attributes, .. } => {
-                    let toplevel = attributes
-                        .iter()
-                        .map(|(k, v)| (k.clone(), v.ty.clone()))
-                        .collect::<Vec<_>>();
-                    let recursed = toplevel
-                        .iter()
-                        .flat_map(|(_, v)| attrs_in_schematype(schema, v))
-                        .collect::<Vec<_>>();
-                    Box::new(toplevel.into_iter().chain(recursed))
-                }
+        cedar_policy_validator::SchemaType::Type(variant) => match variant {
+            SchemaTypeVariant::Boolean => Box::new(std::iter::empty()),
+            SchemaTypeVariant::Long => Box::new(std::iter::empty()),
+            SchemaTypeVariant::String => Box::new(std::iter::empty()),
+            SchemaTypeVariant::Entity { .. } => Box::new(std::iter::empty()),
+            SchemaTypeVariant::Extension { .. } => Box::new(std::iter::empty()),
+            SchemaTypeVariant::Set { element } => attrs_in_schematype(schema, element),
+            SchemaTypeVariant::Record { attributes, .. } => {
+                let toplevel = attributes
+                    .iter()
+                    .map(|(k, v)| (k.clone(), v.ty.clone()))
+                    .collect::<Vec<_>>();
+                let recursed = toplevel
+                    .iter()
+                    .flat_map(|(_, v)| attrs_in_schematype(schema, v))
+                    .collect::<Vec<_>>();
+                Box::new(toplevel.into_iter().chain(recursed))
             }
-        }
+        },
         cedar_policy_validator::SchemaType::TypeDef { type_name } => attrs_in_schematype(
             schema,
             schema


### PR DESCRIPTION
*Issue #, if available:*

Partially addressed #96

*Description of changes:*

The target replaces child-types of `SchemaType`s or themselves with common type IDs in a `SchemaFragment` and tests if the two `SchemaFragment` resolve to the same `ValidatorSchema`.


