### PR TITLE
Introduce `csimp` tactic

### DIFF
--- a/cedar-lean/Cedar/Tactic/Csimp.lean
+++ b/cedar-lean/Cedar/Tactic/Csimp.lean
@@ -1,0 +1,177 @@
+/-
+ Copyright Cedar Contributors
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-/
+
+import Cedar.Data.Set
+import Cedar.Spec.Value
+import Cedar.Thm.Data.Control
+
+namespace Cedar.Tactic
+open Lean Parser
+
+/--
+`csimp` is a version of `simp` that uses a different set of lemmas.
+It exists to avoid the potential breakage when upgrading Lean versions if the
+set of `simp` lemmas changes (because we control the set of lemmas used here,
+and it is stable across Lean versions unless we choose to make changes).
+It is also an alternative to the Mathlib convention of using `simp only`
+everywhere, which is a hassle and clutters proofs.
+
+The set of `csimp` lemmas is intended to be a subset of the `simp` lemmas, so
+(among other things) `csimp` should have intermediate performance between `simp`
+and a dedicated `simp only`.
+
+`csimp` supports `at` syntax, e.g., all of the following are valid:
+* `csimp`
+* `csimp at h`
+* `csimp at *`
+
+but `csimp` does not support extending the lemmas inline, e.g.,
+* `csimp [h₂]` (instead, use `csimp ; simp only [h₂]`, or the other order)
+
+only because I couldn't get that to work. If you can get it to work,
+contributions welcome.
+-/
+syntax (name := csimp) "csimp" (Tactic.config)? (ppSpace Tactic.location)? : tactic
+
+macro_rules
+  | `(tactic| csimp $(config)? $(loc)?) =>
+      `(tactic| simp $(config)? only [
+          and_false,
+          and_true,
+          false_and,
+          true_and,
+          or_false,
+          or_true,
+          false_or,
+          true_or,
+
+          not_and,
+          not_false_eq_true,
+          not_true_eq_false,
+          decide_eq_true_eq,
+
+          ne_eq,
+          id_eq,
+
+          ite_not,
+          ite_true,
+          ite_false,
+
+          false_implies,
+          implies_true,
+          imp_self,
+          and_imp,
+
+          gt_iff_lt,
+
+          beq_eq_false_iff_ne,
+          beq_iff_eq,
+          bne_iff_ne,
+
+          forall_const,
+          forall_eq',
+          forall_eq_or_imp,
+          forall_exists_index,
+          forall_apply_eq_imp_iff₂,
+
+          exists_false,
+          exists_const,
+          exists_eq',
+          exists_eq_left',
+          exists_eq_right,
+          exists_eq_right_right,
+          exists_and_right,
+          exists_eq_or_imp,
+
+          Bool.and_eq_true,
+          Bool.or_eq_true,
+          Bool.not_eq_true',
+          Bool.not_eq_false,
+          Bool.true_or,
+          Bool.false_or,
+
+          List.empty_eq,
+          List.subset_def,
+          List.cons_subset,
+          List.not_mem_nil,
+          List.mem_cons,
+          List.mem_map,
+          List.mem_filterMap,
+          List.map_nil,
+          List.map_cons,
+          List.map_map,
+          List.any_nil,
+          List.any_cons,
+          List.any_eq_true,
+          List.all_nil,
+          List.all_cons,
+          List.all_eq_true,
+          List.find?_nil,
+          List.find?_cons,
+          List.mapM'_nil,
+          List.mapM'_cons,
+          List.mapM_nil,
+          List.mapM_cons,
+          List.filter_nil,
+          List.filter_cons,
+          List.filterMap_nil,
+          List.filterMap_cons,
+          List.foldlM_nil,
+          List.foldlM_cons,
+
+          Option.none_bind,
+          Option.some_bind,
+          Option.isSome_none,
+          Option.isSome_some,
+          Option.bind_eq_none,
+          Option.bind_eq_some,
+          Option.map_none',
+          Option.map_some',
+
+          -- the theorems from Cedar.Thm.Data.Control
+          Except.bind_ok_T,
+          Except.bind_ok,
+          Except.bind_err,
+          Option.bind_some_T,
+          Option.bind_some_fun,
+          Option.bind_none_fun,
+
+          -- some Spec definitions which we want to eagerly expand
+          Cedar.Spec.Result.as,
+          Cedar.Spec.Value.asBool,
+
+          -- `injEq` for a bunch of different types
+          Option.some.injEq,
+          List.cons.injEq,
+          Prod.mk.injEq,
+          Except.ok.injEq,
+          Except.error.injEq,
+          Cedar.Data.Set.mk.injEq,
+          Cedar.Data.Map.mk.injEq,
+          Cedar.Spec.Prim.entityUID.injEq,
+          Cedar.Spec.Value.prim.injEq,
+          Cedar.Spec.Value.record.injEq,
+          Cedar.Spec.Prim.bool.injEq,
+
+          -- some Lean definitions which we want to eagerly expand
+          Coe.coe,
+          pure,
+          Option.pure_def,
+          Option.bind_eq_bind,
+          Except.pure,
+        ]
+        $(loc)?
+      )

--- a/cedar-lean/Cedar/Thm/Authorization.lean
+++ b/cedar-lean/Cedar/Thm/Authorization.lean
@@ -15,6 +15,7 @@
 -/
 
 import Cedar.Spec
+import Cedar.Tactic.Csimp
 import Cedar.Thm.Authorization.Authorizer
 
 /-! This file contains basic theorems about Cedar's authorizer. -/
@@ -60,9 +61,9 @@ theorem allowed_if_explicitly_permitted (request : Request) (entities : Entities
   unfold isAuthorized
   generalize (satisfiedPolicies forbid policies request entities) = forbids
   generalize hp : (satisfiedPolicies permit policies request entities) = permits
-  simp only [Bool.and_eq_true, Bool.not_eq_true']
-  cases forbids.isEmpty <;> simp
-  cases h0 : permits.isEmpty <;> simp
+  csimp
+  cases forbids.isEmpty <;> csimp
+  cases h0 : permits.isEmpty <;> csimp
   unfold IsExplicitlyPermitted
   apply if_satisfiedPolicies_non_empty_then_satisfied permit policies
   simp [hp, h0]

--- a/cedar-lean/Cedar/Thm/Data/List.lean
+++ b/cedar-lean/Cedar/Thm/Data/List.lean
@@ -16,6 +16,7 @@
 
 import Cedar.Data.List
 import Cedar.Data.LT
+import Cedar.Tactic.Csimp
 import Cedar.Thm.Data.Control
 import Std.Logic
 
@@ -76,15 +77,16 @@ theorem swap_cons_cons_equiv (x₁ x₂ : α) (xs : List α) :
   x₁ :: x₂ :: xs ≡ x₂ :: x₁ :: xs
 := by
   unfold List.Equiv
-  simp only [subset_def, mem_cons, forall_eq_or_imp, true_or, or_true, true_and]
+  csimp
   apply And.intro
   all_goals { intro a h₁; simp [h₁] }
 
 theorem filter_equiv (f : α → Bool) (xs ys : List α) :
   xs ≡ ys → xs.filter f ≡ ys.filter f
 := by
-  simp only [Equiv, subset_def, and_imp]
-  intros h₁ h₂
+  unfold Equiv
+  csimp
+  intro h₁ h₂
   apply And.intro <;>
   intro a h₃ <;>
   rw [mem_filter] <;> rw [mem_filter] at h₃
@@ -97,8 +99,7 @@ theorem map_equiv (f : α → β) (xs ys : List α) :
   intro h
   have ⟨a, b⟩ := h
   apply And.intro <;>
-  simp only [subset_def, mem_map, forall_exists_index, and_imp,
-    forall_apply_eq_imp_iff₂] <;>
+  csimp <;>
   intro p h <;>
   exists p <;>
   rw [List.subset_def] at a b <;>
@@ -109,7 +110,8 @@ theorem map_equiv (f : α → β) (xs ys : List α) :
 theorem filterMap_equiv (f : α → Option β) (xs ys : List α) :
   xs ≡ ys → xs.filterMap f ≡ ys.filterMap f
 := by
-  simp only [Equiv, subset_def, mem_filterMap, forall_exists_index, and_imp]
+  unfold Equiv
+  csimp
   intros h₁ h₂
   apply And.intro <;>
   intro b a h₃ h₄ <;>
@@ -182,8 +184,8 @@ theorem sortedBy_equiv_implies_tail_subset [LT β] [StrictLT β] (f : α → β)
 := by
   intro h₁ h₂ h₃
   simp only [cons_subset, mem_cons, true_or, true_and] at h₃
-  simp only [subset_def]
   simp only [subset_def, mem_cons] at h₃
+  rw [subset_def]
   intro y h₄
   specialize h₃ h₄
   cases h₃
@@ -253,36 +255,36 @@ theorem map_eq_implies_sortedBy [LT β] [StrictLT β] {f : α → β} {g : γ �
   constructor
   case mp =>
     intro h₂
-    cases xs <;> cases ys <;> simp only [map_nil, map_cons, cons.injEq] at h₁
+    cases xs <;> cases ys <;> csimp at h₁
     case nil.nil => exact SortedBy.nil
     case cons.cons xhd xtl yhd ytl =>
       replace ⟨h₁, h₃⟩ := h₁
       have ih := map_eq_implies_sortedBy h₃
-      cases ytl <;> simp only [map_nil, map_cons, map_eq_nil] at *
+      cases ytl <;> csimp at *
       case nil => exact SortedBy.cons_nil
       case cons yhd' ytl =>
         simp only [tail_sortedBy h₂, true_iff] at ih
         apply SortedBy.cons_cons _ ih
         rw [← h₁]
-        cases xtl <;> simp only [map_nil, map_cons, cons.injEq] at h₃
+        cases xtl <;> csimp at h₃
         case cons xhd' xtl =>
           rw [← h₃.left]
           apply sortedBy_implies_head_lt_tail h₂
           simp only [mem_cons, true_or]
   case mpr =>
     intro h₂
-    cases xs <;> cases ys <;> simp only [map_nil, map_cons, cons.injEq] at h₁
+    cases xs <;> cases ys <;> csimp at h₁
     case nil.nil => exact SortedBy.nil
     case cons.cons xhd xtl yhd ytl =>
       replace ⟨h₁, h₃⟩ := h₁
       have ih := map_eq_implies_sortedBy h₃
-      cases xtl <;> simp only [map_nil, map_cons, map_eq_nil] at *
+      cases xtl <;> csimp at *
       case nil => exact SortedBy.cons_nil
       case cons xhd' xtl =>
         simp only [tail_sortedBy h₂, iff_true] at ih
         apply SortedBy.cons_cons _ ih
         rw [h₁]
-        cases ytl <;> simp only [map_nil, map_cons, cons.injEq] at h₃
+        cases ytl <;> csimp at h₃
         case cons yhd' ytl =>
           rw [h₃.left]
           apply sortedBy_implies_head_lt_tail h₂
@@ -292,10 +294,9 @@ theorem filter_sortedBy [LT β] [StrictLT β] [DecidableLT β] {f : α → β} (
   SortedBy f xs → SortedBy f (xs.filter p)
 := by
   intro h₁
-  induction xs
-  case nil => simp only [filter_nil, SortedBy.nil]
+  induction xs <;> csimp
+  case nil => exact SortedBy.nil
   case cons hd tl ih =>
-    simp only [filter_cons]
     specialize ih (tail_sortedBy h₁)
     split
     · apply sortedBy_cons ih
@@ -311,23 +312,21 @@ theorem filterMap_sortedBy [LT β] [StrictLT β] [DecidableLT β] {f : α → β
   SortedBy f' (xs.filterMap g)
 := by
   intro h₁ h₂
-  induction xs
-  case nil => simp only [filterMap_nil, SortedBy.nil]
+  induction xs <;> csimp
+  case nil => exact SortedBy.nil
   case cons hd tl ih =>
-    simp only [filterMap_cons]
     specialize ih (tail_sortedBy h₂)
     split
     case h_1 => exact ih
     case h_2 ac heq =>
       cases htl : filterMap g tl
-      case nil =>
-        exact SortedBy.cons_nil
+      case nil => exact SortedBy.cons_nil
       case cons hd' tl' =>
         rw [htl] at ih
         apply SortedBy.cons_cons _ ih
         rw [← h₁ hd ac heq]
         have hhd : hd' ∈ filterMap g tl := by simp only [htl, mem_cons, true_or]
-        simp only [mem_filterMap] at hhd
+        rw [mem_filterMap] at hhd
         have ⟨x, hx, hgx⟩ := hhd
         rw [← h₁ x hd' hgx]
         exact sortedBy_implies_head_lt_tail h₂ x hx
@@ -348,10 +347,8 @@ theorem insertCanonical_not_nil [DecidableEq β] [LT β] [DecidableLT β] (f : �
   insertCanonical f x xs ≠ []
 := by
   unfold insertCanonical
-  cases xs
-  case nil => simp only [ne_eq, not_false_eq_true]
+  cases xs <;> csimp
   case cons hd tl =>
-    simp only [gt_iff_lt, ne_eq]
     intro h
     split at h <;> try trivial
     split at h <;> trivial
@@ -381,7 +378,7 @@ theorem insertCanonical_sortedBy [LT β] [StrictLT β] [DecidableLT β] {f : α 
             exact SortedBy.cons_cons h₆ h₄
           · split <;> rename_i h₇
             · apply SortedBy.cons_cons h₅
-              simp only [insertCanonical, h₆, ↓reduceIte, gt_iff_lt, h₇] at ih
+              simp only [insertCanonical, h₆, h₇] at ih
               exact ih
             · have h₈ := StrictLT.if_not_lt_gt_then_eq (f x) (f y) h₆ h₇
               apply SortedBy.cons_cons h₃
@@ -403,15 +400,9 @@ theorem insertCanonical_cases [LT β] [DecidableLT β] (f : α → β) (x y : α
 := by
   generalize h₁ : insertCanonical f x ys = xys
   unfold insertCanonical
-  simp only [gt_iff_lt, ite_eq_left_iff]
-  by_cases (f x < f y)
-  case pos _ _ h₂ => simp [h₂]
-  case neg _ _ h₂ =>
-    simp only [h₂, not_false_eq_true, forall_const, false_and, ↓reduceIte, true_and,
-      ite_eq_right_iff, cons.injEq, false_or]
-    by_cases (f x > f y)
-    case pos _ _ h₃ => simp [h₃, h₁]
-    case neg _ _ h₃ => simp [h₃]
+  csimp
+  by_cases (f x < f y) <;> rename_i h₂ <;> simp only [h₂] <;> csimp
+  case neg => by_cases (f x > f y) <;> rename_i h₃ <;> simp [h₃, h₁]
 
 theorem insertCanonical_subset [LT β] [DecidableLT β] (f : α → β) (x : α) (xs : List α) :
   insertCanonical f x xs ⊆ x :: xs
@@ -435,7 +426,7 @@ theorem insertCanonical_equiv [LT α] [StrictLT α] [DecidableLT α] (x : α) (x
   induction xs
   case nil => simp only ; exact Equiv.refl
   case cons hd tl ih =>
-    simp only [id_eq, gt_iff_lt]
+    csimp
     split
     case inl => exact Equiv.refl
     case inr _ _ h₁ =>
@@ -447,20 +438,19 @@ theorem insertCanonical_equiv [LT α] [StrictLT α] [DecidableLT α] (x : α) (x
       case inl _ _ h₂ =>
         cases tl
         case nil =>
-          simp only [insertCanonical_singleton id x]
+          rw [insertCanonical_singleton id x]
           apply swap_cons_cons_equiv
         case cons hd' tl' =>
-          simp only [id_eq, gt_iff_lt] at ih
+          csimp at ih
           have h₃ := insertCanonical_cases id x hd' tl'
-          simp only [id_eq] at h₃
+          csimp at h₃
           cases h₃ <;> rename_i h₃
           case inl =>
-            simp only [h₃]
+            rw [h₃.right]
             unfold List.Equiv
-            simp only [cons_subset, mem_cons, true_or, or_true, true_and]
+            csimp
             apply And.intro
             all_goals {
-              simp only [subset_def, mem_cons]
               intro a h₄
               simp [h₄]
             }
@@ -468,8 +458,7 @@ theorem insertCanonical_equiv [LT α] [StrictLT α] [DecidableLT α] (x : α) (x
             cases h₃ <;> rename_i h₃
             case inr =>
               replace ⟨h₃, h₄, h₅⟩ := h₃
-              simp only [h₅]
-              unfold GT.gt at h₄
+              rw [h₅]
               have h₆ := StrictLT.if_not_lt_gt_then_eq x hd' h₃ h₄
               subst h₆
               unfold List.Equiv
@@ -477,7 +466,7 @@ theorem insertCanonical_equiv [LT α] [StrictLT α] [DecidableLT α] (x : α) (x
                 subset_cons]
             case inl =>
               replace ⟨h₃, h₄, h₅⟩ := h₃
-              simp only [h₅]
+              rw [h₅]
               simp only [h₃, h₄] at ih
               have h₆ := swap_cons_cons_equiv x hd (hd' :: tl')
               apply Equiv.trans h₆
@@ -496,7 +485,8 @@ theorem insertCanonical_preserves_forallᵥ {α β γ} [LT α] [StrictLT α] [De
     simp only [insertCanonical_singleton, forall₂_cons, Forall₂.nil, and_true]
     apply h₁
   case cons hd₁ hd₂ tl₁ tl₂ h₃ h₄ =>
-    simp only [insertCanonical, gt_iff_lt]
+    unfold insertCanonical
+    csimp
     split <;> split <;> rename_i h₅ h₆
     · apply Forall₂.cons (by exact h₁)
       exact Forall₂.cons (by exact h₃) (by exact h₄)
@@ -520,7 +510,8 @@ theorem insertCanonical_map_fst {α β γ} [LT α] [StrictLT α] [DecidableLT α
   induction xs generalizing x
   case nil => simp [insertCanonical, canonicalize, Prod.map]
   case cons hd tl ih =>
-    simp only [insertCanonical, Prod.map, id_eq, map_cons, gt_iff_lt]
+    simp only [insertCanonical, Prod.map]
+    csimp
     split
     · simp [Prod.map]
     · split
@@ -576,7 +567,7 @@ theorem canonicalize_not_nil [DecidableEq β] [LT β] [DecidableLT β] (f : α �
   case mpr =>
     unfold canonicalize
     intro h₀
-    cases xs <;> simp only [ne_eq, not_true_eq_false, not_false_eq_true] at *
+    cases xs <;> csimp at h₀ ; csimp
 
 theorem canonicalize_cons [LT β] [DecidableLT β] (f : α → β) (xs : List α) (a : α) :
   canonicalize f xs = canonicalize f ys → canonicalize f (a :: xs) = canonicalize f (a :: ys)
@@ -640,7 +631,7 @@ theorem canonicalize_equiv [LT α] [StrictLT α] [DecidableLT α] (xs : List α)
   case cons hd tl ih =>
     unfold canonicalize
     generalize h₁ : canonicalize id tl = ys
-    simp only [h₁] at ih
+    rw [h₁] at ih
     have h₂ := insertCanonical_equiv hd ys
     apply Equiv.trans _ h₂
     apply cons_equiv_cons
@@ -738,9 +729,9 @@ theorem any_of_mem {f : α → Bool} {x : α} {xs : List α}
   (h₂ : f x) :
   any xs f = true
 := by
-  cases xs <;> simp only [mem_cons, not_mem_nil] at h₁
+  cases xs <;> csimp at h₁
   case cons hd tl =>
-    simp only [any_cons, Bool.or_eq_true, any_eq_true]
+    csimp
     rcases h₁ with h₁ | h₁
     subst h₁
     simp only [h₂, true_or]
@@ -887,18 +878,17 @@ theorem forall₂_implies_all_left {α β} {R : α → β → Prop} {xs : List �
 := by
   intro h
   induction h
-  case nil =>
-    simp only [not_mem_nil, false_and, exists_false, imp_self, implies_true]
+  case nil => csimp
   case cons xhd yhd xtl ytl hhd _ ih =>
     intro x hx
-    simp only [mem_cons] at hx
+    csimp at hx
     rcases hx with hx | hx
     · subst hx
       exists yhd
-      simp only [mem_cons, true_or, hhd, and_self]
+      simp only [hhd, mem_cons, true_or, and_self]
     · have ⟨y, ih⟩ := ih x hx
       exists y
-      simp only [mem_cons, ih, or_true, and_self]
+      simp only [ih, mem_cons, or_true, and_self]
 
 theorem forall₂_implies_all_right {α β} {R : α → β → Prop} {xs : List α} {ys : List β} :
   List.Forall₂ R xs ys →
@@ -906,18 +896,17 @@ theorem forall₂_implies_all_right {α β} {R : α → β → Prop} {xs : List 
 := by
   intro h
   induction h
-  case nil =>
-    simp only [not_mem_nil, false_and, exists_false, imp_self, implies_true]
+  case nil => csimp
   case cons xhd yhd xtl ytl hhd _ ih =>
     intro y hy
-    simp only [mem_cons] at hy
+    csimp at hy
     rcases hy with hy | hy
     · subst hy
       exists xhd
-      simp only [mem_cons, true_or, hhd, and_self]
+      simp only [hhd, mem_cons, true_or, and_self]
     · have ⟨x, ih⟩ := ih y hy
       exists x
-      simp only [mem_cons, ih, or_true, and_self]
+      simp only [ih, mem_cons, or_true, and_self]
 
 /-! ### mapM, mapM', and mapM₁ -/
 
@@ -975,8 +964,8 @@ theorem mapM_implies_nil {f : α → Except β γ} {as : List α}
   cases as
   case nil => rfl
   case cons hd tl =>
-    simp only [List.mapM'] at h₁
-    cases h₂ : f hd <;> simp only [h₂, Except.bind_err, Except.bind_ok] at h₁
+    unfold List.mapM' at h₁
+    cases h₂ : f hd <;> rw [h₂] at h₁ <;> csimp at h₁
     cases h₃ : List.mapM' f tl <;>
     simp [h₃, pure, Except.pure] at h₁
 
@@ -985,8 +974,7 @@ theorem mapM_head_tail {α β γ} {f : α → Except β γ} {x : α} {xs : List 
   (List.mapM f xs) = Except.ok ys
 := by
   simp only [← mapM'_eq_mapM, mapM'_cons]
-  cases h₁ : f x <;>
-  simp only [h₁, Except.bind_ok, Except.bind_err, false_implies]
+  cases f x <;> csimp
   cases h₂ : mapM' f xs <;>
   simp [h₂, pure, Except.pure]
 
@@ -997,30 +985,26 @@ theorem mapM'_ok_iff_forall₂ {α β γ} {f : α → Except γ β} {xs : List �
   constructor
   case mp =>
     intro h₁
-    induction xs generalizing ys
+    induction xs generalizing ys <;> csimp at h₁
     case nil =>
-      simp only [mapM'_nil, pure, Except.pure, Except.ok.injEq] at h₁
       subst h₁
       exact List.Forall₂.nil
     case cons xhd xtl ih =>
-      simp only [mapM'_cons, pure, Except.pure] at h₁
-      cases h₂ : f xhd <;>
-      simp only [h₂, Except.bind_err, Except.bind_ok] at h₁
+      cases h₂ : f xhd <;> rw [h₂] at h₁ <;> csimp at h₁
       rename_i yhd
-      cases h₃ : mapM' f xtl <;>
-      simp only [h₃, Except.bind_err, Except.bind_ok] at h₁
+      cases h₃ : mapM' f xtl <;> rw [h₃] at h₁ <;> csimp at h₁
       rename_i ytl
-      simp only [Except.ok.injEq] at h₁
       subst h₁
       exact List.Forall₂.cons h₂ (ih h₃)
   case mpr =>
     intro h₁
     induction xs generalizing ys
     case nil =>
-      simp only [forall₂_nil_left_iff] at h₁
-      simp only [mapM'_nil, pure, Except.pure, h₁]
+      rw [forall₂_nil_left_iff] at h₁
+      rw [h₁]
+      csimp
     case cons xhd xtl ih =>
-      simp only [mapM'_cons, pure, Except.pure]
+      csimp
       replace ⟨yhd, ytl, h₁, h₃, h₄⟩ := forall₂_cons_left_iff.mp h₁
       subst ys
       cases h₂ : f xhd
@@ -1028,7 +1012,7 @@ theorem mapM'_ok_iff_forall₂ {α β γ} {f : α → Except γ β} {xs : List �
       case ok y' =>
         simp only [h₁, Except.ok.injEq] at h₂
         subst y'
-        specialize @ih ytl h₃
+        specialize ih h₃
         simp only [ih, Except.bind_err, Except.bind_ok]
 
 /-- Deprecated alias for the forward direction of `mapM'_ok_iff_forall₂` -/
@@ -1073,7 +1057,7 @@ theorem all_ok_implies_mapM'_ok {α β γ} {f : α → Except γ β} {xs : List 
   induction xs
   case nil => exists []
   case cons xhd xtl ih =>
-    simp only [mem_cons, forall_eq_or_imp] at h₁
+    csimp at h₁
     replace ⟨⟨yhd, h₁⟩, h₂⟩ := h₁
     replace ⟨ytl, ih⟩ := ih h₂
     exists yhd :: ytl
@@ -1114,7 +1098,7 @@ theorem all_from_ok_implies_mapM'_ok {α β γ} {f : α → Except γ β} {ys : 
   induction ys
   case nil => exists []
   case cons yhd ytl ih =>
-    simp only [mem_cons, forall_eq_or_imp] at h₁
+    csimp at h₁
     replace ⟨⟨xhd, h₁⟩, h₂⟩ := h₁
     replace ⟨xtl, ih⟩ := ih h₂
     exists xhd :: xtl
@@ -1136,13 +1120,11 @@ theorem mapM'_some_iff_forall₂ {α β} {f : α → Option β} {xs : List α} {
   constructor
   case mp =>
     intro h₁
-    induction xs generalizing ys
+    induction xs generalizing ys <;> csimp at h₁
     case nil =>
-      simp only [mapM'_nil, pure, Option.some.injEq] at h₁
       subst h₁
       exact List.Forall₂.nil
     case cons xhd xtl ih =>
-      simp only [mapM'_cons, pure, Option.bind_eq_bind, Option.bind_eq_some, Option.some.injEq] at h₁
       replace ⟨yhd, h₁, ytl, h₂, h₃⟩ := h₁
       subst h₃
       exact List.Forall₂.cons h₁ (ih h₂)
@@ -1150,10 +1132,11 @@ theorem mapM'_some_iff_forall₂ {α β} {f : α → Option β} {xs : List α} {
     intro h₁
     induction xs generalizing ys
     case nil =>
-      simp only [forall₂_nil_left_iff] at h₁
-      simp only [mapM'_nil, pure, Except.pure, h₁]
+      rw [forall₂_nil_left_iff] at h₁
+      rw [h₁]
+      csimp
     case cons xhd xtl ih =>
-      simp only [mapM'_cons, pure, Except.pure]
+      csimp
       replace ⟨yhd, ytl, h₁, h₃, h₄⟩ := forall₂_cons_left_iff.mp h₁
       subst ys
       cases h₂ : f xhd
@@ -1161,7 +1144,7 @@ theorem mapM'_some_iff_forall₂ {α β} {f : α → Option β} {xs : List α} {
       case some y' =>
         simp only [h₁, Option.some.injEq] at h₂
         subst y'
-        simp [@ih ytl h₃]
+        simp [ih h₃]
 
 /-- Deprecated alias for the forward direction of `mapM'_some_iff_forall₂` -/
 @[deprecated]
@@ -1220,12 +1203,12 @@ theorem mapM'_none_iff_exists_none {α β} {f : α → Option β} {xs : List α}
   case mp =>
     intro h₁
     cases xs
-    case nil => simp at h₁
+    case nil => csimp at h₁
     case cons xhd xtl =>
-      cases h₂ : f xhd <;> simp only [h₂, mem_cons, exists_eq_or_imp, true_or, false_or]
+      cases h₂ : f xhd <;> csimp <;> rw [h₂] <;> csimp
       case some yhd =>
-        simp only [mapM'_cons, h₂, Option.pure_def, Option.bind_eq_bind, Option.bind_some_fun,
-          Option.bind_eq_none] at h₁
+        simp only [mapM'_cons, h₂] at h₁
+        csimp at h₁
         apply mapM'_none_iff_exists_none.mp
         by_contra h₃
         rw [← ne_eq] at h₃
@@ -1234,9 +1217,9 @@ theorem mapM'_none_iff_exists_none {α β} {f : α → Option β} {xs : List α}
   case mpr =>
     intro h₁
     replace ⟨x, h₁, h₂⟩ := h₁
-    cases xs <;> simp only [mem_cons, not_mem_nil] at h₁
+    cases xs <;> csimp at h₁
     case cons xhd xtl =>
-      simp only [mapM'_cons, Option.pure_def, Option.bind_eq_bind, Option.bind_eq_none]
+      csimp
       intro yhd h₃ ytl h₄
       rcases h₁ with h₁ | h₁
       · subst h₁ ; simp [h₂] at h₃
@@ -1255,17 +1238,13 @@ theorem mapM'_some_eq_filterMap {α β} {f : α → Option β} {xs : List α} {y
   List.filterMap f xs = ys
 := by
   intro h
-  induction xs generalizing ys
-  case nil =>
-    simp only [mapM'_nil, Option.pure_def, Option.some.injEq, filterMap_nil] at *
-    exact h
+  induction xs generalizing ys <;> csimp at *
+  case nil => exact h
   case cons hd tl ih =>
-    simp only [filterMap_cons]
-    simp only [mapM'_cons, Option.pure_def, Option.bind_eq_bind, Option.bind_eq_some,
-      Option.some.injEq] at h
     replace ⟨hd', h, tl', hm, hys⟩ := h
     subst hys
-    simp only [h, cons.injEq, true_and]
+    rw [h]
+    csimp
     exact ih hm
 
 theorem mapM_some_eq_filterMap {α β} {f : α → Option β} {xs : List α} {ys : List β} :
@@ -1285,23 +1264,21 @@ theorem foldlM_of_assoc_some (f : α → α → Option α) (x₀ x₁ x₂ x₃ 
   (h₃ : List.foldlM f x₂ xs = some x₃):
   (do let y ← List.foldlM f x₁ xs ; f x₀ y) = some x₃
 := by
-  cases xs
+  cases xs <;> csimp at *
   case nil =>
-    simp only [Option.bind_eq_bind, List.foldlM, pure, Option.some.injEq, Option.bind_some_fun] at *
     subst h₃; exact h₂
   case cons hd tl =>
-    simp only [Option.bind_eq_bind, List.foldlM, Option.bind_eq_some] at *
-    cases h₄ : f x₂ hd <;> simp only [h₄, false_and, exists_false, Option.some.injEq, exists_eq_left'] at h₃
+    cases h₄ : f x₂ hd <;> rw [h₄] at h₃ <;> csimp at h₃
     case some x₄ =>
     have h₅ := h₁ x₀ x₁ hd
     simp only [h₂, h₄, Option.some_bind] at h₅
-    cases h₆ : f x₁ hd <;> simp only [h₆, Option.some_bind, Option.none_bind] at h₅
+    cases h₆ : f x₁ hd <;> rw [h₆] at h₅ <;> csimp at h₅
     case some x₅ =>
     have h₇ := List.foldlM_of_assoc_some f x₂ hd x₄ x₃ tl h₁ h₄ h₃
-    cases h₈ : List.foldlM f hd tl <;> simp only [h₈, Option.bind_some_fun, Option.bind_none_fun] at h₇
+    cases h₈ : List.foldlM f hd tl <;> rw [h₈] at h₇ <;> csimp at h₇
     case some x₆ =>
     rw [eq_comm] at h₅
-    cases h₉ : List.foldlM f x₅ tl <;> simp only [h₉, Option.some.injEq, exists_eq_left', false_and, exists_false]
+    cases h₉ : List.foldlM f x₅ tl <;> csimp <;> rw [h₉]
     case none =>
       have h₁₀ := List.foldlM_of_assoc_some f x₀ x₅ x₄ x₃ tl h₁ h₅ h₃
       simp [h₉] at h₁₀
@@ -1320,18 +1297,17 @@ theorem foldlM_of_assoc_none' (f : α → α → Option α) (x₀ x₁ x₂ : α
   (h₃ : List.foldlM f x₁ xs = some x₂):
   f x₀ x₂ = none
 := by
-  cases xs
-  case nil =>
-    simp only [foldlM_nil, pure, Option.some.injEq] at h₃ ; subst h₃; exact h₂
+  cases xs <;> csimp at h₃
+  case nil => subst h₃ ; exact h₂
   case cons hd tl =>
-    simp only [List.foldlM, Option.bind_eq_bind, Option.bind_eq_some] at h₃
-    cases h₄ : f x₁ hd <;> simp only [h₄, false_and, exists_false, Option.some.injEq, exists_eq_left'] at h₃
+    cases h₄ : f x₁ hd <;> rw [h₄] at h₃ <;> csimp at h₃
     case some x₃ =>
     have h₅ := List.foldlM_of_assoc_some f x₁ hd x₃ x₂ tl h₁ h₄ h₃
-    cases h₆ : List.foldlM f hd tl <;> simp only [h₆, Option.bind_some_fun, Option.bind_none_fun] at h₅
+    cases h₆ : List.foldlM f hd tl <;> rw [h₆] at h₅ <;> csimp at h₅
     case some x₄ =>
     specialize h₁ x₀ x₁ x₄
-    simp only [h₂, h₅, Option.bind_none_fun, Option.bind_some_fun] at h₁
+    rw [h₂, h₅] at h₁
+    csimp at h₁
     simp [h₁]
 
 theorem foldlM_of_assoc_none (f : α → α → Option α) (x₀ x₁ x₂ : α) (xs : List α)
@@ -1345,17 +1321,16 @@ theorem foldlM_of_assoc_none (f : α → α → Option α) (x₀ x₁ x₂ : α)
   cases xs
   case nil => simp [List.foldlM] at h₃
   case cons hd tl =>
-    simp only [List.foldlM, Option.bind_eq_bind, Option.bind_eq_none, Option.bind_eq_some,
-      forall_exists_index, and_imp]
-    cases h₄ : f x₁ hd <;> simp only [false_implies, implies_true, Option.some.injEq, forall_eq']
+    csimp
+    cases h₄ : f x₁ hd <;> csimp
     case some x₃ =>
-    cases h₅ : List.foldlM f x₃ tl <;> simp only [false_implies, implies_true, Option.some.injEq, forall_eq']
+    cases h₅ : List.foldlM f x₃ tl <;> csimp
     case some x₄ =>
     have h₆ := List.foldlM_of_assoc_some f x₁ hd x₃ x₄ tl h₁ h₄ h₅
-    cases h₇ : List.foldlM f hd tl <;> simp only [h₇, Option.bind_some_fun, Option.bind_none_fun] at h₆
+    cases h₇ : List.foldlM f hd tl <;> rw [h₇] at h₆ <;> csimp at h₆
     case some x₅ =>
-    simp only [List.foldlM, Option.bind_eq_bind, Option.bind_eq_none] at h₃
-    cases h₈ : f x₂ hd <;> simp only [h₈, false_implies, implies_true, Option.some.injEq, forall_eq'] at h₃
+    csimp at h₃
+    cases h₈ : f x₂ hd <;> rw [h₈] at h₃ <;> csimp at h₃
     case none =>
       have h₉ := List.foldlM_of_assoc_none' f x₂ hd x₅ tl h₁ h₈ h₇
       have h₁₀ := h₁ x₀ x₁ x₅
@@ -1375,19 +1350,19 @@ theorem foldlM_of_assoc (f : α → α → Option α) (x₀ x₁ : α) (xs : Lis
   List.foldlM f x₀ (x₁ :: xs) =
   (do let y ← List.foldlM f x₁ xs ; f x₀ y)
 := by
-  simp only [List.foldlM, Option.bind_eq_bind]
-  cases h₂ : f x₀ x₁ <;> simp only [Option.some_bind, Option.none_bind]
+  csimp
+  cases h₂ : f x₀ x₁ <;> csimp
   case none =>
     induction xs generalizing x₁
     case nil => simp [h₂]
     case cons hd tl ih =>
-      simp only [List.foldlM, Option.bind_eq_bind]
-      cases h₃ : f x₁ hd <;> simp only [Option.some_bind, Option.none_bind]
+      csimp
+      cases h₃ : f x₁ hd <;> csimp
       case some x₂ =>
       apply ih x₂
       specialize h₁ x₀ x₁ hd
       simp only [h₂, h₃, Option.bind_some_fun, Option.bind_none_fun] at h₁
-      rw [eq_comm] at h₁ ; exact h₁
+      exact h₁.symm
   case some x₂ =>
     rw [eq_comm]
     cases h₃ : List.foldlM f x₂ xs
@@ -1414,7 +1389,7 @@ theorem find?_pair_map {α β γ} [BEq α] (f : β → γ) (xs : List (α × β)
         (λ (x : α × γ) => x.fst == k) (hd.fst, f hd.snd)
         (map (λ x => (x.fst, f x.snd)) tl)
       simp only [h₁, not_false_eq_true, forall_const] at h₃
-      simp only [h₂, h₃]
+      rw [h₂, h₃]
       exact ih
     case true =>
       have h₂ := @List.find?_cons_of_pos _
@@ -1422,7 +1397,7 @@ theorem find?_pair_map {α β γ} [BEq α] (f : β → γ) (xs : List (α × β)
       have h₃ := @List.find?_cons_of_pos _
         (λ (x : α × γ) => x.fst == k) (hd.fst, f hd.snd)
         (map (λ x => (x.fst, f x.snd)) tl)
-      simp only [h₁, forall_const] at h₃
+      rw [h₁] at h₃
       simp [h₂, h₃]
 
 theorem find?_fst_map_implies_find? {α β γ} [BEq α] {f : β → γ} {xs : List (α × β)} {k : α} {fx : α × γ}:
@@ -1431,12 +1406,12 @@ theorem find?_fst_map_implies_find? {α β γ} [BEq α] {f : β → γ} {xs : Li
 := by
   intro h
   induction xs
-  case nil => simp at h
+  case nil => csimp at h
   case cons hd tl ih =>
-    simp only [map_cons, find?_cons] at h
+    csimp at h
     split at h <;> rename_i heq
     · exists hd
-      simp only [Option.some.injEq] at h
+      csimp at h
       simp only [h, and_true]
       simp only [Prod.map, id_eq] at heq
       simp only [find?_cons, heq]
@@ -1451,21 +1426,15 @@ theorem mem_of_sortedBy_implies_find? {α β} [LT β] [StrictLT β] [DecidableLT
   xs.find? (fun y => f y == f x) = x
 := by
   intro h₁ h₂
-  induction xs
-  case nil =>
-    simp only [not_mem_nil] at h₁
+  induction xs <;> csimp at h₁
   case cons hd tl ih =>
-    simp only [mem_cons] at h₁
     simp only [find?_cons]
-    split <;> rename_i heq
-    · simp only [beq_iff_eq] at heq
-      simp only [Option.some.injEq]
-      rcases h₁ with h₁ | h₁
+    split <;> rename_i heq <;> csimp at *
+    · rcases h₁ with h₁ | h₁
       · simp only [h₁]
       · have h₃ := sortedBy_implies_head_lt_tail h₂ x h₁
         simp only [heq, StrictLT.irreflexive] at h₃
-    · simp only [beq_eq_false_iff_ne, ne_eq] at heq
-      rcases h₁ with h₁ | h₁
+    · rcases h₁ with h₁ | h₁
       · simp only [h₁, not_true_eq_false] at heq
       · exact ih h₁ (tail_sortedBy h₂)
 
@@ -1475,11 +1444,8 @@ theorem mem_of_sortedBy_unique {α β} [LT β] [StrictLT β] [DecidableLT β] [D
   x = y
 := by
   intro hsrt hx hy hf
-  induction xs
-  case nil =>
-    simp only [not_mem_nil] at hx
+  induction xs <;> csimp at hx hy
   case cons hd tl ih =>
-    simp only [mem_cons] at hx hy
     specialize ih (tail_sortedBy hsrt)
     have hlt := sortedBy_implies_head_lt_tail hsrt
     rcases hx with hx | hx <;> rcases hy with hy | hy
@@ -1510,32 +1476,27 @@ theorem filterMap_empty_iff_all_none {f : α → Option β} {xs : List α} :
   constructor
   case mp =>
     induction xs
-    case nil =>
-      simp only [filterMap_nil, not_mem_nil, false_implies, implies_true, imp_self]
+    case nil => csimp
     case cons hd tl ih =>
       intro h₁ a h₂
-      simp only [List.filterMap_cons] at h₁
+      csimp at h₁
       split at h₁ <;> rename_i h₃
       · rcases (List.mem_cons.mp h₂) with h₄ | h₄
         · subst h₄ ; assumption
-        · apply ih h₁ a ; assumption
+        · exact ih h₁ a h₄
       · simp only at h₁
   case mpr =>
     intro h₁
-    induction xs
-    case nil => simp only [filterMap_nil]
+    induction xs <;> csimp
     case cons hd tl ih =>
-      simp only [List.filterMap_cons]
-      split
-      case h_1 =>
-        apply ih ; clear ih
+      split <;> rename_i b h₂
+      · apply ih ; clear ih
         intro a h₂
         apply h₁ a
         exact List.mem_cons_of_mem hd h₂
-      case h_2 b h₂ =>
-        exfalso
+      · exfalso
         specialize h₁ hd
-        simp only [mem_cons, true_or, forall_const] at h₁
+        csimp at h₁
         simp [h₁] at h₂
 
 theorem filterMap_nonempty_iff_exists_some {f : α → Option β} {xs : List α} :
@@ -1560,10 +1521,9 @@ theorem f_implies_g_then_subset {f g : α → Option β} {xs : List α} :
   xs.filterMap f ⊆ xs.filterMap g
 := by
   intro h₁
-  simp only [subset_def, mem_filterMap, forall_exists_index, and_imp]
+  csimp
   intro b a h₂ h₃
   exists a
-  apply And.intro h₂
-  exact h₁ a b h₃
+  exact And.intro h₂ (h₁ a b h₃)
 
 end List

--- a/cedar-lean/Cedar/Thm/Data/Map.lean
+++ b/cedar-lean/Cedar/Thm/Data/Map.lean
@@ -15,6 +15,7 @@
 -/
 
 import Cedar.Data.Map
+import Cedar.Tactic.Csimp
 import Cedar.Thm.Data.Control
 import Cedar.Thm.Data.List
 
@@ -33,7 +34,7 @@ theorem sizeOf_lt_of_value [SizeOf α] [SizeOf β] {m : Map α β} {k : α} {v :
   (h : (k, v) ∈ m.1) :
   sizeOf v < sizeOf m
 := by
-  simp only [Membership.mem] at h
+  unfold Membership.mem at h
   replace h := List.sizeOf_lt_of_mem h
   have v_lt_kv : sizeOf v < sizeOf (k, v) := by
     simp only [sizeOf, Prod._sizeOf_1]
@@ -46,8 +47,8 @@ theorem sizeOf_lt_of_value [SizeOf α] [SizeOf β] {m : Map α β} {k : α} {v :
   let d := sizeOf m
   have v_lt_m1 : a < c := by apply Nat.lt_trans v_lt_kv h
   have v_lt_m : a < d := by apply Nat.lt_trans v_lt_m1 m1_lt_m
-  have ha : a = sizeOf v := by simp
-  have hd : d = sizeOf m := by simp
+  have ha : a = sizeOf v := by csimp
+  have hd : d = sizeOf m := by csimp
   rw [ha, hd] at v_lt_m
   exact v_lt_m
 
@@ -56,7 +57,6 @@ theorem sizeOf_lt_of_tl [SizeOf α] [SizeOf β] {m : Map α β} {tl : List (α �
   1 + sizeOf tl < sizeOf m
 := by
   conv => rhs ; unfold sizeOf _sizeOf_inst _sizeOf_1
-  simp only
   unfold kvs at h
   simp only [h, List.cons.sizeOf_spec, Prod.mk.sizeOf_spec]
   generalize sizeOf k = kn
@@ -116,7 +116,7 @@ theorem eq_iff_kvs_eq {m₁ m₂ : Map α β} :
     intro h
     match m₁ with
     | mk kvs₁ => match m₂ with
-      | mk kvs₂ => simp at h ; subst h ; rfl
+      | mk kvs₂ => csimp at h ; subst h ; rfl
   case mpr => intro h ; subst h ; rfl
 
 /--
@@ -169,7 +169,8 @@ theorem in_list_in_values {k : α} {v : β} {m : Map α β} :
 theorem in_values_exists_key {m : Map α β} {v : β} :
   v ∈ m.values → ∃ k, (k, v) ∈ m.kvs
 := by
-  simp only [values, List.mem_map, forall_exists_index, and_imp]
+  unfold values
+  csimp
   intro kv h₁ h₂
   subst h₂
   exists kv.fst
@@ -208,10 +209,10 @@ theorem mk_wf [LT α] [StrictLT α] [DecidableLT α] {xs : List (α × β)} :
 theorem make_mem_list_mem [LT α] [StrictLT α] [DecidableLT α] {xs : List (α × β)} :
   x ∈ (Map.make xs).kvs → x ∈ xs
 := by
-  simp only [kvs, make]
+  unfold kvs make
   intro h₁
   have h₂ := List.canonicalize_subseteq Prod.fst xs
-  simp only [List.subset_def] at h₂
+  csimp at h₂
   exact h₂ h₁
 
 /--
@@ -222,15 +223,15 @@ theorem mem_values_make [LT α] [StrictLT α] [DecidableLT α] {xs : List (α ×
 := by
   -- despite the similarity to `make_mem_list_mem`, the proof does not currently
   -- use `make_mem_list_mem`
-  simp only [values, make]
-  simp only [List.mem_map, forall_exists_index, and_imp]
+  unfold values make
+  csimp
   intro (k, v) h₁ h₂
   exists (k, v)
   subst h₂
-  simp only [and_true]
+  csimp
   have h₂ := List.canonicalize_subseteq Prod.fst xs
-  simp only [List.subset_def] at h₂
-  exact @h₂ (k, v) h₁
+  csimp at h₂
+  exact h₂ h₁
 
 theorem make_nil_is_empty {α β} [LT α] [DecidableLT α] :
   (Map.make [] : Map α β) = Map.empty
@@ -261,11 +262,11 @@ theorem find?_mem_toList {α β} [LT α] [DecidableLT α] [DecidableEq α] {m : 
   (k, v) ∈ m.toList
 := by
   unfold toList kvs find? at *
-  split at h₁ <;> simp only [Option.some.injEq] at h₁
+  split at h₁ <;> csimp at h₁
   subst h₁
   rename_i h₂
   have h₃ := List.find?_some h₂
-  simp only [beq_iff_eq] at h₃ ; subst h₃
+  csimp at h₃ ; subst h₃
   exact List.mem_of_find?_eq_some h₂
 
 /--
@@ -287,9 +288,9 @@ theorem in_list_iff_find?_some [DecidableEq α] [LT α] [DecidableLT α] [Strict
       apply h₂ (k, v) h₁ ; clear h₂
       simp only [beq_self_eq_true]
     case some kv =>
-      simp only [Option.some.injEq]
+      csimp
       have h₃ := List.find?_some h₂
-      simp only [beq_iff_eq] at h₃
+      csimp at h₃
       subst h₃
       replace h₃ := List.mem_of_find?_eq_some h₂
       apply (key_maps_to_one_value kv.fst v kv.snd m wf h₁ _).symm
@@ -371,11 +372,8 @@ theorem values_mapOnValues [LT α] [StrictLT α] [DecidableLT α] [DecidableEq �
   (m.mapOnValues f).values = m.values.map f
 := by
   unfold mapOnValues values kvs
-  induction m.1
-  case nil => simp only [List.map_nil]
-  case cons hd tl ih =>
-    simp only [List.map_cons, List.cons.injEq, true_and]
-    trivial
+  cases m.1 <;> csimp
+  case cons hd tl => trivial
 
 theorem findOrErr_mapOnValues [LT α] [DecidableLT α] [DecidableEq α] {f : β → γ} {m : Map α β} {k : α} {e : Error} :
   (m.mapOnValues f).findOrErr k e = (m.findOrErr k e).map f
@@ -388,7 +386,7 @@ theorem findOrErr_ok_iff_find?_some [LT α] [DecidableLT α] [DecidableEq α] {m
   m.findOrErr k e = .ok v ↔ m.find? k = some v
 := by
   unfold findOrErr
-  cases m.find? k <;> simp only [Except.ok.injEq, Option.some.injEq]
+  cases m.find? k <;> csimp
 
 theorem in_values_iff_findOrErr_ok [LT α] [DecidableLT α] [StrictLT α] [DecidableEq α] {m : Map α β} {v : β} {e : Error}
   (wf : m.WellFormed) :
@@ -412,9 +410,9 @@ theorem in_values_iff_findOrErr_ok [LT α] [DecidableLT α] [StrictLT α] [Decid
 theorem in_kvs_in_mapOnValues [LT α] [DecidableLT α] [DecidableEq α] {f : β → γ} {m : Map α β} {k : α} {v : β} :
   (k, v) ∈ m.kvs → (k, f v) ∈ (m.mapOnValues f).kvs
 := by
-  unfold mapOnValues
+  unfold mapOnValues kvs
   intro h₁
-  simp only [kvs, List.mem_map, Prod.mk.injEq]
+  csimp
   exists (k, v)
 
 /-! ### mapMOnValues -/
@@ -428,14 +426,12 @@ theorem mapMOnValues_preserves_keys [LT α] [DecidableLT α] [StrictLT α] {f : 
   m₁.mapMOnValues f = some m₂ →
   m₁.kvs.map Prod.fst = m₂.kvs.map Prod.fst
 := by
+  unfold mapMOnValues
   intro h₁
-  simp only [mapMOnValues, Option.pure_def, Option.bind_eq_bind, Option.bind_eq_some,
-    Option.some.injEq] at h₁
+  csimp at h₁
   replace ⟨xs, h₁, h₂⟩ := h₁
   subst h₂
-  cases h₂ : m₁.kvs <;> simp only [h₂, List.mapM_nil, List.mapM_cons, Option.pure_def,
-    Option.bind_eq_bind, Option.bind_eq_some, Option.some.injEq] at h₁
-  <;> unfold kvs at *
+  cases h₂ : m₁.kvs <;> rw [h₂] at h₁ <;> csimp at h₁ <;> unfold kvs at *
   case nil =>
     subst h₁
     simp [h₂]
@@ -443,12 +439,12 @@ theorem mapMOnValues_preserves_keys [LT α] [DecidableLT α] [StrictLT α] {f : 
     have (k, v) := kv ; clear kv
     replace ⟨(k', y), ⟨y', h₁, h₃⟩, ⟨tl', h₄, h₅⟩⟩ := h₁
     subst h₅
-    simp only [Prod.mk.injEq, List.map_cons, List.cons.injEq] at *
+    csimp at *
     replace ⟨h₃, h₃'⟩ := h₃
     subst k' y'
     have ih := mapMOnValues_preserves_keys (m₁ := mk tl) (m₂ := mk tl') (f := f)
-    simp only [mapMOnValues, kvs, Option.pure_def, Option.bind_eq_bind,
-      Option.bind_eq_some, Option.some.injEq, mk.injEq, exists_eq_right] at ih
+    unfold mapMOnValues kvs at ih
+    csimp at ih
     specialize ih h₄
     simp [ih, h₂]
 
@@ -482,7 +478,7 @@ theorem mapMOnValues_wf_alt_proof [LT α] [DecidableLT α] [StrictLT α] {f : β
   subst h₁
   apply List.filterMap_sortedBy _ wf
   intro (k, v) (k', v') h₁
-  simp only at *
+  simp only
   cases h₂ : f v <;> simp [h₂, Option.bind] at h₁
   exact h₁.left
 
@@ -499,26 +495,24 @@ theorem mapMOnValues_cons {α : Type 0} [LT α] [DecidableLT α] {f : β → Opt
     return mk ((k, v') :: tl'.kvs))
 := by
   intro h₁
-  cases h₂ : f v <;> simp only [Option.pure_def, Option.bind_eq_bind, Option.bind_none_fun, Option.bind_some_fun]
+  cases h₂ : f v <;> csimp
   case none => unfold mapMOnValues ; simp [h₁, h₂]
   case some v' =>
-    cases h₃ : (mk tl).mapMOnValues f <;> simp only [Option.none_bind, Option.some_bind]
+    cases h₃ : (mk tl).mapMOnValues f
     <;> unfold mapMOnValues at *
+    <;> rw [h₁]
+    <;> csimp
     case none =>
-      simp only [h₁, Option.pure_def, Option.bind_eq_bind, List.mapM_cons, Option.bind_eq_none,
-        Option.bind_eq_some, Option.some.injEq, forall_exists_index, and_imp,
-        forall_apply_eq_imp_iff₂]
       intro kvs' v'' h₄ tl' h₅ h₆
-      simp only [h₂, Option.some.injEq] at h₄
+      rw [h₂] at h₄
+      injection h₄
       subst v'' kvs'
       cases (tl.mapM λ x => match x with | (k, v) => do let v' ← f v ; pure (k, v'))
-      <;> simp only [Option.pure_def, Option.bind_eq_bind, Option.bind_eq_none] at h₃
+      <;> csimp at h₃
       <;> exact h₃ tl' h₅
     case some mtl' =>
-      simp only [h₁, Option.pure_def, Option.bind_eq_bind, Option.bind_eq_some, Option.some.injEq,
-        List.mapM_cons, mk.injEq, exists_eq_right, List.cons.injEq, exists_eq_right_right,
-        Prod.mk.injEq, true_and] at *
       apply And.intro h₂
+      csimp at h₃
       replace ⟨tl', h₃, h₄⟩ := h₃
       subst mtl'
       simp [h₃]
@@ -529,17 +523,17 @@ theorem mapMOnValues_some_implies_forall₂ [LT α] [DecidableLT α] {f : β →
 := by
   unfold mapMOnValues kvs
   intro h₁
-  simp only [Option.pure_def, Option.bind_eq_bind, Option.bind_eq_some, Option.some.injEq] at h₁
+  csimp at h₁
   replace ⟨x, h₁, h₂⟩ := h₁
   subst h₂
   replace h₁ := List.mapM_some_iff_forall₂.mp h₁
   simp only
   apply List.Forall₂.imp _ h₁
   intro (k, v) (k', v') h₂
-  simp only [Option.bind_eq_some, Option.some.injEq, Prod.mk.injEq, exists_eq_right_right] at h₂
+  csimp at h₂
   replace ⟨h₂, h₂'⟩ := h₂
   subst k'
-  simp only [true_and]
+  csimp
   exact h₂
 
 theorem mapMOnValues_some_implies_all_some {α : Type 0} [LT α] [DecidableLT α] {f : β → Option γ} {m₁ : Map α β} {m₂ : Map α γ} :
@@ -567,15 +561,14 @@ theorem mapMOnValues_some_implies_all_some_alt_proof [LT α] [DecidableLT α] {f
   intro h₁ kv h₂
   cases h₃ : m₁.kvs.mapM (λ x => match x with | (k, v) => do let v' ← f v ; pure (k, v'))
   <;> rw [h₃] at h₁
-  <;> simp only [Option.pure_def, Option.bind_some_fun, Option.bind_none_fun, Option.some.injEq] at h₁
+  <;> csimp at h₁
   case some ags =>
     subst h₁
     have (a, b) := kv ; clear kv
     simp only
     replace h₃ := List.mapM_some_implies_all_some h₃
     replace ⟨(a', g), h₃, h₄⟩ := h₃ (a, b) h₂
-    simp only [Option.pure_def, Option.bind_eq_bind, Option.bind_eq_some, Option.some.injEq,
-      Prod.mk.injEq, exists_eq_right_right] at h₄
+    csimp at h₄
     replace ⟨h₄, h₄'⟩ := h₄
     subst a'
     exists g
@@ -605,15 +598,14 @@ theorem mapMOnValues_some_implies_all_from_some_alt_proof [LT α] [DecidableLT �
   intro h₁ kv h₂
   cases h₃ : m₁.kvs.mapM (λ x => match x with | (k, v) => do let v' ← f v ; pure (k, v'))
   <;> rw [h₃] at h₁
-  <;> simp only [Option.pure_def, Option.bind_some_fun, Option.bind_none_fun, Option.some.injEq] at h₁
+  <;> csimp at h₁
   case some ags =>
     subst h₁
     have (a, g) := kv ; clear kv
     simp only
     replace h₃ := List.mapM_some_implies_all_from_some h₃
     replace ⟨(a', b), h₃, h₄⟩ := h₃ (a, g) h₂
-    simp only [Option.pure_def, Option.bind_eq_bind, Option.bind_eq_some, Option.some.injEq,
-      Prod.mk.injEq, exists_eq_right_right] at h₄
+    csimp at h₄
     replace ⟨h₄, h₄'⟩ := h₄
     subst a'
     exists b
@@ -630,9 +622,10 @@ theorem mapMOnValues_none_iff_exists_none {α : Type 0} [LT α] [DecidableLT α]
       simp [mapMOnValues_nil] at h₁
     case cons hd tl =>
       have (khd, vhd) := hd ; clear hd
-      simp only [values_cons h₂, List.mem_cons, exists_eq_or_imp]
-      simp only [mapMOnValues_cons h₂, Option.pure_def, Option.bind_eq_bind,
-        Option.bind_eq_none] at h₁
+      rw [values_cons h₂]
+      csimp
+      rw [mapMOnValues_cons h₂] at h₁
+      csimp at h₁
       cases h₃ : f vhd
       case none => simp only [true_or]
       case some yhd =>
@@ -653,8 +646,10 @@ theorem mapMOnValues_none_iff_exists_none {α : Type 0} [LT α] [DecidableLT α]
       simp [values, kvs, empty] at h₁
     case cons hd tl =>
       have (khd, vhd) := hd ; clear hd
-      simp only [values_cons h₃, List.mem_cons] at h₁
-      simp only [mapMOnValues_cons h₃, Option.pure_def, Option.bind_eq_bind, Option.bind_eq_none]
+      rw [values_cons h₃] at h₁
+      csimp at h₁
+      rw [mapMOnValues_cons h₃]
+      csimp
       intro yhd h₄ ytl h₅
       rcases h₁ with h₁ | h₁
       · subst h₁ ; simp [h₂] at h₄

--- a/cedar-lean/Cedar/Thm/Partial/Evaluation.lean
+++ b/cedar-lean/Cedar/Thm/Partial/Evaluation.lean
@@ -123,9 +123,9 @@ theorem on_concrete_gives_concrete (expr : Spec.Expr) (request : Spec.Request) (
   isValueOrError (Partial.evaluate expr request entities)
 := by
   rw [on_concrete_eqv_concrete_eval expr request entities wf]
-  simp only [Except.map, isValueOrError]
+  unfold Except.map isValueOrError
   split
   <;> rename_i h
   <;> split at h
-  <;> simp only [Except.ok.injEq, Except.error.injEq, Partial.Value.value.injEq] at h
+  <;> injection h
   <;> trivial

--- a/cedar-lean/Cedar/Thm/Partial/Evaluation/And.lean
+++ b/cedar-lean/Cedar/Thm/Partial/Evaluation/And.lean
@@ -16,6 +16,7 @@
 
 import Cedar.Partial.Evaluator
 import Cedar.Spec.Evaluator
+import Cedar.Tactic.Csimp
 import Cedar.Thm.Data.Control
 import Cedar.Thm.Partial.Evaluation.Basic
 
@@ -38,21 +39,20 @@ theorem on_concrete_eqv_concrete_eval {x₁ x₂ : Spec.Expr} {request : Spec.Re
   intro ih₁ ih₂
   unfold Partial.evaluate Spec.evaluate Spec.Expr.asPartialExpr
   simp only [ih₁, ih₂]
-  simp only [Except.map, pure, Except.pure, Result.as, Coe.coe]
-  cases h₁ : Spec.evaluate x₁ request entities <;> simp only [Bool.not_eq_true', Except.bind_err, Except.bind_ok]
+  unfold Except.map
+  csimp
+  cases h₁ : Spec.evaluate x₁ request entities <;> csimp
   case ok v₁ =>
-    simp only [Spec.Value.asBool]
-    cases v₁ <;> try simp only [Except.bind_err]
+    cases v₁ <;> try csimp
     case prim p =>
-      cases p <;> simp only [Except.bind_ok, Except.bind_err]
+      cases p <;> csimp
       case bool b =>
-        cases b <;> simp only [ite_true, ite_false]
+        cases b <;> csimp
         case true =>
-          split <;> simp only [Except.bind_ok, Except.bind_err]
-          case h_1 e h₂ => simp only [h₂, Except.bind_err]
-          case h_2 v h₂ =>
-            simp only [h₂]
-            cases v <;> try simp only [Except.bind_err]
-            case prim p => cases p <;> simp
+          split <;> csimp <;> rename_i h₂ <;> rw [h₂]
+          · csimp
+          · rename_i v
+            cases v <;> try csimp
+            case prim p => cases p <;> csimp
 
 end Cedar.Thm.Partial.Evaluation.And

--- a/cedar-lean/Cedar/Thm/Partial/Evaluation/And.lean
+++ b/cedar-lean/Cedar/Thm/Partial/Evaluation/And.lean
@@ -49,9 +49,10 @@ theorem on_concrete_eqv_concrete_eval {x₁ x₂ : Spec.Expr} {request : Spec.Re
       case bool b =>
         cases b <;> csimp
         case true =>
-          split <;> csimp <;> rename_i h₂ <;> rw [h₂]
-          · csimp
-          · rename_i v
+          split <;> csimp
+          case h_1 e h₂ => rw [h₂] ; csimp
+          case h_2 v h₂ =>
+            rw [h₂]
             cases v <;> try csimp
             case prim p => cases p <;> csimp
 

--- a/cedar-lean/Cedar/Thm/Partial/Evaluation/Binary.lean
+++ b/cedar-lean/Cedar/Thm/Partial/Evaluation/Binary.lean
@@ -16,6 +16,7 @@
 
 import Cedar.Partial.Evaluator
 import Cedar.Spec.Evaluator
+import Cedar.Tactic.Csimp
 import Cedar.Thm.Data.Control
 import Cedar.Thm.Data.Map
 import Cedar.Thm.Data.Set
@@ -36,7 +37,7 @@ theorem ancestorsOrEmpty_on_concrete_eqv_concrete {entities : Spec.Entities} {ui
   unfold Partial.Entities.ancestorsOrEmpty Spec.Entities.ancestorsOrEmpty
   unfold Spec.Entities.asPartialEntities Spec.EntityData.asPartialEntityData
   rw [← Map.find?_mapOnValues]
-  cases entities.find? uid <;> simp
+  cases entities.find? uid <;> csimp
 
 /--
   `Partial.inₑ` on concrete arguments is the same as `Spec.inₑ` on those arguments
@@ -45,7 +46,7 @@ theorem partialInₑ_on_concrete_eqv_concrete {uid₁ uid₂ : EntityUID} {entit
   Partial.inₑ uid₁ uid₂ entities = Spec.inₑ uid₁ uid₂ entities
 := by
   unfold Partial.inₑ Spec.inₑ
-  cases uid₁ == uid₂ <;> simp only [Bool.true_or, Bool.false_or]
+  cases uid₁ == uid₂ <;> csimp
   case false => simp [ancestorsOrEmpty_on_concrete_eqv_concrete]
 
 /--
@@ -66,13 +67,13 @@ theorem partialApply₂_on_concrete_eqv_concrete {op : BinaryOp} {v₁ v₂ : Sp
 := by
   unfold Partial.apply₂ Spec.apply₂ Except.map
   cases op <;> split <;> rename_i h
-  <;> simp only [false_implies, forall_const] at h
-  <;> try simp only [Except.ok.injEq, Partial.Value.value.injEq, Spec.Value.prim.injEq, Spec.Prim.bool.injEq]
+  <;> csimp at h
+  <;> try simp only
   case add | sub | mul => split <;> rename_i h <;> simp [h]
-  case mem.h_10 uid₁ uid₂ => simp [partialInₑ_on_concrete_eqv_concrete]
+  case mem.h_10 uid₁ uid₂ => simp only [partialInₑ_on_concrete_eqv_concrete]
   case mem.h_11 uid vs =>
     simp only [partialInₛ_on_concrete_eqv_concrete]
-    cases Spec.inₛ uid vs entities <;> simp
+    cases Spec.inₛ uid vs entities <;> csimp
   case mem.h_12 =>
     split <;> rename_i h₂ <;> split at h₂ <;> simp at *
     assumption
@@ -100,9 +101,9 @@ theorem on_concrete_eqv_concrete_eval {x₁ x₂ : Spec.Expr} {request : Spec.Re
   intro ih₁ ih₂
   unfold Partial.evaluate Spec.evaluate Spec.Expr.asPartialExpr
   simp only [ih₁, ih₂, Except.map]
-  cases h₁ : Spec.evaluate x₁ request entities <;> simp only [h₁, Except.bind_err, Except.bind_ok]
+  cases h₁ : Spec.evaluate x₁ request entities <;> simp only [h₁] <;> csimp
   case ok v₁ =>
-    cases h₂ : Spec.evaluate x₂ request entities <;> simp only [h₂, Except.bind_err, Except.bind_ok]
+    cases h₂ : Spec.evaluate x₂ request entities <;> simp only [h₂] <;> csimp
     case ok v₂ => simp [evaluateBinaryApp_on_concrete_eqv_concrete, Except.map]
 
 end Cedar.Thm.Partial.Evaluation.Binary

--- a/cedar-lean/Cedar/Thm/Partial/Evaluation/Call.lean
+++ b/cedar-lean/Cedar/Thm/Partial/Evaluation/Call.lean
@@ -16,6 +16,7 @@
 
 import Cedar.Partial.Evaluator
 import Cedar.Spec.Evaluator
+import Cedar.Tactic.Csimp
 import Cedar.Thm.Data.Control
 import Cedar.Thm.Data.List
 import Cedar.Thm.Partial.Evaluation.Basic
@@ -33,8 +34,8 @@ theorem evaluateCall_on_concrete_eqv_concrete {vs : List Spec.Value} {xfn : ExtF
   Partial.evaluateCall xfn (vs.map Partial.Value.value) = (Spec.call xfn vs).map Partial.Value.value
 := by
   unfold Partial.evaluateCall
-  simp only [List.mapM_map, List.mapM_some, Except.map]
-  cases Spec.call xfn vs <;> simp
+  simp only [List.mapM_map, List.mapM_some]
+  cases Spec.call xfn vs <;> simp [Except.map]
 
 /--
   Inductive argument that partial evaluating a concrete `Partial.Expr.call`
@@ -54,7 +55,7 @@ theorem on_concrete_eqv_concrete_eval {xs : List Spec.Expr} {request : Spec.Requ
   rw [List.mapM₁_eq_mapM (Spec.evaluate · request entities)]
   rw [List.mapM_map]
   rw [Set.mapM_partial_eval_eqv_concrete_eval ih₁]
-  cases xs.mapM (Spec.evaluate · request entities) <;> simp only [Except.bind_ok, Except.bind_err]
+  cases xs.mapM (Spec.evaluate · request entities) <;> csimp
   case error e => simp [Except.map]
   case ok vs => exact evaluateCall_on_concrete_eqv_concrete
 

--- a/cedar-lean/Cedar/Thm/Partial/Evaluation/GetAttr.lean
+++ b/cedar-lean/Cedar/Thm/Partial/Evaluation/GetAttr.lean
@@ -16,6 +16,7 @@
 
 import Cedar.Partial.Evaluator
 import Cedar.Spec.Evaluator
+import Cedar.Tactic.Csimp
 import Cedar.Thm.Data.Control
 import Cedar.Thm.Data.LT
 import Cedar.Thm.Data.Map
@@ -39,13 +40,12 @@ theorem partialEntities_attrs_wf {entities : Partial.Entities} {uid : EntityUID}
   unfold Partial.Entities.attrs Partial.Entities.AllWellFormed Partial.EntityData.WellFormed
   intro wf h₁
   cases h₂ : entities.findOrErr uid Error.entityDoesNotExist
-  <;> simp only [h₂, Except.bind_err, Except.bind_ok, Except.ok.injEq] at h₁
+  <;> rw [h₂] at h₁ <;> csimp at h₁
   case ok attrs =>
     subst h₁
     have ⟨wf_m, wf_edata⟩ := wf ; clear wf
     apply (wf_edata _ _).left
-    have h₃ := Map.in_values_iff_findOrErr_ok (v := attrs) (e := Error.entityDoesNotExist) wf_m
-    simp only [h₃]
+    rw [Map.in_values_iff_findOrErr_ok (v := attrs) (e := Error.entityDoesNotExist) wf_m]
     exists uid
 
 /--
@@ -60,9 +60,9 @@ theorem attrsOf_wf {entities : Partial.Entities} {v : Spec.Value} {attrs : Map S
 := by
   intro wf_e wf_v
   unfold Partial.attrsOf
-  cases v <;> try simp only [false_implies, Except.ok.injEq]
+  cases v <;> try csimp
   case prim p =>
-    cases p <;> simp only [false_implies]
+    cases p <;> csimp
     case entityUID uid => exact partialEntities_attrs_wf wf_e
   case record r =>
     intro h₁
@@ -94,7 +94,7 @@ theorem getAttr_on_concrete_eqv_concrete {v : Spec.Value} {entities : Spec.Entit
 := by
   unfold Partial.getAttr Spec.getAttr
   simp only [attrsOf_on_concrete_eqv_concrete, Except.map]
-  cases Spec.attrsOf v entities.attrs <;> simp only [Except.bind_err, Except.bind_ok]
+  cases Spec.attrsOf v entities.attrs <;> csimp
   case ok m => simp [Map.findOrErr_mapOnValues, Except.map]
 
 /--
@@ -104,8 +104,8 @@ theorem getAttr_on_concrete_eqv_concrete {v : Spec.Value} {entities : Spec.Entit
 theorem evaluateGetAttr_on_concrete_eqv_concrete {v : Spec.Value} {a : Attr} {entities : Spec.Entities} :
   Partial.evaluateGetAttr v a entities = Spec.getAttr v a entities
 := by
-  simp only [Partial.evaluateGetAttr, getAttr_on_concrete_eqv_concrete, pure, Except.pure, Except.map]
-  cases h : Spec.getAttr v a entities <;> simp [h]
+  simp only [Partial.evaluateGetAttr, getAttr_on_concrete_eqv_concrete, pure, Except.pure]
+  cases h : Spec.getAttr v a entities <;> simp [h, Except.map]
 
 /--
   Inductive argument that partial evaluating a concrete `Partial.Expr.getAttr`
@@ -120,7 +120,7 @@ theorem on_concrete_eqv_concrete_eval {x₁ : Spec.Expr} {request : Spec.Request
   intro ih₁
   unfold Partial.evaluate Spec.evaluate Spec.Expr.asPartialExpr
   simp only [ih₁]
-  cases Spec.evaluate x₁ request entities <;> simp only [Except.bind_err, Except.bind_ok]
+  cases Spec.evaluate x₁ request entities <;> csimp
   case error e => simp [Except.map]
   case ok v₁ => exact evaluateGetAttr_on_concrete_eqv_concrete
 

--- a/cedar-lean/Cedar/Thm/Partial/Evaluation/HasAttr.lean
+++ b/cedar-lean/Cedar/Thm/Partial/Evaluation/HasAttr.lean
@@ -16,6 +16,7 @@
 
 import Cedar.Partial.Evaluator
 import Cedar.Spec.Evaluator
+import Cedar.Tactic.Csimp
 import Cedar.Thm.Data.Control
 import Cedar.Thm.Data.Map
 import Cedar.Thm.Data.Set
@@ -45,7 +46,7 @@ theorem Partial.attrsOf_on_concrete_eqv_attrsOf {v : Spec.Value} {entities : Spe
     case entityUID uid =>
       unfold Partial.Entities.attrsOrEmpty Spec.Entities.attrsOrEmpty Spec.Entities.asPartialEntities
       cases h₁ : (entities.mapOnValues Spec.EntityData.asPartialEntityData).find? uid
-      <;> simp only [Except.ok.injEq]
+      <;> csimp
       <;> cases h₂ : entities.find? uid <;> simp only
       <;> unfold Spec.EntityData.asPartialEntityData at h₁
       <;> simp only [← Map.find?_mapOnValues, Option.map_eq_none', Option.map_eq_some'] at h₁
@@ -54,7 +55,8 @@ theorem Partial.attrsOf_on_concrete_eqv_attrsOf {v : Spec.Value} {entities : Spe
       case some.none => simp [h₂] at h₁
       case some.some edata₁ edata₂ =>
         replace ⟨edata₁, ⟨h₁, h₃⟩⟩ := h₁
-        simp only [h₂, Option.some.injEq] at h₁
+        rw [h₂] at h₁
+        csimp at h₁
         subst h₁ h₃
         simp [Map.mapOnValues]
 
@@ -67,8 +69,7 @@ theorem Partial.hasAttr_on_concrete_eqv_hasAttr {v : Spec.Value} {entities : Spe
 := by
   unfold Partial.hasAttr Spec.hasAttr
   simp only [Partial.attrsOf_on_concrete_eqv_attrsOf, Except.map]
-  cases Spec.attrsOf v λ uid => .ok (entities.attrsOrEmpty uid)
-  <;> simp only [Except.bind_ok, Except.bind_err, Except.ok.injEq, Spec.Value.prim.injEq, Spec.Prim.bool.injEq]
+  cases Spec.attrsOf v λ uid => .ok (entities.attrsOrEmpty uid) <;> csimp
   case ok m => simp [← Map.mapOnValues_contains]
 
 /--
@@ -93,7 +94,7 @@ theorem on_concrete_eqv_concrete_eval {x₁ : Spec.Expr} {request : Spec.Request
   intro ih₁
   unfold Partial.evaluate Spec.evaluate Spec.Expr.asPartialExpr
   simp only [ih₁]
-  cases Spec.evaluate x₁ request entities <;> simp only [Except.bind_err, Except.bind_ok]
+  cases Spec.evaluate x₁ request entities <;> csimp
   case error e => simp [Except.map]
   case ok v₁ => exact Partial.evaluateHasAttr_on_concrete_eqv_hasAttr
 

--- a/cedar-lean/Cedar/Thm/Partial/Evaluation/Ite.lean
+++ b/cedar-lean/Cedar/Thm/Partial/Evaluation/Ite.lean
@@ -16,6 +16,7 @@
 
 import Cedar.Partial.Evaluator
 import Cedar.Spec.Evaluator
+import Cedar.Tactic.Csimp
 import Cedar.Thm.Data.Control
 import Cedar.Thm.Partial.Evaluation.Basic
 
@@ -38,13 +39,12 @@ theorem on_concrete_eqv_concrete_eval {x₁ x₂ x₃ : Spec.Expr} {request : Sp
   intro ih₁ ih₂ ih₃
   unfold Partial.evaluate Spec.evaluate Spec.Expr.asPartialExpr
   simp only [ih₁, ih₂, ih₃]
-  simp only [Except.map, Result.as, Coe.coe]
-  cases Spec.evaluate x₁ request entities <;> simp only [Except.bind_err, Except.bind_ok]
+  unfold Except.map
+  cases Spec.evaluate x₁ request entities <;> csimp
   case ok v₁ =>
-    simp only [Spec.Value.asBool]
-    cases v₁ <;> try simp only [Except.bind_err]
+    cases v₁ <;> try csimp
     case prim p =>
-      cases p <;> simp only [Except.bind_ok, Except.bind_err]
-      case bool b => cases b <;> simp
+      cases p <;> csimp
+      case bool b => cases b <;> csimp
 
 end Cedar.Thm.Partial.Evaluation.Ite

--- a/cedar-lean/Cedar/Thm/Partial/Evaluation/Or.lean
+++ b/cedar-lean/Cedar/Thm/Partial/Evaluation/Or.lean
@@ -16,6 +16,7 @@
 
 import Cedar.Partial.Evaluator
 import Cedar.Spec.Evaluator
+import Cedar.Tactic.Csimp
 import Cedar.Thm.Data.Control
 import Cedar.Thm.Partial.Evaluation.Basic
 
@@ -37,21 +38,20 @@ theorem on_concrete_eqv_concrete_eval {x₁ x₂ : Spec.Expr} {request : Spec.Re
   intro ih₁ ih₂
   unfold Partial.evaluate Spec.evaluate Spec.Expr.asPartialExpr
   simp only [ih₁, ih₂]
-  simp only [Except.map, pure, Except.pure, Result.as, Coe.coe]
-  cases Spec.evaluate x₁ request entities <;> simp only [Except.bind_err, Except.bind_ok]
+  unfold Except.map
+  cases Spec.evaluate x₁ request entities <;> csimp
   case ok v₁ =>
-    simp only [Spec.Value.asBool]
-    cases v₁ <;> try simp only [Except.bind_err]
+    cases v₁ <;> try csimp
     case prim p =>
-      cases p <;> simp only [Except.bind_ok, Except.bind_err]
+      cases p <;> csimp
       case bool b =>
-        cases b <;> simp only [ite_true, ite_false]
+        cases b <;> csimp
         case false =>
-          split <;> simp only [Except.bind_ok, Except.bind_err]
-          case h_1 e h₂ => simp only [h₂, Except.bind_err]
+          split <;> csimp
+          case h_1 e h₂ => simp [h₂]
           case h_2 v h₂ =>
-            simp only [h₂]
-            cases v <;> try simp only [Except.bind_err]
-            case prim p => cases p <;> simp
+            rw [h₂]
+            cases v <;> try csimp
+            case prim p => cases p <;> csimp
 
 end Cedar.Thm.Partial.Evaluation.Or

--- a/cedar-lean/Cedar/Thm/Partial/Evaluation/Unary.lean
+++ b/cedar-lean/Cedar/Thm/Partial/Evaluation/Unary.lean
@@ -16,6 +16,7 @@
 
 import Cedar.Partial.Evaluator
 import Cedar.Spec.Evaluator
+import Cedar.Tactic.Csimp
 import Cedar.Thm.Data.Control
 import Cedar.Thm.Partial.Evaluation.Basic
 
@@ -45,7 +46,7 @@ theorem on_concrete_eqv_concrete_eval {x₁ : Spec.Expr} {request : Spec.Request
   intro ih₁
   unfold Partial.evaluate Spec.evaluate Spec.Expr.asPartialExpr
   simp only [ih₁]
-  cases Spec.evaluate x₁ request entities <;> simp only [Except.bind_err, Except.bind_ok]
+  cases Spec.evaluate x₁ request entities <;> csimp
   case error e => simp [Except.map]
   case ok v₁ => rfl
 

--- a/cedar-lean/Cedar/Thm/Partial/Evaluation/Var.lean
+++ b/cedar-lean/Cedar/Thm/Partial/Evaluation/Var.lean
@@ -16,6 +16,7 @@
 
 import Cedar.Partial.Evaluator
 import Cedar.Spec.Evaluator
+import Cedar.Tactic.Csimp
 import Cedar.Thm.Data.Control
 import Cedar.Thm.Data.Map
 import Cedar.Thm.Partial.Evaluation.Basic
@@ -33,9 +34,9 @@ theorem partialEvaluateVar_on_concrete_eqv_concrete_eval (v : Var) (request : Sp
   (wf : request.WellFormed) :
   Partial.evaluateVar v request = (Spec.evaluate (Spec.Expr.var v) request entities).map Partial.Value.value
 := by
-  unfold Partial.evaluateVar Spec.evaluate
+  unfold Partial.evaluateVar Spec.evaluate Except.map Spec.Request.asPartialRequest
   unfold Spec.Request.WellFormed at wf
-  cases v <;> simp only [Spec.Request.asPartialRequest, Except.map]
+  cases v <;> simp only
   case context =>
     split
     case h_1 m h₁ =>
@@ -49,7 +50,7 @@ theorem partialEvaluateVar_on_concrete_eqv_concrete_eval (v : Var) (request : Sp
         unfold Map.toList at h₁
         replace ⟨pv, h₁, h₃⟩ := Map.mapMOnValues_some_implies_all_from_some h₁ (k, v) h₂
         replace h₁ := Map.make_mem_list_mem h₁
-        cases pv <;> simp only [Option.some.injEq] at h₃
+        cases pv <;> csimp at h₃
         case value v =>
           subst v
           rw [List.mem_map] at h₁
@@ -61,7 +62,7 @@ theorem partialEvaluateVar_on_concrete_eqv_concrete_eval (v : Var) (request : Sp
       case right =>
         intro (k, v) h₂
         have ⟨v', h₃, h₄⟩ := Map.mapMOnValues_some_implies_all_some h₁ (k, v) (Map.in_kvs_in_mapOnValues h₂)
-        simp only [Option.some.injEq] at h₄
+        csimp at h₄
         subst h₄
         simp [h₃]
     case h_2 h₁ =>

--- a/cedar-lean/Cedar/Thm/Slicing.lean
+++ b/cedar-lean/Cedar/Thm/Slicing.lean
@@ -15,6 +15,7 @@
 -/
 
 import Cedar.Spec
+import Cedar.Tactic.Csimp
 import Cedar.Thm.Authorization.Authorizer
 import Cedar.Thm.Authorization.Slicing
 
@@ -79,7 +80,7 @@ theorem sound_bound_analysis_produces_sound_slices (ba : BoundAnalysis) (request
     rw [List.mem_filter] at h₃
     simp [h₂] at h₃
     by_contra h₄
-    simp at h₄
+    csimp at h₄
     unfold IsSoundPolicyBound at h₁
     specialize h₁ request entities
     have ⟨h₅, h₆⟩ := h₁; clear h₁
@@ -111,30 +112,30 @@ theorem scope_bound_is_sound (policy : Policy) :
   unfold satisfiedBound
   unfold Scope.bound
   unfold inSomeOrNone
-  simp only [decide_eq_true_eq]
+  rw [decide_eq_true_eq]
   apply And.intro <;>
   intro h₁ <;>
   apply And.intro
   case left.left =>
     generalize h₂ : policy.principalScope.scope = s
-    cases s <;> simp <;>
+    cases s <;> csimp <;>
     apply satisfied_implies_principal_scope h₁ <;>
     simp only [Scope.bound, h₂]
   case left.right =>
     generalize h₂ : policy.resourceScope.scope = s
-    cases s <;> simp <;>
+    cases s <;> csimp <;>
     apply satisfied_implies_resource_scope h₁ <;>
     simp only [Scope.bound, h₂]
   case right.left =>
     generalize h₂ : policy.principalScope.scope = s
     replace ⟨err, h₁⟩ := if_hasError_then_exists_error h₁
-    cases s <;> simp <;>
+    cases s <;> csimp <;>
     apply error_implies_principal_scope_in h₁ <;>
     simp only [Scope.bound, h₂]
   case right.right =>
     generalize h₂ : policy.resourceScope.scope = s
     replace ⟨err, h₁⟩ := if_hasError_then_exists_error h₁
-    cases s <;> simp <;>
+    cases s <;> csimp <;>
     apply error_implies_resource_scope_in h₁ <;>
     simp only [Scope.bound, h₂]
 

--- a/cedar-lean/Cedar/Thm/Typechecking.lean
+++ b/cedar-lean/Cedar/Thm/Typechecking.lean
@@ -48,7 +48,7 @@ theorem typecheck_is_sound (policy : Policy) (env : Environment) (t : CedarType)
   intro h₁ h₂
   simp [typecheck] at h₂
   cases h₃ : typeOf (Policy.toExpr policy) [] env <;> simp [h₃] at h₂
-  split at h₂ <;> simp at h₂
+  split at h₂ <;> csimp at h₂
   rename_i ht
   have hc := empty_capabilities_invariant request entities
   have ⟨_, v, h₄, h₅⟩ := type_of_is_sound hc h₁ h₃

--- a/cedar-lean/Cedar/Thm/Validation/Typechecker/And.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Typechecker/And.lean
@@ -45,25 +45,25 @@ theorem type_of_and_inversion {x₁ x₂ : Expr} {c c' : Capabilities} {env : En
   split at h₁ <;> simp [ok, err] at h₁
   case ok.h_1 h₃ =>
     exists BoolType.ff, res₁.snd ; simp [h₁]
-    simp at h₃
+    csimp at h₃
     have ⟨h₁, _⟩ := h₁ ; subst h₁
     have ⟨h₃, _⟩ := h₃
     simp [←h₃]
   case ok.h_2 bty₁ c₁ h₃ h₄ =>
     exists bty₁, c₁
-    simp at h₄
+    csimp at h₄
     have ⟨hty₁, hc₁⟩ := h₄
     simp [←hty₁, ←hc₁]
     split ; contradiction
     cases h₄ : typeOf x₂ (c ∪ res₁.snd) env <;> simp [h₄] at *
     rename_i res₂
-    split at h₁ <;> simp at h₁ <;>
+    split at h₁ <;> csimp at h₁ <;>
     have ⟨hty, hc⟩ := h₁ <;> subst hty hc
     case inr.ok.h_1 hty₂ =>
       exists BoolType.ff, res₂.snd ; simp [←hty₂]
     case inr.ok.h_2 hty₂ =>
       exists BoolType.tt, res₂.snd ; simp [←hty₂, hc₁]
-      cases bty₁ <;> simp at h₃ <;> simp [lubBool]
+      cases bty₁ <;> csimp at h₃ <;> simp [lubBool]
     case inr.ok.h_3 bty₂ h₄ h₅ hty₂ =>
       exists BoolType.anyBool, res₂.snd
       cases bty₂ <;> simp at *
@@ -93,7 +93,7 @@ theorem type_of_and_is_sound {x₁ x₂ : Expr} {c₁ c₂ : Capabilities} {env 
     subst hty hc
     apply And.intro empty_guarded_capabilities_invariant
     have h₇ := instance_of_ff_is_false ih₁₃
-    simp at h₇ ; subst h₇
+    csimp at h₇ ; subst h₇
     simp [EvaluatesTo] at ih₁₂
     rcases ih₁₂ with ih₁₂ | ih₁₂ | ih₁₂ | ih₁₂ <;>
     simp [EvaluatesTo, evaluate, Result.as, ih₁₂, Coe.coe, Value.asBool] <;>

--- a/cedar-lean/Cedar/Thm/Validation/Typechecker/BinaryApp.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Typechecker/BinaryApp.lean
@@ -14,6 +14,7 @@
  limitations under the License.
 -/
 
+import Cedar.Tactic.Csimp
 import Cedar.Thm.Data.LT
 import Cedar.Thm.Validation.Typechecker.Basic
 
@@ -50,15 +51,15 @@ theorem type_of_eq_inversion {x₁ x₂ : Expr} {c c' : Capabilities} {env : Env
   rename_i tc₁ tc₂
   split at h₁
   case h_1 p₁ p₂ =>
-    split at h₁ <;> simp at h₁ <;> simp [h₁] <;>
+    split at h₁ <;> csimp at h₁ <;> simp [h₁] <;>
     rename_i h₄ <;> simp [h₄]
   case h_2 h₄ =>
     split at h₁
     case h_1 h₅ =>
-      simp at h₁ ; simp [h₁]
+      csimp at h₁ ; simp [h₁]
       split
       case h_1 p₁ p₂ _ =>
-        specialize h₄ p₁ p₂ ; simp at h₄
+        specialize h₄ p₁ p₂ ; csimp at h₄
       case h_2 =>
         exists tc₁.fst
         constructor
@@ -68,10 +69,10 @@ theorem type_of_eq_inversion {x₁ x₂ : Expr} {c c' : Capabilities} {env : Env
           · exists tc₂.snd
           · simp [h₅]
     case h_2 h₅ =>
-      split at h₁ <;> simp at h₁ ; simp [h₁]
+      split at h₁ <;> csimp at h₁ ; simp [h₁]
       split
       case h_1 p₁ p₂ _ =>
-        specialize h₄ p₁ p₂ ; simp at h₄
+        specialize h₄ p₁ p₂ ; csimp at h₄
       case h_2 ety₁ ety₂ _ true_is_instance_of_tt _ _ _ _ =>
         exists tc₁.fst
         constructor
@@ -136,16 +137,13 @@ theorem type_of_eq_is_sound {x₁ x₂ : Expr} {c₁ c₂ : Capabilities} {env :
     replace ⟨ihl₂, ih₄⟩ := ih₂
     rw [eq_comm] at ihl₁ ihl₂; subst ihl₁ ihl₂
     simp [apply₂]
-    split at hty
-    case h_1 =>
-      rw [hty]
+    split at hty <;> rename_i heq
+    · rw [hty]
       apply bool_is_instance_of_anyBool
-    case h_2 heq =>
-      have ⟨hty₀, ⟨ety₁, hty₁⟩, ⟨ety₂, hty₂⟩⟩ := hty ; clear hty
+    · have ⟨hty₀, ⟨ety₁, hty₁⟩, ⟨ety₂, hty₂⟩⟩ := hty ; clear hty
       subst hty₀ hty₁ hty₂
       have h₆ := no_entity_type_lub_implies_not_eq ih₃ ih₄ heq
-      cases h₇ : v₁ == v₂ <;>
-      simp only [beq_iff_eq, beq_eq_false_iff_ne, ne_eq, Value.prim.injEq] at h₇
+      cases h₇ : v₁ == v₂ <;> csimp at h₇
       case false => exact false_is_instance_of_ff
       case true  => contradiction
 
@@ -165,7 +163,7 @@ theorem type_of_int_cmp_inversion {op₂ : BinaryOp} {x₁ x₂ : Expr} {c c' : 
     subst h₁
     simp [typeOfBinaryApp, err, ok] at h₂
     split at h₂ <;> try contradiction
-    simp at h₂ ; simp [h₂]
+    csimp at h₂ ; simp [h₂]
     rename_i tc₁ tc₂ _ _ _ _ h₅ h₆
     constructor
     · exists tc₁.snd ; simp [←h₅]
@@ -222,7 +220,7 @@ theorem type_of_int_arith_inversion {op₂ : BinaryOp} {x₁ x₂ : Expr} {c c' 
     subst h₁
     simp [typeOfBinaryApp, err, ok] at h₂
     split at h₂ <;> try contradiction
-    simp at h₂ ; simp [h₂]
+    csimp at h₂ ; simp [h₂]
     rename_i tc₁ tc₂ _ _ _ _ h₅ h₆
     replace ⟨h₂, _⟩ := h₂
     constructor
@@ -286,7 +284,7 @@ theorem type_of_contains_inversion {x₁ x₂ : Expr} {c c' : Capabilities} {env
   simp [typeOfBinaryApp, err, ok] at h₁
   split at h₁ <;> try contradiction
   simp [ifLubThenBool, err, ok] at h₁
-  split at h₁ <;> simp only [Except.ok.injEq, Prod.mk.injEq] at h₁
+  split at h₁ <;> csimp at h₁
   simp [h₁]
   rename_i tc₁ tc₂ _ ty₁ ty₂ ty₃ _ h₄ _ _ h₅
   exists ty₃, tc₂.fst
@@ -343,7 +341,7 @@ theorem type_of_containsA_inversion {op₂ : BinaryOp} {x₁ x₂ : Expr} {c c' 
     simp [typeOfBinaryApp, err, ok] at h₂
     split at h₂ <;> try contradiction
     simp [ifLubThenBool, err, ok] at h₂
-    split at h₂ <;> simp only [Except.ok.injEq, Prod.mk.injEq] at h₂
+    split at h₂ <;> csimp at h₂
     simp [h₂]
     rename_i tc₁ tc₂ _ _ _ ty₁ ty₂ _ h₅ h₆ _ _ h₇
     exists ty₁, ty₂
@@ -405,8 +403,8 @@ theorem type_of_mem_inversion {x₁ x₂ : Expr} {c c' : Capabilities} {env : En
   simp [typeOfBinaryApp, ok] at h₁
   split at h₁ <;> try { contradiction }
   all_goals {
-    simp only [Except.ok.injEq, Prod.mk.injEq] at h₁
-    simp [h₁]
+    csimp at h₁
+    simp only [List.empty_eq, h₁, Except.ok.injEq, exists_and_left, true_and]
     rename_i tc₁ tc₂ _ _ _ ety₁ ety₂ _ h₄ h₅
     exists ety₁
     constructor
@@ -419,7 +417,7 @@ theorem entityUID?_some_implies_entity_lit {x : Expr} {euid : EntityUID}
   x = Expr.lit (.entityUID euid)
 := by
   simp [entityUID?] at h₁
-  split at h₁ <;> simp at h₁ ; subst h₁ ; rfl
+  split at h₁ <;> csimp at h₁ ; subst h₁ ; rfl
 
 
 theorem actionUID?_some_implies_action_lit {x : Expr} {euid : EntityUID} {acts : ActionSchema}
@@ -440,14 +438,10 @@ theorem entityUIDs?_some_implies_entity_lits {x : Expr} {euids : List EntityUID}
   x = Expr.set ((List.map (Expr.lit ∘ Prim.entityUID) euids))
 := by
   simp [entityUIDs?] at h₁
-  split at h₁ <;> try simp at h₁
+  split at h₁ <;> try csimp at h₁
   rw [←List.mapM'_eq_mapM] at h₁ ; rename_i xs
-  cases euids
-  case nil =>
-    cases hxs : xs <;> subst xs <;> simp at *
-  case cons hd tl =>
-    cases hxs : xs <;> subst xs <;> simp [pure, Except.pure] at *
-    rename_i hd' tl'
+  cases euids <;> cases hxs : xs <;> subst xs <;> csimp at *
+  case cons.cons hd tl hd' tl' =>
     cases h₂ : entityUID? hd' <;> simp [h₂] at h₁
     cases h₃ : List.mapM' entityUID? tl' <;> simp [h₃] at h₁
     have ⟨hhd, htl⟩ := h₁ ; clear h₁ ; rw [eq_comm] at hhd htl ; subst hhd htl
@@ -464,9 +458,9 @@ theorem entity_type_in_false_implies_inₑ_false {euid₁ euid₂ : EntityUID} {
   inₑ euid₁ euid₂ entities = false
 := by
   simp [EntitySchema.descendentOf] at h₂
-  simp [inₑ] ; by_contra h₃ ; simp at h₃
+  simp [inₑ] ; by_contra h₃ ; csimp at h₃
   rcases h₃ with h₃ | h₃
-  case inl => subst h₃ ; simp at h₂
+  case inl => subst h₃ ; csimp at h₂
   case inr =>
   simp [Entities.ancestorsOrEmpty] at h₃
   split at h₃
@@ -489,7 +483,7 @@ theorem action_type_in_eq_action_inₑ (euid₁ euid₂ : EntityUID) {env : Envi
   rename_i entry
   have ⟨data, h₁₁, h₁₂⟩ := h₁ euid₁ entry h₃
   simp [inₑ, ActionSchema.descendentOf, h₃, Entities.ancestorsOrEmpty, h₁₁]
-  rcases h₄ : euid₁ == euid₂ <;> simp at h₄ <;> simp [h₄, h₁₂]
+  rcases h₄ : euid₁ == euid₂ <;> csimp at h₄ <;> simp [h₄, h₁₂]
 
 theorem type_of_mem_is_soundₑ {x₁ x₂ : Expr} {c₁ c₁' c₂' : Capabilities} {env : Environment} {request : Request} {entities : Entities} {ety₁ ety₂ : EntityType}
   (h₁ : CapabilitiesInvariant c₁ request entities)
@@ -553,17 +547,15 @@ theorem entity_set_type_implies_set_of_entities {vs : List Value} {ety : EntityT
     ∀ euid, euid ∈ euids → euid.ty = ety
 := by
   rw [←List.mapM'_eq_mapM]
-  cases vs
-  case nil =>
-    simp [pure, Except.pure]
+  cases vs <;> csimp
   case cons hd tl =>
-    simp only [List.mapM'_cons]
     cases h₁ ; rename_i h₁
     have h₂ := h₁ hd
     simp [Set.mem_cons_self] at h₂
     replace ⟨heuid, hdty, h₂⟩ := instance_of_entity_type_is_entity h₂
     subst h₂
-    rw [Value.asEntityUID] ; simp only [Except.bind_ok]
+    rw [Value.asEntityUID]
+    csimp
     rw [List.mapM'_eq_mapM]
     have h₃ : InstanceOfType (Value.set (Set.mk tl)) (CedarType.set (CedarType.entity ety)) := by
       apply InstanceOfType.instance_of_set
@@ -585,7 +577,7 @@ theorem entity_type_in_false_implies_inₛ_false {euid : EntityUID} {euids : Lis
   simp [InstanceOfEntitySchema] at h₁
   simp [EntitySchema.descendentOf] at h₂
   rw [Set.make_any_iff_any]
-  by_contra h₄ ; simp at h₄
+  by_contra h₄ ; csimp at h₄
   replace ⟨euid', h₄, h₅⟩ := h₄
   simp [inₑ] at h₅
   rcases h₅ with h₅ | h₅
@@ -648,7 +640,7 @@ theorem mapM'_asEntityUID_eq_entities {vs : List Value} {euids : List EntityUID}
     simp [List.map]
     constructor
     · simp [Value.asEntityUID] at h₂
-      split at h₂ <;> simp at h₂
+      split at h₂ <;> csimp at h₂
       rw [eq_comm] at h₂ ; subst h₂
       rfl
     · exact mapM'_asEntityUID_eq_entities h₃
@@ -754,7 +746,7 @@ theorem type_of_mem_is_soundₛ {x₁ x₂ : Expr} {c₁ c₁' c₂' : Capabilit
   simp [h₇]
   apply InstanceOfType.instance_of_bool
   simp [InstanceOfBoolType]
-  split <;> try simp
+  split <;> try csimp
   rename_i h₈ h₉ h₁₀
   have ⟨_, hents, hacts⟩ := h₂ ; clear h₂
   simp [typeOfInₛ] at *

--- a/cedar-lean/Cedar/Thm/Validation/Typechecker/Call.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Typechecker/Call.lean
@@ -41,7 +41,7 @@ theorem type_of_call_decimal_inversion {xs : List Expr} {c c' : Capabilities} {e
   simp [typeOfCall, typeOfConstructor] at h₁
   split at h₁ <;> simp [ok, err] at h₁
   rename_i s
-  split at h₁ <;> simp at h₁
+  split at h₁ <;> csimp at h₁
   simp [h₁]
   rename_i h₃
   simp [h₃]
@@ -77,7 +77,7 @@ theorem type_of_call_ip_inversion {xs : List Expr} {c c' : Capabilities} {env : 
   simp [typeOfCall, typeOfConstructor] at h₁
   split at h₁ <;> simp [ok, err] at h₁
   rename_i s
-  split at h₁ <;> simp at h₁
+  split at h₁ <;> csimp at h₁
   simp [h₁]
   rename_i h₃
   simp [h₃]
@@ -122,14 +122,14 @@ theorem typeOf_of_binary_call_inversion {xs : List Expr} {c : Capabilities} {env
         rw [List.attach, List.pmap, List.mapM, List.mapM.loop, justType, Except.map] at h₁
         split at h₁ <;> simp at h₁
         rw [List.mapM.loop, justType, Except.map] at h₁
-        split at h₁ <;> simp at h₁
+        split at h₁ <;> csimp at h₁
         simp [List.mapM.loop, pure, Except.pure] at h₁
         rename_i res₁ h₂ _ res₂ h₃
         exists hd₁, hd₂, res₁.2, res₂.2
         simp [ok]
         have ⟨hl₁, hr₁⟩ := h₁
         subst hl₁ hr₁
-        simp at h₂ h₃
+        csimp at h₂ h₃
         simp [h₂, h₃]
       case cons hd₃ tl₃ =>
         simp [List.attach] at h₁
@@ -290,7 +290,7 @@ theorem typeOf_of_unary_call_inversion {xs : List Expr} {c : Capabilities} {env 
       simp [justType, Except.map] at h₂
       simp [pure, Except.pure] at h₁
       subst h₁
-      split at h₂ <;> simp at h₂
+      split at h₂ <;> csimp at h₂
       rename_i res₁ h₃
       exists hd₁, res₁.snd
       simp [ok, h₃, ←h₂]
@@ -302,7 +302,7 @@ theorem typeOf_of_unary_call_inversion {xs : List Expr} {c : Capabilities} {env 
       rw [justType, Except.map] at h₁
       split at h₁ <;> simp at h₁
       rename_i res₁ _ _ res₂ _
-      simp [pure, Except.pure] at h₁
+      csimp at h₁
       cases h₂ : List.mapM (fun x => justType (typeOf x c env)) tl₂ <;> simp [h₂] at h₁
 
 theorem type_of_call_ipAddr_recognizer_inversion {xfn : ExtFun} {xs : List Expr} {c c' : Capabilities} {env : Environment} {ty : CedarType}

--- a/cedar-lean/Cedar/Thm/Validation/Typechecker/GetAttr.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Typechecker/GetAttr.lean
@@ -14,6 +14,7 @@
  limitations under the License.
 -/
 
+import Cedar.Tactic.Csimp
 import Cedar.Thm.Validation.Typechecker.Basic
 
 /-!
@@ -34,7 +35,7 @@ theorem getAttrInRecord_has_empty_capabilities {x₁ : Expr} {a : Attr} {c₁ c�
   simp [getAttrInRecord] at h₁
   split at h₁ <;> simp [ok, err] at h₁
   simp [h₁]
-  split at h₁ <;> simp at h₁
+  split at h₁ <;> csimp at h₁
   simp [h₁]
 
 theorem type_of_getAttr_inversion {x₁ : Expr} {a : Attr} {c₁ c₂ : Capabilities} {env : Environment} {ty : CedarType}
@@ -55,7 +56,7 @@ theorem type_of_getAttr_inversion {x₁ : Expr} {a : Attr} {c₁ c₂ : Capabili
       apply getAttrInRecord_has_empty_capabilities h₁
     · simp only [List.empty_eq, Except.ok.injEq, Prod.mk.injEq, CedarType.entity.injEq,
         exists_and_right, exists_eq', true_and, false_and, exists_const, or_false, and_true]
-      split at h₁ <;> try simp [err] at h₁
+      split at h₁ <;> try simp only [err] at h₁
       apply getAttrInRecord_has_empty_capabilities h₁
 
 theorem type_of_getAttr_is_sound_for_records {x₁ : Expr} {a : Attr} {c₁ c₁' : Capabilities} {env : Environment} {rty : RecordType} {request : Request} {entities : Entities} {v₁ : Value}
@@ -74,9 +75,8 @@ theorem type_of_getAttr_is_sound_for_records {x₁ : Expr} {a : Attr} {c₁ c₁
   have ⟨r, h₆⟩ := instance_of_record_type_is_record h₅
   subst h₆
   simp [getAttr, attrsOf, Map.findOrErr]
-  cases h₈ : Map.find? r a
+  cases h₈ : Map.find? r a <;> csimp
   case none =>
-    simp only [or_self, false_and, exists_const]
     simp [typeOf, h₃, typeOfGetAttr, getAttrInRecord] at h₂
     split at h₂ <;> simp [ok, err] at h₂
     case h_1 _ _ h₉ =>
@@ -84,19 +84,18 @@ theorem type_of_getAttr_is_sound_for_records {x₁ : Expr} {a : Attr} {c₁ c₁
       have ⟨_, h₁₀⟩ := required_attribute_is_present h₅ h₉
       simp [h₈] at h₁₀
     case h_2 =>
-      split at h₂ <;> simp at h₂
+      split at h₂ <;> csimp at h₂
       subst h₂ ; rename_i h₁₀
       have ⟨_, h₁₁⟩ := capability_implies_record_attribute h₁ h₄ h₁₀
       simp [h₈] at h₁₁
   case some vₐ =>
-    simp only [Except.ok.injEq, false_or, exists_eq_left']
     simp [typeOf, h₃, typeOfGetAttr, getAttrInRecord] at h₂
     split at h₂ <;> simp [ok, err] at h₂
     case h_1 _ _ h₉ =>
       subst h₂
       apply instance_of_attribute_type h₅ h₉ (by simp [Qualified.getType]) h₈
     case h_2 _ _ h₉ =>
-      split at h₂ <;> simp at h₂
+      split at h₂ <;> csimp at h₂
       subst h₂
       apply instance_of_attribute_type h₅ h₉ (by simp [Qualified.getType]) h₈
 
@@ -117,43 +116,34 @@ theorem type_of_getAttr_is_sound_for_entities {x₁ : Expr} {a : Attr} {c₁ c�
   have ⟨uid, h₇, h₈⟩ := instance_of_entity_type_is_entity h₆
   subst h₈
   simp [getAttr, attrsOf, Entities.attrs, Map.findOrErr]
-  cases h₈ : Map.find? entities uid
+  cases h₈ : Map.find? entities uid <;> csimp
   case none =>
-    simp only [Except.bind_err, Except.error.injEq, or_self, or_false, true_and]
     exact type_is_inhabited ty
   case some d =>
     subst h₇
-    simp only [Except.bind_ok]
-    cases h₉ : Map.find? d.attrs a
-    case none =>
-      simp only [Except.error.injEq, or_self, false_and, exists_const]
-      simp only [typeOf, h₄, typeOfGetAttr, getAttrInRecord, List.empty_eq, Except.bind_ok] at h₃
-      split at h₃ <;> simp [ok, err] at h₃
-      split at h₃ <;> try simp at h₃
-      case h_1.h_1 _ _ h₁₀ _ _ h₁₁ =>
-        subst h₃
-        have h₁₂ := well_typed_entity_attributes h₂ h₈ h₁₀
-        have ⟨aᵥ, h₁₃⟩ := required_attribute_is_present h₁₂ h₁₁
-        simp [h₉] at h₁₃
-      case h_1.h_2 =>
-        split at h₃ <;> simp at h₃
-        subst h₃ ; rename_i h₁₃
-        have ⟨_, h₁₄⟩ := capability_implies_entity_attribute h₁ h₅ h₈ h₁₃
-        simp [h₉] at h₁₄
-    case some vₐ =>
-      simp only [Except.ok.injEq, false_or, exists_eq_left']
-      simp [typeOf, h₄, typeOfGetAttr, getAttrInRecord] at h₃
-      split at h₃ <;> simp [ok, err] at h₃
-      split at h₃ <;> try simp at h₃
-      case h_1.h_1 _ _ h₁₀ _ _ h₁₁ =>
-        subst h₃
-        apply instance_of_attribute_type _ h₁₁ (by simp [Qualified.getType]) h₉
-        apply well_typed_entity_attributes h₂ h₈ h₁₀
-      case h_1.h_2 _ _ h₁₀ _ _ h₁₁ =>
-        split at h₃ <;> simp at h₃
-        subst h₃
-        apply instance_of_attribute_type _ h₁₁ (by simp [Qualified.getType]) h₉
-        apply well_typed_entity_attributes h₂ h₈ h₁₀
+    cases h₉ : Map.find? d.attrs a <;> csimp
+    <;> simp only [typeOf, h₄, typeOfGetAttr, getAttrInRecord, List.empty_eq, Except.bind_ok] at h₃
+    <;> split at h₃ <;> simp only [ok, err] at h₃
+    <;> split at h₃ <;> try csimp at h₃
+    case none.h_1.h_1 h₁₀ _ _ h₁₁ =>
+      subst h₃
+      have h₁₂ := well_typed_entity_attributes h₂ h₈ h₁₀
+      have ⟨aᵥ, h₁₃⟩ := required_attribute_is_present h₁₂ h₁₁
+      simp [h₉] at h₁₃
+    case none.h_1.h_2 =>
+      split at h₃ <;> csimp at h₃
+      subst h₃ ; rename_i h₁₃
+      have ⟨_, h₁₄⟩ := capability_implies_entity_attribute h₁ h₅ h₈ h₁₃
+      simp [h₉] at h₁₄
+    case some.h_1.h_1 vₐ _ _ h₁₀ _ _ h₁₁ =>
+      subst h₃
+      apply instance_of_attribute_type _ h₁₁ (by simp [Qualified.getType]) h₉
+      apply well_typed_entity_attributes h₂ h₈ h₁₀
+    case some.h_1.h_2 vₐ _ _ h₁₀ _ _ h₁₁ =>
+      split at h₃ <;> csimp at h₃
+      subst h₃
+      apply instance_of_attribute_type _ h₁₁ (by simp [Qualified.getType]) h₉
+      apply well_typed_entity_attributes h₂ h₈ h₁₀
 
 theorem type_of_getAttr_is_sound {x₁ : Expr} {a : Attr} {c₁ c₂ : Capabilities} {env : Environment} {ty : CedarType} {request : Request} {entities : Entities}
   (h₁ : CapabilitiesInvariant c₁ request entities)

--- a/cedar-lean/Cedar/Thm/Validation/Typechecker/HasAttr.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Typechecker/HasAttr.lean
@@ -37,7 +37,7 @@ theorem type_of_hasAttr_inversion {x₁ : Expr} {a : Attr} {c₁ c₂ : Capabili
   cases h₂ : typeOf x₁ c₁ env <;> simp [h₂] at h₁
   case ok res =>
     have ⟨ty₁, c₁'⟩ := res
-    simp at h₁
+    csimp at h₁
     split at h₁
     <;> simp [err, ok, hasAttrInRecord] at h₁
     <;> split at h₁
@@ -71,16 +71,16 @@ theorem type_of_hasAttr_is_sound_for_records {x₁ : Expr} {a : Attr} {c₁ c₁
     have ⟨hₜ, _⟩ := h₂ <;> simp [←hₜ] <;>
     apply InstanceOfType.instance_of_bool <;>
     simp [InstanceOfBoolType]
-    cases h₆ : (Map.contains r a) <;> simp
+    cases h₆ : (Map.contains r a) <;> csimp
     rename_i h₇ _
     cases h₇
-    case inl.h₁.false.inl _ h₇ =>
+    case inl _ h₇ =>
       simp [CapabilitiesInvariant] at h₁
       specialize h₁ x₁ a h₇
       simp [EvaluatesTo, evaluate, h₄, hasAttr, attrsOf, h₆] at h₁
-    case inl.h₁.false.inr h₇ _ h₈ =>
+    case inr h₇ _ h₈ =>
       simp [Qualified.isRequired] at h₈
-      split at h₈ <;> simp at h₈
+      split at h₈ <;> csimp at h₈
       have h₉ := required_attribute_is_present h₅ h₇
       simp [←Map.contains_iff_some_find?, h₆] at h₉
   case h_2 =>
@@ -89,7 +89,7 @@ theorem type_of_hasAttr_is_sound_for_records {x₁ : Expr} {a : Attr} {c₁ c₁
     simp [←h₂]
     apply InstanceOfType.instance_of_bool
     simp [InstanceOfBoolType]
-    cases h₆ : (Map.contains r a) <;> simp
+    cases h₆ : (Map.contains r a) <;> csimp
     rename_i _ h₇ _ _
     have h₇ := absent_attribute_is_absent h₅ h₇
     simp [Map.contains_iff_some_find?, h₇] at h₆
@@ -120,7 +120,7 @@ theorem type_of_hasAttr_is_sound_for_entities {x₁ : Expr} {a : Attr} {c₁ c�
     split at h₃ <;> rcases h₃ with ⟨h₃, _⟩ <;>
     apply InstanceOfType.instance_of_bool <;>
     simp [InstanceOfBoolType]
-    cases h₈ : Map.contains (Entities.attrsOrEmpty entities uid) a <;> simp
+    cases h₈ : Map.contains (Entities.attrsOrEmpty entities uid) a <;> csimp
     rename_i _ _ _ _  h₉
     simp [CapabilitiesInvariant] at h₁
     specialize h₁ x₁ a h₉
@@ -131,7 +131,7 @@ theorem type_of_hasAttr_is_sound_for_entities {x₁ : Expr} {a : Attr} {c₁ c�
     simp [←h₃]
     apply InstanceOfType.instance_of_bool
     simp [InstanceOfBoolType]
-    cases h₈ : Map.contains (Entities.attrsOrEmpty entities uid) a <;> simp
+    cases h₈ : Map.contains (Entities.attrsOrEmpty entities uid) a <;> csimp
     rename_i _ _ h₉ _ _
     simp [Entities.attrsOrEmpty] at h₈
     split at h₈
@@ -152,7 +152,7 @@ theorem type_of_hasAttr_is_sound_for_entities {x₁ : Expr} {a : Attr} {c₁ c�
     rename_i _ h₇ _ _
     simp [EntitySchema.attrs?] at h₇
     replace ⟨_, h₂, _⟩ := h₂
-    cases h₈ : Map.find? entities uid <;> simp
+    cases h₈ : Map.find? entities uid <;> csimp
     simp [Map.not_contains_of_empty, InstanceOfBoolType]
     replace ⟨_, h₈, _⟩ := h₂ uid _ h₈
     rw [h₇] at h₈

--- a/cedar-lean/Cedar/Thm/Validation/Typechecker/IfThenElse.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Typechecker/IfThenElse.lean
@@ -14,6 +14,7 @@
  limitations under the License.
 -/
 
+import Cedar.Tactic.Csimp
 import Cedar.Thm.Validation.Typechecker.Basic
 
 /-!
@@ -44,7 +45,7 @@ theorem type_of_ite_inversion {x₁ x₂ x₃ : Expr} {c c' : Capabilities} {env
   cases h₂ : typeOf x₁ c env <;> simp [h₂, typeOfIf] at *
   rename_i res₁
   split at h₁ <;> try { simp [ok, err] at h₁ } <;>
-  rename_i c₁ hr₁ <;> simp at hr₁ <;> have ⟨ht₁, hc₁⟩ := hr₁
+  rename_i c₁ hr₁ <;> csimp at hr₁ <;> have ⟨ht₁, hc₁⟩ := hr₁
   case ok.h_1 =>
     exists BoolType.tt, res₁.snd ; simp [←ht₁]
     cases h₃ : typeOf x₂ (c ∪ res₁.snd) env <;> simp [h₃] at h₁
@@ -65,7 +66,7 @@ theorem type_of_ite_inversion {x₁ x₂ x₃ : Expr} {c c' : Capabilities} {env
     have ⟨ht, hc⟩ := h₁
     subst ht hc hc₁
     exists res₂.fst, res₂.snd
-    simp only [Except.ok.injEq, true_and]
+    csimp
     exists res₃.fst, res₃.snd
 
 theorem type_of_ite_is_sound {x₁ x₂ x₃ : Expr} {c₁ c₂ : Capabilities} {env : Environment} {ty : CedarType} {request : Request} {entities : Entities}
@@ -83,7 +84,7 @@ theorem type_of_ite_is_sound {x₁ x₂ x₃ : Expr} {c₁ c₂ : Capabilities} 
   have ⟨ih₁₁, v₁, ih₁₂, ih₁₃⟩ := ih₁
   have ⟨b₁, hb₁⟩ := instance_of_bool_is_bool ih₁₃
   subst hb₁
-  cases bty₁ <;> simp at h₅
+  cases bty₁ <;> csimp at h₅
   case anyBool =>
     have ⟨h₅, h₆, ht, hc⟩ := h₅
     cases b₁
@@ -131,7 +132,7 @@ theorem type_of_ite_is_sound {x₁ x₂ x₃ : Expr} {c₁ c₂ : Capabilities} 
     simp [EvaluatesTo, evaluate, Result.as, ih₁₂, Coe.coe, Value.asBool, GuardedCapabilitiesInvariant] <;>
     try exact type_is_inhabited ty
     have hb₁ := instance_of_tt_is_true ih₁₃
-    simp at hb₁ ; subst hb₁ ; simp only [ite_true]
+    csimp at hb₁ ; subst hb₁ ; csimp
     simp [GuardedCapabilitiesInvariant, ih₁₂] at ih₁₁
     have h₆ := capability_union_invariant h₁ ih₁₁
     specialize ih₂ h₆ h₂ h₅
@@ -148,7 +149,7 @@ theorem type_of_ite_is_sound {x₁ x₂ x₃ : Expr} {c₁ c₂ : Capabilities} 
     simp [EvaluatesTo, evaluate, Result.as, ih₁₂, Coe.coe, Value.asBool, GuardedCapabilitiesInvariant] <;>
     try exact type_is_inhabited ty
     have hb₁ := instance_of_ff_is_false ih₁₃
-    simp at hb₁ ; simp [hb₁]
+    csimp at hb₁ ; simp [hb₁]
     specialize ih₃ h₁ h₂ h₅
     have ⟨ih₃₁, v₃, ih₃₂, ih₃₃⟩ := ih₃
     subst ht hc

--- a/cedar-lean/Cedar/Thm/Validation/Typechecker/LUB.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Typechecker/LUB.lean
@@ -16,6 +16,7 @@
 
 import Cedar.Spec
 import Cedar.Validation
+import Cedar.Tactic.Csimp
 import Cedar.Thm.Data.Control
 import Cedar.Thm.Data.Map
 
@@ -43,7 +44,7 @@ theorem lubRecordType_is_lub_of_record_types {rty rty₁ rty₂ : List (Attr × 
 := by
   intro h₁
   unfold lubRecordType at h₁
-  split at h₁ <;> try simp at h₁
+  split at h₁ <;> try csimp at h₁
   case h_1 => subst h₁ ; exact IsLubOfRecordTypes.nil
   case h_2 a hd₁ tl₁ a' hd₂ tl₂ =>
     split at h₁ <;> try contradiction
@@ -116,7 +117,7 @@ theorem lubRecord_find_implies_find_left {a : Attr} {qty : QualifiedType} {rty r
   have ⟨qty₁, qty₂, h₃, h₄, h₅⟩ := lubRecord_find_implies_find h₁ h₂
   exists qty₁ ; simp [h₃]
   unfold lubQualifiedType at h₅
-  split at h₅ <;> try simp at h₅
+  split at h₅ <;> try csimp at h₅
   all_goals {
     rename_i ty₁ ty₂
     cases h₆ : ty₁ ⊔ ty₂ <;> simp [h₆] at h₅
@@ -129,7 +130,7 @@ theorem lubRecordType_nil_some {rty₁ rty₂ : List (Attr × QualifiedType)} :
   (rty₁ = [] ∧ rty₂ = [])
 := by
   unfold lubRecordType
-  cases rty₁ <;> simp
+  cases rty₁ <;> csimp
   intro h₁ ; simp [h₁]
 
 theorem lubBool_comm {bty₁ bty₂ : BoolType} :
@@ -159,7 +160,7 @@ theorem lubRecord_comm {rty₁ rty₂ : List (Attr × Qualified CedarType)} :
   lubRecordType rty₁ rty₂ = lubRecordType rty₂ rty₁
 := by
   unfold lubRecordType
-  split <;> simp
+  split <;> csimp
   case h_2 =>
     rename_i a₁ hd₁ tl₁ a₂ hd₂ tl₂
     split <;> rename_i h₃ <;> rw [eq_comm] at h₃ <;> simp [h₃]
@@ -210,7 +211,7 @@ theorem lub_refl (ty : CedarType) :
   (ty ⊔ ty) = some ty
 := by
   unfold lub?
-  split <;> try simp
+  split <;> try csimp
   case h_1 => simp [lubBool]
   case h_2 eltTy =>
     have h₁ := lub_refl eltTy
@@ -223,16 +224,16 @@ theorem lubRecordType_refl (rty : List (Attr × QualifiedType)) :
   lubRecordType rty rty = some rty
 := by
   unfold lubRecordType
-  split <;> try simp
+  split <;> try csimp
   case h_2 k qty tl =>
     have h₁ := lubQualifiedType_refl qty
     have h₂ := lubRecordType_refl tl
     simp [h₁, h₂]
   case h_3 h₁ h₂ =>
-    cases rty <;> simp at h₁
+    cases rty <;> csimp at h₁
     case cons hd tl =>
       specialize h₂ hd.fst hd.snd tl hd.fst hd.snd tl
-      simp at h₂
+      csimp at h₂
 
 theorem lubQualifiedType_refl (qty : QualifiedType) :
   lubQualifiedType qty qty = some qty
@@ -245,7 +246,7 @@ theorem lubQualifiedType_refl (qty : QualifiedType) :
       rename_i ty
       specialize h₁ ty ty
       specialize h₂ ty ty
-      simp at h₁ h₂
+      csimp at h₁ h₂
     }
   all_goals {
     rename_i ty
@@ -260,10 +261,14 @@ theorem lubQualified_is_lub_of_getType {qty qty₁ qty₂: Qualified CedarType}
   (qty₁.getType ⊔ qty₂.getType) = .some qty.getType
 := by
   unfold lubQualifiedType at h₁
-  split at h₁ <;> try simp only [Option.bind_eq_bind, Option.bind_eq_some, Option.some.injEq] at h₁
+  split at h₁ <;> try csimp at h₁
   all_goals {
     rename_i aty₁ aty₂
-    cases h₂ : (aty₁ ⊔ aty₂) <;> simp only [Qualified.getType] <;> rw [h₂] <;> simp only [h₂, false_and, exists_const, exists_eq_left', Option.some.injEq] at h₁
+    cases h₂ : (aty₁ ⊔ aty₂)
+    <;> unfold Qualified.getType
+    <;> rw [h₂]
+    <;> rw [h₂] at h₁
+    <;> csimp at h₁
     simp only [Qualified.getType, ← h₁]
   }
 
@@ -278,7 +283,7 @@ theorem lub_trans {ty₁ ty₂ ty₃ : CedarType} :
   unfold lub? ; split
   case h_1 bty₁ bty₃ =>
     unfold lub? at h₁ h₂
-    cases ty₂ <;> simp at h₁ h₂
+    cases ty₂ <;> csimp at h₁ h₂
     simp [lubBool] at *
     rename_i bty₄
     split ; assumption
@@ -287,7 +292,7 @@ theorem lub_trans {ty₁ ty₂ ty₃ : CedarType} :
     subst h₂ ; contradiction
   case h_2 sty₁ sty₃ =>
     unfold lub? at h₁ h₂
-    cases ty₂ <;> simp at h₁ h₂
+    cases ty₂ <;> csimp at h₁ h₂
     rename_i sty₂
     cases h₃ : sty₁ ⊔ sty₂ <;> simp [h₃] at h₁
     cases h₄ : sty₂ ⊔ sty₃ <;> simp [h₄] at h₂
@@ -296,9 +301,9 @@ theorem lub_trans {ty₁ ty₂ ty₃ : CedarType} :
     simp [h₅]
   case h_3 rty₁ rty₃ =>
     unfold lub? at h₁ h₂
-    cases ty₂ <;> simp at h₁ h₂
+    cases ty₂ <;> csimp at h₁ h₂
     rename_i mty₂ ; cases mty₂ ; rename_i rty₂
-    simp at h₁ h₂
+    csimp at h₁ h₂
     cases h₃ : lubRecordType rty₁ rty₂ <;> simp [h₃] at h₁
     cases h₄ : lubRecordType rty₂ rty₃ <;> simp [h₄] at h₂
     rw [eq_comm] at h₁ h₂ ; subst h₁ h₂
@@ -310,7 +315,7 @@ theorem lub_trans {ty₁ ty₂ ty₃ : CedarType} :
     case inr h₃ h₄ h₅ h₆ =>
       unfold lub? at h₁ h₂
       cases ty₁ <;> cases ty₂ <;> simp at h₁ <;>
-      cases ty₃ <;> simp at h₂ <;> simp at h₆
+      cases ty₃ <;> simp at h₂ h₆
       case bool bty₁ _ bty₃ =>
         apply h₃ bty₁ bty₃ <;> rfl
       case set sty₁ _ sty₃ =>
@@ -334,7 +339,7 @@ theorem lubRecordType_trans {rty₁ rty₂ rty₃ : List (Attr × QualifiedType)
   cases rty₁ <;> cases rty₃ <;>
   simp only
   case cons.cons hd₁ tl₁ hd₃ tl₃ =>
-    cases rty₂ <;> simp at h₁ h₂
+    cases rty₂ <;> csimp at h₁ h₂
     rename_i hd₂ tl₂
     split at h₁ <;> try contradiction
     split at h₂ <;> try contradiction
@@ -355,7 +360,7 @@ theorem lubRecordType_trans {rty₁ rty₂ rty₃ : List (Attr × QualifiedType)
     have h₁₀ := lubRecordType_trans h₆ h₈
     simp [h₉, h₁₀]
   all_goals {
-    cases rty₂ <;> simp at h₁ h₂
+    cases rty₂ <;> csimp at h₁ h₂
   }
 
 theorem lubQualifiedType_trans {qty₁ qty₂ qty₃ : QualifiedType} :
@@ -365,9 +370,9 @@ theorem lubQualifiedType_trans {qty₁ qty₂ qty₃ : QualifiedType} :
 := by
   unfold lubQualifiedType
   intro h₁ h₂
-  cases qty₁ <;> cases qty₃ <;> simp
+  cases qty₁ <;> cases qty₃ <;> csimp
   case optional.optional ty₁' ty₃' | required.required ty₁' ty₃' =>
-    cases qty₂ <;> simp at h₁ h₂
+    cases qty₂ <;> csimp at h₁ h₂
     rename_i ty₂'
     cases h₃ : ty₁' ⊔ ty₂' <;> simp [h₃] at h₁
     cases h₄ : ty₂' ⊔ ty₃' <;> simp [h₄] at h₂
@@ -375,7 +380,7 @@ theorem lubQualifiedType_trans {qty₁ qty₂ qty₃ : QualifiedType} :
     have h₅ := lub_trans h₃ h₄
     simp [h₅]
   all_goals {
-    cases qty₂ <;> simp at h₁ h₂
+    cases qty₂ <;> csimp at h₁ h₂
   }
 
 end
@@ -388,7 +393,7 @@ theorem subty_trans {ty₁ ty₂ ty₃ : CedarType} :
   split at h₁ <;> try contradiction
   split at h₂ <;> try contradiction
   rename_i ty₄ h₃ _ ty₅ h₄
-  simp at h₁ h₂ ; rw [eq_comm] at h₁ h₂; subst h₁ h₂
+  csimp at h₁ h₂ ; rw [eq_comm] at h₁ h₂; subst h₁ h₂
   have h₅ := lub_trans h₃ h₄
   simp [h₅]
 
@@ -426,7 +431,7 @@ theorem lub_left_subty {ty₁ ty₂ ty₃ : CedarType} :
     split at h₁ <;> try contradiction
     rename_i h₂
     subst h₂
-    simp at h₁
+    csimp at h₁
     subst h₁
     simp [lub_refl ty₁]
 
@@ -436,9 +441,9 @@ theorem lubRecordType_left_subty {rty₁ rty₂ rty₃ : List (Attr × Qualified
 := by
   unfold lubRecordType
   intro h₁
-  split at h₁ <;> try simp at h₁
+  split at h₁ <;> try csimp at h₁
   case h_1 =>
-    subst h₁ ; simp
+    subst h₁ ; csimp
   case h_2 a₁ qty₁ rty₁' a₂ qty₂ rty₂' =>
     split at h₁ <;> try contradiction
     rename_i h₂ ; subst h₂
@@ -456,7 +461,7 @@ theorem lubQualifiedType_left_subty {qty₁ qty₂ qty₃ : QualifiedType} :
 := by
   unfold lubQualifiedType
   intro h₁
-  split at h₁ <;> try simp at h₁
+  split at h₁ <;> try csimp at h₁
   all_goals {
     rename_i aty₁ aty₂
     cases h₂ : aty₁ ⊔ aty₂ <;> simp [h₂] at h₁
@@ -476,11 +481,7 @@ end
 theorem sizeOf_qualified_lt_sizeOf_record_type (x : Attr × Qualified CedarType) (xs : List (Attr × Qualified CedarType)) :
   sizeOf x.snd < sizeOf (x :: xs)
 := by
-  simp only [List.cons.sizeOf_spec]
-  simp only [Nat.add_assoc]
-  rw [Nat.add_comm]
-  apply Nat.lt_add_right
-  apply Nat.lt_add_right
+  rw [List.cons.sizeOf_spec]
   simp only [sizeOf, Prod._sizeOf_1]
   omega
 
@@ -489,7 +490,7 @@ theorem lubBool_assoc_none_some {ty₁ ty₂ : CedarType} {bty₁ bty₂ : BoolT
   (h₂ : some (CedarType.bool (lubBool bty₁ bty₂)) = some ty₂) :
   (ty₁ ⊔ ty₂) = none
 := by
-  simp at h₂
+  csimp at h₂
   unfold lub? at h₁
   split at h₁ <;> try contradiction
   rename_i ty₁' ty₂' ty₃' h₃ h₄ h₅
@@ -515,7 +516,7 @@ theorem lub_assoc_none_some {ty₁ ty₂ ty₃ ty₄ : CedarType}
     rename_i sty₄
     subst h₂
     unfold lub? at h₁ ; unfold lub?
-    cases ty₁ <;> simp at *
+    cases ty₁ <;> csimp at *
     rename_i ty₁'
     cases h₄ : ty₁' ⊔ sty₂ <;> simp [h₄] at h₁
     have h₅ := lub_assoc_none_some h₄ h₃
@@ -524,15 +525,16 @@ theorem lub_assoc_none_some {ty₁ ty₂ ty₃ ty₄ : CedarType}
     cases h₃ : lubRecordType rty₂ rty₃ <;> simp [h₃] at h₂
     subst h₂
     unfold lub? at h₁ ; unfold lub?
-    cases ty₁ <;> simp at *
+    cases ty₁ <;> csimp at *
     rename_i mty₁ ; cases mty₁ ; rename_i rty₁
-    simp at *
+    csimp at *
     cases h₄ : lubRecordType rty₁ rty₂ <;> simp [h₄] at h₁
     have h₅ := lubRecordType_assoc_none_some h₄ h₃
     simp [h₅]
   case h_4 =>
     split at h₂ <;> try contradiction
-    rename_i h₃ ; simp at h₂
+    rename_i h₃
+    csimp at h₂
     subst h₂ h₃
     exact h₁
 
@@ -543,9 +545,9 @@ theorem lubRecordType_assoc_none_some {rty₁ rty₂ rty₃ rty₄ : List (Attr 
 := by
   unfold lubRecordType at h₂
   split at h₂ <;> try contradiction
-  case h_1 => simp at h₂ ; subst h₂ ; exact h₁
+  case h_1 => csimp at h₂ ; subst h₂ ; exact h₁
   case h_2 a₂ qty₂ rty₂' a₃ qty₃ rty₃'  =>
-    simp at h₂
+    csimp at h₂
     split at h₂ <;> try contradiction
     rename_i h₃
     cases h₄ : lubQualifiedType qty₂ qty₃ <;> simp [h₄] at h₂
@@ -553,7 +555,7 @@ theorem lubRecordType_assoc_none_some {rty₁ rty₂ rty₃ rty₄ : List (Attr 
     subst h₂ h₃
     rename_i qty₁ rty₁'
     unfold lubRecordType at h₁
-    cases hrty₁ : rty₁ <;> simp at h₁
+    cases hrty₁ : rty₁ <;> csimp at h₁
     case nil =>
       simp [lubRecordType]
     case cons hd tl =>
@@ -586,7 +588,7 @@ theorem lubQualifiedType_assoc_none_some {qty₁ qty₂ qty₃ qty₄ : Qualifie
     cases h₃ : ty₂' ⊔ ty₃' <;> simp [h₃] at h₂
     rename_i ty₄ ; subst h₂
     unfold lubQualifiedType at h₁
-    cases qty₁ <;> simp at h₁ <;>
+    cases qty₁ <;> csimp at h₁ <;>
     simp [lubQualifiedType]
     rename_i ty₁'
     cases h₄ : ty₁' ⊔ ty₂' <;> simp [h₄] at h₁
@@ -605,7 +607,7 @@ theorem lubBool_assoc_some_some {ty₄ ty₅ : CedarType } { bty₁ bty₂ bty�
   simp [lubBool] at h₁ h₂
   subst h₁ h₂
   simp [lub?, lubBool]
-  cases bty₁ <;> cases bty₂ <;> cases bty₃ <;> simp
+  cases bty₁ <;> cases bty₂ <;> cases bty₃ <;> csimp
 
 mutual
 
@@ -635,7 +637,7 @@ theorem lub_assoc_some_some {ty₁ ty₂ ty₃ ty₄ ty₅ : CedarType}
     simp [h₅]
   case record mty₁ mty₂ mty₃ =>
     cases mty₁ ; cases mty₂ ; cases mty₃
-    simp at *
+    csimp at *
     rename_i rty₁ rty₂ rty₃
     cases h₃ : lubRecordType rty₁ rty₂ <;> simp [h₃] at h₁
     cases h₄ : lubRecordType rty₂ rty₃ <;> simp [h₄] at h₂
@@ -682,7 +684,7 @@ theorem lubRecordType_assoc_some_some {rty₁ rty₂ rty₃ rty₄ rty₅ : List
           apply sizeOf_qualified_lt_sizeOf_record_type hd₂ tl₂
         subst hrty₁ hrty₂
         unfold lubRecordType at *
-        simp only [bne_iff_ne, ne_eq, ite_not] at h₁
+        csimp at h₁
         split at h₁ <;> try contradiction
         split at h₂ <;> try contradiction
         rename_i h₁₂ h₂₃
@@ -703,7 +705,7 @@ theorem lubQualifiedType_assoc_some_some {qty₁ qty₂ qty₃ qty₄ qty₅ : Q
   (lubQualifiedType qty₄ qty₃) = (lubQualifiedType qty₁ qty₅)
 := by
   unfold lubQualifiedType at *
-  cases qty₁ <;> cases qty₂ <;> cases qty₃ <;> simp at h₁ h₂
+  cases qty₁ <;> cases qty₂ <;> cases qty₃ <;> csimp at h₁ h₂
   all_goals {
     rename_i ty₁' ty₂' ty₃'
     cases h₃ : (ty₁' ⊔ ty₂') <;> simp [h₃] at h₁
@@ -723,7 +725,7 @@ theorem lub_assoc (ty₁ ty₂ ty₃ : CedarType) :
 := by
   cases h₁ : (ty₁ ⊔ ty₂) <;>
   cases h₂ : (ty₂ ⊔ ty₃) <;>
-  simp only [Option.bind_none_fun, Option.bind_some_fun]
+  csimp
   case none.some ty₄ =>
     rw [eq_comm]
     exact lub_assoc_none_some h₁ h₂

--- a/cedar-lean/Cedar/Thm/Validation/Typechecker/LitVar.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Typechecker/LitVar.lean
@@ -14,6 +14,7 @@
  limitations under the License.
 -/
 
+import Cedar.Tactic.Csimp
 import Cedar.Thm.Validation.Typechecker.Basic
 import Std.Tactic.Case
 
@@ -36,7 +37,7 @@ theorem type_of_lit_is_sound {l : Prim} {c₁ c₂ : Capabilities} {env : Enviro
   split at h₃ <;> simp [ok] at h₃
   case h_5;
   split at h₃ <;> try { simp [err] at h₃ }
-  simp at h₃
+  csimp at h₃
   all_goals {
     have ⟨h₃, h₄⟩ := h₃
     rw [←h₃, ←h₄]

--- a/cedar-lean/Cedar/Thm/Validation/Typechecker/Or.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Typechecker/Or.lean
@@ -47,7 +47,7 @@ theorem type_of_or_inversion {x₁ x₂ : Expr} {c c' : Capabilities} {env : Env
   rename_i res₁
   simp [typeOfOr] at h₁
   split at h₁ <;> simp [ok, err] at h₁ <;>
-  rename_i hr₁ <;> simp at hr₁ <;>
+  rename_i hr₁ <;> csimp at hr₁ <;>
   have ⟨ht₁, hc₁⟩ := hr₁
   case ok.h_1 c₁  =>
     exists BoolType.tt, c₁
@@ -65,7 +65,7 @@ theorem type_of_or_inversion {x₁ x₂ : Expr} {c c' : Capabilities} {env : Env
     exists bty₂
     simp [←hr₂]
   case ok.h_3 bty₁ c₁ hneq₁ hneq₂ =>
-    cases bty₁ <;> simp at hneq₁ hneq₂
+    cases bty₁ <;> csimp at hneq₁ hneq₂
     exists BoolType.anyBool, c₁
     simp [←ht₁, ←hc₁]
     cases h₃ : typeOf x₂ c env <;> simp [h₃] at *
@@ -82,7 +82,7 @@ theorem type_of_or_inversion {x₁ x₂ : Expr} {c c' : Capabilities} {env : Env
     case anyBool.ok.h_3 bty₂ hneq₁ hneq₂ =>
       exists bty₂, res₂.snd
       simp [←hr₂, ←ht₁, ←hc₁]
-      cases bty₂ <;> simp at *
+      cases bty₂ <;> csimp at *
 
 theorem type_of_or_is_sound {x₁ x₂ : Expr} {c₁ c₂ : Capabilities} {env : Environment} {ty : CedarType} {request : Request} {entities : Entities}
   (h₁ : CapabilitiesInvariant c₁ request entities)
@@ -103,7 +103,7 @@ theorem type_of_or_is_sound {x₁ x₂ : Expr} {c₁ c₂ : Capabilities} {env :
     have ⟨hty, hc⟩ := h₅ ; subst hty hc
     apply And.intro empty_guarded_capabilities_invariant
     have h₇ := instance_of_tt_is_true ih₁₃
-    simp at h₇ ; subst h₇
+    csimp at h₇ ; subst h₇
     simp [EvaluatesTo] at ih₁₂
     rcases ih₁₂ with ih₁₂ | ih₁₂ | ih₁₂ | ih₁₂ <;>
     simp [EvaluatesTo, evaluate, Result.as, ih₁₂, Coe.coe, Value.asBool] <;>
@@ -125,9 +125,9 @@ theorem type_of_or_is_sound {x₁ x₂ : Expr} {c₁ c₂ : Capabilities} {env :
       cases b₂ <;>
       simp [CoeT.coe, CoeHTCT.coe, CoeHTC.coe, CoeOTC.coe, CoeTC.coe, Coe.coe]
       case false h₆ =>
-        cases bty₁ <;> simp at h₆ h₇
+        cases bty₁ <;> csimp at h₆ h₇
         case anyBool =>
-          cases bty₂ <;> simp at h₇ <;>
+          cases bty₂ <;> csimp at h₇ <;>
           have ⟨h₇, _⟩ := h₇ <;> subst h₇ <;>
           try exact bool_is_instance_of_anyBool false
           exact ih₂₃
@@ -135,7 +135,7 @@ theorem type_of_or_is_sound {x₁ x₂ : Expr} {c₁ c₂ : Capabilities} {env :
           rw [h₇.left]
           exact ih₂₃
       case true h₆ =>
-        cases bty₁ <;> cases bty₂ <;> simp at h₆ h₇ <;>
+        cases bty₁ <;> cases bty₂ <;> csimp at h₆ h₇ <;>
         have ⟨hty, hc⟩ := h₇ <;> simp [hty, hc] at *
         case ff.ff =>
           rcases ih₂₃ with ⟨_, _, ih₂₃⟩
@@ -166,8 +166,8 @@ theorem type_of_or_is_sound {x₁ x₂ : Expr} {c₁ c₂ : Capabilities} {env :
       rename_i h₆
       rcases ih₁₃ with ⟨_, _, ih₁₃⟩
       simp [InstanceOfBoolType] at ih₁₃
-      cases bty₁ <;> simp at h₆ ih₁₃ h₇
-      cases bty₂ <;> simp at h₇ <;>
+      cases bty₁ <;> csimp at h₆ ih₁₃ h₇
+      cases bty₂ <;> csimp at h₇ <;>
       have ⟨ht, hc⟩ := h₇ <;> simp [ht, hc] at * <;>
       simp [true_is_instance_of_tt, bool_is_instance_of_anyBool] <;>
       try { apply empty_capabilities_invariant } <;>

--- a/cedar-lean/Cedar/Thm/Validation/Typechecker/Record.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Typechecker/Record.lean
@@ -14,6 +14,7 @@
  limitations under the License.
 -/
 
+import Cedar.Tactic.Csimp
 import Cedar.Thm.Data.LT
 import Cedar.Thm.Validation.Typechecker.Basic
 
@@ -59,7 +60,7 @@ theorem type_of_record_inversion_forall {axs : List (Attr × Expr)} {c : Capabil
         have ⟨hl₁, hr₁⟩ := h₁
         rw [eq_comm] at hl₁ hr₁ ; subst hl₁ hr₁
         simp [requiredAttr, Except.map] at h₂
-        split at h₂ <;> simp at h₂
+        split at h₂ <;> csimp at h₂
         subst h₂
         rename_i _ r _
         simp [AttrExprHasAttrType]
@@ -200,14 +201,10 @@ theorem vals_instance_of_types {axs : List (Attr × Expr)} {c₁ : Capabilities}
     subst h₄
     rename_i vhd vtl
     apply List.Forall₂.cons
-    {
-      apply head_of_vals_instance_of_head_of_types _ h₁ h₂ h₅ h₇
-      apply ih ; simp only [List.mem_cons, true_or]
-    }
-    {
-      apply @vals_instance_of_types xtl c₁ env request entities rtl vtl _ h₁ h₂ h₆ h₈
+    · apply head_of_vals_instance_of_head_of_types _ h₁ h₂ h₅ h₇
+      apply ih ; csimp
+    · apply @vals_instance_of_types xtl c₁ env request entities rtl vtl _ h₁ h₂ h₆ h₈
       intro ax h₉ ; apply ih ; simp [h₉]
-    }
 
 theorem type_of_record_is_sound_ok {axs : List (Attr × Expr)} {c₁ : Capabilities} {env : Environment} {request : Request} {entities : Entities} {rty : List (Attr × QualifiedType)} {avs : List (Attr × Value)}
   (ih : ∀ (axᵢ : Attr × Expr), axᵢ ∈ axs → TypeOfIsSound axᵢ.snd)
@@ -244,10 +241,11 @@ theorem type_of_record_is_sound_err {axs : List (Attr × Expr)} {c₁ : Capabili
       cases h₆ : evaluate hd.snd request entities <;> simp [h₆] at h₅
       subst h₄ h₅
       specialize ih hd
-      simp only [List.mem_cons, true_or, TypeOfIsSound, forall_const] at ih
+      unfold TypeOfIsSound at ih
+      csimp at ih
       have ⟨ty', c', _, hh₃⟩ := hh₃
       specialize ih h₁ h₂ hh₃
-      have ⟨_, v, ih, _⟩ := ih
+      replace ⟨_, v, ih, _⟩ := ih
       simp [EvaluatesTo, h₆] at ih
       exact ih
     case ok vhd =>

--- a/cedar-lean/Cedar/Thm/Validation/Typechecker/Set.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Typechecker/Set.lean
@@ -37,7 +37,7 @@ theorem lub_lub_fixed {ty₁ ty₂ ty₃ ty₄ : CedarType}
   have h₄ := lub_left_subty h₂
   have h₅ := subty_trans h₃ h₄
   simp [subty] at h₅
-  split at h₅ <;> simp at h₅ ; subst h₅
+  split at h₅ <;> csimp at h₅ ; subst h₅
   assumption
 
 theorem foldlM_of_lub_is_LUB {ty lubTy : CedarType } {tys : List CedarType}
@@ -94,20 +94,17 @@ theorem type_of_set_tail
       have h₁ := List.mapM_head_tail h₁
       rw [←List.mapM₁_eq_mapM] at h₁
       simp [h₁, typeOfSet]
-      cases h₄ : List.foldlM lub? hd' tl' <;>
-      simp [h₄, err, ok]
-      case none =>
-        have h₅ := foldlM_of_lub_assoc hd hd' tl'
-        rw [h₂, h₄] at h₅
-        simp at h₅
+      cases h₄ : List.foldlM lub? hd' tl'
+      <;> simp [h₄, err, ok]
+      <;> have h₅ := foldlM_of_lub_assoc hd hd' tl'
+      <;> rw [h₂, h₄] at h₅
+      <;> csimp at h₅
       case some ty' =>
-        have h₅ := foldlM_of_lub_assoc hd hd' tl'
-        rw [h₂, h₄] at h₅
-        simp at h₅ ; rw [eq_comm, lub_comm] at h₅
-        have h₆ := lub_left_subty h₅
-        simp [subty] at h₆
-        split at h₆ <;> simp at h₆
-        subst h₆
+        rw [eq_comm, lub_comm] at h₅
+        replace h₅ := lub_left_subty h₅
+        simp [subty] at h₅
+        split at h₅ <;> csimp at h₅
+        subst h₅
         assumption
 
 theorem type_of_set_inversion {xs : List Expr} {c c' : Capabilities} {env : Environment} {sty : CedarType}
@@ -124,11 +121,11 @@ theorem type_of_set_inversion {xs : List Expr} {c c' : Capabilities} {env : Envi
   cases h₂ : List.mapM₁ xs fun x => justType (typeOf x.val c env) <;>
   simp [h₂] at h₁
   simp [typeOfSet] at h₁
-  split at h₁ <;> simp [ok, err] at h₁
+  split at h₁ <;> simp only [ok, err] at h₁
   rename_i hd tl
-  split at h₁ <;> simp at h₁
+  split at h₁ <;> csimp at h₁
   rename_i ty h₃
-  have ⟨hl₁, hr₁⟩ := h₁
+  have ⟨hl₁, hr₁⟩ := h₁ ; clear h₁
   subst hl₁ hr₁
   simp only [List.empty_eq, CedarType.set.injEq, exists_and_right, exists_eq_left', true_and]
   intro x h₄
@@ -143,7 +140,7 @@ theorem type_of_set_inversion {xs : List Expr} {c c' : Capabilities} {env : Envi
     have ⟨hl₂, hr₂⟩ := h₂ ; subst hl₂ hr₂
     rename_i hdty tlty
     simp [justType, Except.map] at h₅
-    split at h₅ <;> simp at h₅
+    split at h₅ <;> csimp at h₅
     rename_i res h₇
     exists hdty
     apply And.intro
@@ -155,9 +152,8 @@ theorem type_of_set_inversion {xs : List Expr} {c c' : Capabilities} {env : Envi
     have h₇ := @type_of_set_inversion xtl c ∅ env (.set ty')
     simp [h₅] at h₇
     specialize h₇ x h₄
-    have ⟨tyᵢ, h₇, h₈⟩ := h₇
+    replace ⟨tyᵢ, ⟨cᵢ, h₇⟩, h₈⟩ := h₇
     exists tyᵢ
-    have ⟨cᵢ, h₇⟩ := h₇
     apply And.intro
     · exists cᵢ
     . exact lub_lub_fixed h₈ h₆
@@ -198,9 +194,9 @@ theorem type_of_set_is_sound_err {xs : List Expr} {c₁ : Capabilities} {env : E
     simp only [h₆, List.mem_cons, true_or, forall_const] at h₄
     have ⟨tyᵢ, cᵢ, h₇, _⟩ := h₄
     have h₉ := ih hd ; simp [h₆, TypeOfIsSound] at h₉
-    specialize (h₉ h₁ h₂ h₇) ; have ⟨_, v, h₉⟩ := h₉
+    specialize h₉ h₁ h₂ h₇ ; replace ⟨_, v, h₉⟩ := h₉
     simp [EvaluatesTo] at h₉
-    have ⟨h₉, _⟩ := h₉
+    replace ⟨h₉, _⟩ := h₉
     rcases h₉ with h₉ | h₉ | h₉ | h₉ <;>
     simp [h₉] at h₅ <;>
     try { simp [h₅] }

--- a/cedar-lean/Cedar/Thm/Validation/Typechecker/Types.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Typechecker/Types.lean
@@ -16,6 +16,7 @@
 
 import Cedar.Spec
 import Cedar.Validation
+import Cedar.Tactic.Csimp
 import Cedar.Thm.Data.Control
 import Cedar.Thm.Data.Set
 import Cedar.Thm.Validation.Typechecker.LUB
@@ -144,7 +145,7 @@ theorem instance_of_ff_is_false {v₁ : Value} :
   cases h₁ with
   | instance_of_bool b _ h₁ =>
     simp [InstanceOfBoolType] at h₁
-    cases b <;> simp at h₁
+    cases b <;> csimp at h₁
     rfl
 
 theorem instance_of_tt_is_true {v₁ : Value} :
@@ -155,7 +156,7 @@ theorem instance_of_tt_is_true {v₁ : Value} :
   cases h₁ with
   | instance_of_bool b _ h₁ =>
     simp [InstanceOfBoolType] at h₁
-    cases b <;> simp at h₁
+    cases b <;> csimp at h₁
     rfl
 
 theorem instance_of_anyBool_is_bool {v₁ : Value} :
@@ -460,7 +461,7 @@ theorem sizeOf_attr_type_lt_sizeOf_record_type {a : Attr} {qty : QualifiedType }
       apply @Nat.lt_trans _ (sizeOf rty)
       case h₁ =>
         simp [Map.find?, Map.kvs] at h₂
-        split at h₂ <;> simp at h₂
+        split at h₂ <;> csimp at h₂
         rename_i a' qty' h₃ ; rw [eq_comm] at h₂ ; subst h₂
         have h₄ := List.mem_of_find?_eq_some h₃
         apply @Nat.lt_trans _ (sizeOf (a', qty))
@@ -485,7 +486,7 @@ theorem instance_of_lub_left {v : Value} {ty ty₁ ty₂ : CedarType}
   simp [hty₁, hty₂] at h₂
   split at h₁
   case h_1 =>
-    simp at h₁ ; subst h₁ hty₁ hty₂
+    csimp at h₁ ; subst h₁ hty₁ hty₂
     exact instance_of_lubBool_left h₂
   case h_2 _ _ sty₁ sty₂ =>
     cases h₃ : sty₁ ⊔ sty₂ <;> simp [h₃] at h₁
@@ -521,7 +522,7 @@ theorem instance_of_lub_left {v : Value} {ty ty₁ ty₂ : CedarType}
       apply h₆ a qty₁ h₉
       simp [h₁₀, h₈]
   case h_4 =>
-    split at h₁ <;> simp at h₁
+    split at h₁ <;> csimp at h₁
     rename_i h₃
     subst h₁ h₃ hty₁ hty₂
     exact h₂

--- a/cedar-lean/Cedar/Thm/Validation/Typechecker/UnaryApp.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Typechecker/UnaryApp.lean
@@ -14,6 +14,7 @@
  limitations under the License.
 -/
 
+import Cedar.Tactic.Csimp
 import Cedar.Thm.Validation.Typechecker.Basic
 
 /-!
@@ -112,18 +113,14 @@ theorem type_of_neg_is_sound {x₁ : Expr} {c₁ c₂ : Capabilities} {env : Env
   have ⟨_, v₁, h₆, h₇⟩ := ih h₁ h₂ h₄ -- IH
   simp [EvaluatesTo] at h₆
   simp [EvaluatesTo, evaluate]
-  rcases h₆ with h₆ | h₆ | h₆ | h₆ <;> simp [h₆]
+  rcases h₆ with h₆ | h₆ | h₆ | h₆ <;> rw [h₆] <;> csimp
   case inr.inr.inr =>
     have ⟨i, h₈⟩ := instance_of_int_is_int h₇
     subst h₈
     simp [apply₁, intOrErr]
-    cases __ : i.neg?
-    case none =>
-      simp only [or_false, or_true, true_and]
-      exact type_is_inhabited CedarType.int
-    case some i' =>
-      simp only [Except.ok.injEq, false_or, exists_eq_left']
-      apply InstanceOfType.instance_of_int
+    cases i.neg? <;> csimp
+    case none => exact type_is_inhabited CedarType.int
+    case some i' => exact InstanceOfType.instance_of_int
   all_goals {
     exact type_is_inhabited CedarType.int
   }
@@ -207,9 +204,7 @@ theorem type_of_is_is_sound {x₁ : Expr} {ety : EntityType} {c₁ c₂ : Capabi
   case inr.inr.inr =>
     have ⟨uid, h₈, h₉⟩ := instance_of_entity_type_is_entity h₇
     simp [apply₁, h₉, h₈]
-    cases h₁₀ : ety == ety' <;>
-    simp at h₁₀ <;>
-    simp [h₁₀]
+    cases h₁₀ : ety == ety' <;> csimp at h₁₀ <;> simp [h₁₀]
     case false => exact false_is_instance_of_ff
     case true => exact true_is_instance_of_tt
   all_goals {

--- a/cedar-lean/GUIDE.md
+++ b/cedar-lean/GUIDE.md
@@ -65,7 +65,10 @@ Main theorems should have a docstring comment `/-- ... -/` explaining what is pr
 ## Proof stability
 To make version upgrades easier, strive to follow these guidelines:
 
-- Use `simp only` instead of `simp`. It's okay to use `simp` to close a goal.
-- Use `have` to deconstruct values. Use `rcases` only to split disjunctions.
-- Use `exact` instead of `apply` whenever possible.
+- Use `simp only` or `csimp` instead of `simp`. As an exception to this, it's
+    okay to use `simp` to close a goal (but if `csimp` works, you're still
+    encouraged to use that instead).
+- Use `have` or `replace` to deconstruct values. Use `rcases` only to split
+    disjunctions.
+- Use `exact` instead of `apply` or `assumption` whenever possible.
 - Fully spell out types in function and theorem declarations.


### PR DESCRIPTION
*Issue #, if available:*

Resolves #279

*Description of changes:*

Resolves #279 and also proposes a different (cleaner IMO) way to resolve the proof-stability problem with `simp` across Lean versions.  Introduces a custom tactic `csimp` (Cedar-simp) that can be used like `simp` but internally uses a stable set of lemmas that will not change with the Lean version (unless we intentionally make changes).

`csimp` supports `at` syntax, e.g., all of the following are valid:
* `csimp`
* `csimp at h`
* `csimp at *`

but `csimp` does not support extending the lemmas inline, e.g.,
* `csimp [h₂]` (instead, use `csimp ; simp only [h₂]`, or the other order)

only because I couldn't get that to work.  Specifically, although I was able to get `csimp` to take an optional list argument of the appropriate type, and even append those items to the lemmas such that `csimp [h₂]` works, Lean's handling of the optional argument meant that it dropped the whole merged list of lemmas when trying to use `csimp` without the argument.  Lean's [documentation for macros](https://lean-lang.org/lean4/doc/macro_overview.html) doesn't explain details of how to use optional arguments to macros; it's very possible there's some simple syntax to accomplish this and I just don't know it.  However, this PR demonstrates that even the current version of `csimp` is still very useful and improves proofs (making them more stable and readable).