### PR TITLE
Assert that comments are not reordered by formatter

### DIFF
--- a/cedar-drt/fuzz/Cargo.toml
+++ b/cedar-drt/fuzz/Cargo.toml
@@ -27,6 +27,7 @@ rayon = { version = "1.5", optional = true }
 rand = { version = "0.8", optional = true }
 clap = { version = "4.0", features = ["derive"], optional = true }
 rand_chacha = { version = "0.3", optional = true }
+similar-asserts = "1.5.0"
 
 [dependencies.uuid]
 version = "1.3.1"


### PR DESCRIPTION
The formatter fuzz target only  checked that all comments in the original policy were present in the output without checking that they appeared in the same order.  This allowed cedar-policy/cedar#787 to exist. The fuzz target with the new, stronger, assertion passed local fuzzing after applying the fixes in  cedar-policy/cedar#861.

As a pleasant side effect, it's actually more efficient to check for the comments in the order they were inserted than in an arbitrary order. The check is now a single linear scan rather than a linear scan for each comment, likely resolving the slow units noted in #268. The slow input in that issue is improved from 16 second to about 4 seconds.  
