### PR TITLE
Git ignore cloned `cedar` repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,7 @@ cedar-drt/fuzz/corpus
 cedar-drt/fuzz/artifacts
 
 .vscode
+
+# We expect a copy of `cedar-policy/cedar` present in this directory, but do
+# not track it in version control.
+cedar/


### PR DESCRIPTION


After #269 we don't track `cedar` as submodule, but we still expect that it will be cloned in the root of this repo. Add to gitignore so it doesn't show up in `git status`.




