### PR TITLE
Assert that comments are not reordered by formatter (#318)

### DIFF
--- a/cedar-drt/fuzz/Cargo.toml
+++ b/cedar-drt/fuzz/Cargo.toml
@@ -26,6 +26,7 @@ rayon = { version = "1.5", optional = true }
 rand = { version = "0.8", optional = true }
 clap = { version = "4.0", features = ["derive"], optional = true }
 rand_chacha = { version = "0.3", optional = true }
+similar-asserts = "1.5.0"
 
 [dependencies.uuid]
 version = "1.3.1"


### PR DESCRIPTION
Pulling back #318 to the 3.2 release branch, per discussion on [cedar#872](https://github.com/cedar-policy/cedar/pull/872).


