### PR TITLE
`PartialOnConcrete` proof for the rest of the `Partial.Response`

### DIFF
--- a/cedar-lean/Cedar/Partial/Response.lean
+++ b/cedar-lean/Cedar/Partial/Response.lean
@@ -116,10 +116,11 @@ def Response.forbids (resp : Partial.Response) : Set PolicyID :=
   All policies which definitely produce errors (for all possible substitutions
   of the unknowns)
 -/
-def Response.errors (resp : Partial.Response) : List (PolicyID × Error) :=
-  resp.residuals.filterMap λ residual => match residual with
-    | .error id error => some (id, error)
+def Response.errorPolicies (resp : Partial.Response) : Set PolicyID :=
+  Set.make (resp.residuals.filterMap λ residual => match residual with
+    | .error id _ => some id
     | _ => none
+  )
 
 inductive Decision where
   /-- definitely Allow, for any substitution of the unknowns -/

--- a/cedar-lean/Cedar/Thm/Authorization/Authorizer.lean
+++ b/cedar-lean/Cedar/Thm/Authorization/Authorizer.lean
@@ -30,6 +30,20 @@ namespace Cedar.Thm
 open Cedar.Spec
 open Cedar.Data
 
+theorem determiningPolicies_wf {policies : Policies} {request : Request} {entities : Entities} :
+  (isAuthorized request entities policies).determiningPolicies.WellFormed
+:= by
+  simp only [Set.WellFormed, isAuthorized, Set.toList, Bool.and_eq_true, Bool.not_eq_true']
+  cases (satisfiedPolicies .forbid policies request entities).isEmpty <;>
+  cases (satisfiedPolicies .permit policies request entities).isEmpty <;>
+  simp only [and_true, and_false, and_self, ite_true, ite_false]
+  all_goals {
+    unfold satisfiedPolicies
+    simp only [Set.make_make_eqv]
+    apply List.Equiv.symm
+    exact Set.elts_make_equiv
+  }
+
 theorem if_hasError_then_exists_error {policy : Policy} {request : Request} {entities : Entities} :
   hasError policy request entities →
   ∃ err, evaluate policy.toExpr request entities = .error err

--- a/cedar-lean/Cedar/Thm/Authorization/Evaluator.lean
+++ b/cedar-lean/Cedar/Thm/Authorization/Evaluator.lean
@@ -134,7 +134,7 @@ theorem ways_and_can_error {e₁ e₂ : Expr} {request : Request} {entities : En
 /--
   Every `and` expression produces either .ok bool or .error
 -/
-theorem and_produces_bool_or_error {e₁ e₂ : Expr} {request : Request} {entities : Entities} :
+theorem and_produces_bool_or_error (e₁ e₂ : Expr) (request : Request) (entities : Entities) :
   match (evaluate (Expr.and e₁ e₂) request entities) with
   | .ok (.prim (.bool _)) => true
   | .error _ => true

--- a/cedar-lean/Cedar/Thm/Partial/Authorization.lean
+++ b/cedar-lean/Cedar/Thm/Partial/Authorization.lean
@@ -132,14 +132,14 @@ theorem underapproximate_determining_eqv_determining_on_concrete {policies : Pol
     <;> simpa [h₃] using h₁
 
 /--
-  On concrete inputs, partial authorization's `errors` are the same policies as
-  concrete authorization's `erroringPolicies`
+  On concrete inputs, partial authorization's `errorPolicies` are the same
+  policies as concrete authorization's `erroringPolicies`
 -/
-theorem partial_authz_errors_eqv_erroringPolicies_on_concrete {policies : Policies} {req : Spec.Request} {entities : Spec.Entities} {presp : Partial.Response} {resp : Spec.Response}
+theorem partial_authz_errorPolicies_eqv_erroringPolicies_on_concrete {policies : Policies} {req : Spec.Request} {entities : Spec.Entities} {presp : Partial.Response} {resp : Spec.Response}
   (wf : req.WellFormed) :
   Spec.isAuthorized req entities policies = resp →
   Partial.isAuthorized req entities policies = presp →
-  Set.make (presp.errors.map Prod.fst) = resp.erroringPolicies
+  presp.errorPolicies = resp.erroringPolicies
 := by
   intro h₁ h₂
   subst h₁ h₂
@@ -147,7 +147,7 @@ theorem partial_authz_errors_eqv_erroringPolicies_on_concrete {policies : Polici
   cases (Spec.satisfiedPolicies .forbid policies req entities).isEmpty <;>
   cases (Spec.satisfiedPolicies .permit policies req entities).isEmpty <;>
   simp only [and_true, and_false, ite_true, ite_false] <;>
-  exact PartialOnConcrete.errors_eq_errorPolicies wf
+  exact PartialOnConcrete.errorPolicies_eq_errorPolicies wf
 
 /--
   Partial-authorizing with concrete inputs gives the same concrete outputs as
@@ -160,12 +160,12 @@ theorem partial_authz_eqv_authz_on_concrete {policies : Policies} {req : Spec.Re
   (resp.decision = .allow ∧ presp.decision = .allow ∨ resp.decision = .deny ∧ presp.decision = .deny) ∧
   presp.overapproximateDeterminingPolicies = resp.determiningPolicies ∧
   presp.underapproximateDeterminingPolicies = resp.determiningPolicies ∧
-  Set.make (presp.errors.map Prod.fst) = resp.erroringPolicies
+  presp.errorPolicies = resp.erroringPolicies
 := by
   intro h₁ h₂
   apply And.intro (partial_authz_decision_eqv_authz_decision_on_concrete wf h₁ h₂)
   apply And.intro (overapproximate_determining_eqv_determining_on_concrete wf h₁ h₂)
   apply And.intro (underapproximate_determining_eqv_determining_on_concrete wf h₁ h₂)
-  exact partial_authz_errors_eqv_erroringPolicies_on_concrete wf h₁ h₂
+  exact partial_authz_errorPolicies_eqv_erroringPolicies_on_concrete wf h₁ h₂
 
 end Cedar.Thm.Partial.Authorization

--- a/cedar-lean/Cedar/Thm/Partial/Authorization.lean
+++ b/cedar-lean/Cedar/Thm/Partial/Authorization.lean
@@ -18,7 +18,9 @@ import Cedar.Partial.Authorizer
 import Cedar.Partial.Response
 import Cedar.Spec.Authorizer
 import Cedar.Spec.Response
+import Cedar.Thm.Authorization.Authorizer
 import Cedar.Thm.Partial.Authorization.PartialOnConcrete
+import Cedar.Thm.Partial.Authorization.PartialResponse
 
 /-! This file contains toplevel theorems about Cedar's partial authorizer. -/
 
@@ -66,5 +68,104 @@ theorem partial_authz_on_concrete_gives_concrete {policies : Policies} {req : Sp
   cases h₃ : (Spec.isAuthorized req entities policies).decision
   <;> simp only [h₃, true_and, false_and, or_false, false_or] at h₂
   <;> simp only [h₂] at h₁
+
+/--
+  On concrete inputs, partial authorization's `overapproximateDeterminingPolicies`
+  are identical to concrete authorization's `determiningPolicies`
+-/
+theorem overapproximate_determining_eqv_determining_on_concrete {policies : Policies} {req : Spec.Request} {entities : Spec.Entities} {presp : Partial.Response} {resp : Spec.Response}
+  (wf : req.WellFormed) :
+  Spec.isAuthorized req entities policies = resp →
+  Partial.isAuthorized req entities policies = presp →
+  presp.overapproximateDeterminingPolicies = resp.determiningPolicies
+:= by
+  intro h₁ h₂
+  subst h₁ h₂
+  rw [← Set.eq_means_eqv Partial.Response.overapproximateDeterminingPolicies_wf determiningPolicies_wf]
+  simp only [List.Equiv, List.subset_def]
+  simp only [Partial.Response.overapproximateDeterminingPolicies, Spec.isAuthorized]
+  simp only [Partial.Response.decision]
+  simp only [PartialOnConcrete.knownForbids_eq_forbids wf]
+  simp only [PartialOnConcrete.knownPermits_eq_permits wf]
+  simp only [PartialOnConcrete.forbids_eq_satisfied_forbids wf]
+  simp only [PartialOnConcrete.permits_eq_satisfied_permits wf]
+  constructor <;> intro pid h₁
+  <;> rw [Set.in_list_iff_in_set] at *
+  <;> cases h₂ : (Spec.satisfiedPolicies .forbid policies req entities).isEmpty
+  <;> simp only [not_true_eq_false, ↓reduceIte, Bool.not_eq_true, Bool.decide_eq_false,
+    Bool.true_and, Bool.false_and, Bool.not_eq_true']
+  <;> simp only [h₂] at h₁
+  case left.false | right.false => simpa using h₁
+  case left.true | right.true =>
+    cases h₃ : (Spec.satisfiedPolicies .permit policies req entities).isEmpty
+    <;> simpa [h₃] using h₁
+
+/--
+  On concrete inputs, partial authorization's `underapproximateDeterminingPolicies`
+  are identical to concrete authorization's `determiningPolicies`
+-/
+theorem underapproximate_determining_eqv_determining_on_concrete {policies : Policies} {req : Spec.Request} {entities : Spec.Entities} {presp : Partial.Response} {resp : Spec.Response}
+  (wf : req.WellFormed) :
+  Spec.isAuthorized req entities policies = resp →
+  Partial.isAuthorized req entities policies = presp →
+  presp.underapproximateDeterminingPolicies = resp.determiningPolicies
+:= by
+  intro h₁ h₂
+  subst h₁ h₂
+  rw [← Set.eq_means_eqv Partial.Response.underapproximateDeterminingPolicies_wf determiningPolicies_wf]
+  simp only [List.Equiv, List.subset_def]
+  simp only [Partial.Response.underapproximateDeterminingPolicies, Spec.isAuthorized]
+  simp only [Partial.Response.decision]
+  simp only [PartialOnConcrete.knownForbids_eq_forbids wf]
+  simp only [PartialOnConcrete.knownPermits_eq_permits wf]
+  simp only [PartialOnConcrete.forbids_eq_satisfied_forbids wf]
+  simp only [PartialOnConcrete.permits_eq_satisfied_permits wf]
+  constructor <;> intro pid h₁
+  <;> rw [Set.in_list_iff_in_set] at *
+  <;> cases h₂ : (Spec.satisfiedPolicies .forbid policies req entities).isEmpty
+  <;> simp only [not_true_eq_false, ↓reduceIte, Bool.not_eq_true, Bool.decide_eq_false,
+    Bool.true_and, Bool.false_and, Bool.not_eq_true']
+  <;> simp only [h₂] at h₁
+  case left.false | right.false => simpa using h₁
+  case left.true | right.true =>
+    cases h₃ : (Spec.satisfiedPolicies .permit policies req entities).isEmpty
+    <;> simpa [h₃] using h₁
+
+/--
+  On concrete inputs, partial authorization's `errors` are the same policies as
+  concrete authorization's `erroringPolicies`
+-/
+theorem partial_authz_errors_eqv_erroringPolicies_on_concrete {policies : Policies} {req : Spec.Request} {entities : Spec.Entities} {presp : Partial.Response} {resp : Spec.Response}
+  (wf : req.WellFormed) :
+  Spec.isAuthorized req entities policies = resp →
+  Partial.isAuthorized req entities policies = presp →
+  Set.make (presp.errors.map Prod.fst) = resp.erroringPolicies
+:= by
+  intro h₁ h₂
+  subst h₁ h₂
+  simp only [Spec.isAuthorized, Bool.and_eq_true, Bool.not_eq_true']
+  cases (Spec.satisfiedPolicies .forbid policies req entities).isEmpty <;>
+  cases (Spec.satisfiedPolicies .permit policies req entities).isEmpty <;>
+  simp only [and_true, and_false, ite_true, ite_false] <;>
+  exact PartialOnConcrete.errors_eq_errorPolicies wf
+
+/--
+  Partial-authorizing with concrete inputs gives the same concrete outputs as
+  concrete-authorizing with those inputs.
+-/
+theorem partial_authz_eqv_authz_on_concrete {policies : Policies} {req : Spec.Request} {entities : Spec.Entities} {presp : Partial.Response} {resp : Spec.Response}
+  (wf : req.WellFormed) :
+  Spec.isAuthorized req entities policies = resp →
+  Partial.isAuthorized req entities policies = presp →
+  (resp.decision = .allow ∧ presp.decision = .allow ∨ resp.decision = .deny ∧ presp.decision = .deny) ∧
+  presp.overapproximateDeterminingPolicies = resp.determiningPolicies ∧
+  presp.underapproximateDeterminingPolicies = resp.determiningPolicies ∧
+  Set.make (presp.errors.map Prod.fst) = resp.erroringPolicies
+:= by
+  intro h₁ h₂
+  apply And.intro (partial_authz_decision_eqv_authz_decision_on_concrete wf h₁ h₂)
+  apply And.intro (overapproximate_determining_eqv_determining_on_concrete wf h₁ h₂)
+  apply And.intro (underapproximate_determining_eqv_determining_on_concrete wf h₁ h₂)
+  exact partial_authz_errors_eqv_erroringPolicies_on_concrete wf h₁ h₂
 
 end Cedar.Thm.Partial.Authorization

--- a/cedar-lean/Cedar/Thm/Partial/Authorization/PartialOnConcrete.lean
+++ b/cedar-lean/Cedar/Thm/Partial/Authorization/PartialOnConcrete.lean
@@ -200,4 +200,53 @@ theorem knownForbids_eq_forbids {policies : Policies} {req : Spec.Request} {enti
   unfold Partial.Response.knownForbids Partial.Response.forbids
   apply mustBeSatisfied_eq_mayBeSatisfied (eff := .forbid) wf
 
+/--
+  on concrete inputs, `Partial.Response.errors` and `Spec.errorPolicies` are equal
+-/
+theorem errors_eq_errorPolicies {policies : Policies} {req : Spec.Request} {entities : Spec.Entities}
+  (wf : req.WellFormed) :
+  Set.make ((Partial.isAuthorized req entities policies).errors.map Prod.fst) =
+  Spec.errorPolicies policies req entities
+:= by
+  unfold Spec.errorPolicies Partial.Response.errors
+  rw [Set.make_make_eqv]
+  simp only [List.Equiv, List.map_filterMap, List.subset_def, List.mem_filterMap,
+    Option.map_eq_some', forall_exists_index, and_imp]
+  constructor
+  case left =>
+    intro pid r h₁ pair h₂ h₃
+    split at h₂ <;> simp only [Option.some.injEq] at h₂
+    case h_1 r pid' e =>
+      subst pair
+      simp only at h₃
+      subst pid'
+      simp only [Partial.isAuthorized, List.mem_filterMap, Spec.errored, Spec.hasError,
+        ite_some_none_eq_some] at *
+      replace ⟨policy, h₁, h₂⟩ := h₁
+      exists policy
+      apply And.intro h₁
+      simp only [Partial.Evaluation.on_concrete_eqv_concrete_eval _ req entities wf] at h₂
+      split <;> split at h₂
+      <;> simp only [Option.some.injEq, Residual.error.injEq] at h₂
+      <;> try simp only [h₂, and_true, and_self]
+      case h_1.h_4 h₃ _ e' h₄ => simp [h₃, Except.map] at h₄
+  case right =>
+    intro pid policy h₁ h₂
+    unfold Spec.errored Spec.hasError at h₂
+    simp only [ite_some_none_eq_some] at h₂
+    replace ⟨h₂, h₂'⟩ := h₂
+    subst h₂'
+    split at h₂ <;> simp only at h₂
+    case h_2 e h₃ =>
+      exists (.error policy.id e)
+      apply And.intro _ (by exists (policy.id, e))
+      unfold Partial.isAuthorized
+      simp [Partial.Evaluation.on_concrete_eqv_concrete_eval _ req entities wf]
+      exists policy
+      apply And.intro h₁
+      split <;> simp only [Option.some.injEq, Residual.error.injEq, true_and]
+      <;> rename_i h₄
+      <;> simp only [Except.map, h₃, Except.error.injEq] at h₄
+      exact h₄.symm
+
 end Cedar.Thm.Partial.Authorization.PartialOnConcrete

--- a/cedar-lean/Cedar/Thm/Partial/Authorization/PartialResponse.lean
+++ b/cedar-lean/Cedar/Thm/Partial/Authorization/PartialResponse.lean
@@ -1,5 +1,5 @@
 /-
- Copyright 2022-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ Copyright Cedar Contributors
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/cedar-lean/Cedar/Thm/Partial/Authorization/PartialResponse.lean
+++ b/cedar-lean/Cedar/Thm/Partial/Authorization/PartialResponse.lean
@@ -1,0 +1,82 @@
+/-
+ Copyright 2022-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-/
+
+import Cedar.Partial.Response
+import Cedar.Thm.Data.Set
+
+namespace Cedar.Thm.Partial.Response
+
+open Cedar.Data
+open Cedar.Spec (Effect PolicyID)
+open Cedar.Partial (Residual)
+
+theorem mayBeSatisfied_wf {resp : Partial.Response} {eff : Effect} :
+  (resp.mayBeSatisfied eff).WellFormed
+:= by
+  unfold Set.WellFormed Partial.Response.mayBeSatisfied Set.toList
+  simp only [Set.make_make_eqv]
+  apply List.Equiv.symm
+  exact Set.elts_make_equiv
+
+theorem mustBeSatisfied_wf {resp : Partial.Response} {eff : Effect} :
+  (resp.mustBeSatisfied eff).WellFormed
+:= by
+  unfold Set.WellFormed Partial.Response.mustBeSatisfied Set.toList
+  simp only [Set.make_make_eqv]
+  apply List.Equiv.symm
+  exact Set.elts_make_equiv
+
+theorem permits_wf {resp : Partial.Response} :
+  resp.permits.WellFormed
+:= by
+  unfold Partial.Response.permits
+  apply mayBeSatisfied_wf (eff := .permit)
+
+theorem knownPermits_wf {resp : Partial.Response} :
+  resp.knownPermits.WellFormed
+:= by
+  unfold Partial.Response.knownPermits
+  apply mustBeSatisfied_wf (eff := .permit)
+
+theorem forbids_wf {resp : Partial.Response} :
+  resp.forbids.WellFormed
+:= by
+  unfold Partial.Response.forbids
+  apply mayBeSatisfied_wf (eff := .forbid)
+
+theorem knownForbids_wf {resp : Partial.Response} :
+  resp.knownForbids.WellFormed
+:= by
+  unfold Partial.Response.knownForbids
+  apply mustBeSatisfied_wf (eff := .forbid)
+
+theorem overapproximateDeterminingPolicies_wf {resp : Partial.Response} :
+  resp.overapproximateDeterminingPolicies.WellFormed
+:= by
+  unfold Partial.Response.overapproximateDeterminingPolicies
+  cases resp.decision <;> simp only
+  case allow => exact permits_wf
+  case deny => exact forbids_wf
+  case unknown => exact Set.union_wf resp.permits resp.forbids
+
+theorem underapproximateDeterminingPolicies_wf {resp : Partial.Response} :
+  resp.underapproximateDeterminingPolicies.WellFormed
+:= by
+  unfold Partial.Response.underapproximateDeterminingPolicies
+  cases resp.decision <;> simp only
+  case allow => exact knownPermits_wf
+  case deny => exact knownForbids_wf
+  case unknown => exact Set.empty_wf


### PR DESCRIPTION
Follows on to #320 by extending the proof to not cover just the partial decision, but also the other parts of the `Partial.Response`: the `overapproximateDeterminingPolicies`, `underapproximateDeterminingPolicies`, and `errors`.  Wraps everything up in a top-level theorem `partial_authz_eqv_authz_on_concrete`.


