### PR TITLE
Proof that subst preserves evaluation to value

### DIFF
--- a/cedar-lean/Cedar/Thm/Data/List/Lemmas.lean
+++ b/cedar-lean/Cedar/Thm/Data/List/Lemmas.lean
@@ -561,6 +561,8 @@ theorem mapM_some_iff_forall₂ {α β} {f : α → Option β} {xs : List α} {y
 /--
   Note that the converse is not true:
   counterexample `xs` is `[1]`, `ys` is `[1, 2]`, `f` is `Option.some`
+
+  But for a limited converse, see `all_some_implies_mapM'_some`
 -/
 theorem mapM'_some_implies_all_some {α β} {f : α → Option β} {xs : List α} {ys : List β} :
   List.mapM' f xs = .some ys →
@@ -576,9 +578,32 @@ theorem mapM_some_implies_all_some {α β} {f : α → Option β} {xs : List α}
   rw [← List.mapM'_eq_mapM]
   exact mapM'_some_implies_all_some
 
+theorem all_some_implies_mapM'_some {α β} {f : α → Option β} {xs : List α} :
+  (∀ x ∈ xs, ∃ y, f x = some y) →
+  ∃ ys, List.mapM' f xs = some ys
+:= by
+  intro h₁
+  induction xs
+  case nil => exists []
+  case cons xhd xtl ih =>
+    simp only [mem_cons, forall_eq_or_imp] at h₁
+    replace ⟨⟨yhd, h₁⟩, h₂⟩ := h₁
+    replace ⟨ytl, ih⟩ := ih h₂
+    exists yhd :: ytl
+    simp [h₁, ih, pure, Except.pure]
+
+theorem all_some_implies_mapM_some {α β} {f : α → Option β} {xs : List α} :
+  (∀ x ∈ xs, ∃ y, f x = some y) →
+  ∃ ys, List.mapM f xs = some ys
+:= by
+  rw [← List.mapM'_eq_mapM]
+  exact all_some_implies_mapM'_some
+
 /--
   Note that the converse is not true:
   counterexample `ys` is `[1]`, `xs` is `[1, 2]`, `f` is `Option.some`
+
+  But for a limited converse, see `all_from_some_implies_mapM'_some`
 -/
 theorem mapM'_some_implies_all_from_some {α β} {f : α → Option β} {xs : List α} {ys : List β} :
   List.mapM' f xs = .some ys →
@@ -593,6 +618,29 @@ theorem mapM_some_implies_all_from_some {α β} {f : α → Option β} {xs : Lis
 := by
   rw [← List.mapM'_eq_mapM]
   exact mapM'_some_implies_all_from_some
+
+theorem all_from_some_implies_mapM'_some {α β} {f : α → Option β} {ys : List β} :
+  (∀ y ∈ ys, ∃ x, f x = some y) →
+  ∃ xs, List.mapM' f xs = some ys
+:= by
+  intro h₁
+  induction ys
+  case nil => exists []
+  case cons yhd ytl ih =>
+    simp only [mem_cons, forall_eq_or_imp] at h₁
+    replace ⟨⟨xhd, h₁⟩, h₂⟩ := h₁
+    replace ⟨xtl, ih⟩ := ih h₂
+    exists xhd :: xtl
+    simp [h₁, ih, pure, Except.pure]
+
+theorem all_from_some_implies_mapM_some {α β} {f : α → Option β} {ys : List β} :
+  (∀ y ∈ ys, ∃ x, f x = some y) →
+  ∃ xs, List.mapM f xs = some ys
+:= by
+  intro h
+  have ⟨xs, h₂⟩ := all_from_some_implies_mapM'_some h
+  rw [List.mapM'_eq_mapM] at h₂
+  exists xs
 
 theorem mapM'_none_iff_exists_none {α β} {f : α → Option β} {xs : List α} :
   List.mapM' f xs = none ↔ ∃ x ∈ xs, f x = none

--- a/cedar-lean/Cedar/Thm/Data/Map.lean
+++ b/cedar-lean/Cedar/Thm/Data/Map.lean
@@ -349,7 +349,7 @@ theorem keys_mapOnValues [LT α] [StrictLT α] [DecidableLT α] [DecidableEq α]
   (m.mapOnValues f).keys = m.keys
 := by
   unfold mapOnValues keys kvs
-  simp
+  simp only [List.map_map, Set.mk.injEq]
   induction m.1
   case nil => simp only [List.map_nil]
   case cons hd tl ih =>

--- a/cedar-lean/Cedar/Thm/Data/Map.lean
+++ b/cedar-lean/Cedar/Thm/Data/Map.lean
@@ -18,6 +18,7 @@ import Cedar.Data.Map
 import Cedar.Data.SizeOf
 import Cedar.Thm.Data.Control
 import Cedar.Thm.Data.List
+import Cedar.Thm.Data.Set
 
 /-!
 # Map properties
@@ -103,7 +104,20 @@ theorem eq_iff_kvs_equiv [LT α] [DecidableLT α] [StrictLT α] {m₁ m₂ : Map
     subst h₁
     exact List.Equiv.refl
 
-/-! ### contains, mem, kvs, values -/
+/-! ### contains, mem, kvs, keys, values -/
+
+theorem keys_wf [LT α] [DecidableLT α] [StrictLT α] (m : Map α β) :
+  m.WellFormed → m.keys.WellFormed
+:= by
+  unfold keys
+  intro wf
+  simp only [wf_iff_sorted, toList] at wf
+  simp only [Set.wf_iff_sorted]
+  simp only [Set.elts]
+  apply (List.map_eq_implies_sortedBy _).mp wf
+  simp only [List.map_map]
+  apply List.map_congr
+  simp only [Function.comp_apply, id_eq, implies_true]
 
 theorem kvs_nil_iff_empty {m : Map α β} :
   m.kvs = [] ↔ m = Map.empty
@@ -331,6 +345,17 @@ theorem mapOnValues_contains {α β γ} [LT α] [DecidableLT α] [DecidableEq α
   · simp [find?_mapOnValues_some f h]
   · simp [find?_mapOnValues_none f h]
 
+theorem keys_mapOnValues [LT α] [StrictLT α] [DecidableLT α] [DecidableEq α] (f : β → γ) (m : Map α β) :
+  (m.mapOnValues f).keys = m.keys
+:= by
+  unfold mapOnValues keys kvs
+  simp
+  induction m.1
+  case nil => simp only [List.map_nil]
+  case cons hd tl ih =>
+    simp only [List.map_cons, Function.comp_apply, List.cons.injEq, true_and]
+    exact ih
+
 theorem values_mapOnValues [LT α] [StrictLT α] [DecidableLT α] [DecidableEq α] {f : β → γ} {m : Map α β} :
   (m.mapOnValues f).values = m.values.map f
 := by
@@ -339,7 +364,7 @@ theorem values_mapOnValues [LT α] [StrictLT α] [DecidableLT α] [DecidableEq �
   case nil => simp only [List.map_nil]
   case cons hd tl ih =>
     simp only [List.map_cons, List.cons.injEq, true_and]
-    trivial
+    exact ih
 
 theorem findOrErr_mapOnValues [LT α] [DecidableLT α] [DecidableEq α] {f : β → γ} {m : Map α β} {k : α} {e : Error} :
   (m.mapOnValues f).findOrErr k e = (m.findOrErr k e).map f

--- a/cedar-lean/Cedar/Thm/Partial/Evaluation.lean
+++ b/cedar-lean/Cedar/Thm/Partial/Evaluation.lean
@@ -161,7 +161,11 @@ theorem subst_preserves_evaluation_to_value {expr : Partial.Expr} {req req' : Pa
     simp only [Except.ok.injEq, Partial.Value.value.injEq, Bool.not_eq_true']
     intro _ h₁ ; subst h₁
     simp only [Partial.Expr.subst]
-  case var v => exact Var.subst_preserves_evaluation_to_value wf_r
+  case var var =>
+    have h₁ := Var.subst_preserves_evaluation_to_value var req req' entities subsmap wf_r
+    unfold SubstPreservesEvaluationToConcrete at h₁
+    intro h_req
+    exact h₁ h_req v
   case unknown u =>
     unfold Partial.evaluate
     simp only [Except.ok.injEq, Bool.not_eq_true', false_implies, implies_true]

--- a/cedar-lean/Cedar/Thm/Partial/Evaluation.lean
+++ b/cedar-lean/Cedar/Thm/Partial/Evaluation.lean
@@ -15,8 +15,10 @@
 -/
 
 import Cedar.Partial.Evaluator
+import Cedar.Partial.Expr
 import Cedar.Spec.Evaluator
 import Cedar.Thm.Partial.Evaluation.And
+import Cedar.Thm.Partial.Evaluation.AndOr
 import Cedar.Thm.Partial.Evaluation.Basic
 import Cedar.Thm.Partial.Evaluation.Binary
 import Cedar.Thm.Partial.Evaluation.Call
@@ -141,3 +143,214 @@ theorem on_concrete_gives_concrete (expr : Spec.Expr) (request : Spec.Request) (
   <;> split at h
   <;> simp only [Except.ok.injEq, Except.error.injEq, Partial.Value.value.injEq] at h
   <;> trivial
+
+/--
+  If partial evaluation returns a concrete value, then it returns the same value
+  after any substitution of unknowns
+-/
+theorem subst_preserves_evaluation_to_value {expr : Partial.Expr} {req req' : Partial.Request} {entities : Partial.Entities} {v : Spec.Value} {subsmap : Map Unknown Partial.Value}
+  (wf_r : req.AllWellFormed)
+  (wf_e : entities.AllWellFormed) :
+  req.subst subsmap = some req' →
+  Partial.evaluate expr req entities = .ok (.value v) →
+  Partial.evaluate (expr.subst subsmap) req' (entities.subst subsmap) = .ok (.value v)
+:= by
+  cases expr
+  case lit p =>
+    unfold Partial.evaluate
+    simp
+    intro _ h₁ ; subst h₁
+    simp [Partial.Expr.subst]
+  case var v => exact Var.subst_preserves_evaluation_to_value wf_r
+  case unknown u => unfold Partial.evaluate ; simp
+  case and x₁ x₂ =>
+    intro h_req h₁
+    have h₂ := And.evals_to_concrete_then_operands_eval_to_concrete (by
+      unfold EvaluatesToConcrete
+      exists v
+    )
+    unfold EvaluatesToConcrete at h₂
+    rcases h₂ with h₂ | ⟨⟨v₁, hx₁⟩, ⟨v₂, hx₂⟩⟩
+    · have ih := subst_preserves_evaluation_to_value wf_r wf_e h_req h₂
+      unfold Partial.Expr.subst Partial.evaluate Spec.Value.asBool
+      simp [ih]
+      unfold Partial.evaluate Spec.Value.asBool at h₁
+      simp [h₂] at h₁
+      exact h₁
+    · have ih₁ := subst_preserves_evaluation_to_value wf_r wf_e h_req hx₁
+      have ih₂ := subst_preserves_evaluation_to_value wf_r wf_e h_req hx₂
+      apply (AndOr.subst_preserves_evaluation_to_value _ _).left h_req v h₁
+      · unfold SubstPreservesEvaluationToConcrete
+        intro _ v₁' hx₁'
+        simp [hx₁'] at hx₁ ; subst v₁'
+        exact ih₁
+      · unfold SubstPreservesEvaluationToConcrete
+        intro _ v₂' hx₂'
+        simp [hx₂'] at hx₂ ; subst v₂'
+        exact ih₂
+  case or x₁ x₂ =>
+    intro h_req h₁
+    have h₂ := Or.evals_to_concrete_then_operands_eval_to_concrete (by
+      unfold EvaluatesToConcrete
+      exists v
+    )
+    unfold EvaluatesToConcrete at h₂
+    rcases h₂ with h₂ | ⟨⟨v₁, hx₁⟩, ⟨v₂, hx₂⟩⟩
+    · have ih := subst_preserves_evaluation_to_value wf_r wf_e h_req h₂
+      unfold Partial.Expr.subst Partial.evaluate Spec.Value.asBool
+      simp [ih]
+      unfold Partial.evaluate Spec.Value.asBool at h₁
+      simp [h₂] at h₁
+      exact h₁
+    · have ih₁ := subst_preserves_evaluation_to_value wf_r wf_e h_req hx₁
+      have ih₂ := subst_preserves_evaluation_to_value wf_r wf_e h_req hx₂
+      apply (AndOr.subst_preserves_evaluation_to_value _ _).right h_req v h₁
+      · unfold SubstPreservesEvaluationToConcrete
+        intro _ v₁' hx₁'
+        simp [hx₁'] at hx₁ ; subst v₁'
+        exact ih₁
+      · unfold SubstPreservesEvaluationToConcrete
+        intro _ v₂' hx₂'
+        simp [hx₂'] at hx₂ ; subst v₂'
+        exact ih₂
+  case binaryApp op x₁ x₂ =>
+    intro h_req h₁
+    have h₂ := Binary.evals_to_concrete_then_operands_eval_to_concrete (by
+      unfold EvaluatesToConcrete
+      exists v
+    )
+    unfold EvaluatesToConcrete at h₂
+    have ⟨⟨v₁, hx₁⟩, ⟨v₂, hx₂⟩⟩ := h₂ ; clear h₂
+    have ih₁ := subst_preserves_evaluation_to_value wf_r wf_e h_req hx₁
+    have ih₂ := subst_preserves_evaluation_to_value wf_r wf_e h_req hx₂
+    apply Binary.subst_preserves_evaluation_to_value _ _ h_req v h₁
+    · unfold SubstPreservesEvaluationToConcrete
+      intro _ v₁' hx₁'
+      simp [hx₁'] at hx₁ ; subst v₁'
+      exact ih₁
+    · unfold SubstPreservesEvaluationToConcrete
+      intro _ v₂' hx₂'
+      simp [hx₂'] at hx₂ ; subst v₂'
+      exact ih₂
+  case unaryApp op x₁ =>
+    intro h_req h₁
+    have h₂ := Unary.evals_to_concrete_then_operand_evals_to_concrete (by
+      unfold EvaluatesToConcrete
+      exists v
+    )
+    unfold EvaluatesToConcrete at h₂
+    have ⟨v₁, hx₁⟩ := h₂ ; clear h₂
+    have ih₁ := subst_preserves_evaluation_to_value wf_r wf_e h_req hx₁
+    apply Unary.subst_preserves_evaluation_to_value _ h_req v h₁
+    · unfold SubstPreservesEvaluationToConcrete
+      intro _ v₁' hx₁'
+      simp [hx₁'] at hx₁ ; subst v₁'
+      exact ih₁
+  case ite x₁ x₂ x₃ =>
+    intro h_req h₁
+    have h₂ := Ite.evals_to_concrete_then_operands_eval_to_concrete (by
+      unfold EvaluatesToConcrete
+      exists v
+    )
+    unfold EvaluatesToConcrete at h₂
+    rcases h₂ with ⟨hx₁, ⟨v₂, hx₂⟩⟩ | ⟨hx₁, ⟨v₃, hx₃⟩⟩
+    · have ih₁ := subst_preserves_evaluation_to_value wf_r wf_e h_req hx₁
+      have ih₂ := subst_preserves_evaluation_to_value wf_r wf_e h_req hx₂
+      apply Ite.subst_preserves_evaluation_to_value _ _ h_req v h₁
+      · unfold SubstPreservesEvaluationToConcrete
+        intro _ v₁' hx₁'
+        simp [hx₁'] at hx₁ ; subst v₁'
+        exact ih₁
+      · unfold SubstPreservesEvaluationToConcrete
+        left
+        apply And.intro hx₁
+        intro _ v₂' hx₂'
+        simp [hx₂'] at hx₂ ; subst v₂'
+        exact ih₂
+    · have ih₁ := subst_preserves_evaluation_to_value wf_r wf_e h_req hx₁
+      have ih₃ := subst_preserves_evaluation_to_value wf_r wf_e h_req hx₃
+      apply Ite.subst_preserves_evaluation_to_value _ _ h_req v h₁
+      · unfold SubstPreservesEvaluationToConcrete
+        intro _ v₁' hx₁'
+        simp [hx₁'] at hx₁ ; subst v₁'
+        exact ih₁
+      · unfold SubstPreservesEvaluationToConcrete
+        right
+        apply And.intro hx₁
+        intro _ v₃' hx₃'
+        simp [hx₃'] at hx₃ ; subst v₃'
+        exact ih₃
+  case getAttr x₁ attr =>
+    intro h_req h₁
+    have h₂ := GetAttr.evals_to_concrete_then_operand_evals_to_concrete (by
+      unfold EvaluatesToConcrete
+      exists v
+    )
+    unfold EvaluatesToConcrete at h₂
+    have ⟨v₁, hx₁⟩ := h₂ ; clear h₂
+    have ih₁ := subst_preserves_evaluation_to_value wf_r wf_e h_req hx₁
+    apply GetAttr.subst_preserves_evaluation_to_value wf_e _ h_req v h₁
+    · unfold SubstPreservesEvaluationToConcrete
+      intro _ v₁' hx₁'
+      simp [hx₁'] at hx₁ ; subst v₁'
+      exact ih₁
+  case hasAttr x₁ attr =>
+    intro h_req h₁
+    have h₂ := HasAttr.evals_to_concrete_then_operand_evals_to_concrete (by
+      unfold EvaluatesToConcrete
+      exists v
+    )
+    unfold EvaluatesToConcrete at h₂
+    have ⟨v₁, hx₁⟩ := h₂ ; clear h₂
+    have ih₁ := subst_preserves_evaluation_to_value wf_r wf_e h_req hx₁
+    apply HasAttr.subst_preserves_evaluation_to_value wf_e _ h_req v h₁
+    · unfold SubstPreservesEvaluationToConcrete
+      intro _ v₁' hx₁'
+      simp [hx₁'] at hx₁ ; subst v₁'
+      exact ih₁
+  case set xs =>
+    intro h_req h₁
+    have hx := Set.evals_to_concrete_then_elts_eval_to_concrete (by
+      unfold EvaluatesToConcrete
+      exists v
+    )
+    unfold EvaluatesToConcrete at hx
+    have ih : ∀ x ∈ xs, SubstPreservesEvaluationToConcrete x req req' entities subsmap := by
+      unfold SubstPreservesEvaluationToConcrete
+      intro x h₂ _ v' hx'
+      replace ⟨v, hx⟩ := hx x h₂
+      simp [hx] at hx' ; subst v'
+      have := List.sizeOf_lt_of_mem h₂
+      exact subst_preserves_evaluation_to_value wf_r wf_e h_req hx
+    exact Set.subst_preserves_evaluation_to_value ih h_req v h₁
+  case record attrs =>
+    intro h_req h₁
+    have hx := Record.evals_to_concrete_then_vals_eval_to_concrete (by
+      unfold EvaluatesToConcrete
+      exists v
+    )
+    unfold EvaluatesToConcrete at hx
+    have ih: ∀ kv ∈ attrs, SubstPreservesEvaluationToConcrete kv.snd req req' entities subsmap := by
+      unfold SubstPreservesEvaluationToConcrete
+      intro (k, x) h₂ _ v' hx'
+      replace ⟨v, hx⟩ := hx (k, x) h₂
+      simp [hx] at hx' ; subst v'
+      have := Map.sizeOf_lt_of_value h₂
+      exact subst_preserves_evaluation_to_value wf_r wf_e h_req hx
+    exact Record.subst_preserves_evaluation_to_value ih h_req v h₁
+  case call xfn xs =>
+    intro h_req h₁
+    have hx := Call.evals_to_concrete_then_args_eval_to_concrete (by
+      unfold EvaluatesToConcrete
+      exists v
+    )
+    unfold EvaluatesToConcrete at hx
+    have ih : ∀ x ∈ xs, SubstPreservesEvaluationToConcrete x req req' entities subsmap := by
+      unfold SubstPreservesEvaluationToConcrete
+      intro x h₂ _ v' hx'
+      replace ⟨v, hx⟩ := hx x h₂
+      simp [hx] at hx' ; subst v'
+      have := List.sizeOf_lt_of_mem h₂
+      exact subst_preserves_evaluation_to_value wf_r wf_e h_req hx
+    exact Call.subst_preserves_evaluation_to_value ih h_req v h₁
+termination_by expr

--- a/cedar-lean/Cedar/Thm/Partial/Evaluation.lean
+++ b/cedar-lean/Cedar/Thm/Partial/Evaluation.lean
@@ -158,11 +158,13 @@ theorem subst_preserves_evaluation_to_value {expr : Partial.Expr} {req req' : Pa
   cases expr
   case lit p =>
     unfold Partial.evaluate
-    simp
+    simp only [Except.ok.injEq, Partial.Value.value.injEq, Bool.not_eq_true']
     intro _ h₁ ; subst h₁
-    simp [Partial.Expr.subst]
+    simp only [Partial.Expr.subst]
   case var v => exact Var.subst_preserves_evaluation_to_value wf_r
-  case unknown u => unfold Partial.evaluate ; simp
+  case unknown u =>
+    unfold Partial.evaluate
+    simp only [Except.ok.injEq, Bool.not_eq_true', false_implies, implies_true]
   case and x₁ x₂ =>
     intro h_req h₁
     have h₂ := And.evals_to_concrete_then_operands_eval_to_concrete (by
@@ -173,20 +175,24 @@ theorem subst_preserves_evaluation_to_value {expr : Partial.Expr} {req req' : Pa
     rcases h₂ with h₂ | ⟨⟨v₁, hx₁⟩, ⟨v₂, hx₂⟩⟩
     · have ih := subst_preserves_evaluation_to_value wf_r wf_e h_req h₂
       unfold Partial.Expr.subst Partial.evaluate Spec.Value.asBool
-      simp [ih]
       unfold Partial.evaluate Spec.Value.asBool at h₁
-      simp [h₂] at h₁
+      simp only [Bool.not_eq_true', Except.bind_ok, reduceIte, Except.ok.injEq,
+        Partial.Value.value.injEq] at *
+      simp only [ih]
+      simp only [h₂] at h₁
       exact h₁
     · have ih₁ := subst_preserves_evaluation_to_value wf_r wf_e h_req hx₁
       have ih₂ := subst_preserves_evaluation_to_value wf_r wf_e h_req hx₂
       apply (AndOr.subst_preserves_evaluation_to_value _ _).left h_req v h₁
       · unfold SubstPreservesEvaluationToConcrete
         intro _ v₁' hx₁'
-        simp [hx₁'] at hx₁ ; subst v₁'
+        simp only [hx₁', Except.ok.injEq, Partial.Value.value.injEq] at hx₁
+        subst v₁'
         exact ih₁
       · unfold SubstPreservesEvaluationToConcrete
         intro _ v₂' hx₂'
-        simp [hx₂'] at hx₂ ; subst v₂'
+        simp only [hx₂', Except.ok.injEq, Partial.Value.value.injEq] at hx₂
+        subst v₂'
         exact ih₂
   case or x₁ x₂ =>
     intro h_req h₁
@@ -198,20 +204,24 @@ theorem subst_preserves_evaluation_to_value {expr : Partial.Expr} {req req' : Pa
     rcases h₂ with h₂ | ⟨⟨v₁, hx₁⟩, ⟨v₂, hx₂⟩⟩
     · have ih := subst_preserves_evaluation_to_value wf_r wf_e h_req h₂
       unfold Partial.Expr.subst Partial.evaluate Spec.Value.asBool
-      simp [ih]
       unfold Partial.evaluate Spec.Value.asBool at h₁
-      simp [h₂] at h₁
+      simp only [Bool.not_eq_true', Except.bind_ok, reduceIte, Except.ok.injEq,
+        Partial.Value.value.injEq] at *
+      simp only [ih]
+      simp only [h₂] at h₁
       exact h₁
     · have ih₁ := subst_preserves_evaluation_to_value wf_r wf_e h_req hx₁
       have ih₂ := subst_preserves_evaluation_to_value wf_r wf_e h_req hx₂
       apply (AndOr.subst_preserves_evaluation_to_value _ _).right h_req v h₁
       · unfold SubstPreservesEvaluationToConcrete
         intro _ v₁' hx₁'
-        simp [hx₁'] at hx₁ ; subst v₁'
+        simp only [hx₁', Except.ok.injEq, Partial.Value.value.injEq] at hx₁
+        subst v₁'
         exact ih₁
       · unfold SubstPreservesEvaluationToConcrete
         intro _ v₂' hx₂'
-        simp [hx₂'] at hx₂ ; subst v₂'
+        simp only [hx₂', Except.ok.injEq, Partial.Value.value.injEq] at hx₂
+        subst v₂'
         exact ih₂
   case binaryApp op x₁ x₂ =>
     intro h_req h₁
@@ -226,11 +236,13 @@ theorem subst_preserves_evaluation_to_value {expr : Partial.Expr} {req req' : Pa
     apply Binary.subst_preserves_evaluation_to_value _ _ h_req v h₁
     · unfold SubstPreservesEvaluationToConcrete
       intro _ v₁' hx₁'
-      simp [hx₁'] at hx₁ ; subst v₁'
+      simp only [hx₁', Except.ok.injEq, Partial.Value.value.injEq] at hx₁
+      subst v₁'
       exact ih₁
     · unfold SubstPreservesEvaluationToConcrete
       intro _ v₂' hx₂'
-      simp [hx₂'] at hx₂ ; subst v₂'
+      simp only [hx₂', Except.ok.injEq, Partial.Value.value.injEq] at hx₂
+      subst v₂'
       exact ih₂
   case unaryApp op x₁ =>
     intro h_req h₁
@@ -244,7 +256,8 @@ theorem subst_preserves_evaluation_to_value {expr : Partial.Expr} {req req' : Pa
     apply Unary.subst_preserves_evaluation_to_value _ h_req v h₁
     · unfold SubstPreservesEvaluationToConcrete
       intro _ v₁' hx₁'
-      simp [hx₁'] at hx₁ ; subst v₁'
+      simp only [hx₁', Except.ok.injEq, Partial.Value.value.injEq] at hx₁
+      subst v₁'
       exact ih₁
   case ite x₁ x₂ x₃ =>
     intro h_req h₁
@@ -259,26 +272,30 @@ theorem subst_preserves_evaluation_to_value {expr : Partial.Expr} {req req' : Pa
       apply Ite.subst_preserves_evaluation_to_value _ _ h_req v h₁
       · unfold SubstPreservesEvaluationToConcrete
         intro _ v₁' hx₁'
-        simp [hx₁'] at hx₁ ; subst v₁'
+        simp only [hx₁', Except.ok.injEq, Partial.Value.value.injEq] at hx₁
+        subst v₁'
         exact ih₁
       · unfold SubstPreservesEvaluationToConcrete
         left
         apply And.intro hx₁
         intro _ v₂' hx₂'
-        simp [hx₂'] at hx₂ ; subst v₂'
+        simp only [hx₂', Except.ok.injEq, Partial.Value.value.injEq] at hx₂
+        subst v₂'
         exact ih₂
     · have ih₁ := subst_preserves_evaluation_to_value wf_r wf_e h_req hx₁
       have ih₃ := subst_preserves_evaluation_to_value wf_r wf_e h_req hx₃
       apply Ite.subst_preserves_evaluation_to_value _ _ h_req v h₁
       · unfold SubstPreservesEvaluationToConcrete
         intro _ v₁' hx₁'
-        simp [hx₁'] at hx₁ ; subst v₁'
+        simp only [hx₁', Except.ok.injEq, Partial.Value.value.injEq] at hx₁
+        subst v₁'
         exact ih₁
       · unfold SubstPreservesEvaluationToConcrete
         right
         apply And.intro hx₁
         intro _ v₃' hx₃'
-        simp [hx₃'] at hx₃ ; subst v₃'
+        simp only [hx₃', Except.ok.injEq, Partial.Value.value.injEq] at hx₃
+        subst v₃'
         exact ih₃
   case getAttr x₁ attr =>
     intro h_req h₁
@@ -292,7 +309,8 @@ theorem subst_preserves_evaluation_to_value {expr : Partial.Expr} {req req' : Pa
     apply GetAttr.subst_preserves_evaluation_to_value wf_e _ h_req v h₁
     · unfold SubstPreservesEvaluationToConcrete
       intro _ v₁' hx₁'
-      simp [hx₁'] at hx₁ ; subst v₁'
+      simp only [hx₁', Except.ok.injEq, Partial.Value.value.injEq] at hx₁
+      subst v₁'
       exact ih₁
   case hasAttr x₁ attr =>
     intro h_req h₁
@@ -306,7 +324,8 @@ theorem subst_preserves_evaluation_to_value {expr : Partial.Expr} {req req' : Pa
     apply HasAttr.subst_preserves_evaluation_to_value wf_e _ h_req v h₁
     · unfold SubstPreservesEvaluationToConcrete
       intro _ v₁' hx₁'
-      simp [hx₁'] at hx₁ ; subst v₁'
+      simp only [hx₁', Except.ok.injEq, Partial.Value.value.injEq] at hx₁
+      subst v₁'
       exact ih₁
   case set xs =>
     intro h_req h₁
@@ -319,7 +338,8 @@ theorem subst_preserves_evaluation_to_value {expr : Partial.Expr} {req req' : Pa
       unfold SubstPreservesEvaluationToConcrete
       intro x h₂ _ v' hx'
       replace ⟨v, hx⟩ := hx x h₂
-      simp [hx] at hx' ; subst v'
+      simp only [hx, Except.ok.injEq, Partial.Value.value.injEq] at hx'
+      subst v'
       have := List.sizeOf_lt_of_mem h₂
       exact subst_preserves_evaluation_to_value wf_r wf_e h_req hx
     exact Set.subst_preserves_evaluation_to_value ih h_req v h₁
@@ -334,7 +354,8 @@ theorem subst_preserves_evaluation_to_value {expr : Partial.Expr} {req req' : Pa
       unfold SubstPreservesEvaluationToConcrete
       intro (k, x) h₂ _ v' hx'
       replace ⟨v, hx⟩ := hx (k, x) h₂
-      simp [hx] at hx' ; subst v'
+      simp only [hx, Except.ok.injEq, Partial.Value.value.injEq] at hx'
+      subst v'
       have := Map.sizeOf_lt_of_value h₂
       exact subst_preserves_evaluation_to_value wf_r wf_e h_req hx
     exact Record.subst_preserves_evaluation_to_value ih h_req v h₁
@@ -349,7 +370,8 @@ theorem subst_preserves_evaluation_to_value {expr : Partial.Expr} {req req' : Pa
       unfold SubstPreservesEvaluationToConcrete
       intro x h₂ _ v' hx'
       replace ⟨v, hx⟩ := hx x h₂
-      simp [hx] at hx' ; subst v'
+      simp only [hx, Except.ok.injEq, Partial.Value.value.injEq] at hx'
+      subst v'
       have := List.sizeOf_lt_of_mem h₂
       exact subst_preserves_evaluation_to_value wf_r wf_e h_req hx
     exact Call.subst_preserves_evaluation_to_value ih h_req v h₁

--- a/cedar-lean/Cedar/Thm/Partial/Evaluation/And.lean
+++ b/cedar-lean/Cedar/Thm/Partial/Evaluation/And.lean
@@ -71,26 +71,28 @@ theorem evals_to_concrete_then_operands_eval_to_concrete {x₁ x₂ : Partial.Ex
   replace ⟨v, h₁⟩ := h₁
   cases hx₁ : Partial.evaluate x₁ request entities
   <;> cases hx₂ : Partial.evaluate x₂ request entities
-  <;> simp [hx₁, hx₂, Spec.Value.asBool] at h₁
+  <;> simp only [hx₁, Spec.Value.asBool, Bool.not_eq_true', hx₂, Except.bind_ok, Except.bind_err] at h₁
   case ok.ok pval₁ pval₂ =>
-    cases pval₁ <;> cases pval₂ <;> simp at h₁
+    cases pval₁ <;> cases pval₂ <;> simp only [Except.ok.injEq] at h₁
     case value.value v₁ v₂ =>
       right ; exact And.intro (by exists v₁) (by exists v₂)
     case value.residual v₁ r₂ =>
       cases v₁
       case prim p =>
-        cases p <;> simp at h₁
+        cases p <;> simp only [Except.bind_ok, Except.bind_err] at h₁
         case bool b => cases b <;> simp at *
       case set s | record m => simp at h₁
       case ext x => cases x <;> simp at h₁
   case ok.error pval e =>
-    cases pval <;> simp at h₁
+    cases pval <;> simp only [Except.ok.injEq] at h₁
     case value v =>
       cases v
       case prim p =>
-        cases p <;> simp at h₁
+        cases p <;> simp only [Except.bind_ok, Except.bind_err] at h₁
         case bool b =>
-          cases b <;> simp at h₁ <;> simp [h₁]
+          cases b
+          <;> simp only [reduceIte, Except.ok.injEq, Partial.Value.value.injEq] at h₁
+          <;> simp [h₁]
       case set s | record m => simp at h₁
       case ext x => cases x <;> simp at h₁
 

--- a/cedar-lean/Cedar/Thm/Partial/Evaluation/And.lean
+++ b/cedar-lean/Cedar/Thm/Partial/Evaluation/And.lean
@@ -55,4 +55,43 @@ theorem on_concrete_eqv_concrete_eval {x₁ x₂ : Spec.Expr} {request : Spec.Re
             cases v <;> try simp only [Except.bind_err]
             case prim p => cases p <;> simp
 
+/--
+  If partial-evaluating a `Partial.Expr.and` produces `ok` with a concrete
+  value, then so would partial-evaluating either of the operands, unless the
+  `and` short-circuits
+-/
+theorem evals_to_concrete_then_operands_eval_to_concrete {x₁ x₂ : Partial.Expr} {request : Partial.Request} {entities : Partial.Entities} :
+  EvaluatesToConcrete (Partial.Expr.and x₁ x₂) request entities →
+  Partial.evaluate x₁ request entities = .ok (.value (.prim (.bool false))) ∨
+  (EvaluatesToConcrete x₁ request entities ∧ EvaluatesToConcrete x₂ request entities)
+:= by
+  unfold EvaluatesToConcrete
+  intro h₁
+  unfold Partial.evaluate at h₁
+  replace ⟨v, h₁⟩ := h₁
+  cases hx₁ : Partial.evaluate x₁ request entities
+  <;> cases hx₂ : Partial.evaluate x₂ request entities
+  <;> simp [hx₁, hx₂, Spec.Value.asBool] at h₁
+  case ok.ok pval₁ pval₂ =>
+    cases pval₁ <;> cases pval₂ <;> simp at h₁
+    case value.value v₁ v₂ =>
+      right ; exact And.intro (by exists v₁) (by exists v₂)
+    case value.residual v₁ r₂ =>
+      cases v₁
+      case prim p =>
+        cases p <;> simp at h₁
+        case bool b => cases b <;> simp at *
+      case set s | record m => simp at h₁
+      case ext x => cases x <;> simp at h₁
+  case ok.error pval e =>
+    cases pval <;> simp at h₁
+    case value v =>
+      cases v
+      case prim p =>
+        cases p <;> simp at h₁
+        case bool b =>
+          cases b <;> simp at h₁ <;> simp [h₁]
+      case set s | record m => simp at h₁
+      case ext x => cases x <;> simp at h₁
+
 end Cedar.Thm.Partial.Evaluation.And

--- a/cedar-lean/Cedar/Thm/Partial/Evaluation/And.lean
+++ b/cedar-lean/Cedar/Thm/Partial/Evaluation/And.lean
@@ -81,7 +81,7 @@ theorem evals_to_concrete_then_operands_eval_to_concrete {x₁ x₂ : Partial.Ex
       case prim p =>
         cases p <;> simp only [Except.bind_ok, Except.bind_err] at h₁
         case bool b => cases b <;> simp at *
-      case set s | record m => simp at h₁
+      case set | record => simp at h₁
       case ext x => cases x <;> simp at h₁
   case ok.error pval e =>
     cases pval <;> simp only [Except.ok.injEq] at h₁
@@ -93,7 +93,7 @@ theorem evals_to_concrete_then_operands_eval_to_concrete {x₁ x₂ : Partial.Ex
           cases b
           <;> simp only [reduceIte, Except.ok.injEq, Partial.Value.value.injEq] at h₁
           <;> simp [h₁]
-      case set s | record m => simp at h₁
+      case set | record => simp at h₁
       case ext x => cases x <;> simp at h₁
 
 end Cedar.Thm.Partial.Evaluation.And

--- a/cedar-lean/Cedar/Thm/Partial/Evaluation/AndOr.lean
+++ b/cedar-lean/Cedar/Thm/Partial/Evaluation/AndOr.lean
@@ -46,28 +46,34 @@ theorem subst_preserves_evaluation_to_value {x₁ x₂ : Partial.Expr} {req req'
     unfold Partial.Expr.subst
     cases hx₁ : Partial.evaluate x₁ req entities
     <;> cases hx₂ : Partial.evaluate x₂ req entities
-    <;> simp [hx₁, hx₂] at *
+    <;> simp only [hx₁, false_implies, forall_const, hx₂, Except.ok.injEq, Bool.not_eq_true',
+      Except.bind_ok, Except.bind_err] at *
     case ok.ok pval₁ pval₂ =>
-      cases pval₁ <;> cases pval₂ <;> simp at *
+      cases pval₁ <;> cases pval₂
+      <;> simp only [Partial.Value.value.injEq, Except.ok.injEq, forall_eq', false_implies, forall_const] at *
       case value.value v₁ v₂ =>
-        simp [ih₁, ih₂]
+        simp only [ih₁, ih₂, Except.bind_ok, imp_self]
       case value.residual v₁ r₂ =>
-        simp [ih₁]
+        simp only [ih₁, Except.bind_ok]
         cases v₁
         case prim p₁ =>
-          cases p₁ <;> simp
+          cases p₁ <;> simp only [Except.bind_ok, Except.bind_err, imp_self]
           case bool b₁ => cases b₁ <;> simp
         case set s | record m => simp
         case ext x => cases x <;> simp
     case ok.error pval₁ e₂ =>
-      cases pval₁ <;> simp at *
+      cases pval₁
+      case residual r₁ => simp only [false_implies, forall_const, Except.ok.injEq]
       case value v₁ =>
+        simp only [Partial.Value.value.injEq, forall_eq'] at *
         cases v₁
         case prim p₁ =>
-          cases p₁ <;> simp
+          cases p₁ <;> simp only [Except.bind_ok, Except.bind_err, false_implies]
           case bool b₁ =>
-            cases b₁ <;> simp <;> intro h₁ <;> subst v
-            simp [ih₁]
+            cases b₁
+            <;> simp only [reduceIte, Except.ok.injEq, Partial.Value.value.injEq, false_implies]
+            <;> intro h₁ <;> subst v
+            simp only [ih₁, Except.bind_ok, reduceIte]
         case set s | record m => simp
         case ext x => cases x <;> simp
   }

--- a/cedar-lean/Cedar/Thm/Partial/Evaluation/AndOr.lean
+++ b/cedar-lean/Cedar/Thm/Partial/Evaluation/AndOr.lean
@@ -1,0 +1,75 @@
+/-
+ Copyright Cedar Contributors
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-/
+
+import Cedar.Partial.Evaluator
+import Cedar.Thm.Data.Control
+import Cedar.Thm.Partial.Evaluation.Basic
+
+namespace Cedar.Thm.Partial.Evaluation.AndOr
+
+open Cedar.Data
+open Cedar.Partial (Unknown)
+
+/- ## Lemmas shared by And.lean and Or.lean -/
+
+/--
+  Inductive argument that if partial-evaluation of a `Partial.Expr.and` or
+  `Partial.Expr.or` returns a concrete value, then it returns the same value
+  after any substitution of unknowns
+-/
+theorem subst_preserves_evaluation_to_value {x₁ x₂ : Partial.Expr} {req req' : Partial.Request} {entities : Partial.Entities} {subsmap : Map Unknown Partial.Value}
+  (ih₁ : SubstPreservesEvaluationToConcrete x₁ req req' entities subsmap)
+  (ih₂ : SubstPreservesEvaluationToConcrete x₂ req req' entities subsmap) :
+  SubstPreservesEvaluationToConcrete (Partial.Expr.and x₁ x₂) req req' entities subsmap ∧
+  SubstPreservesEvaluationToConcrete (Partial.Expr.or x₁ x₂) req req' entities subsmap
+:= by
+  unfold SubstPreservesEvaluationToConcrete at *
+  unfold Partial.evaluate Spec.Value.asBool
+  constructor
+  all_goals {
+    intro h_req v
+    specialize ih₁ h_req
+    specialize ih₂ h_req
+    unfold Partial.Expr.subst
+    cases hx₁ : Partial.evaluate x₁ req entities
+    <;> cases hx₂ : Partial.evaluate x₂ req entities
+    <;> simp [hx₁, hx₂] at *
+    case ok.ok pval₁ pval₂ =>
+      cases pval₁ <;> cases pval₂ <;> simp at *
+      case value.value v₁ v₂ =>
+        simp [ih₁, ih₂]
+      case value.residual v₁ r₂ =>
+        simp [ih₁]
+        cases v₁
+        case prim p₁ =>
+          cases p₁ <;> simp
+          case bool b₁ => cases b₁ <;> simp
+        case set s | record m => simp
+        case ext x => cases x <;> simp
+    case ok.error pval₁ e₂ =>
+      cases pval₁ <;> simp at *
+      case value v₁ =>
+        cases v₁
+        case prim p₁ =>
+          cases p₁ <;> simp
+          case bool b₁ =>
+            cases b₁ <;> simp <;> intro h₁ <;> subst v
+            simp [ih₁]
+        case set s | record m => simp
+        case ext x => cases x <;> simp
+  }
+
+end Cedar.Thm.Partial.Evaluation.AndOr

--- a/cedar-lean/Cedar/Thm/Partial/Evaluation/AndOr.lean
+++ b/cedar-lean/Cedar/Thm/Partial/Evaluation/AndOr.lean
@@ -59,7 +59,7 @@ theorem subst_preserves_evaluation_to_value {x₁ x₂ : Partial.Expr} {req req'
         case prim p₁ =>
           cases p₁ <;> simp only [Except.bind_ok, Except.bind_err, imp_self]
           case bool b₁ => cases b₁ <;> simp
-        case set s | record m => simp
+        case set | record => simp
         case ext x => cases x <;> simp
     case ok.error pval₁ e₂ =>
       cases pval₁
@@ -74,7 +74,7 @@ theorem subst_preserves_evaluation_to_value {x₁ x₂ : Partial.Expr} {req req'
             <;> simp only [reduceIte, Except.ok.injEq, Partial.Value.value.injEq, false_implies]
             <;> intro h₁ <;> subst v
             simp only [ih₁, Except.bind_ok, reduceIte]
-        case set s | record m => simp
+        case set | record => simp
         case ext x => cases x <;> simp
   }
 

--- a/cedar-lean/Cedar/Thm/Partial/Evaluation/Basic.lean
+++ b/cedar-lean/Cedar/Thm/Partial/Evaluation/Basic.lean
@@ -106,7 +106,9 @@ def EvaluatesToConcrete (expr : Partial.Expr) (request : Partial.Request) (entit
 -/
 def SubstPreservesEvaluationToConcrete (expr : Partial.Expr) (req req' : Partial.Request) (entities : Partial.Entities) (subsmap : Map Unknown Partial.Value) : Prop :=
   req.subst subsmap = some req' →
-  ∀ v, Partial.evaluate expr req entities = .ok (.value v) → Partial.evaluate (expr.subst subsmap) req' (entities.subst subsmap) = .ok (.value v)
+  ∀ v,
+    Partial.evaluate expr req entities = .ok (.value v) →
+    Partial.evaluate (expr.subst subsmap) req' (entities.subst subsmap) = .ok (.value v)
 
 /--
   Prop that a list of partial values is actually a list of concrete values

--- a/cedar-lean/Cedar/Thm/Partial/Evaluation/Basic.lean
+++ b/cedar-lean/Cedar/Thm/Partial/Evaluation/Basic.lean
@@ -85,11 +85,33 @@ end Cedar.Partial
 
 namespace Cedar.Thm.Partial
 
+open Cedar.Data
+open Cedar.Partial (Unknown)
+
 /--
   Prop that partial evaluation and concrete evaluation of the same concrete
   expression produce the same result
 -/
 def PartialEvalEquivConcreteEval (expr : Spec.Expr) (request : Spec.Request) (entities : Spec.Entities) : Prop :=
   Partial.evaluate expr request entities = (Spec.evaluate expr request entities).map Partial.Value.value
+
+/--
+  Prop that partial evaluation returns a concrete value
+-/
+def EvaluatesToConcrete (expr : Partial.Expr) (request : Partial.Request) (entities : Partial.Entities) : Prop :=
+  ∃ v, Partial.evaluate expr request entities = .ok (.value v)
+
+/--
+  Prop that .subst preserves evaluation to a concrete value
+-/
+def SubstPreservesEvaluationToConcrete (expr : Partial.Expr) (req req' : Partial.Request) (entities : Partial.Entities) (subsmap : Map Unknown Partial.Value) : Prop :=
+  req.subst subsmap = some req' →
+  ∀ v, Partial.evaluate expr req entities = .ok (.value v) → Partial.evaluate (expr.subst subsmap) req' (entities.subst subsmap) = .ok (.value v)
+
+/--
+  Prop that a list of partial values is actually a list of concrete values
+-/
+def is_all_concrete (pvals : List Partial.Value) : Prop :=
+  ∃ vs, pvals.mapM (λ x => match x with | .value v => some v | .residual _ => none) = some vs
 
 end Cedar.Thm.Partial

--- a/cedar-lean/Cedar/Thm/Partial/Evaluation/Basic.lean
+++ b/cedar-lean/Cedar/Thm/Partial/Evaluation/Basic.lean
@@ -111,7 +111,7 @@ def SubstPreservesEvaluationToConcrete (expr : Partial.Expr) (req req' : Partial
 /--
   Prop that a list of partial values is actually a list of concrete values
 -/
-def is_all_concrete (pvals : List Partial.Value) : Prop :=
+def IsAllConcrete (pvals : List Partial.Value) : Prop :=
   ∃ vs, pvals.mapM (λ x => match x with | .value v => some v | .residual _ => none) = some vs
 
 end Cedar.Thm.Partial

--- a/cedar-lean/Cedar/Thm/Partial/Evaluation/Binary.lean
+++ b/cedar-lean/Cedar/Thm/Partial/Evaluation/Binary.lean
@@ -20,10 +20,12 @@ import Cedar.Thm.Data.Control
 import Cedar.Thm.Data.Map
 import Cedar.Thm.Data.Set
 import Cedar.Thm.Partial.Evaluation.Basic
+import Cedar.Thm.Partial.Subst
 
 namespace Cedar.Thm.Partial.Evaluation.Binary
 
 open Cedar.Data
+open Cedar.Partial (Unknown)
 open Cedar.Spec (BinaryOp EntityUID intOrErr Result)
 
 /--
@@ -104,5 +106,139 @@ theorem on_concrete_eqv_concrete_eval {x₁ x₂ : Spec.Expr} {request : Spec.Re
   case ok v₁ =>
     cases h₂ : Spec.evaluate x₂ request entities <;> simp only [h₂, Except.bind_err, Except.bind_ok]
     case ok v₂ => simp [evaluateBinaryApp_on_concrete_eqv_concrete, Except.map]
+
+/--
+  If `Partial.evaluateBinaryApp` produces `ok` with a concrete value, then so
+  would partial-evaluating either of the operands
+-/
+theorem evaluateBinaryApp_returns_concrete_then_operands_eval_to_concrete {pval₁ pval₂ : Partial.Value} {op : BinaryOp} {entities : Partial.Entities} :
+  Partial.evaluateBinaryApp op pval₁ pval₂ entities = .ok (.value v) →
+  (∃ v₁, pval₁ = .value v₁) ∧ (∃ v₂, pval₂ = .value v₂)
+:= by
+  unfold Partial.evaluateBinaryApp
+  intro h₁
+  cases pval₁ <;> cases pval₂
+  case value.value v₁ v₂ =>
+    exact And.intro (by exists v₁) (by exists v₂)
+  case value.residual v₁ r₂ =>
+    cases v₁ <;> simp at h₁
+  case residual.value r₁ v₂ =>
+    cases v₂ <;> simp at h₁
+  case residual.residual r₁ r₂ =>
+    simp at h₁
+
+/--
+  If partial-evaluating a `Partial.Expr.binaryApp` produces `ok` with a concrete
+  value, then so would partial-evaluating either of the operands
+-/
+theorem evals_to_concrete_then_operands_eval_to_concrete {x₁ x₂ : Partial.Expr} {op : BinaryOp} {request : Partial.Request} {entities : Partial.Entities} :
+  EvaluatesToConcrete (Partial.Expr.binaryApp op x₁ x₂) request entities →
+  (EvaluatesToConcrete x₁ request entities ∧ EvaluatesToConcrete x₂ request entities)
+:= by
+  unfold EvaluatesToConcrete
+  intro h₁
+  unfold Partial.evaluate at h₁
+  replace ⟨v, h₁⟩ := h₁
+  cases hx₁ : Partial.evaluate x₁ request entities
+  <;> cases hx₂ : Partial.evaluate x₂ request entities
+  <;> simp [hx₁, hx₂] at h₁
+  case ok.ok pval₁ pval₂ =>
+    have ⟨⟨v₁, hv₁⟩, ⟨v₂, hv₂⟩⟩ := evaluateBinaryApp_returns_concrete_then_operands_eval_to_concrete h₁
+    subst pval₁ pval₂
+    exact And.intro (by exists v₁) (by exists v₂)
+
+/--
+  The return value of `Partial.inₑ` is not affected by substitution of unknowns
+  in `entities`
+-/
+theorem partialInₑ_subst_const {uid₁ uid₂ : EntityUID} {entities : Partial.Entities} {subsmap : Map Unknown Partial.Value} :
+  Partial.inₑ uid₁ uid₂ entities = Partial.inₑ uid₁ uid₂ (entities.subst subsmap)
+:= by
+  unfold Partial.inₑ
+  cases uid₁ == uid₂ <;> simp
+  case false =>
+    rw [← Partial.Subst.entities_subst_preserves_ancestorsOrEmpty entities uid₁ subsmap]
+
+/--
+  The return value of `Partial.inₛ` is not affected by substitution of unknowns
+  in `entities`
+-/
+theorem partialInₛ_subst_const {uid₁ : EntityUID} {s₂ : Set Spec.Value} {entities : Partial.Entities} {subsmap : Map Unknown Partial.Value} :
+  Partial.inₛ uid₁ s₂ entities = Partial.inₛ uid₁ s₂ (entities.subst subsmap)
+:= by
+  unfold Partial.inₛ
+  cases s₂.mapOrErr Spec.Value.asEntityUID .typeError <;> simp
+  case ok uids => simp [← partialInₑ_subst_const]
+
+/--
+  If `Partial.apply₂` returns a concrete value, then it returns the same value
+  after any substitution of unknowns in `entities`
+-/
+theorem partialApply₂_subst_preserves_evaluation_to_value {v₁ v₂ : Spec.Value} {op : BinaryOp} {entities : Partial.Entities} {subsmap : Map Unknown Partial.Value} :
+  Partial.apply₂ op v₁ v₂ entities = .ok (.value v) →
+  Partial.apply₂ op v₁ v₂ (entities.subst subsmap) = .ok (.value v)
+:= by
+  unfold Partial.apply₂
+  cases op
+  case eq => simp
+  case mem =>
+    cases v₁ <;> cases v₂
+    case prim.prim p₁ p₂ =>
+      cases p₁ <;> cases p₂ <;> simp
+      case entityUID.entityUID uid₁ uid₂ =>
+        rw [← partialInₑ_subst_const]
+        simp
+    case prim.set p₁ s₂ =>
+      cases p₁ <;> simp
+      case entityUID uid₁ =>
+        rw [← partialInₛ_subst_const]
+        simp
+    all_goals simp
+  all_goals {
+    cases v₁ <;> cases v₂
+    case prim.prim p₁ p₂ =>
+      cases p₁ <;> cases p₂ <;> simp
+    all_goals simp
+  }
+
+/--
+  If `Partial.evaluateBinaryApp` returns a concrete value, then it returns
+  the same value after any substitution of unknowns in `entities`
+-/
+theorem evaluateBinaryApp_subst_preserves_evaluation_to_value {pval₁ pval₂ : Partial.Value} {op : BinaryOp} {entities : Partial.Entities} {subsmap : Map Unknown Partial.Value} :
+  Partial.evaluateBinaryApp op pval₁ pval₂ entities = .ok (.value v) →
+  Partial.evaluateBinaryApp op pval₁ pval₂ (entities.subst subsmap) = .ok (.value v)
+:= by
+  unfold Partial.evaluateBinaryApp
+  cases pval₁ <;> cases pval₂ <;> simp
+  case value.value v₁ v₂ => exact partialApply₂_subst_preserves_evaluation_to_value
+
+/--
+  Inductive argument that if partial-evaluation of a `Partial.Expr.binaryApp`
+  returns a concrete value, then it returns the same value after any
+  substitution of unknowns
+-/
+theorem subst_preserves_evaluation_to_value {x₁ x₂ : Partial.Expr} {op : BinaryOp} {req req' : Partial.Request} {entities : Partial.Entities} {subsmap : Map Unknown Partial.Value}
+  (ih₁ : SubstPreservesEvaluationToConcrete x₁ req req' entities subsmap)
+  (ih₂ : SubstPreservesEvaluationToConcrete x₂ req req' entities subsmap) :
+  SubstPreservesEvaluationToConcrete (Partial.Expr.binaryApp op x₁ x₂) req req' entities subsmap
+:= by
+  unfold SubstPreservesEvaluationToConcrete at *
+  unfold Partial.evaluate Spec.Value.asBool
+  intro h_req v
+  specialize ih₁ h_req
+  specialize ih₂ h_req
+  unfold Partial.Expr.subst
+  cases hx₁ : Partial.evaluate x₁ req entities
+  <;> cases hx₂ : Partial.evaluate x₂ req entities
+  <;> simp [hx₁, hx₂] at *
+  case ok.ok pval₁ pval₂ =>
+    cases pval₁ <;> cases pval₂ <;> simp at *
+    case value.value v₁ v₂ =>
+      simp [ih₁, ih₂]
+      exact evaluateBinaryApp_subst_preserves_evaluation_to_value
+    case value.residual v₁ r₂ => simp [Partial.evaluateBinaryApp]
+    case residual.value r₁ v₂ => simp [Partial.evaluateBinaryApp]
+    case residual.residual r₁ r₂ => simp [Partial.evaluateBinaryApp]
 
 end Cedar.Thm.Partial.Evaluation.Binary

--- a/cedar-lean/Cedar/Thm/Partial/Evaluation/Binary.lean
+++ b/cedar-lean/Cedar/Thm/Partial/Evaluation/Binary.lean
@@ -48,7 +48,7 @@ theorem partialInₑ_on_concrete_eqv_concrete {uid₁ uid₂ : EntityUID} {entit
 := by
   unfold Partial.inₑ Spec.inₑ
   cases uid₁ == uid₂ <;> simp only [Bool.true_or, Bool.false_or]
-  case false => simp [ancestorsOrEmpty_on_concrete_eqv_concrete]
+  case false => simp only [ancestorsOrEmpty_on_concrete_eqv_concrete]
 
 /--
   `Partial.inₛ` on concrete arguments is the same as `Spec.inₛ` on those arguments
@@ -57,7 +57,7 @@ theorem partialInₛ_on_concrete_eqv_concrete {uid : EntityUID} {vs : Set Spec.V
   Partial.inₛ uid vs entities = Spec.inₛ uid vs entities
 := by
   unfold Partial.inₛ Spec.inₛ
-  simp [partialInₑ_on_concrete_eqv_concrete]
+  simp only [partialInₑ_on_concrete_eqv_concrete]
 
 /--
   `Partial.apply₂` on concrete arguments is the same as `Spec.apply₂` on those
@@ -71,13 +71,16 @@ theorem partialApply₂_on_concrete_eqv_concrete {op : BinaryOp} {v₁ v₂ : Sp
   <;> simp only [false_implies, forall_const] at h
   <;> try simp only [Except.ok.injEq, Partial.Value.value.injEq, Spec.Value.prim.injEq, Spec.Prim.bool.injEq]
   case add | sub | mul => split <;> rename_i h <;> simp [h]
-  case mem.h_10 uid₁ uid₂ => simp [partialInₑ_on_concrete_eqv_concrete]
+  case mem.h_10 uid₁ uid₂ => simp only [partialInₑ_on_concrete_eqv_concrete]
   case mem.h_11 uid vs =>
     simp only [partialInₛ_on_concrete_eqv_concrete]
-    cases Spec.inₛ uid vs entities <;> simp
+    cases Spec.inₛ uid vs entities <;> simp only [Except.bind_ok, Except.bind_err]
   case mem.h_12 =>
-    split <;> rename_i h₂ <;> split at h₂ <;> simp at *
-    assumption
+    split <;> rename_i h₂ <;> split at h₂
+    <;> simp only [imp_self, false_implies, implies_true, forall_const, forall_eq',
+      Except.error.injEq, Spec.Value.prim.injEq, Spec.Value.set.injEq, Spec.Prim.entityUID.injEq,
+      forall_apply_eq_imp_iff] at *
+    exact h₂
 
 /--
   `Partial.evaluateBinaryApp` on concrete arguments is the same as `Spec.apply₂` on
@@ -86,7 +89,7 @@ theorem partialApply₂_on_concrete_eqv_concrete {op : BinaryOp} {v₁ v₂ : Sp
 theorem evaluateBinaryApp_on_concrete_eqv_concrete {op : BinaryOp} {v₁ v₂ : Spec.Value} {entities : Spec.Entities} :
   Partial.evaluateBinaryApp op v₁ v₂ entities = (Spec.apply₂ op v₁ v₂ entities).map Partial.Value.value
 := by
-  simp [Partial.evaluateBinaryApp, partialApply₂_on_concrete_eqv_concrete]
+  simp only [Partial.evaluateBinaryApp, partialApply₂_on_concrete_eqv_concrete]
 
 /--
   Inductive argument that partial evaluating a concrete `Partial.Expr.binaryApp`
@@ -105,7 +108,7 @@ theorem on_concrete_eqv_concrete_eval {x₁ x₂ : Spec.Expr} {request : Spec.Re
   cases h₁ : Spec.evaluate x₁ request entities <;> simp only [h₁, Except.bind_err, Except.bind_ok]
   case ok v₁ =>
     cases h₂ : Spec.evaluate x₂ request entities <;> simp only [h₂, Except.bind_err, Except.bind_ok]
-    case ok v₂ => simp [evaluateBinaryApp_on_concrete_eqv_concrete, Except.map]
+    case ok v₂ => simp only [evaluateBinaryApp_on_concrete_eqv_concrete, Except.map]
 
 /--
   If `Partial.evaluateBinaryApp` produces `ok` with a concrete value, then so
@@ -120,12 +123,7 @@ theorem evaluateBinaryApp_returns_concrete_then_operands_eval_to_concrete {pval�
   cases pval₁ <;> cases pval₂
   case value.value v₁ v₂ =>
     exact And.intro (by exists v₁) (by exists v₂)
-  case value.residual v₁ r₂ =>
-    cases v₁ <;> simp at h₁
-  case residual.value r₁ v₂ =>
-    cases v₂ <;> simp at h₁
-  case residual.residual r₁ r₂ =>
-    simp at h₁
+  all_goals simp only [Except.ok.injEq] at h₁
 
 /--
   If partial-evaluating a `Partial.Expr.binaryApp` produces `ok` with a concrete
@@ -141,7 +139,7 @@ theorem evals_to_concrete_then_operands_eval_to_concrete {x₁ x₂ : Partial.Ex
   replace ⟨v, h₁⟩ := h₁
   cases hx₁ : Partial.evaluate x₁ request entities
   <;> cases hx₂ : Partial.evaluate x₂ request entities
-  <;> simp [hx₁, hx₂] at h₁
+  <;> simp only [hx₁, hx₂, Except.bind_ok, Except.bind_err] at h₁
   case ok.ok pval₁ pval₂ =>
     have ⟨⟨v₁, hv₁⟩, ⟨v₂, hv₂⟩⟩ := evaluateBinaryApp_returns_concrete_then_operands_eval_to_concrete h₁
     subst pval₁ pval₂
@@ -155,7 +153,7 @@ theorem partialInₑ_subst_const {uid₁ uid₂ : EntityUID} {entities : Partial
   Partial.inₑ uid₁ uid₂ entities = Partial.inₑ uid₁ uid₂ (entities.subst subsmap)
 := by
   unfold Partial.inₑ
-  cases uid₁ == uid₂ <;> simp
+  cases uid₁ == uid₂ <;> simp only [Bool.false_or, Bool.true_or]
   case false =>
     rw [← Partial.Subst.entities_subst_preserves_ancestorsOrEmpty entities uid₁ subsmap]
 
@@ -167,8 +165,9 @@ theorem partialInₛ_subst_const {uid₁ : EntityUID} {s₂ : Set Spec.Value} {e
   Partial.inₛ uid₁ s₂ entities = Partial.inₛ uid₁ s₂ (entities.subst subsmap)
 := by
   unfold Partial.inₛ
-  cases s₂.mapOrErr Spec.Value.asEntityUID .typeError <;> simp
-  case ok uids => simp [← partialInₑ_subst_const]
+  cases s₂.mapOrErr Spec.Value.asEntityUID .typeError
+  case error e => simp only [Except.bind_err]
+  case ok uids => simp only [← partialInₑ_subst_const, Except.bind_ok]
 
 /--
   If `Partial.apply₂` returns a concrete value, then it returns the same value
@@ -180,25 +179,27 @@ theorem partialApply₂_subst_preserves_evaluation_to_value {v₁ v₂ : Spec.Va
 := by
   unfold Partial.apply₂
   cases op
-  case eq => simp
+  case eq => simp only [Except.ok.injEq, Partial.Value.value.injEq, imp_self]
   case mem =>
     cases v₁ <;> cases v₂
     case prim.prim p₁ p₂ =>
-      cases p₁ <;> cases p₂ <;> simp
+      cases p₁ <;> cases p₂
+      <;> simp only [Except.ok.injEq, Partial.Value.value.injEq, imp_self]
       case entityUID.entityUID uid₁ uid₂ =>
         rw [← partialInₑ_subst_const]
-        simp
+        simp only [imp_self]
     case prim.set p₁ s₂ =>
-      cases p₁ <;> simp
+      cases p₁ <;> simp only [imp_self]
       case entityUID uid₁ =>
         rw [← partialInₛ_subst_const]
-        simp
-    all_goals simp
+        simp only [imp_self]
+    all_goals simp only [Partial.apply₂.match_1.eq_12, imp_self]
   all_goals {
     cases v₁ <;> cases v₂
     case prim.prim p₁ p₂ =>
-      cases p₁ <;> cases p₂ <;> simp
-    all_goals simp
+      cases p₁ <;> cases p₂
+      <;> simp only [Except.ok.injEq, Partial.Value.value.injEq, imp_self]
+    all_goals simp only [Partial.apply₂.match_1.eq_12, imp_self]
   }
 
 /--
@@ -210,7 +211,7 @@ theorem evaluateBinaryApp_subst_preserves_evaluation_to_value {pval₁ pval₂ :
   Partial.evaluateBinaryApp op pval₁ pval₂ (entities.subst subsmap) = .ok (.value v)
 := by
   unfold Partial.evaluateBinaryApp
-  cases pval₁ <;> cases pval₂ <;> simp
+  cases pval₁ <;> cases pval₂ <;> simp only [Except.ok.injEq, imp_self]
   case value.value v₁ v₂ => exact partialApply₂_subst_preserves_evaluation_to_value
 
 /--
@@ -231,14 +232,14 @@ theorem subst_preserves_evaluation_to_value {x₁ x₂ : Partial.Expr} {op : Bin
   unfold Partial.Expr.subst
   cases hx₁ : Partial.evaluate x₁ req entities
   <;> cases hx₂ : Partial.evaluate x₂ req entities
-  <;> simp [hx₁, hx₂] at *
+  <;> simp only [hx₁, hx₂, Except.ok.injEq, false_implies, forall_const,
+    Except.bind_err, Except.bind_ok] at *
   case ok.ok pval₁ pval₂ =>
-    cases pval₁ <;> cases pval₂ <;> simp at *
+    cases pval₁ <;> cases pval₂
+    <;> simp only [Partial.Value.value.injEq, forall_eq', false_implies, forall_const] at *
     case value.value v₁ v₂ =>
-      simp [ih₁, ih₂]
+      simp only [ih₁, ih₂, Except.bind_ok]
       exact evaluateBinaryApp_subst_preserves_evaluation_to_value
-    case value.residual v₁ r₂ => simp [Partial.evaluateBinaryApp]
-    case residual.value r₁ v₂ => simp [Partial.evaluateBinaryApp]
-    case residual.residual r₁ r₂ => simp [Partial.evaluateBinaryApp]
+    all_goals simp only [Partial.evaluateBinaryApp, Except.ok.injEq, false_implies]
 
 end Cedar.Thm.Partial.Evaluation.Binary

--- a/cedar-lean/Cedar/Thm/Partial/Evaluation/Call.lean
+++ b/cedar-lean/Cedar/Thm/Partial/Evaluation/Call.lean
@@ -58,7 +58,7 @@ theorem on_concrete_eqv_concrete_eval {xs : List Spec.Expr} {request : Spec.Requ
   rw [List.mapM_map]
   rw [Set.mapM_partial_eval_eqv_concrete_eval ih₁]
   cases xs.mapM (Spec.evaluate · request entities) <;> simp only [Except.bind_ok, Except.bind_err]
-  case error e => simp [Except.map]
+  case error e => simp only [Except.map, Except.bind_err]
   case ok vs => exact evaluateCall_on_concrete_eqv_concrete
 
 /--
@@ -73,12 +73,12 @@ theorem partialEvaluateCall_concrete_then_args_concrete {args : List Partial.Val
   split <;> intro h₁ arg h₂
   · rename_i vs h₃
     replace ⟨v, h₃, h₄⟩ := List.mapM_some_implies_all_some h₃ arg h₂
-    cases arg <;> simp at h₄
+    cases arg <;> simp only [Option.some.injEq] at h₄
     subst v ; rename_i v
     exists v
   · rename_i h₃
     replace ⟨arg', h₃, h₄⟩ := List.mapM_none_iff_exists_none.mp h₃
-    cases arg' <;> simp at h₁ h₄
+    cases arg' <;> simp only [Except.ok.injEq] at h₁ h₄
 
 /--
   If partial-evaluating a `Partial.Expr.call` produces `ok` with a concrete
@@ -93,7 +93,8 @@ theorem evals_to_concrete_then_args_eval_to_concrete {xs : List Partial.Expr} {r
   unfold Partial.evaluate at h₁
   replace ⟨v, h₁⟩ := h₁
   rw [List.mapM₁_eq_mapM (Partial.evaluate · request entities)] at h₁
-  cases h₃ : xs.mapM (Partial.evaluate · request entities) <;> simp [h₃] at h₁
+  cases h₃ : xs.mapM (Partial.evaluate · request entities)
+  <;> simp only [h₃, Except.bind_ok, Except.bind_err] at h₁
   case ok pvals =>
     replace ⟨pval, h₃, h₄⟩ := List.mapM_ok_implies_all_ok h₃ x h₂
     replace ⟨v, h₁⟩ := partialEvaluateCall_concrete_then_args_concrete h₁ pval h₃
@@ -113,23 +114,25 @@ theorem subst_preserves_evaluation_to_value {args : List Partial.Expr} {req req'
   unfold Partial.evaluate Partial.evaluateCall Spec.Value.asBool
   intro h_req v
   rw [List.mapM₁_eq_mapM (Partial.evaluate · req entities)]
-  cases h₁ : args.mapM (Partial.evaluate · req entities) <;> simp [h₁]
+  cases h₁ : args.mapM (Partial.evaluate · req entities)
+  <;> simp only [Except.bind_ok, Except.bind_err, Bool.not_eq_true', false_implies]
   case ok pvals =>
     split
     · rename_i vs h₂
       -- vs are the concrete values produced by evaluating the args pre-subst
       unfold Partial.Expr.subst
       rw [List.map₁_eq_map]
-      simp
+      simp only
       rw [List.mapM₁_eq_mapM (Partial.evaluate · req' (entities.subst subsmap))]
       rw [Set.mapM_subst_preserves_evaluation_to_values ih h_req pvals h₁ (by unfold is_all_concrete ; exists vs)]
-      cases h₃ : Spec.call xfn vs <;> simp
+      cases h₃ : Spec.call xfn vs
+      <;> simp only [Except.bind_err, Except.bind_ok, false_implies, Except.ok.injEq, Partial.Value.value.injEq]
       case ok v' =>
         intro h ; subst v'
-        simp [h₂, h₃]
+        simp only [h₂, h₃, Except.bind_ok]
     · rename_i h₂
       replace ⟨pval, h₂, h₃⟩ := List.mapM_none_iff_exists_none.mp h₂
-      cases pval <;> simp at h₃
-      case residual r => simp
+      cases pval <;> simp only at h₃
+      case residual r => simp only [Except.ok.injEq, false_implies]
 
 end Cedar.Thm.Partial.Evaluation.Call

--- a/cedar-lean/Cedar/Thm/Partial/Evaluation/Call.lean
+++ b/cedar-lean/Cedar/Thm/Partial/Evaluation/Call.lean
@@ -124,7 +124,7 @@ theorem subst_preserves_evaluation_to_value {args : List Partial.Expr} {req req'
       rw [List.map₁_eq_map]
       simp only
       rw [List.mapM₁_eq_mapM (Partial.evaluate · req' (entities.subst subsmap))]
-      rw [Set.mapM_subst_preserves_evaluation_to_values ih h_req pvals h₁ (by unfold is_all_concrete ; exists vs)]
+      rw [Set.mapM_subst_preserves_evaluation_to_values ih h_req pvals h₁ (by unfold IsAllConcrete ; exists vs)]
       cases h₃ : Spec.call xfn vs
       <;> simp only [Except.bind_err, Except.bind_ok, false_implies, Except.ok.injEq, Partial.Value.value.injEq]
       case ok v' =>

--- a/cedar-lean/Cedar/Thm/Partial/Evaluation/GetAttr.lean
+++ b/cedar-lean/Cedar/Thm/Partial/Evaluation/GetAttr.lean
@@ -188,7 +188,7 @@ theorem getAttr_subst_preserves_evaluation_to_value {v₁ : Spec.Value} {attr : 
         apply (Map.in_list_iff_find?_some _).mp h₄
         have wf' := Partial.Subst.entities_subst_preserves_wf subsmap wf
         exact partialEntities_attrs_wf wf' h₃
-  case set s | record m => simp
+  case set | record => simp
   case ext x => cases x <;> simp
 
 /--

--- a/cedar-lean/Cedar/Thm/Partial/Evaluation/Ite.lean
+++ b/cedar-lean/Cedar/Thm/Partial/Evaluation/Ite.lean
@@ -21,6 +21,8 @@ import Cedar.Thm.Partial.Evaluation.Basic
 
 namespace Cedar.Thm.Partial.Evaluation.Ite
 
+open Cedar.Data
+open Cedar.Partial (Unknown)
 open Cedar.Spec (Result)
 
 /--
@@ -46,5 +48,74 @@ theorem on_concrete_eqv_concrete_eval {x₁ x₂ x₃ : Spec.Expr} {request : Sp
     case prim p =>
       cases p <;> simp only [Except.bind_ok, Except.bind_err]
       case bool b => cases b <;> simp
+
+/--
+  If partial-evaluating a `Partial.Expr.ite` produces `ok` with a concrete
+  value, then so would partial-evaluating any of the operands, unless the `ite`
+  short-circuits
+-/
+theorem evals_to_concrete_then_operands_eval_to_concrete {x₁ x₂ x₃ : Partial.Expr} {request : Partial.Request} {entities : Partial.Entities} :
+  EvaluatesToConcrete (Partial.Expr.ite x₁ x₂ x₃) request entities →
+  (Partial.evaluate x₁ request entities = .ok (.value (.prim (.bool true))) ∧ EvaluatesToConcrete x₂ request entities) ∨
+  (Partial.evaluate x₁ request entities = .ok (.value (.prim (.bool false))) ∧ EvaluatesToConcrete x₃ request entities)
+:= by
+  unfold EvaluatesToConcrete
+  intro h₁
+  unfold Partial.evaluate at h₁
+  replace ⟨v, h₁⟩ := h₁
+  cases hx₁ : Partial.evaluate x₁ request entities
+  <;> simp [hx₁, Spec.Value.asBool] at h₁
+  case ok pval₁ =>
+    cases pval₁ <;> simp at h₁
+    case value v₁ =>
+      cases v₁
+      case prim p₁ =>
+        cases p₁ <;> simp at h₁
+        case bool b₁ =>
+          cases b₁ <;> simp at h₁
+          case true =>
+            left
+            cases hx₂ : Partial.evaluate x₂ request entities
+            <;> simp [hx₂] at h₁
+            case ok v₂ => subst h₁ ; simp
+          case false =>
+            right
+            cases hx₃ : Partial.evaluate x₃ request entities
+            <;> simp [hx₃] at h₁
+            case ok v₃ => subst h₁ ; simp
+      case set s | record m => simp at h₁
+      case ext x => cases x <;> simp at h₁
+
+/--
+  Inductive argument that if partial-evaluation of a `Partial.Expr.ite` returns
+  a concrete value, then it returns the same value after any substitution of
+  unknowns
+-/
+theorem subst_preserves_evaluation_to_value {x₁ x₂ x₃ : Partial.Expr} {req req' : Partial.Request} {entities : Partial.Entities} {subsmap : Map Unknown Partial.Value}
+  (ih₁ : SubstPreservesEvaluationToConcrete x₁ req req' entities subsmap)
+  (ih₂₃ :
+    (Partial.evaluate x₁ req entities = .ok (.value (.prim (.bool true))) ∧ SubstPreservesEvaluationToConcrete x₂ req req' entities subsmap) ∨
+    (Partial.evaluate x₁ req entities = .ok (.value (.prim (.bool false))) ∧ SubstPreservesEvaluationToConcrete x₃ req req' entities subsmap)
+  ) :
+  SubstPreservesEvaluationToConcrete (Partial.Expr.ite x₁ x₂ x₃) req req' entities subsmap
+:= by
+  unfold SubstPreservesEvaluationToConcrete Partial.evaluate Spec.Value.asBool
+  intro h_req v
+  specialize ih₁ h_req
+  rcases ih₂₃ with ⟨hx₁, ih₂⟩ | ⟨hx₁, ih₃⟩
+  · specialize ih₂ h_req
+    specialize ih₁ (.prim (.bool true)) hx₁
+    unfold Partial.Expr.subst
+    simp [hx₁]
+    intro h₁
+    simp [ih₁]
+    exact ih₂ v h₁
+  · specialize ih₃ h_req
+    specialize ih₁ (.prim (.bool false)) hx₁
+    unfold Partial.Expr.subst
+    simp [hx₁]
+    intro h₁
+    simp [ih₁]
+    exact ih₃ v h₁
 
 end Cedar.Thm.Partial.Evaluation.Ite

--- a/cedar-lean/Cedar/Thm/Partial/Evaluation/Ite.lean
+++ b/cedar-lean/Cedar/Thm/Partial/Evaluation/Ite.lean
@@ -83,7 +83,7 @@ theorem evals_to_concrete_then_operands_eval_to_concrete {x₁ x₂ x₃ : Parti
             cases hx₃ : Partial.evaluate x₃ request entities
             <;> simp only [hx₃, Except.ok.injEq] at h₁
             case ok v₃ => subst h₁ ; simp
-      case set s | record m => simp at h₁
+      case set | record => simp at h₁
       case ext x => cases x <;> simp at h₁
 
 /--

--- a/cedar-lean/Cedar/Thm/Partial/Evaluation/Ite.lean
+++ b/cedar-lean/Cedar/Thm/Partial/Evaluation/Ite.lean
@@ -64,24 +64,24 @@ theorem evals_to_concrete_then_operands_eval_to_concrete {x₁ x₂ x₃ : Parti
   unfold Partial.evaluate at h₁
   replace ⟨v, h₁⟩ := h₁
   cases hx₁ : Partial.evaluate x₁ request entities
-  <;> simp [hx₁, Spec.Value.asBool] at h₁
+  <;> simp only [hx₁, Spec.Value.asBool, Except.bind_err, Except.bind_ok] at h₁
   case ok pval₁ =>
-    cases pval₁ <;> simp at h₁
+    cases pval₁ <;> simp only [Except.ok.injEq] at h₁
     case value v₁ =>
       cases v₁
       case prim p₁ =>
-        cases p₁ <;> simp at h₁
+        cases p₁ <;> simp only [Except.bind_ok, Except.bind_err] at h₁
         case bool b₁ =>
-          cases b₁ <;> simp at h₁
+          cases b₁ <;> simp only [reduceIte] at h₁
           case true =>
             left
             cases hx₂ : Partial.evaluate x₂ request entities
-            <;> simp [hx₂] at h₁
+            <;> simp only [hx₂, Except.ok.injEq] at h₁
             case ok v₂ => subst h₁ ; simp
           case false =>
             right
             cases hx₃ : Partial.evaluate x₃ request entities
-            <;> simp [hx₃] at h₁
+            <;> simp only [hx₃, Except.ok.injEq] at h₁
             case ok v₃ => subst h₁ ; simp
       case set s | record m => simp at h₁
       case ext x => cases x <;> simp at h₁
@@ -106,16 +106,16 @@ theorem subst_preserves_evaluation_to_value {x₁ x₂ x₃ : Partial.Expr} {req
   · specialize ih₂ h_req
     specialize ih₁ (.prim (.bool true)) hx₁
     unfold Partial.Expr.subst
-    simp [hx₁]
+    simp only [hx₁, Except.bind_ok, reduceIte]
     intro h₁
-    simp [ih₁]
+    simp only [ih₁, Except.bind_ok, reduceIte]
     exact ih₂ v h₁
   · specialize ih₃ h_req
     specialize ih₁ (.prim (.bool false)) hx₁
     unfold Partial.Expr.subst
-    simp [hx₁]
+    simp only [hx₁, Except.bind_ok, reduceIte]
     intro h₁
-    simp [ih₁]
+    simp only [ih₁, Except.bind_ok, reduceIte]
     exact ih₃ v h₁
 
 end Cedar.Thm.Partial.Evaluation.Ite

--- a/cedar-lean/Cedar/Thm/Partial/Evaluation/Ite.lean
+++ b/cedar-lean/Cedar/Thm/Partial/Evaluation/Ite.lean
@@ -51,8 +51,9 @@ theorem on_concrete_eqv_concrete_eval {x₁ x₂ x₃ : Spec.Expr} {request : Sp
 
 /--
   If partial-evaluating a `Partial.Expr.ite` produces `ok` with a concrete
-  value, then so would partial-evaluating any of the operands, unless the `ite`
-  short-circuits
+  value, then partial-evaluating the guard produces either concrete `true` or
+  `false`, and partial-evaluating whichever operand isn't short-circuited out
+  produces `ok` with a concrete value
 -/
 theorem evals_to_concrete_then_operands_eval_to_concrete {x₁ x₂ x₃ : Partial.Expr} {request : Partial.Request} {entities : Partial.Entities} :
   EvaluatesToConcrete (Partial.Expr.ite x₁ x₂ x₃) request entities →

--- a/cedar-lean/Cedar/Thm/Partial/Evaluation/Or.lean
+++ b/cedar-lean/Cedar/Thm/Partial/Evaluation/Or.lean
@@ -81,7 +81,7 @@ theorem evals_to_concrete_then_operands_eval_to_concrete {x₁ x₂ : Partial.Ex
       case prim p =>
         cases p <;> simp only [Except.bind_ok, Except.bind_err] at h₁
         case bool b => cases b <;> simp at *
-      case set s | record m => simp at h₁
+      case set | record => simp at h₁
       case ext x => cases x <;> simp at h₁
   case ok.error pval e =>
     cases pval <;> simp only [Except.ok.injEq] at h₁
@@ -93,7 +93,7 @@ theorem evals_to_concrete_then_operands_eval_to_concrete {x₁ x₂ : Partial.Ex
           cases b
           <;> simp only [reduceIte, Except.ok.injEq, Partial.Value.value.injEq] at h₁
           <;> simp [h₁]
-      case set s | record m => simp at h₁
+      case set | record => simp at h₁
       case ext x => cases x <;> simp at h₁
 
 end Cedar.Thm.Partial.Evaluation.Or

--- a/cedar-lean/Cedar/Thm/Partial/Evaluation/Or.lean
+++ b/cedar-lean/Cedar/Thm/Partial/Evaluation/Or.lean
@@ -70,26 +70,29 @@ theorem evals_to_concrete_then_operands_eval_to_concrete {x₁ x₂ : Partial.Ex
   replace ⟨v, h₁⟩ := h₁
   cases hx₁ : Partial.evaluate x₁ request entities
   <;> cases hx₂ : Partial.evaluate x₂ request entities
-  <;> simp [hx₁, hx₂, Spec.Value.asBool] at h₁
+  <;> simp only [hx₁, hx₂, Spec.Value.asBool, Except.bind_ok, Except.bind_err] at h₁
   case ok.ok pval₁ pval₂ =>
-    cases pval₁ <;> cases pval₂ <;> simp at h₁
+    cases pval₁ <;> cases pval₂
+    <;> simp only [Except.ok.injEq] at h₁
     case value.value v₁ v₂ =>
       right ; exact And.intro (by exists v₁) (by exists v₂)
     case value.residual v₁ r₂ =>
       cases v₁
       case prim p =>
-        cases p <;> simp at h₁
+        cases p <;> simp only [Except.bind_ok, Except.bind_err] at h₁
         case bool b => cases b <;> simp at *
       case set s | record m => simp at h₁
       case ext x => cases x <;> simp at h₁
   case ok.error pval e =>
-    cases pval <;> simp at h₁
+    cases pval <;> simp only [Except.ok.injEq] at h₁
     case value v =>
       cases v
       case prim p =>
-        cases p <;> simp at h₁
+        cases p <;> simp only [Except.bind_ok, Except.bind_err] at h₁
         case bool b =>
-          cases b <;> simp at h₁ <;> simp [h₁]
+          cases b
+          <;> simp only [reduceIte, Except.ok.injEq, Partial.Value.value.injEq] at h₁
+          <;> simp [h₁]
       case set s | record m => simp at h₁
       case ext x => cases x <;> simp at h₁
 

--- a/cedar-lean/Cedar/Thm/Partial/Evaluation/Or.lean
+++ b/cedar-lean/Cedar/Thm/Partial/Evaluation/Or.lean
@@ -54,4 +54,43 @@ theorem on_concrete_eqv_concrete_eval {x₁ x₂ : Spec.Expr} {request : Spec.Re
             cases v <;> try simp only [Except.bind_err]
             case prim p => cases p <;> simp
 
+/--
+  If partial-evaluating a `Partial.Expr.or` produces `ok` with a concrete
+  value, then so would partial-evaluating either of the operands, unless the
+  `or` short-circuits
+-/
+theorem evals_to_concrete_then_operands_eval_to_concrete {x₁ x₂ : Partial.Expr} {request : Partial.Request} {entities : Partial.Entities} :
+  EvaluatesToConcrete (Partial.Expr.or x₁ x₂) request entities →
+  Partial.evaluate x₁ request entities = .ok (.value (.prim (.bool true))) ∨
+  (EvaluatesToConcrete x₁ request entities ∧ EvaluatesToConcrete x₂ request entities)
+:= by
+  unfold EvaluatesToConcrete
+  intro h₁
+  unfold Partial.evaluate at h₁
+  replace ⟨v, h₁⟩ := h₁
+  cases hx₁ : Partial.evaluate x₁ request entities
+  <;> cases hx₂ : Partial.evaluate x₂ request entities
+  <;> simp [hx₁, hx₂, Spec.Value.asBool] at h₁
+  case ok.ok pval₁ pval₂ =>
+    cases pval₁ <;> cases pval₂ <;> simp at h₁
+    case value.value v₁ v₂ =>
+      right ; exact And.intro (by exists v₁) (by exists v₂)
+    case value.residual v₁ r₂ =>
+      cases v₁
+      case prim p =>
+        cases p <;> simp at h₁
+        case bool b => cases b <;> simp at *
+      case set s | record m => simp at h₁
+      case ext x => cases x <;> simp at h₁
+  case ok.error pval e =>
+    cases pval <;> simp at h₁
+    case value v =>
+      cases v
+      case prim p =>
+        cases p <;> simp at h₁
+        case bool b =>
+          cases b <;> simp at h₁ <;> simp [h₁]
+      case set s | record m => simp at h₁
+      case ext x => cases x <;> simp at h₁
+
 end Cedar.Thm.Partial.Evaluation.Or

--- a/cedar-lean/Cedar/Thm/Partial/Evaluation/Record.lean
+++ b/cedar-lean/Cedar/Thm/Partial/Evaluation/Record.lean
@@ -187,7 +187,7 @@ theorem evals_to_concrete_then_vals_eval_to_concrete {attrs : List (Attr × Part
   list of concrete vals, then it produces the same list of concrete vals after
   any substitution of unknowns
 -/
-theorem mapM_subst_preserves_evaluation_to_values {attrs : List (Attr × Partial.Expr)} {req req' : Partial.Request} {entities : Partial.Entities} {subsmap : Map Unknown Partial.Value}
+theorem mapM_subst_snd_preserves_evaluation_to_values {attrs : List (Attr × Partial.Expr)} {req req' : Partial.Request} {entities : Partial.Entities} {subsmap : Map Unknown Partial.Value}
   (ih : ∀ kv ∈ attrs, SubstPreservesEvaluationToConcrete kv.snd req req' entities subsmap) :
   req.subst subsmap = some req' →
   ∀ (pvals : List (Attr × Partial.Value)),
@@ -227,7 +227,7 @@ theorem mapM_subst_preserves_evaluation_to_values {attrs : List (Attr × Partial
             unfold SubstPreservesEvaluationToConcrete at ih_hd
             simp only [ih_hd h_req v h₃] at h₄
         case ok hd'_pval =>
-          have ih₂ := mapM_subst_preserves_evaluation_to_values ih_tl h_req tl_pvals h₅ (by
+          have ih₂ := mapM_subst_snd_preserves_evaluation_to_values ih_tl h_req tl_pvals h₅ (by
             unfold IsAllConcrete
             apply List.all_some_implies_mapM_some
             intro tl_pval h₆
@@ -296,7 +296,7 @@ theorem subst_preserves_evaluation_to_value {attrs : List (Attr × Partial.Expr)
     simp only
     rw [mapM₂_eq_mapM_partial_bindAttr (Partial.evaluate · req' (entities.subst subsmap))]
     simp only [Partial.bindAttr] at *
-    rw [mapM_subst_preserves_evaluation_to_values ih h_req pvals h₁ (by
+    rw [mapM_subst_snd_preserves_evaluation_to_values ih h_req pvals h₁ (by
       unfold IsAllConcrete
       exists (avs.map Prod.snd)
       simp only [List.mapM_map]

--- a/cedar-lean/Cedar/Thm/Partial/Evaluation/Record.lean
+++ b/cedar-lean/Cedar/Thm/Partial/Evaluation/Record.lean
@@ -192,7 +192,7 @@ theorem mapM_subst_preserves_evaluation_to_values {attrs : List (Attr × Partial
   req.subst subsmap = some req' →
   ∀ (pvals : List (Attr × Partial.Value)),
     attrs.mapM (λ kv => do let v ← Partial.evaluate kv.snd req entities ; .ok (kv.fst, v)) = .ok pvals →
-    is_all_concrete (pvals.map Prod.snd) →
+    IsAllConcrete (pvals.map Prod.snd) →
     (attrs.map (λ kv => (kv.fst, kv.snd.subst subsmap))).mapM (λ kv => do let v ← Partial.evaluate kv.snd req' (entities.subst subsmap) ; .ok (kv.fst, v)) = .ok pvals
 := by
   intro h_req pvals h₁ h₂
@@ -210,7 +210,7 @@ theorem mapM_subst_preserves_evaluation_to_values {attrs : List (Attr × Partial
     cases h₃ : Partial.evaluate xhd req entities
     <;> simp only [h₃, Except.bind_err, Except.bind_ok] at h₁
     case ok hd_pval =>
-      unfold is_all_concrete at h₂
+      unfold IsAllConcrete at h₂
       replace ⟨vs, h₂⟩ := h₂
       replace ⟨h₂, h₂'⟩ := And.intro (List.mapM_some_implies_all_some h₂) (List.mapM_some_implies_all_from_some h₂)
       cases h₅ : tl.mapM (λ kv => do let v ← Partial.evaluate kv.snd req entities ; .ok (kv.fst, v))
@@ -228,7 +228,7 @@ theorem mapM_subst_preserves_evaluation_to_values {attrs : List (Attr × Partial
             simp only [ih_hd h_req v h₃] at h₄
         case ok hd'_pval =>
           have ih₂ := mapM_subst_preserves_evaluation_to_values ih_tl h_req tl_pvals h₅ (by
-            unfold is_all_concrete
+            unfold IsAllConcrete
             apply List.all_some_implies_mapM_some
             intro tl_pval h₆
             replace ⟨v, _, h₂⟩ := h₂ tl_pval (by simp [h₆])
@@ -297,7 +297,7 @@ theorem subst_preserves_evaluation_to_value {attrs : List (Attr × Partial.Expr)
     rw [mapM₂_eq_mapM_partial_bindAttr (Partial.evaluate · req' (entities.subst subsmap))]
     simp only [Partial.bindAttr] at *
     rw [mapM_subst_preserves_evaluation_to_values ih h_req pvals h₁ (by
-      unfold is_all_concrete
+      unfold IsAllConcrete
       exists (avs.map Prod.snd)
       simp only [List.mapM_map]
       exact mapM_pairs_snd h₂

--- a/cedar-lean/Cedar/Thm/Partial/Evaluation/Record.lean
+++ b/cedar-lean/Cedar/Thm/Partial/Evaluation/Record.lean
@@ -244,7 +244,8 @@ theorem mapM_subst_preserves_evaluation_to_values {attrs : List (Attr × Partial
             simp only [ih_hd h_req hd_val h₃, Except.ok.injEq] at h₄
             exact h₄.symm
 
-private theorem lemma {pvals : List (Attr × Partial.Value)} {pairs : List (Attr × Spec.Value)}:
+/-- Helper lemma proved by induction -/
+private theorem mapM_pairs_snd {pvals : List (Attr × Partial.Value)} {pairs : List (Attr × Spec.Value)}:
   pvals.mapM (λ kv => match kv.snd with
       | .value v => some (kv.fst, v)
       | .residual _ => none)
@@ -268,7 +269,7 @@ private theorem lemma {pvals : List (Attr × Partial.Value)} {pairs : List (Attr
     subst h₃
     exists (tl'.map Prod.snd)
     simp only [List.map_cons, and_true]
-    exact lemma h₂
+    exact mapM_pairs_snd h₂
 
 /--
   Inductive argument that if partial-evaluation of a `Partial.Expr.record`
@@ -299,7 +300,7 @@ theorem subst_preserves_evaluation_to_value {attrs : List (Attr × Partial.Expr)
       unfold is_all_concrete
       exists (avs.map Prod.snd)
       simp only [List.mapM_map]
-      exact lemma h₂
+      exact mapM_pairs_snd h₂
     )]
     simp only [Except.bind_ok, h₂]
 

--- a/cedar-lean/Cedar/Thm/Partial/Evaluation/Set.lean
+++ b/cedar-lean/Cedar/Thm/Partial/Evaluation/Set.lean
@@ -124,7 +124,7 @@ theorem mapM_subst_preserves_evaluation_to_values {xs : List Partial.Expr} {req 
   req.subst subsmap = some req' →
   ∀ (pvals : List Partial.Value),
     xs.mapM (Partial.evaluate · req entities) = .ok pvals →
-    is_all_concrete pvals →
+    IsAllConcrete pvals →
     (xs.map (Partial.Expr.subst subsmap)).mapM (Partial.evaluate · req' (entities.subst subsmap)) = .ok pvals
 := by
   intro h_req pvals h₁ h₂
@@ -140,7 +140,7 @@ theorem mapM_subst_preserves_evaluation_to_values {xs : List Partial.Expr} {req 
     cases h₃ : Partial.evaluate hd req entities
     <;> simp only [h₃, Except.bind_ok, Except.bind_err] at h₁
     case ok hd_pval =>
-      unfold is_all_concrete at h₂
+      unfold IsAllConcrete at h₂
       replace ⟨vs, h₂⟩ := h₂
       replace ⟨h₂, h₂'⟩ := And.intro (List.mapM_some_implies_all_some h₂) (List.mapM_some_implies_all_from_some h₂)
       cases h₅ : tl.mapM (Partial.evaluate · req entities)
@@ -158,7 +158,7 @@ theorem mapM_subst_preserves_evaluation_to_values {xs : List Partial.Expr} {req 
             simp only [ih_hd h_req v h₃] at h₄
         case ok hd'_pval =>
           have ih₂ := mapM_subst_preserves_evaluation_to_values ih_tl h_req tl_pvals h₅ (by
-            unfold is_all_concrete
+            unfold IsAllConcrete
             apply List.all_some_implies_mapM_some
             intro tl_pval h₆
             replace ⟨v, _, h₂⟩ := h₂ tl_pval (by simp [h₆])
@@ -196,7 +196,7 @@ theorem subst_preserves_evaluation_to_value {xs : List Partial.Expr} {req req' :
     rw [List.map₁_eq_map]
     simp only
     rw [List.mapM₁_eq_mapM (Partial.evaluate · req' (entities.subst subsmap))]
-    rw [mapM_subst_preserves_evaluation_to_values ih h_req pvals h₁ (by unfold is_all_concrete ; exists vs)]
+    rw [mapM_subst_preserves_evaluation_to_values ih h_req pvals h₁ (by unfold IsAllConcrete ; exists vs)]
     simp only [h₂, Except.bind_ok]
 
 end Cedar.Thm.Partial.Evaluation.Set

--- a/cedar-lean/Cedar/Thm/Partial/Evaluation/Unary.lean
+++ b/cedar-lean/Cedar/Thm/Partial/Evaluation/Unary.lean
@@ -21,13 +21,15 @@ import Cedar.Thm.Partial.Evaluation.Basic
 
 namespace Cedar.Thm.Partial.Evaluation.Unary
 
+open Cedar.Data
+open Cedar.Partial (Unknown)
 open Cedar.Spec (UnaryOp)
 
 /--
   `Partial.apply₁` on concrete arguments gives the same output as `Spec.apply₁`
   on the same arguments
 -/
-theorem apply₁_on_concrete_eqv_concrete {op : UnaryOp} {v : Spec.Value} :
+theorem apply₁_on_concrete_eqv_concrete (op : UnaryOp) (v : Spec.Value) :
   Partial.apply₁ op v = (Spec.apply₁ op v).map Partial.Value.value
 := by
   rfl
@@ -48,5 +50,59 @@ theorem on_concrete_eqv_concrete_eval {x₁ : Spec.Expr} {request : Spec.Request
   cases Spec.evaluate x₁ request entities <;> simp only [Except.bind_err, Except.bind_ok]
   case error e => simp [Except.map]
   case ok v₁ => rfl
+
+/--
+  If `Partial.apply₁` produces `ok` with a concrete value, then so would
+  partial-evaluating its operand
+-/
+theorem partialApply₁_returns_concrete_then_operand_evals_to_concrete {pval₁ : Partial.Value} {op : UnaryOp} :
+  Partial.apply₁ op pval₁ = .ok (.value v) →
+  ∃ v₁, pval₁ = .value v₁
+:= by
+  unfold Partial.apply₁
+  intro h₁
+  cases pval₁
+  case value v₁ => exists v₁
+  case residual r₁ => simp at h₁
+
+/--
+  If partial-evaluating a `Partial.Expr.unaryApp` produces `ok` with a concrete
+  value, then so would partial-evaluating its operand
+-/
+theorem evals_to_concrete_then_operand_evals_to_concrete {x₁ : Partial.Expr} {op : UnaryOp} {request : Partial.Request} {entities : Partial.Entities} :
+  EvaluatesToConcrete (Partial.Expr.unaryApp op x₁) request entities →
+  EvaluatesToConcrete x₁ request entities
+:= by
+  unfold EvaluatesToConcrete
+  intro h₁
+  unfold Partial.evaluate at h₁
+  replace ⟨v, h₁⟩ := h₁
+  cases hx₁ : Partial.evaluate x₁ request entities
+  <;> simp [hx₁] at h₁
+  case ok pval₁ =>
+    have ⟨v₁, hv₁⟩ := partialApply₁_returns_concrete_then_operand_evals_to_concrete h₁
+    subst pval₁
+    exists v₁
+
+/--
+  Inductive argument that if partial-evaluation of a `Partial.Expr.unaryApp`
+  returns a concrete value, then it returns the same value after any
+  substitution of unknowns
+-/
+theorem subst_preserves_evaluation_to_value {x₁ : Partial.Expr} {op : UnaryOp} {req req' : Partial.Request} {entities : Partial.Entities} {subsmap : Map Unknown Partial.Value}
+  (ih₁ : SubstPreservesEvaluationToConcrete x₁ req req' entities subsmap) :
+  SubstPreservesEvaluationToConcrete (Partial.Expr.unaryApp op x₁) req req' entities subsmap
+:= by
+  unfold SubstPreservesEvaluationToConcrete at *
+  unfold Partial.evaluate Spec.Value.asBool
+  intro h_req v
+  specialize ih₁ h_req
+  unfold Partial.Expr.subst
+  cases hx₁ : Partial.evaluate x₁ req entities
+  <;> simp [hx₁] at *
+  case ok pval₁ =>
+    cases pval₁ <;> simp at *
+    case value v₁ => simp [ih₁]
+    case residual r₁ => simp [Partial.apply₁]
 
 end Cedar.Thm.Partial.Evaluation.Unary

--- a/cedar-lean/Cedar/Thm/Partial/Evaluation/Unary.lean
+++ b/cedar-lean/Cedar/Thm/Partial/Evaluation/Unary.lean
@@ -63,7 +63,7 @@ theorem partialApply₁_returns_concrete_then_operand_evals_to_concrete {pval₁
   intro h₁
   cases pval₁
   case value v₁ => exists v₁
-  case residual r₁ => simp at h₁
+  case residual r₁ => simp only [Except.ok.injEq] at h₁
 
 /--
   If partial-evaluating a `Partial.Expr.unaryApp` produces `ok` with a concrete
@@ -78,7 +78,7 @@ theorem evals_to_concrete_then_operand_evals_to_concrete {x₁ : Partial.Expr} {
   unfold Partial.evaluate at h₁
   replace ⟨v, h₁⟩ := h₁
   cases hx₁ : Partial.evaluate x₁ request entities
-  <;> simp [hx₁] at h₁
+  <;> simp only [hx₁, Except.bind_err, Except.bind_ok] at h₁
   case ok pval₁ =>
     have ⟨v₁, hv₁⟩ := partialApply₁_returns_concrete_then_operand_evals_to_concrete h₁
     subst pval₁
@@ -99,10 +99,10 @@ theorem subst_preserves_evaluation_to_value {x₁ : Partial.Expr} {op : UnaryOp}
   specialize ih₁ h_req
   unfold Partial.Expr.subst
   cases hx₁ : Partial.evaluate x₁ req entities
-  <;> simp [hx₁] at *
+  <;> simp only [hx₁, Except.ok.injEq, Except.bind_ok, Except.bind_err, false_implies, forall_const] at *
   case ok pval₁ =>
-    cases pval₁ <;> simp at *
-    case value v₁ => simp [ih₁]
+    cases pval₁
+    case value v₁ => simp only [Partial.Value.value.injEq, forall_eq'] at * ; simp [ih₁]
     case residual r₁ => simp [Partial.apply₁]
 
 end Cedar.Thm.Partial.Evaluation.Unary

--- a/cedar-lean/Cedar/Thm/Partial/Evaluation/Var.lean
+++ b/cedar-lean/Cedar/Thm/Partial/Evaluation/Var.lean
@@ -205,13 +205,12 @@ theorem subst_preserves_evaluateVar_to_value {var : Var} {req req' : Partial.Req
   If partial-evaluation of a `Var` returns a concrete value, then it returns the
   same value after any substitution of unknowns
 -/
-theorem subst_preserves_evaluation_to_value {var : Var} {req req' : Partial.Request} {entities : Partial.Entities} {v : Spec.Value} {subsmap : Map Unknown Partial.Value}
+theorem subst_preserves_evaluation_to_value (var : Var) (req req' : Partial.Request) (entities : Partial.Entities) (subsmap : Map Unknown Partial.Value)
   (wf : req.AllWellFormed) :
-  req.subst subsmap = some req' →
-  Partial.evaluate (Partial.Expr.var var) req entities = .ok (.value v) →
-  Partial.evaluate ((Partial.Expr.var var).subst substmap) req' (entities.subst subsmap) = .ok (.value v)
+  SubstPreservesEvaluationToConcrete (Partial.Expr.var var) req req' entities subsmap
 := by
-  unfold Partial.Expr.subst Partial.evaluate
-  exact subst_preserves_evaluateVar_to_value wf
+  unfold SubstPreservesEvaluationToConcrete Partial.Expr.subst Partial.evaluate
+  intro h_req v
+  exact subst_preserves_evaluateVar_to_value wf h_req
 
 end Cedar.Thm.Partial.Evaluation.Var

--- a/cedar-lean/Cedar/Thm/Partial/Subst.lean
+++ b/cedar-lean/Cedar/Thm/Partial/Subst.lean
@@ -15,10 +15,14 @@
 -/
 
 import Cedar.Data.Map
+import Cedar.Partial.Entities
 import Cedar.Partial.Expr
+import Cedar.Partial.Request
 import Cedar.Partial.Value
 import Cedar.Spec.Expr
 import Cedar.Thm.Data.List
+import Cedar.Thm.Data.LT
+import Cedar.Thm.Partial.Evaluation.Basic
 
 /-! ## Lemmas about `subst` operations -/
 
@@ -26,6 +30,7 @@ namespace Cedar.Thm.Partial.Subst
 
 open Cedar.Data
 open Cedar.Partial (Unknown)
+open Cedar.Spec (Attr EntityUID)
 
 /--
   subst on a concrete expression is that expression
@@ -119,3 +124,252 @@ decreasing_by
     have h₃ := Map.sizeOf_lt_of_kvs m
     simp [Map.kvs] at h₂ h₃
     omega
+
+/--
+  Partial.Value.subst preserves well-formedness
+-/
+theorem val_subst_preserves_wf {v v' : Partial.Value} {subsmap : Map Unknown Partial.Value} :
+  v.WellFormed →
+  v.subst subsmap = some v' →
+  v'.WellFormed
+:= by
+  unfold Partial.Value.WellFormed Partial.Value.subst
+  cases v <;> simp
+  case value v =>
+    intro h₁ h₂
+    subst h₂
+    simp [h₁]
+  case residual r =>
+    intro h₁
+    subst h₁
+    simp
+
+/--
+  Partial.Request.subst preserves well-formedness
+-/
+theorem req_subst_preserves_wf {req req' : Partial.Request} {subsmap : Map Unknown Partial.Value} :
+  req.AllWellFormed →
+  req.subst subsmap = some req' →
+  req'.AllWellFormed
+:= by
+  unfold Partial.Request.AllWellFormed Partial.Request.subst
+  intro wf h₁
+  have ⟨wf_c, wf_vals⟩ := wf ; clear wf
+  simp at h₁
+  replace ⟨principal, _, ⟨action, _, ⟨resource, _, h₁⟩⟩⟩ := h₁
+  subst h₁
+  simp
+  apply And.intro (Map.mapOnValues_wf.mp wf_c)
+  intro pval' h₁
+  rw [Map.values_mapOnValues] at h₁
+  replace ⟨pval, h₁, h₂⟩ := List.mem_map.mp h₁
+  subst pval'
+  apply val_subst_preserves_wf (wf_vals pval h₁) (subsmap := subsmap)
+  rfl
+
+/--
+  Partial.Request.subst preserves a known principal UID
+-/
+theorem req_subst_preserves_known_principal {req req' : Partial.Request} {uid : EntityUID} {subsmap : Map Unknown Partial.Value} :
+  req.principal = .known uid →
+  req.subst subsmap = some req' →
+  req'.principal = .known uid
+:= by
+  intro h₁ h_req
+  simp [Partial.Request.subst] at h_req
+  replace ⟨principal, h_p, ⟨action, _, ⟨resource, _, h_req⟩⟩⟩ := h_req
+  subst req'
+  simp only
+  simp [h₁, Partial.UidOrUnknown.subst] at h_p
+  exact h_p.symm
+
+/--
+  Partial.Request.subst preserves a known action UID
+-/
+theorem req_subst_preserves_known_action {req req' : Partial.Request} {uid : EntityUID} {subsmap : Map Unknown Partial.Value} :
+  req.action = .known uid →
+  req.subst subsmap = some req' →
+  req'.action = .known uid
+:= by
+  intro h₁ h_req
+  simp [Partial.Request.subst] at h_req
+  replace ⟨principal, _, ⟨action, h_a, ⟨resource, _, h_req⟩⟩⟩ := h_req
+  subst req'
+  simp only
+  simp [h₁, Partial.UidOrUnknown.subst] at h_a
+  exact h_a.symm
+
+/--
+  Partial.Request.subst preserves a known resource UID
+-/
+theorem req_subst_preserves_known_resource {req req' : Partial.Request} {uid : EntityUID} {subsmap : Map Unknown Partial.Value} :
+  req.resource = .known uid →
+  req.subst subsmap = some req' →
+  req'.resource = .known uid
+:= by
+  intro h₁ h_req
+  simp [Partial.Request.subst] at h_req
+  replace ⟨principal, _, ⟨action, _, ⟨resource, h_r, h_req⟩⟩⟩ := h_req
+  subst req'
+  simp only
+  simp [h₁, Partial.UidOrUnknown.subst] at h_r
+  exact h_r.symm
+
+/--
+  Partial.Request.subst preserves the keyset of `context`
+-/
+theorem req_subst_preserves_keys_of_context {req req' : Partial.Request} {subsmap : Map Unknown Partial.Value} :
+  req.subst subsmap = some req' →
+  req.context.keys = req'.context.keys
+:= by
+  unfold Partial.Request.subst
+  simp only [Option.bind_eq_bind, Option.bind_eq_some, Option.some.injEq, forall_exists_index,
+    and_imp]
+  intro p _ a _ r _ _
+  subst req' ; simp only
+  exact (Map.keys_mapOnValues (Partial.Value.subst subsmap) req.context).symm
+
+/--
+  Partial.Request.subst preserves concrete values in the `context`
+-/
+theorem req_subst_preserves_concrete_context_vals {req req' : Partial.Request} {k : Attr} {subsmap : Map Unknown Partial.Value} :
+  (k, .value v) ∈ req.context.kvs →
+  req.subst subsmap = some req' →
+  (k, .value v) ∈ req'.context.kvs
+:= by
+  unfold Partial.Request.subst
+  simp
+  intro h₁ p _ a _ r _ h₂
+  subst req'
+  simp
+  rw [← subst_concrete_value v subsmap]
+  exact Map.in_kvs_in_mapOnValues h₁
+
+/--
+  Partial.EntityData.subst preserves well-formedness
+-/
+theorem entitydata_subst_preserves_wf {ed : Partial.EntityData} (subsmap : Map Unknown Partial.Value) :
+  ed.WellFormed → (ed.subst subsmap).WellFormed
+:= by
+  unfold Partial.EntityData.WellFormed Partial.EntityData.subst
+  intro h₁
+  simp only
+  and_intros
+  · exact Map.mapOnValues_wf.mp h₁.left
+  · exact h₁.right
+
+/--
+  Partial.Entities.subst preserves well-formedness
+-/
+theorem entities_subst_preserves_wf {entities : Partial.Entities} (subsmap : Map Unknown Partial.Value) :
+  entities.AllWellFormed → (entities.subst subsmap).AllWellFormed
+:= by
+  unfold Partial.Entities.AllWellFormed Partial.Entities.subst
+  intro h₁
+  constructor
+  · exact Map.mapOnValues_wf.mp h₁.left
+  · intro ed' h₂
+    simp [Map.values_mapOnValues] at h₂
+    replace ⟨ed, h₂, h₃⟩ := h₂
+    subst ed'
+    exact entitydata_subst_preserves_wf subsmap (h₁.right ed h₂)
+
+/--
+  Partial.EntityData.subst preserves .ancestors
+-/
+theorem entitydata_subst_preserves_ancestors (ed : Partial.EntityData) (subsmap : Map Unknown Partial.Value) :
+  ed.ancestors = (ed.subst subsmap).ancestors
+:= by
+  simp [Partial.EntityData.subst]
+
+/--
+  Partial.EntityData.subst preserves .contains on .attrs
+-/
+theorem entitydata_subst_preserves_contains_on_attrs (ed : Partial.EntityData) (attr : Attr) (subsmap : Map Unknown Partial.Value)
+  (wf : ed.WellFormed) :
+  ed.attrs.contains attr = (ed.subst subsmap).attrs.contains attr
+:= by
+  simp [Partial.EntityData.subst]
+  unfold Partial.EntityData.WellFormed at wf
+  apply Eq.symm
+  cases h₁ : ed.attrs.contains attr
+  case false =>
+    rw [← Bool.not_eq_true] at *
+    rw [Map.contains_iff_some_find?] at *
+    simp at *
+    intro pval h₂
+    conv at h₁ => intro pval ; rw [← Map.in_list_iff_find?_some wf.left]
+    rw [← Map.in_list_iff_find?_some (Map.mapOnValues_wf.mp wf.left)] at h₂
+    simp [Map.mapOnValues, Map.kvs] at h₂
+    replace ⟨(attr', pval'), h₂, h₃, h₄⟩ := h₂
+    subst h₃ h₄
+    simp [Map.kvs] at h₁
+    exact h₁ pval' h₂
+  case true =>
+    rw [Map.contains_iff_some_find?] at *
+    replace ⟨pval, h₁⟩ := h₁
+    rw [← Map.in_list_iff_find?_some wf.left] at h₁
+    exists (pval.subst subsmap)
+    rw [← Map.in_list_iff_find?_some (Map.mapOnValues_wf.mp wf.left)]
+    simp [Map.mapOnValues, Map.kvs]
+    exists (attr, pval)
+
+/--
+  Partial.EntityData.subst preserves concrete attribute values
+-/
+theorem entitydata_subst_preserves_concrete_attrs {ed : Partial.EntityData} (subsmap : Map Unknown Partial.Value) :
+  (k, .value v) ∈ ed.attrs.kvs → (k, .value v) ∈ (ed.subst subsmap).attrs.kvs
+:= by
+  simp [Partial.EntityData.subst]
+  intro h₁
+  rw [← subst_concrete_value v subsmap]
+  exact Map.in_kvs_in_mapOnValues h₁
+
+/--
+  Partial.Entities.subst preserves .ancestorsOrEmpty
+-/
+theorem entities_subst_preserves_ancestorsOrEmpty (entities : Partial.Entities) (uid : EntityUID) (subsmap : Map Unknown Partial.Value) :
+  entities.ancestorsOrEmpty uid = (entities.subst subsmap).ancestorsOrEmpty uid
+:= by
+  unfold Partial.Entities.subst Partial.Entities.ancestorsOrEmpty
+  cases h₁ : entities.find? uid
+  case none => simp [Map.find?_mapOnValues_none _ h₁]
+  case some ed =>
+    simp [Map.find?_mapOnValues_some _ h₁]
+    exact entitydata_subst_preserves_ancestors ed subsmap
+
+/--
+  Partial.Entities.subst preserves concrete attribute values
+-/
+theorem entities_subst_preserves_concrete_attrs {entities : Partial.Entities} {uid : EntityUID} (subsmap : Map Unknown Partial.Value) :
+  entities.attrs uid = .ok attrs →
+  (k, .value v) ∈ attrs.kvs →
+  ∃ attrs', (entities.subst subsmap).attrs uid = .ok attrs' ∧ (k, .value v) ∈ attrs'.kvs
+:= by
+  unfold Partial.Entities.subst Partial.Entities.attrs
+  cases h₁ : entities.findOrErr uid Spec.Error.entityDoesNotExist <;> simp
+  case ok ed =>
+    intro h h₂ ; subst h
+    have h₃ := entitydata_subst_preserves_concrete_attrs subsmap h₂
+    exists (ed.subst subsmap).attrs
+    apply And.intro _ h₃
+    simp [Map.findOrErr_mapOnValues]
+    simp [h₁, Except.map]
+
+/--
+  Partial.Entities.subst preserves `Map.contains` for the attrs maps
+-/
+theorem entities_subst_preserves_contains_on_attrsOrEmpty (entities : Partial.Entities) (uid : EntityUID) (attr : Attr) (subsmap : Map Unknown Partial.Value)
+  (wf : entities.AllWellFormed) :
+  (entities.attrsOrEmpty uid).contains attr = ((entities.subst subsmap).attrsOrEmpty uid).contains attr
+:= by
+  unfold Partial.Entities.subst Partial.Entities.attrsOrEmpty
+  cases h₁ : entities.find? uid
+  case none => simp [Map.find?_mapOnValues_none _ h₁]
+  case some ed =>
+    simp [Map.find?_mapOnValues_some _ h₁]
+    apply entitydata_subst_preserves_contains_on_attrs ed attr subsmap
+    unfold Partial.Entities.AllWellFormed at wf
+    apply wf.right
+    simp [← Map.in_list_iff_find?_some wf.left] at h₁
+    exact Map.in_list_in_values h₁


### PR DESCRIPTION
A major lemma needed for the PE soundness proof; split into its own PR because it's large enough by itself.


