### PR TITLE
Revise model and proofs for the IPAddr extension.

### DIFF
--- a/cedar-lean/Cedar/Spec/Ext/IPAddr.lean
+++ b/cedar-lean/Cedar/Spec/Ext/IPAddr.lean
@@ -20,133 +20,119 @@ namespace Cedar.Spec.Ext
 
 namespace IPAddr
 
------ UInt128 -----
-
--- Type of 128-bit unsigned numbers: 0 <= n < 2^128.
-abbrev UInt128 := Fin 0x100000000000000000000000000000000
-
-def UInt128.ofNat (n : Nat) : UInt128 := Fin.ofNat n
-
-instance : Coe UInt128 Nat where
-  coe n := n.1
-
-instance : Coe Nat UInt128 where
-  coe n := Fin.ofNat n
-
-instance : Coe UInt8 Nat where
-  coe n := n.toNat
-
-instance : Coe UInt16 Nat where
-  coe n := n.toNat
-
-instance : Coe UInt32 Nat where
-  coe n := n.toNat
-
-instance : Coe Nat UInt32 where
-  coe n := UInt32.ofNat n
+open BitVec
 
 ----- IPv4Addr and IPv6Addr -----
+
+abbrev ADDR_SIZE (w : Nat) := 2 ^ w
+
+abbrev V4_WIDTH := 5
+abbrev V6_WIDTH := 7
+abbrev V4_SIZE := ADDR_SIZE V4_WIDTH
+abbrev V6_SIZE := ADDR_SIZE V6_WIDTH
+
+abbrev IPNetAddr (w : Nat) := BitVec (ADDR_SIZE w)
 
 /--
 IPv4 address: a 32 bit number partitioned into 4 groups. a0 is most signifcant
 and a3 is the least significant. In other words, the number represented is
-a0++a1++a2++a3
+a0++a1++a2++a3.
 --/
-abbrev IPv4Addr := UInt32
+abbrev IPv4Addr := IPNetAddr V4_WIDTH
 
-def IPv4Addr.toUInt128 (ip4 : IPv4Addr) : UInt128 := UInt128.ofNat ip4.toNat
-
-def UInt128.toIPv4Addr (bits : UInt128) : IPv4Addr := UInt32.ofNat bits
-
-def IPv4Addr.mk (a₀ a₁ a₂ a₃ : UInt8) : IPv4Addr :=
-  (a₀ : Nat) <<< 24 |||
-  (a₁ : Nat) <<< 16 |||
-  (a₂ : Nat) <<<  8 |||
-  (a₃ : Nat)
+def IPv4Addr.mk (a₀ a₁ a₂ a₃ : BitVec 8) : IPv4Addr :=
+  a₀ ++ a₁ ++ a₂ ++ a₃
 
 /--
 IPv6 address: a 128 bit number partitioned into 8 groups. a0 is most signifcant
 and a7 is the least significant. In other words, the number represented is
-a0++a1++a2++a3++a4++a5++a6++a7
+a0++a1++a2++a3++a4++a5++a6++a7.
 --/
-abbrev IPv6Addr := UInt128
+abbrev IPv6Addr := IPNetAddr V6_WIDTH
 
-def IPv6Addr.toUInt128 (ip6 : IPv6Addr) : UInt128 := ip6
+def IPv6Addr.mk (a₀ a₁ a₂ a₃ a₄ a₅ a₆ a₇ : BitVec 16) : IPv6Addr :=
+  a₀ ++ a₁ ++ a₂ ++ a₃ ++ a₄ ++ a₅ ++ a₆ ++ a₇
 
-def UInt128.toIPv6Addr (bits : UInt128) : IPv6Addr := bits
+----- IPNetPrefix, CIDR, and IPNet -----
 
-def IPv6Addr.mk (a₀ a₁ a₂ a₃ a₄ a₅ a₆ a₇ : UInt16) : IPv6Addr :=
-  (a₀ : Nat) <<< 112 |||
-  (a₁ : Nat) <<<  96 |||
-  (a₂ : Nat) <<<  80 |||
-  (a₃ : Nat) <<<  64 |||
-  (a₄ : Nat) <<<  48 |||
-  (a₅ : Nat) <<<  32 |||
-  (a₆ : Nat) <<<  16 |||
-  (a₇ : Nat)
+abbrev IPNetPrefix (n : Nat) := Option (BitVec n)
+abbrev IPv4Prefix := IPNetPrefix V4_WIDTH
+abbrev IPv6Prefix := IPNetPrefix V6_WIDTH
 
------ IPNet -----
+def IPNetPrefix.ofNat (w : Nat) (pre : Nat) : IPNetPrefix w :=
+  if pre < ADDR_SIZE w then .some pre#w else .none
 
-def V4_SIZE := 32
-abbrev Prefix4 := Fin (V4_SIZE + 1)
+def IPNetPrefix.toNat {w} : IPNetPrefix w → Nat
+  | .none         => ADDR_SIZE w
+  | .some preSize => preSize.toNat
 
-def V6_SIZE := 128
-abbrev Prefix6 := Fin (V6_SIZE + 1)
+instance {w} : Coe Nat (IPNetPrefix w) where
+  coe n := IPNetPrefix.ofNat w n
 
-inductive IPNet where
-  | V4 (v4 : IPv4Addr) (prefix4 : Prefix4)
-  | V6 (v6 : IPv6Addr) (prefix6 : Prefix6)
+instance : CoeOut (IPNetPrefix w) Nat where
+  coe p := p.toNat
 
-def IPNet.isV4 : IPNet → Bool
-  | .V4 _ _ => true
-  | _       => false
+instance instOfNat : OfNat (IPNetPrefix w) n
+  where ofNat := IPNetPrefix.ofNat w n
 
-def IPNet.isV6 : IPNet → Bool
-  | .V6 _ _ => true
-  | _       => false
+structure CIDR (w : Nat) where
+  addr : IPNetAddr w
+  pre  : IPNetPrefix w  -- We use "pre" because "prefix" is a keyword in Lean
 
-def IPNet.toUInt128 : IPNet → UInt128
-  | .V4 v4 _ => v4.toUInt128
-  | .V6 v6 _ => v6.toUInt128
+def CIDR.subnetWidth {w} (cidr : CIDR w) : BitVec (ADDR_SIZE w) :=
+  let n := ADDR_SIZE w
+  match cidr.pre with
+  | .none            => 0#n
+  | .some prefixSize => n#n - (prefixSize.zeroExtend n)
 
-def IPNet.subnetWidth : IPNet → UInt128
-  | .V4 _ p4 => V4_SIZE - p4
-  | .V6 _ p6 => V6_SIZE - p6
-
-def IPNet.applySubnetMask (ip : IPNet) : UInt128 :=
-  let width := ip.subnetWidth
-  (ip.toUInt128 >>> width) <<< width
-
-def IPNet.range (ip : IPNet) : UInt128 × UInt128 :=
-  let lo := ip.applySubnetMask
-  let hi := lo + (1 <<< ip.subnetWidth) - 1
+def CIDR.range {w} (cidr : CIDR w) : (IPNetAddr w) × (IPNetAddr w) :=
+  let n := ADDR_SIZE w
+  let width := cidr.subnetWidth
+  let lo := (cidr.addr >>> width) <<< width
+  let hi := lo + (1#n <<< width) - 1#n
   (lo, hi)
 
+def CIDR.inRange {w} (cidr₁ cidr₂ : CIDR w) : Bool :=
+  let r₁ := cidr₁.range
+  let r₂ := cidr₂.range
+  r₂.2 ≥ r₁.2 && r₁.1 ≥ r₂.1
+
+inductive IPNet where
+  | V4 : CIDR V4_WIDTH → IPNet
+  | V6 : CIDR V6_WIDTH → IPNet
+
+def IPNet.isV4 : IPNet → Bool
+  | .V4 _ => true
+  | _     => false
+
+def IPNet.isV6 : IPNet → Bool
+  | .V6 _ => true
+  | _     => false
+
 def IPNet.inRange : IPNet → IPNet → Bool
-  | .V4 _ _, .V6 _ _ => false
-  | .V6 _ _, .V4 _ _ => false
-  | ip₁    , ip₂     =>
-    let r₁ := ip₁.range
-    let r₂ := ip₂.range
-    r₂.2 ≥ r₁.2 && r₁.1 ≥ r₂.1
+  | .V4 cidr₁, .V4 cidr₂
+  | .V6 cidr₁, .V6 cidr₂ => cidr₁.inRange cidr₂
+  | _, _                 => false
 
 def LOOP_BACK_ADDRESS_V4 := IPv4Addr.mk 127 0 0 0
 def LOOP_BACK_ADDRESS_V6 := IPv6Addr.mk 0 0 0 0 0 0 0 1
-def LOOP_BACK_NET_V4     := IPNet.V4 LOOP_BACK_ADDRESS_V4 8
-def LOOP_BACK_NET_V6     := IPNet.V6 LOOP_BACK_ADDRESS_V6 128
+def LOOP_BACK_CIDR_V4    := CIDR.mk LOOP_BACK_ADDRESS_V4 8
+def LOOP_BACK_CIDR_V6    := CIDR.mk LOOP_BACK_ADDRESS_V6 128
 
 def MULTICAST_ADDRESS_V4 := IPv4Addr.mk 224 0 0 0
 def MULTICAST_ADDRESS_V6 := IPv6Addr.mk 65280 0 0 0 0 0 0 0
-def MULTICAST_NET_V4     := IPNet.V4 MULTICAST_ADDRESS_V4 4
-def MULTICAST_NET_V6     := IPNet.V6 MULTICAST_ADDRESS_V6 8
+def MULTICAST_CIDR_V4    := CIDR.mk MULTICAST_ADDRESS_V4 4
+def MULTICAST_CIDR_V6    := CIDR.mk MULTICAST_ADDRESS_V6 8
 
-def IPNet.isLoopback (ip : IPNet) : Bool :=
-  ip.inRange (if ip.isV4 then LOOP_BACK_NET_V4 else LOOP_BACK_NET_V6)
+def IPNet.isLoopback : IPNet → Bool
+  | .V4 cidr => cidr.inRange LOOP_BACK_CIDR_V4
+  | .V6 cidr => cidr.inRange LOOP_BACK_CIDR_V6
 
-def IPNet.isMulticast (ip : IPNet) : Bool :=
-  ip.inRange (if ip.isV4 then MULTICAST_NET_V4 else MULTICAST_NET_V6)
+def IPNet.isMulticast : IPNet → Bool
+  | .V4 cidr => cidr.inRange MULTICAST_CIDR_V4
+  | .V6 cidr => cidr.inRange MULTICAST_CIDR_V6
 
-def parseCIDR (str : String) (digits : Nat) (size : Nat) : Option (Fin (size + 1)) :=
+private def parsePrefixNat (str : String) (digits : Nat) (size : Nat) : Option (Fin (size + 1)) :=
   let len := str.length
   if 0 < len && len ≤ digits && (str.startsWith "0" → str = "0")
   then do
@@ -154,19 +140,15 @@ def parseCIDR (str : String) (digits : Nat) (size : Nat) : Option (Fin (size + 1
     if n ≤ size then .some (Fin.ofNat n) else .none
   else .none
 
-def parseCIDRV4 (str : String) : Option Prefix4 := parseCIDR str 2 V4_SIZE
-
-def parseCIDRV6 (str : String) : Option Prefix6 := parseCIDR str 3 V6_SIZE
-
-def parseNumV4 (str : String) : Option UInt8 :=
+private def parseNumV4 (str : String) : Option (BitVec 8) :=
   let len := str.length
   if 0 < len && len ≤ 3 && (str.startsWith "0" → str = "0")
   then do
     let n ← str.toNat?
-    if n ≤ 0xff then .some (UInt8.ofNat n) else .none
+    if n ≤ 0xff then .some n#8 else .none
   else .none
 
-def parseSegsV4 (str : String) : Option IPv4Addr :=
+private def parseSegsV4 (str : String) : Option IPv4Addr :=
   match str.split (· = '.') with
   | [s₀, s₁, s₂, s₃] => do
     let a₀ ← parseNumV4 s₀
@@ -176,16 +158,16 @@ def parseSegsV4 (str : String) : Option IPv4Addr :=
     .some (IPv4Addr.mk a₀ a₁ a₂ a₃)
   | _ => .none
 
-def parseIPv4Net (str : String) : Option IPNet :=
+private def parseIPv4Net (str : String) : Option IPNet :=
   match str.split (· = '/') with
   | strV4 :: rest => do
     let pre ←
       match rest with
-      | []       => .some (Fin.ofNat V4_SIZE)
-      | [strPre] => parseCIDRV4 strPre
+      | []       => .some (ADDR_SIZE V4_WIDTH)
+      | [strPre] => parsePrefixNat strPre 2 (ADDR_SIZE V4_WIDTH)
       | _        => .none
     let v4 ← parseSegsV4 strV4
-    .some (IPNet.V4 v4 pre)
+    .some (IPNet.V4 ⟨v4, pre⟩)
   | _ => .none
 
 private def isHexDigit (c : Char) : Bool :=
@@ -200,20 +182,20 @@ private def toHexNat (c : Char) : Nat :=
   then c.toNat - 'A'.toNat + 10
   else c.toNat
 
-def parseNumV6 (str : String) : Option UInt16 :=
+private def parseNumV6 (str : String) : Option (BitVec 16) :=
   let len := str.length
   if 0 < len && len ≤ 4 && str.all isHexDigit
   then
     let n := str.foldl (fun n c => n * 16 + toHexNat c) 0
-    if n ≤ 0xffff then .some (UInt16.ofNat n) else .none
+    if n ≤ 0xffff then .some n#16 else .none
   else .none
 
-def parseNumSegsV6 (str : String) : Option (List UInt16) :=
+private def parseNumSegsV6 (str : String) : Option (List (BitVec 16)) :=
   if str.isEmpty
   then .some []
   else (str.split (· = ':')).mapM parseNumV6
 
-def parseSegsV6 (str : String) : Option IPv6Addr := do
+private def parseSegsV6 (str : String) : Option IPv6Addr := do
   let segs ←
     match str.splitOn "::" with
     | [s₁] => parseNumSegsV6 s₁
@@ -230,24 +212,61 @@ def parseSegsV6 (str : String) : Option IPv6Addr := do
     .some (IPv6Addr.mk a₀ a₁ a₂ a₃ a₄ a₅ a₆ a₇)
   | _ => .none
 
-def parseIPv6Net (str : String) : Option IPNet :=
+private def parseIPv6Net (str : String) : Option IPNet :=
   match str.split (· = '/') with
   | strV6 :: rest => do
     let pre ←
       match rest with
-      | []       => .some (Fin.ofNat V6_SIZE)
-      | [strPre] => parseCIDRV6 strPre
+      | []       => .some (ADDR_SIZE V6_WIDTH)
+      | [strPre] => parsePrefixNat strPre 3 (ADDR_SIZE V6_WIDTH)
       | _        => .none
     let v6 ← parseSegsV6 strV6
-    .some (IPNet.V6 v6 pre)
+    .some (IPNet.V6 ⟨v6, pre⟩)
   | _ => .none
 
 def parse (str : String) : Option IPNet :=
   let ip := parseIPv4Net str
   if ip.isSome then ip else parseIPv6Net str
 
+def ip (str : String) : Option IPNet := parse str
+
+----- IPNet deriviations -----
+
+deriving instance Repr, DecidableEq, Inhabited for CIDR
+deriving instance Repr, DecidableEq, Inhabited for IPNet
+
+def IPNetPrefix.lt {w} (p₁ p₂ : IPNetPrefix w) : Bool :=
+  p₁.toNat < p₂.toNat
+
+instance {w} : LT (IPNetPrefix w) where
+  lt := λ d₁ d₂ => IPNetPrefix.lt d₁ d₂
+
+instance IPNetPrefix.decLt {w} (d₁ d₂ : IPNetPrefix w) : Decidable (d₁ < d₂) :=
+  if h : IPNetPrefix.lt d₁ d₂ then isTrue h else isFalse h
+
+def CIDR.lt {w} (cidr₁ cidr₂ : CIDR w) : Bool :=
+  cidr₁.addr < cidr₂.addr || (cidr₁.addr = cidr₂.addr && cidr₁.pre < cidr₂.pre)
+
+instance {w} : LT (CIDR w) where
+  lt := λ d₁ d₂ => CIDR.lt d₁ d₂
+
+instance CIDR.decLt {w} (d₁ d₂ : CIDR w) : Decidable (d₁ < d₂) :=
+  if h : CIDR.lt d₁ d₂ then isTrue h else isFalse h
+
+def IPNet.lt : IPNet → IPNet → Bool
+  | .V4 _, .V6 _         => true
+  | .V6 _, .V4 _         => false
+  | .V4 cidr₁, .V4 cidr₂
+  | .V6 cidr₁, .V6 cidr₂ => cidr₁ < cidr₂
+
+instance : LT IPNet where
+  lt := fun d₁ d₂ => IPNet.lt d₁ d₂
+
+instance IPNet.decLt (d₁ d₂ : IPNet) : Decidable (d₁ < d₂) :=
+  if h : IPNet.lt d₁ d₂ then isTrue h else isFalse h
+
 -- as of this writing, only handles nats up to 0xffff
-def toHex (n : Nat) : String :=
+private def toHex (n : Nat) : String :=
   let a0 := hexDigitRepr ((n % 0x10000) / 0x1000)
   let a1 := hexDigitRepr ((n % 0x1000) / 0x100)
   let a2 := hexDigitRepr ((n % 0x100) / 0x10)
@@ -256,13 +275,15 @@ def toHex (n : Nat) : String :=
 
 instance : ToString IPNet where
   toString : IPNet → String
-  | .V4 v p =>
+  | .V4 ⟨addr, pre⟩ =>
+    let v  := addr.toNat
     let a0 := (v >>> 24) &&& 0xFF
     let a1 := (v >>> 16) &&& 0xFF
     let a2 := (v >>> 8) &&& 0xFF
     let a3 := v &&& 0xFF
-    s!"{a0}.{a1}.{a2}.{a3}/{p}"
-  | .V6 v p =>
+    s!"{a0}.{a1}.{a2}.{a3}/{pre.toNat}"
+  | .V6 ⟨addr, pre⟩ =>
+    let v  := addr.toNat
     let a0 := toHex ((v >>> 112) &&& 0xFFFF)
     let a1 := toHex ((v >>> 96) &&& 0xFFFF)
     let a2 := toHex ((v >>> 80) &&& 0xFFFF)
@@ -271,25 +292,7 @@ instance : ToString IPNet where
     let a5 := toHex ((v >>> 32) &&& 0xFFFF)
     let a6 := toHex ((v >>> 16) &&& 0xFFFF)
     let a7 := toHex (v &&& 0xFFFF)
-    s!"{a0}:{a1}:{a2}:{a3}:{a4}:{a5}:{a6}:{a7}/{p}"
-
-def ip (str : String) : Option IPNet := parse str
-
-def IPNet.lt : IPNet → IPNet → Bool
-  | .V4 _ _, .V6 _ _ => true
-  | .V6 _ _, .V4 _ _ => false
-  | .V4 v₁ p₁, .V4 v₂ p₂ => v₁.val < v₂.val || (v₁.val = v₂.val && p₁.val < p₂.val)
-  | .V6 v₁ p₁, .V6 v₂ p₂ => v₁.val < v₂.val || (v₁.val = v₂.val && p₁.val < p₂.val)
-
------ IPNet deriviations -----
-
-deriving instance Repr, DecidableEq, Inhabited for IPNet
-
-instance : LT IPNet where
-  lt := fun d₁ d₂ => IPNet.lt d₁ d₂
-
-instance IPNet.decLt (d₁ d₂ : IPNet) : Decidable (d₁ < d₂) :=
-if h : IPNet.lt d₁ d₂ then isTrue h else isFalse h
+    s!"{a0}:{a1}:{a2}:{a3}:{a4}:{a5}:{a6}:{a7}/{pre.toNat}"
 
 end IPAddr
 

--- a/cedar-lean/UnitTest/IPAddr.lean
+++ b/cedar-lean/UnitTest/IPAddr.lean
@@ -32,11 +32,11 @@ theorem test6 : toString ((parse "7:70:700:7000::a00/128").get!) = "0007:0070:07
 theorem test7 : toString ((parse "::ffff/128").get!) = "0000:0000:0000:0000:0000:0000:0000:ffff/128" := by decide
 theorem test8 : toString ((parse "ffff::/4").get!) = "ffff:0000:0000:0000:0000:0000:0000:0000/4" := by decide
 
-private def ipv4 (a₀ a₁ a₂ a₃ : UInt8) (pre : Nat) : IPNet :=
-  IPNet.V4 (IPv4Addr.mk a₀ a₁ a₂ a₃) (Fin.ofNat pre)
+private def ipv4 (a₀ a₁ a₂ a₃ : BitVec 8) (pre : Nat) : IPNet :=
+  IPNet.V4 ⟨IPv4Addr.mk a₀ a₁ a₂ a₃, pre⟩
 
-private def ipv6 (a₀ a₁ a₂ a₃ a₄ a₅ a₆ a₇ : UInt16) (pre : Nat) : IPNet :=
-  IPNet.V6 (IPv6Addr.mk a₀ a₁ a₂ a₃ a₄ a₅ a₆ a₇) (Fin.ofNat pre)
+private def ipv6 (a₀ a₁ a₂ a₃ a₄ a₅ a₆ a₇ : BitVec 16) (pre : Nat) : IPNet :=
+  IPNet.V6 ⟨IPv6Addr.mk a₀ a₁ a₂ a₃ a₄ a₅ a₆ a₇, pre⟩
 
 private def testValid (str : String) (ip : IPNet) : TestCase IO :=
   test str ⟨λ _ => checkEq (parse str) ip⟩
@@ -90,8 +90,6 @@ private def parse! (str : String) : IPNet :=
 private def testIsLoopback (str : String) (expected : Bool) : TestCase IO :=
   test s!"isLoopback {str}" ⟨λ _ => checkEq (parse! str).isLoopback expected⟩
 
-private def testToUInt128 (str : String) (expected : UInt128) : TestCase IO :=
-  test s!"toUInt128 {str}" ⟨λ _ => checkEq (parse! str).toUInt128 expected⟩
 
 def testsForIsLoopback :=
   suite "IPAddr.isLoopback"
@@ -101,13 +99,6 @@ def testsForIsLoopback :=
     testIsLoopback "::1" true,
     -- As in Rust, IPv4 embedded in IPv6 only uses IPv6 loopback:
     testIsLoopback "::ffff:ff00:0001" false
-  ]
-
-def testsForUInt128Conversion :=
-  suite "IPAddr.toUInt128"
-  [
-    testToUInt128 "192.0.2.235" 3221226219,
-    testToUInt128 "::1:2" (0x10000 + 0x2)
   ]
 
 def ip! (str : String) : IPNet :=
@@ -170,7 +161,6 @@ def tests := [
   testsForValidStrings,
   testsForInvalidStrings,
   testsForIsLoopback,
-  testsForUInt128Conversion,
   testsForInRange,
   testsForIpNetEquality]
 


### PR DESCRIPTION
This PR revises the model and relevant proofs for the IP Address extension type and functions.

The semantics of the operations is still the same, but the representation and code are more uniform.  

In particular:

* We use the `BitVec` type to uniformly model all parts of an IP Address.  The existing model uses a mix of data types (UInts and Fins), which led to non-uniform proof obligations (for example, in `Cedar.Data.Thm.LT`).

* We introduce a new `CIDR` structure that is parametric in address width.  The `IPNet` data wraps the new structure, and IP operations are defined as parametric functions over their underlying `CIDR` values.  One pleasant consequence of this design is that we no longer need to convert 32-bit addresses to 128 bits to operate on them.
