### PR TITLE
split Thm/Partial/Evaluation/Basic into Thm/Partial/Evaluation/Props and Thm/Partial/Evaluation/WellFormed

### DIFF
--- a/cedar-lean/Cedar/Thm/Partial/Authorization/PartialOnConcrete.lean
+++ b/cedar-lean/Cedar/Thm/Partial/Authorization/PartialOnConcrete.lean
@@ -21,7 +21,7 @@ import Cedar.Partial.Authorizer
 import Cedar.Partial.Response
 import Cedar.Thm.Authorization.Evaluator
 import Cedar.Thm.Partial.Evaluation
-import Cedar.Thm.Partial.Evaluation.Basic
+import Cedar.Thm.Partial.Evaluation.WellFormed
 
 /-!
   This file contains lemmas about the behavior of partial authorization on

--- a/cedar-lean/Cedar/Thm/Partial/Evaluation.lean
+++ b/cedar-lean/Cedar/Thm/Partial/Evaluation.lean
@@ -19,17 +19,18 @@ import Cedar.Partial.Expr
 import Cedar.Spec.Evaluator
 import Cedar.Thm.Partial.Evaluation.And
 import Cedar.Thm.Partial.Evaluation.AndOr
-import Cedar.Thm.Partial.Evaluation.Basic
 import Cedar.Thm.Partial.Evaluation.Binary
 import Cedar.Thm.Partial.Evaluation.Call
 import Cedar.Thm.Partial.Evaluation.GetAttr
 import Cedar.Thm.Partial.Evaluation.HasAttr
 import Cedar.Thm.Partial.Evaluation.Ite
 import Cedar.Thm.Partial.Evaluation.Or
+import Cedar.Thm.Partial.Evaluation.Props
 import Cedar.Thm.Partial.Evaluation.Record
 import Cedar.Thm.Partial.Evaluation.Set
 import Cedar.Thm.Partial.Evaluation.Unary
 import Cedar.Thm.Partial.Evaluation.Var
+import Cedar.Thm.Partial.Evaluation.WellFormed
 import Cedar.Thm.Data.Control
 
 /-! This file contains theorems about Cedar's partial evaluator. -/

--- a/cedar-lean/Cedar/Thm/Partial/Evaluation/And.lean
+++ b/cedar-lean/Cedar/Thm/Partial/Evaluation/And.lean
@@ -17,7 +17,7 @@
 import Cedar.Partial.Evaluator
 import Cedar.Spec.Evaluator
 import Cedar.Thm.Data.Control
-import Cedar.Thm.Partial.Evaluation.Basic
+import Cedar.Thm.Partial.Evaluation.Props
 
 namespace Cedar.Thm.Partial.Evaluation.And
 

--- a/cedar-lean/Cedar/Thm/Partial/Evaluation/AndOr.lean
+++ b/cedar-lean/Cedar/Thm/Partial/Evaluation/AndOr.lean
@@ -16,7 +16,7 @@
 
 import Cedar.Partial.Evaluator
 import Cedar.Thm.Data.Control
-import Cedar.Thm.Partial.Evaluation.Basic
+import Cedar.Thm.Partial.Evaluation.Props
 
 namespace Cedar.Thm.Partial.Evaluation.AndOr
 

--- a/cedar-lean/Cedar/Thm/Partial/Evaluation/Binary.lean
+++ b/cedar-lean/Cedar/Thm/Partial/Evaluation/Binary.lean
@@ -19,7 +19,7 @@ import Cedar.Spec.Evaluator
 import Cedar.Thm.Data.Control
 import Cedar.Thm.Data.Map
 import Cedar.Thm.Data.Set
-import Cedar.Thm.Partial.Evaluation.Basic
+import Cedar.Thm.Partial.Evaluation.Props
 import Cedar.Thm.Partial.Subst
 
 namespace Cedar.Thm.Partial.Evaluation.Binary

--- a/cedar-lean/Cedar/Thm/Partial/Evaluation/Call.lean
+++ b/cedar-lean/Cedar/Thm/Partial/Evaluation/Call.lean
@@ -19,7 +19,7 @@ import Cedar.Spec.Evaluator
 import Cedar.Thm.Data.Control
 import Cedar.Thm.Data.List
 import Cedar.Thm.Data.Set
-import Cedar.Thm.Partial.Evaluation.Basic
+import Cedar.Thm.Partial.Evaluation.Props
 import Cedar.Thm.Partial.Evaluation.Set
 
 namespace Cedar.Thm.Partial.Evaluation.Call

--- a/cedar-lean/Cedar/Thm/Partial/Evaluation/GetAttr.lean
+++ b/cedar-lean/Cedar/Thm/Partial/Evaluation/GetAttr.lean
@@ -20,7 +20,8 @@ import Cedar.Thm.Data.Control
 import Cedar.Thm.Data.LT
 import Cedar.Thm.Data.Map
 import Cedar.Thm.Data.Set
-import Cedar.Thm.Partial.Evaluation.Basic
+import Cedar.Thm.Partial.Evaluation.Props
+import Cedar.Thm.Partial.Evaluation.WellFormed
 import Cedar.Thm.Partial.Subst
 
 namespace Cedar.Thm.Partial.Evaluation.GetAttr

--- a/cedar-lean/Cedar/Thm/Partial/Evaluation/HasAttr.lean
+++ b/cedar-lean/Cedar/Thm/Partial/Evaluation/HasAttr.lean
@@ -19,7 +19,8 @@ import Cedar.Spec.Evaluator
 import Cedar.Thm.Data.Control
 import Cedar.Thm.Data.Map
 import Cedar.Thm.Data.Set
-import Cedar.Thm.Partial.Evaluation.Basic
+import Cedar.Thm.Partial.Evaluation.Props
+import Cedar.Thm.Partial.Evaluation.WellFormed
 import Cedar.Thm.Partial.Subst
 
 namespace Cedar.Thm.Partial.Evaluation.HasAttr

--- a/cedar-lean/Cedar/Thm/Partial/Evaluation/Ite.lean
+++ b/cedar-lean/Cedar/Thm/Partial/Evaluation/Ite.lean
@@ -17,7 +17,7 @@
 import Cedar.Partial.Evaluator
 import Cedar.Spec.Evaluator
 import Cedar.Thm.Data.Control
-import Cedar.Thm.Partial.Evaluation.Basic
+import Cedar.Thm.Partial.Evaluation.Props
 
 namespace Cedar.Thm.Partial.Evaluation.Ite
 

--- a/cedar-lean/Cedar/Thm/Partial/Evaluation/Or.lean
+++ b/cedar-lean/Cedar/Thm/Partial/Evaluation/Or.lean
@@ -17,7 +17,7 @@
 import Cedar.Partial.Evaluator
 import Cedar.Spec.Evaluator
 import Cedar.Thm.Data.Control
-import Cedar.Thm.Partial.Evaluation.Basic
+import Cedar.Thm.Partial.Evaluation.Props
 
 namespace Cedar.Thm.Partial.Evaluation.Or
 

--- a/cedar-lean/Cedar/Thm/Partial/Evaluation/Props.lean
+++ b/cedar-lean/Cedar/Thm/Partial/Evaluation/Props.lean
@@ -14,74 +14,12 @@
  limitations under the License.
 -/
 
-import Cedar.Partial.Entities
 import Cedar.Partial.Evaluator
-import Cedar.Partial.Expr
-import Cedar.Partial.Request
-import Cedar.Partial.Value
-import Cedar.Spec.Evaluator
-import Cedar.Spec.Expr
-import Cedar.Spec.Request
-import Cedar.Spec.Value
-import Cedar.Thm.Data.Map
-import Cedar.Thm.Data.Set
 
 /-!
-  This file contains definitions used by multiple files in the Thm/Partial
-  folder
+  This file contains definitions of `Prop`s used by multiple files in the
+  Thm/Partial/Evaluation folder
 -/
-
-namespace Cedar.Spec
-
-/--
-  We define `WellFormed` for `Value` in the obvious way
--/
-def Value.WellFormed (v : Value) : Prop :=
-  match v with
-  | .set s => s.WellFormed
-  | .record r => r.WellFormed
-  | _ => true
-
-/--
-  `Request`s are `WellFormed` if the context is `WellFormed`
--/
-def Request.WellFormed (req : Request) : Prop :=
-  req.context.WellFormed
-
-end Cedar.Spec
-
-namespace Cedar.Partial
-
-/--
-  We define `WellFormed` for `Partial.Value` using `Spec.Value.WellFormed`
--/
-def Value.WellFormed (pval : Partial.Value) : Prop :=
-  match pval with
-  | .value v => v.WellFormed
-  | .residual _ => true
-
-/--
-  `Partial.Request`s are `AllWellFormed` if the context is `WellFormed` and
-  all the context's constituent `Partial.RestrictedValue`s are also `WellFormed`.
-  (principal, action, and resource are always well-formed)
--/
-def Request.AllWellFormed (preq : Partial.Request) : Prop :=
-  preq.context.WellFormed ∧ ∀ rpval ∈ preq.context.values, rpval.WellFormed
-
-/--
-  We define `WellFormed` for `Partial.EntityData` in the obvious way
--/
-def EntityData.WellFormed (edata : Partial.EntityData) : Prop :=
-  edata.attrs.WellFormed ∧ edata.ancestors.WellFormed
-
-/--
-  `Partial.Entities` are `AllWellFormed` if they are `WellFormed` and all the
-  constituent `Partial.EntityData` are also `WellFormed`
--/
-def Entities.AllWellFormed (entities : Partial.Entities) : Prop :=
-  entities.WellFormed ∧ ∀ edata ∈ entities.values, edata.WellFormed
-
-end Cedar.Partial
 
 namespace Cedar.Thm.Partial
 

--- a/cedar-lean/Cedar/Thm/Partial/Evaluation/Record.lean
+++ b/cedar-lean/Cedar/Thm/Partial/Evaluation/Record.lean
@@ -18,7 +18,7 @@ import Cedar.Partial.Evaluator
 import Cedar.Spec.Evaluator
 import Cedar.Thm.Data.Control
 import Cedar.Thm.Data.Map
-import Cedar.Thm.Partial.Evaluation.Basic
+import Cedar.Thm.Partial.Evaluation.Props
 
 namespace Cedar.Thm.Partial.Evaluation.Record
 

--- a/cedar-lean/Cedar/Thm/Partial/Evaluation/Set.lean
+++ b/cedar-lean/Cedar/Thm/Partial/Evaluation/Set.lean
@@ -19,7 +19,7 @@ import Cedar.Spec.Policy
 import Cedar.Thm.Data.Control
 import Cedar.Thm.Data.List
 import Cedar.Thm.Data.Set
-import Cedar.Thm.Partial.Evaluation.Basic
+import Cedar.Thm.Partial.Evaluation.Props
 
 namespace Cedar.Thm.Partial.Evaluation.Set
 

--- a/cedar-lean/Cedar/Thm/Partial/Evaluation/Unary.lean
+++ b/cedar-lean/Cedar/Thm/Partial/Evaluation/Unary.lean
@@ -17,7 +17,7 @@
 import Cedar.Partial.Evaluator
 import Cedar.Spec.Evaluator
 import Cedar.Thm.Data.Control
-import Cedar.Thm.Partial.Evaluation.Basic
+import Cedar.Thm.Partial.Evaluation.Props
 
 namespace Cedar.Thm.Partial.Evaluation.Unary
 

--- a/cedar-lean/Cedar/Thm/Partial/Evaluation/Var.lean
+++ b/cedar-lean/Cedar/Thm/Partial/Evaluation/Var.lean
@@ -19,7 +19,8 @@ import Cedar.Spec.Evaluator
 import Cedar.Thm.Data.Control
 import Cedar.Thm.Data.LT
 import Cedar.Thm.Data.Map
-import Cedar.Thm.Partial.Evaluation.Basic
+import Cedar.Thm.Partial.Evaluation.Props
+import Cedar.Thm.Partial.Evaluation.WellFormed
 import Cedar.Thm.Partial.Subst
 
 namespace Cedar.Thm.Partial.Evaluation.Var

--- a/cedar-lean/Cedar/Thm/Partial/Evaluation/WellFormed.lean
+++ b/cedar-lean/Cedar/Thm/Partial/Evaluation/WellFormed.lean
@@ -1,0 +1,79 @@
+/-
+ Copyright Cedar Contributors
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-/
+
+import Cedar.Partial.Entities
+import Cedar.Partial.Request
+import Cedar.Partial.Value
+import Cedar.Spec.Request
+import Cedar.Spec.Value
+import Cedar.Thm.Data.Map
+import Cedar.Thm.Data.Set
+
+/-!
+  This file defines `WellFormed` for various Spec and Partial types
+-/
+
+namespace Cedar.Spec
+
+/--
+  We define `WellFormed` for `Value` in the obvious way
+-/
+def Value.WellFormed (v : Value) : Prop :=
+  match v with
+  | .set s => s.WellFormed
+  | .record r => r.WellFormed
+  | _ => true
+
+/--
+  `Request`s are `WellFormed` if the context is `WellFormed`
+-/
+def Request.WellFormed (req : Request) : Prop :=
+  req.context.WellFormed
+
+end Cedar.Spec
+
+namespace Cedar.Partial
+
+/--
+  We define `WellFormed` for `Partial.Value` using `Spec.Value.WellFormed`
+-/
+def Value.WellFormed (pval : Partial.Value) : Prop :=
+  match pval with
+  | .value v => v.WellFormed
+  | .residual _ => true
+
+/--
+  `Partial.Request`s are `AllWellFormed` if the context is `WellFormed` and
+  all the context's constituent `Partial.RestrictedValue`s are also `WellFormed`.
+  (principal, action, and resource are always well-formed)
+-/
+def Request.AllWellFormed (preq : Partial.Request) : Prop :=
+  preq.context.WellFormed ∧ ∀ rpval ∈ preq.context.values, rpval.WellFormed
+
+/--
+  We define `WellFormed` for `Partial.EntityData` in the obvious way
+-/
+def EntityData.WellFormed (edata : Partial.EntityData) : Prop :=
+  edata.attrs.WellFormed ∧ edata.ancestors.WellFormed
+
+/--
+  `Partial.Entities` are `AllWellFormed` if they are `WellFormed` and all the
+  constituent `Partial.EntityData` are also `WellFormed`
+-/
+def Entities.AllWellFormed (entities : Partial.Entities) : Prop :=
+  entities.WellFormed ∧ ∀ edata ∈ entities.values, edata.WellFormed
+
+end Cedar.Partial

--- a/cedar-lean/Cedar/Thm/Partial/Subst.lean
+++ b/cedar-lean/Cedar/Thm/Partial/Subst.lean
@@ -22,7 +22,7 @@ import Cedar.Partial.Value
 import Cedar.Spec.Expr
 import Cedar.Thm.Data.List
 import Cedar.Thm.Data.LT
-import Cedar.Thm.Partial.Evaluation.Basic
+import Cedar.Thm.Partial.Evaluation.WellFormed
 
 /-! ## Lemmas about `subst` operations -/
 


### PR DESCRIPTION
This file had two pretty different things going on, so it makes sense to make two more focused files instead, particularly as the Props section keeps growing (as it is anticipated to as more of the PE soundness proof gets checked in).


