### PR TITLE
combine the And and Or cases of the concrete-equivalence proof

### DIFF
--- a/cedar-lean/Cedar/Thm/Partial/Evaluation.lean
+++ b/cedar-lean/Cedar/Thm/Partial/Evaluation.lean
@@ -54,14 +54,11 @@ theorem on_concrete_eqv_concrete_eval' (expr : Spec.Expr) (request : Spec.Reques
   case var v =>
     have h := Var.on_concrete_eqv_concrete_eval v request entities wf
     unfold PartialEvalEquivConcreteEval at h ; exact h
-  case and x₁ x₂ =>
+  case and x₁ x₂ | or x₁ x₂ =>
     have ih₁ := on_concrete_eqv_concrete_eval' x₁ request entities wf
     have ih₂ := on_concrete_eqv_concrete_eval' x₂ request entities wf
-    exact And.on_concrete_eqv_concrete_eval ih₁ ih₂
-  case or x₁ x₂ =>
-    have ih₁ := on_concrete_eqv_concrete_eval' x₁ request entities wf
-    have ih₂ := on_concrete_eqv_concrete_eval' x₂ request entities wf
-    exact Or.on_concrete_eqv_concrete_eval ih₁ ih₂
+    have := AndOr.on_concrete_eqv_concrete_eval ih₁ ih₂
+    first | exact this.left | exact this.right
   case ite x₁ x₂ x₃ =>
     have ih₁ := on_concrete_eqv_concrete_eval' x₁ request entities wf
     have ih₂ := on_concrete_eqv_concrete_eval' x₂ request entities wf

--- a/cedar-lean/Cedar/Thm/Partial/Evaluation/And.lean
+++ b/cedar-lean/Cedar/Thm/Partial/Evaluation/And.lean
@@ -22,38 +22,6 @@ import Cedar.Thm.Partial.Evaluation.Basic
 namespace Cedar.Thm.Partial.Evaluation.And
 
 open Cedar.Data
-open Cedar.Spec (Result)
-
-/--
-  Inductive argument that partial evaluating a concrete `Partial.Expr.and`
-  expression gives the same output as concrete-evaluating the `Spec.Expr.and`
-  with the same subexpressions
--/
-theorem on_concrete_eqv_concrete_eval {x₁ x₂ : Spec.Expr} {request : Spec.Request} {entities : Spec.Entities} :
-  PartialEvalEquivConcreteEval x₁ request entities →
-  PartialEvalEquivConcreteEval x₂ request entities →
-  PartialEvalEquivConcreteEval (Spec.Expr.and x₁ x₂) request entities
-:= by
-  unfold PartialEvalEquivConcreteEval
-  intro ih₁ ih₂
-  unfold Partial.evaluate Spec.evaluate Spec.Expr.asPartialExpr
-  simp only [ih₁, ih₂]
-  simp only [Except.map, pure, Except.pure, Result.as, Coe.coe]
-  cases h₁ : Spec.evaluate x₁ request entities <;> simp only [Bool.not_eq_true', Except.bind_err, Except.bind_ok]
-  case ok v₁ =>
-    simp only [Spec.Value.asBool]
-    cases v₁ <;> try simp only [Except.bind_err]
-    case prim p =>
-      cases p <;> simp only [Except.bind_ok, Except.bind_err]
-      case bool b =>
-        cases b <;> simp only [ite_true, ite_false]
-        case true =>
-          split <;> simp only [Except.bind_ok, Except.bind_err]
-          case h_1 e h₂ => simp only [h₂, Except.bind_err]
-          case h_2 v h₂ =>
-            simp only [h₂]
-            cases v <;> try simp only [Except.bind_err]
-            case prim p => cases p <;> simp
 
 /--
   If partial-evaluating a `Partial.Expr.and` produces `ok` with a concrete

--- a/cedar-lean/Cedar/Thm/Partial/Evaluation/AndOr.lean
+++ b/cedar-lean/Cedar/Thm/Partial/Evaluation/AndOr.lean
@@ -22,8 +22,43 @@ namespace Cedar.Thm.Partial.Evaluation.AndOr
 
 open Cedar.Data
 open Cedar.Partial (Unknown)
+open Cedar.Spec (Result)
 
 /- ## Lemmas shared by And.lean and Or.lean -/
+
+/--
+  Inductive argument that partial evaluating a concrete `Partial.Expr.and` or
+  `Partial.Expr.or` gives the same output as concrete-evaluating the
+  `Spec.Expr.and` or `Spec.Expr.or` with the same subexpressions
+-/
+theorem on_concrete_eqv_concrete_eval {x₁ x₂ : Spec.Expr} {request : Spec.Request} {entities : Spec.Entities} :
+  PartialEvalEquivConcreteEval x₁ request entities →
+  PartialEvalEquivConcreteEval x₂ request entities →
+  PartialEvalEquivConcreteEval (Spec.Expr.and x₁ x₂) request entities ∧
+  PartialEvalEquivConcreteEval (Spec.Expr.or x₁ x₂) request entities
+:= by
+  unfold PartialEvalEquivConcreteEval
+  intro ih₁ ih₂
+  unfold Partial.evaluate Spec.evaluate Spec.Expr.asPartialExpr
+  simp only [ih₁, ih₂]
+  simp only [Except.map, pure, Except.pure, Result.as, Coe.coe]
+  constructor
+  all_goals {
+    cases h₁ : Spec.evaluate x₁ request entities <;> simp only [Bool.not_eq_true', Except.bind_err, Except.bind_ok]
+    case ok v₁ =>
+      simp only [Spec.Value.asBool]
+      cases v₁ <;> try simp only [Except.bind_err]
+      case prim p =>
+        cases p <;> simp only [Except.bind_ok, Except.bind_err]
+        case bool b =>
+          cases b <;> simp only [ite_true, ite_false]
+          split <;> simp only [Except.bind_ok, Except.bind_err]
+          case h_1 e h₂ => simp only [h₂, Except.bind_err]
+          case h_2 v h₂ =>
+            simp only [h₂]
+            cases v <;> try simp only [Except.bind_err]
+            case prim p => cases p <;> simp
+  }
 
 /--
   Inductive argument that if partial-evaluation of a `Partial.Expr.and` or

--- a/cedar-lean/Cedar/Thm/Partial/Evaluation/Or.lean
+++ b/cedar-lean/Cedar/Thm/Partial/Evaluation/Or.lean
@@ -21,38 +21,7 @@ import Cedar.Thm.Partial.Evaluation.Basic
 
 namespace Cedar.Thm.Partial.Evaluation.Or
 
-open Cedar.Spec (Result)
-
-/--
-  Inductive argument that partial evaluating a concrete `Partial.Expr.or`
-  expression gives the same output as concrete-evaluating the `Spec.Expr.or`
-  with the same subexpressions
--/
-theorem on_concrete_eqv_concrete_eval {x₁ x₂ : Spec.Expr} {request : Spec.Request} {entities : Spec.Entities} :
-  PartialEvalEquivConcreteEval x₁ request entities →
-  PartialEvalEquivConcreteEval x₂ request entities →
-  PartialEvalEquivConcreteEval (Spec.Expr.or x₁ x₂) request entities
-:= by
-  unfold PartialEvalEquivConcreteEval
-  intro ih₁ ih₂
-  unfold Partial.evaluate Spec.evaluate Spec.Expr.asPartialExpr
-  simp only [ih₁, ih₂]
-  simp only [Except.map, pure, Except.pure, Result.as, Coe.coe]
-  cases Spec.evaluate x₁ request entities <;> simp only [Except.bind_err, Except.bind_ok]
-  case ok v₁ =>
-    simp only [Spec.Value.asBool]
-    cases v₁ <;> try simp only [Except.bind_err]
-    case prim p =>
-      cases p <;> simp only [Except.bind_ok, Except.bind_err]
-      case bool b =>
-        cases b <;> simp only [ite_true, ite_false]
-        case false =>
-          split <;> simp only [Except.bind_ok, Except.bind_err]
-          case h_1 e h₂ => simp only [h₂, Except.bind_err]
-          case h_2 v h₂ =>
-            simp only [h₂]
-            cases v <;> try simp only [Except.bind_err]
-            case prim p => cases p <;> simp
+open Cedar.Data
 
 /--
   If partial-evaluating a `Partial.Expr.or` produces `ok` with a concrete


### PR DESCRIPTION
The And and Or cases were basically identical proofs; this refactoring uses the same proof to prove both cases.


