### PR TITLE
Adding stups for PE/PA trait methods

### DIFF
--- a/cedar-drt/src/lean_impl.rs
+++ b/cedar-drt/src/lean_impl.rs
@@ -307,6 +307,26 @@ impl CedarTestImplementation for LeanDefinitionalEngine {
         self.is_authorized(request, policies, entities)
     }
 
+    fn partial_evaluate(
+        &self,
+        _request: &ast::Request,
+        _entities: &Entities,
+        _expr: &Expr,
+        _enable_extensions: bool,
+        _expected: Option<ExprOrValue>,
+    ) -> TestResult<bool> {
+        unimplemented!()
+    }
+
+    fn partial_is_authorized(
+        &self,
+        _request: &ast::Request,
+        _entities: &Entities,
+        _policies: &ast::PolicySet,
+    ) -> TestResult<partial::FlatPartialResponse> {
+        unimplemented!()
+    }
+
     fn interpret(
         &self,
         request: &ast::Request,


### PR DESCRIPTION
*Issue #, if available:*
N/A
*Description of changes:*
This stubs out the new trait methods for `CedarTestImplementation` so that CI will work while reviews of #308 are under way
