### PR TITLE
Add target for json-to-cedar policy conversion

### DIFF
--- a/cedar-drt/README.md
+++ b/cedar-drt/README.md
@@ -25,6 +25,7 @@ The table below lists all available fuzz targets, including which component of t
 | [`convert-schema-json-to-human`](fuzz/fuzz_targets/convert-schema-json-to-human.rs) | Schema parser | PBT | Test we can convert all human schemas to equivalent JSON. parse == parse-json ∘ print-json ∘ parse 
 | [`convert-schema-human-to-json`](fuzz/fuzz_targets/convert-schema-human-to-json.rs) | Schema parser | PBT | Test we can convert all JSON schemas to an equivalent human format schema. parse-json == parse ∘ pretty-print ∘ parse-json
 | [`convert-policy-cedar-to-json`](fuzz/fuzz_targets/convert-policy-cedar-to-json.rs) | Parser, Conversion to JSON | PBT | Test we can convert all policies to an equivalent EST.  parse-ast ∘ parse-cst == deserialize ∘ serialize ∘ parse-cst
+| [`convert-policy-json-to-cedar`](fuzz/fuzz_targets/convert-policy-json-to-cedar.rs) | Parser, JSON Parser | PBT | Test we can convert all EST to an equivalent policy in the human-readable cedar syntax. deserialize == parse-ast ∘ pretty-print ∘ deserialize
 |  |  |  |  |
 | [`partial-eval`](fuzz/fuzz_targets/partial-eval.rs) | Partial evaluator | PBT | Test that residual policies with unknowns substituted are equivalent to original policies with unknowns replaced |
 | [`simple-parser`](fuzz/fuzz_targets/simple-parser.rs) |  Parser | PBT | Test that parsing doesn't crash with random input strings |

--- a/cedar-drt/fuzz/Cargo.toml
+++ b/cedar-drt/fuzz/Cargo.toml
@@ -166,3 +166,9 @@ name = "convert-policy-cedar-to-json"
 path = "fuzz_targets/convert-policy-cedar-to-json.rs"
 test = false
 doc = false
+
+[[bin]]
+name = "convert-policy-json-to-cedar"
+path = "fuzz_targets/convert-policy-json-to-cedar.rs"
+test = false
+doc = false

--- a/cedar-drt/fuzz/fuzz_targets/convert-policy-json-to-cedar.rs
+++ b/cedar-drt/fuzz/fuzz_targets/convert-policy-json-to-cedar.rs
@@ -1,0 +1,54 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#![no_main]
+use thiserror::Error;
+
+use cedar_drt_inner::*;
+use cedar_policy_core::{ast::PolicyID, est::FromJsonError};
+
+#[derive(miette::Diagnostic, Error, Debug)]
+enum ESTParseError {
+    #[error(transparent)]
+    JSONToEST(#[from] serde_json::error::Error),
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    ESTToAST(#[from] FromJsonError),
+}
+
+fuzz_target!(|est_json_str: String| {
+    if let Ok(ast_from_est) = serde_json::from_str::<cedar_policy_core::est::Policy>(&est_json_str)
+        .map_err(|e| ESTParseError::from(e))
+        .and_then(|est| {
+            est.try_into_ast_template(Some(PolicyID::from_string("policy0")))
+                .map_err(|e| ESTParseError::from(e))
+        })
+    {
+        let ast_from_cedar =
+            cedar_policy_core::parser::parse_policy_template(None, &ast_from_est.to_string());
+
+        match ast_from_cedar {
+            Ok(ast_from_cedar) => {
+                check_policy_equivalence(&ast_from_est, &ast_from_cedar);
+            }
+
+            Err(e) => {
+                println!("{:?}", miette::Report::new(e));
+                panic!("Policy parsed from est to ast but did not roundtrip ast->text->ast");
+            }
+        }
+    }
+});

--- a/cedar-drt/initialize_corpus.sh
+++ b/cedar-drt/initialize_corpus.sh
@@ -33,7 +33,7 @@ print_usage() {
 }
 
 if [ $# -ne 1 ]; then
-    echo "Expected exactly one arguemtn, but $# arguments provided."
+    echo "Expected exactly one argument, but $# arguments provided."
     print_usage
 fi
 

--- a/cedar-drt/initialize_corpus.sh
+++ b/cedar-drt/initialize_corpus.sh
@@ -47,6 +47,11 @@ initialize_corpus() {
       cp "$f" "$corpus_dir/$(uuidgen)-$(basename "$f")"
     done ;;
 
+  convert-policy-json-to-cedar)
+    for f in ../cedar/**/*.cedar.json; do
+      cp "$f" "$corpus_dir/$(uuidgen)-$(basename "$f")"
+    done ;;
+
   convert-schema-json-to-human)
     for f in ../cedar/**/*.cedarschema.json; do
       cp "$f" "$corpus_dir/$(uuidgen)-$(basename "$f")"


### PR DESCRIPTION
Given a JSON formatted policy, check that, if we can parse it to an AST then we can round-trip that AST through the human-readable format and get back the same policy. Finds cedar-policy/cedar#925

There aren't actually any `*.cedar.json` files in the repo currently. I opened https://github.com/cedar-policy/cedar/pull/926 to add one example, but that's a very small corpus. We'll need to add some more or seed this target another way. Possibly by implementing cedar-policy/cedar#461 and converting existing `*.cedar` files to JSON. 


