### PR TITLE
Updates for cedar#922

### DIFF
--- a/cedar-drt/fuzz/fuzz_targets/convert-policy-json-to-cedar.rs
+++ b/cedar-drt/fuzz/fuzz_targets/convert-policy-json-to-cedar.rs
@@ -31,10 +31,10 @@ enum ESTParseError {
 
 fuzz_target!(|est_json_str: String| {
     if let Ok(ast_from_est) = serde_json::from_str::<cedar_policy_core::est::Policy>(&est_json_str)
-        .map_err(|e| ESTParseError::from(e))
+        .map_err(ESTParseError::from)
         .and_then(|est| {
             est.try_into_ast_template(Some(PolicyID::from_string("policy0")))
-                .map_err(|e| ESTParseError::from(e))
+                .map_err(ESTParseError::from)
         })
     {
         let ast_from_cedar =

--- a/cedar-drt/fuzz/fuzz_targets/partial-eval.rs
+++ b/cedar-drt/fuzz/fuzz_targets/partial-eval.rs
@@ -172,7 +172,7 @@ fn partial_response_correctness(partial: &PartialResponse, concrete: &Response) 
         .may_be_determining()
         .map(|p| p.id().clone())
         .collect::<HashSet<_>>();
-    assert!(over_approx.is_superset(&determining));
+    assert!(over_approx.is_superset(determining));
     // Ensure that `must_be_determining` produces an under approximation of policies in the
     // reasons set
     let under_approx = partial

--- a/cedar-drt/fuzz/fuzz_targets/simple-parser.rs
+++ b/cedar-drt/fuzz/fuzz_targets/simple-parser.rs
@@ -32,12 +32,12 @@ fuzz_target!(|input: String| {
             // entirely clear when `MissingNodeData` might be returned, but I don't believe it
             // should be possible, and, practically, it doesn't make this target fail.
             assert!(
-                !errs.0.iter().any(|e| matches!(
+                !errs.iter().any(|e| matches!(
                 e,
                 ParseError::ToAST(e) if matches!(e.kind(),
                     ToASTErrorKind::AnnotationInvariantViolation
                         | ToASTErrorKind::MembershipInvariantViolation
-                        | ToASTErrorKind::MissingNodeData)
+                        | ToASTErrorKind::EmptyNodeInvariantViolation)
                 )),
                 "{:?}",
                 errs

--- a/cedar-drt/fuzz/fuzz_targets/simple-parser.rs
+++ b/cedar-drt/fuzz/fuzz_targets/simple-parser.rs
@@ -16,8 +16,7 @@
 
 #![no_main]
 
-use cedar_drt_inner::fuzz_target;
-use cedar_policy_core::parser::err::{ParseError, ToASTErrorKind};
+use cedar_drt_inner::{check_for_internal_errors, fuzz_target};
 use cedar_policy_core::parser::parse_policyset;
 
 fuzz_target!(|input: String| {
@@ -25,23 +24,6 @@ fuzz_target!(|input: String| {
     #[allow(clippy::single_match)]
     match parse_policyset(&input) {
         Ok(_) => (),
-        Err(errs) => {
-            // Also check that we don't see a few specific errors.
-            // `AnnotationInvariantViolation` and `MembershipInvariantViolation`
-            // are documented as only being returned for internal invariant violations.  It's not
-            // entirely clear when `MissingNodeData` might be returned, but I don't believe it
-            // should be possible, and, practically, it doesn't make this target fail.
-            assert!(
-                !errs.iter().any(|e| matches!(
-                e,
-                ParseError::ToAST(e) if matches!(e.kind(),
-                    ToASTErrorKind::AnnotationInvariantViolation
-                        | ToASTErrorKind::MembershipInvariantViolation
-                        | ToASTErrorKind::EmptyNodeInvariantViolation)
-                )),
-                "{:?}",
-                errs
-            )
-        }
+        Err(errs) => check_for_internal_errors(errs),
     };
 });

--- a/cedar-drt/fuzz/src/lib.rs
+++ b/cedar-drt/fuzz/src/lib.rs
@@ -15,11 +15,11 @@
  */
 
 mod dump;
-mod policy_equiv;
+mod parsing_utils;
 mod prt;
 
 pub use dump::*;
-pub use policy_equiv::*;
+pub use parsing_utils::*;
 pub use prt::*;
 pub mod schemas;
 

--- a/cedar-drt/fuzz/src/parsing_utils.rs
+++ b/cedar-drt/fuzz/src/parsing_utils.rs
@@ -1,4 +1,21 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 use cedar_policy_core::ast::{AnyId, Template};
+use cedar_policy_core::parser::err::{ParseError, ParseErrors, ToASTErrorKind};
 use smol_str::SmolStr;
 use std::collections::HashMap;
 
@@ -28,4 +45,20 @@ pub fn check_policy_equivalence(p_old: &Template, p_new: &Template) {
             "old"
         )
     );
+}
+
+// Check that we don't see a few specific errors, which correspond to violations
+// of internal invariants.
+pub fn check_for_internal_errors(errs: ParseErrors) {
+    assert!(
+        !errs.iter().any(|e| matches!(
+        e,
+        ParseError::ToAST(e) if matches!(e.kind(),
+            ToASTErrorKind::AnnotationInvariantViolation
+                | ToASTErrorKind::MembershipInvariantViolation
+                | ToASTErrorKind::EmptyNodeInvariantViolation)
+        )),
+        "Parse errors included unexpected internal errors: {:?}",
+        miette::Report::new(errs).wrap_err("unexpected internal error")
+    )
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Fixes for [cedar#922](https://github.com/cedar-policy/cedar/pull/922).

Also adds the internal invariant violation check from `simple-parser` to `convert-policy-cedar-to-json` and `formatter-bytes`.

