### PR TITLE
Create a separate `Subsmap` type

### DIFF
--- a/cedar-lean/Cedar/Partial/Entities.lean
+++ b/cedar-lean/Cedar/Partial/Entities.lean
@@ -100,7 +100,7 @@ open Cedar.Data
   It's fine for some unknowns to not be in `subsmap`, in which case the returned
   `Partial.EntityData` will still contain some unknowns.
 -/
-def EntityData.subst (subsmap : Map Unknown Partial.Value) : Partial.EntityData → Partial.EntityData
+def EntityData.subst (subsmap : Subsmap) : Partial.EntityData → Partial.EntityData
   | { attrs, ancestors } => {
       attrs := attrs.mapOnValues (Partial.Value.subst subsmap),
       ancestors,
@@ -112,7 +112,7 @@ def EntityData.subst (subsmap : Map Unknown Partial.Value) : Partial.EntityData 
   It's fine for some unknowns to not be in `subsmap`, in which case the returned
   `Partial.Entities` will still contain some unknowns.
 -/
-def Entities.subst (subsmap : Map Unknown Partial.Value) : Partial.Entities → Partial.Entities
+def Entities.subst (subsmap : Subsmap) : Partial.Entities → Partial.Entities
   | { es } => {
       es := es.mapOnValues (Partial.EntityData.subst subsmap)
   }

--- a/cedar-lean/Cedar/Partial/Request.lean
+++ b/cedar-lean/Cedar/Partial/Request.lean
@@ -78,9 +78,9 @@ open Cedar.Spec (EntityUID)
   Returns `none` if the substitution is invalid -- e.g., if trying to substitute
   a non-`EntityUID` into `UidOrUnknown`.
 -/
-def UidOrUnknown.subst (subsmap : Map Unknown Partial.Value) : UidOrUnknown → Option UidOrUnknown
+def UidOrUnknown.subst (subsmap : Subsmap) : UidOrUnknown → Option UidOrUnknown
   | .known uid => some (.known uid)
-  | .unknown unk => match subsmap.find? unk with
+  | .unknown unk => match subsmap.m.find? unk with
     | some (.value (.prim (.entityUID uid))) => some (.known uid)
     | some (.residual (.unknown unk')) => some (.unknown unk') -- substituting an unknown with another unknown, we'll allow it
     | none => some (.unknown unk) -- no substitution available, return `unk` unchanged
@@ -95,7 +95,7 @@ def UidOrUnknown.subst (subsmap : Map Unknown Partial.Value) : UidOrUnknown → 
   Returns `none` if the substitution is invalid -- e.g., if trying to substitute
   a non-`EntityUID` into `UidOrUnknown`.
 -/
-def Request.subst (subsmap : Map Unknown Partial.Value) : Partial.Request → Option Partial.Request
+def Request.subst (subsmap : Subsmap) : Partial.Request → Option Partial.Request
   | { principal, action, resource, context } => do
     let principal ← principal.subst subsmap
     let action ← action.subst subsmap

--- a/cedar-lean/Cedar/Partial/Response.lean
+++ b/cedar-lean/Cedar/Partial/Response.lean
@@ -26,6 +26,7 @@ This file defines Cedar partial responses.
 namespace Cedar.Partial
 
 open Cedar.Data
+open Cedar.Partial (Subsmap)
 open Cedar.Spec (Effect Error PolicyID)
 
 /-- The result of partial-evaluating a policy -/
@@ -210,7 +211,7 @@ def Response.underapproximateDeterminingPolicies (resp : Partial.Response) : Set
 
   Assumes that `req` and `entities` have already been substituted.
 -/
-def Residual.reEvaluateWithSubst (subsmap : Map String Partial.Value) (req : Partial.Request) (entities : Partial.Entities) : Residual → Option Residual
+def Residual.reEvaluateWithSubst (subsmap : Subsmap) (req : Partial.Request) (entities : Partial.Entities) : Residual → Option Residual
   | .error id e => some (.error id e)
   | .residual id effect cond =>
     match Partial.evaluate (cond.subst subsmap) req entities with
@@ -236,7 +237,7 @@ def Residual.reEvaluateWithSubst (subsmap : Map String Partial.Value) (req : Par
     - the substitution is invalid (e.g., if trying to substitute a
         non-`EntityUID` into `UidOrUnknown`)
 -/
-def Response.reEvaluateWithSubst (subsmap : Map String Partial.Value) : Partial.Response → Option Partial.Response
+def Response.reEvaluateWithSubst (subsmap : Subsmap) : Partial.Response → Option Partial.Response
   | { residuals, req, entities } => do
   let req' ← req.subst subsmap
   let entities' := entities.subst subsmap

--- a/cedar-lean/Cedar/Thm/Partial/Evaluation.lean
+++ b/cedar-lean/Cedar/Thm/Partial/Evaluation.lean
@@ -38,7 +38,7 @@ import Cedar.Thm.Data.Control
 namespace Cedar.Thm.Partial.Evaluation
 
 open Cedar.Data
-open Cedar.Partial (Unknown)
+open Cedar.Partial (Subsmap Unknown)
 open Cedar.Spec (Error Prim Result)
 
 /--
@@ -212,7 +212,7 @@ decreasing_by
   If partial evaluation returns a concrete value, then it returns the same value
   after any substitution of unknowns
 -/
-theorem subst_preserves_evaluation_to_value {expr : Partial.Expr} {req req' : Partial.Request} {entities : Partial.Entities} {v : Spec.Value} {subsmap : Map Unknown Partial.Value}
+theorem subst_preserves_evaluation_to_value {expr : Partial.Expr} {req req' : Partial.Request} {entities : Partial.Entities} {v : Spec.Value} {subsmap : Subsmap}
   (wf_r : req.WellFormed)
   (wf_e : entities.WellFormed) :
   req.subst subsmap = some req' →

--- a/cedar-lean/Cedar/Thm/Partial/Evaluation/AndOr.lean
+++ b/cedar-lean/Cedar/Thm/Partial/Evaluation/AndOr.lean
@@ -22,7 +22,7 @@ import Cedar.Thm.Partial.Evaluation.WellFormed
 namespace Cedar.Thm.Partial.Evaluation.AndOr
 
 open Cedar.Data
-open Cedar.Partial (Unknown)
+open Cedar.Partial (Subsmap Unknown)
 open Cedar.Spec (Prim Result)
 
 /- ## Lemmas shared by And.lean and Or.lean -/
@@ -104,7 +104,7 @@ theorem partial_eval_wf (x₁ x₂ : Partial.Expr) (request : Partial.Request) (
   `Partial.Expr.or` returns a concrete value, then it returns the same value
   after any substitution of unknowns
 -/
-theorem subst_preserves_evaluation_to_value {x₁ x₂ : Partial.Expr} {req req' : Partial.Request} {entities : Partial.Entities} {subsmap : Map Unknown Partial.Value}
+theorem subst_preserves_evaluation_to_value {x₁ x₂ : Partial.Expr} {req req' : Partial.Request} {entities : Partial.Entities} {subsmap : Subsmap}
   (ih₁ : SubstPreservesEvaluationToConcrete x₁ req req' entities subsmap)
   (ih₂ : SubstPreservesEvaluationToConcrete x₂ req req' entities subsmap) :
   SubstPreservesEvaluationToConcrete (Partial.Expr.and x₁ x₂) req req' entities subsmap ∧

--- a/cedar-lean/Cedar/Thm/Partial/Evaluation/Binary.lean
+++ b/cedar-lean/Cedar/Thm/Partial/Evaluation/Binary.lean
@@ -26,7 +26,7 @@ import Cedar.Thm.Partial.Subst
 namespace Cedar.Thm.Partial.Evaluation.Binary
 
 open Cedar.Data
-open Cedar.Partial (Unknown)
+open Cedar.Partial (Subsmap Unknown)
 open Cedar.Spec (BinaryOp EntityUID intOrErr Prim Result)
 
 /--
@@ -246,7 +246,7 @@ theorem evals_to_concrete_then_operands_eval_to_concrete {x₁ x₂ : Partial.Ex
   The return value of `Partial.inₑ` is not affected by substitution of unknowns
   in `entities`
 -/
-theorem partialInₑ_subst_const {uid₁ uid₂ : EntityUID} {entities : Partial.Entities} {subsmap : Map Unknown Partial.Value} :
+theorem partialInₑ_subst_const {uid₁ uid₂ : EntityUID} {entities : Partial.Entities} {subsmap : Subsmap} :
   Partial.inₑ uid₁ uid₂ entities = Partial.inₑ uid₁ uid₂ (entities.subst subsmap)
 := by
   unfold Partial.inₑ
@@ -258,7 +258,7 @@ theorem partialInₑ_subst_const {uid₁ uid₂ : EntityUID} {entities : Partial
   The return value of `Partial.inₛ` is not affected by substitution of unknowns
   in `entities`
 -/
-theorem partialInₛ_subst_const {uid₁ : EntityUID} {s₂ : Set Spec.Value} {entities : Partial.Entities} {subsmap : Map Unknown Partial.Value} :
+theorem partialInₛ_subst_const {uid₁ : EntityUID} {s₂ : Set Spec.Value} {entities : Partial.Entities} {subsmap : Subsmap} :
   Partial.inₛ uid₁ s₂ entities = Partial.inₛ uid₁ s₂ (entities.subst subsmap)
 := by
   unfold Partial.inₛ
@@ -270,7 +270,7 @@ theorem partialInₛ_subst_const {uid₁ : EntityUID} {s₂ : Set Spec.Value} {e
   If `Partial.apply₂` returns a concrete value, then it returns the same value
   after any substitution of unknowns in `entities`
 -/
-theorem partialApply₂_subst_preserves_evaluation_to_value {v₁ v₂ : Spec.Value} {op : BinaryOp} {entities : Partial.Entities} {subsmap : Map Unknown Partial.Value} :
+theorem partialApply₂_subst_preserves_evaluation_to_value {v₁ v₂ : Spec.Value} {op : BinaryOp} {entities : Partial.Entities} {subsmap : Subsmap} :
   Partial.apply₂ op v₁ v₂ entities = .ok (.value v) →
   Partial.apply₂ op v₁ v₂ (entities.subst subsmap) = .ok (.value v)
 := by
@@ -303,7 +303,7 @@ theorem partialApply₂_subst_preserves_evaluation_to_value {v₁ v₂ : Spec.Va
   If `Partial.evaluateBinaryApp` returns a concrete value, then it returns
   the same value after any substitution of unknowns in `entities`
 -/
-theorem evaluateBinaryApp_subst_preserves_evaluation_to_value {pval₁ pval₂ : Partial.Value} {op : BinaryOp} {entities : Partial.Entities} {subsmap : Map Unknown Partial.Value} :
+theorem evaluateBinaryApp_subst_preserves_evaluation_to_value {pval₁ pval₂ : Partial.Value} {op : BinaryOp} {entities : Partial.Entities} {subsmap : Subsmap} :
   Partial.evaluateBinaryApp op pval₁ pval₂ entities = .ok (.value v) →
   Partial.evaluateBinaryApp op pval₁ pval₂ (entities.subst subsmap) = .ok (.value v)
 := by
@@ -316,7 +316,7 @@ theorem evaluateBinaryApp_subst_preserves_evaluation_to_value {pval₁ pval₂ :
   returns a concrete value, then it returns the same value after any
   substitution of unknowns
 -/
-theorem subst_preserves_evaluation_to_value {x₁ x₂ : Partial.Expr} {op : BinaryOp} {req req' : Partial.Request} {entities : Partial.Entities} {subsmap : Map Unknown Partial.Value}
+theorem subst_preserves_evaluation_to_value {x₁ x₂ : Partial.Expr} {op : BinaryOp} {req req' : Partial.Request} {entities : Partial.Entities} {subsmap : Subsmap}
   (ih₁ : SubstPreservesEvaluationToConcrete x₁ req req' entities subsmap)
   (ih₂ : SubstPreservesEvaluationToConcrete x₂ req req' entities subsmap) :
   SubstPreservesEvaluationToConcrete (Partial.Expr.binaryApp op x₁ x₂) req req' entities subsmap

--- a/cedar-lean/Cedar/Thm/Partial/Evaluation/Call.lean
+++ b/cedar-lean/Cedar/Thm/Partial/Evaluation/Call.lean
@@ -26,7 +26,7 @@ import Cedar.Thm.Partial.Evaluation.WellFormed
 namespace Cedar.Thm.Partial.Evaluation.Call
 
 open Cedar.Data
-open Cedar.Partial (Unknown)
+open Cedar.Partial (Subsmap Unknown)
 open Cedar.Spec (Error Ext ExtFun Prim Result)
 
 /--
@@ -165,7 +165,7 @@ theorem evals_to_concrete_then_args_eval_to_concrete {xs : List Partial.Expr} {r
   a concrete value, then it returns the same value after any substitution of
   unknowns
 -/
-theorem subst_preserves_evaluation_to_value {args : List Partial.Expr} {req req' : Partial.Request} {entities : Partial.Entities} {subsmap : Map Unknown Partial.Value} {xfn : ExtFun}
+theorem subst_preserves_evaluation_to_value {args : List Partial.Expr} {req req' : Partial.Request} {entities : Partial.Entities} {subsmap : Subsmap} {xfn : ExtFun}
   (ih : ∀ arg ∈ args, SubstPreservesEvaluationToConcrete arg req req' entities subsmap) :
   SubstPreservesEvaluationToConcrete (Partial.Expr.call xfn args) req req' entities subsmap
 := by

--- a/cedar-lean/Cedar/Thm/Partial/Evaluation/GetAttr.lean
+++ b/cedar-lean/Cedar/Thm/Partial/Evaluation/GetAttr.lean
@@ -27,7 +27,7 @@ import Cedar.Thm.Partial.Subst
 namespace Cedar.Thm.Partial.Evaluation.GetAttr
 
 open Cedar.Data
-open Cedar.Partial (Unknown)
+open Cedar.Partial (Subsmap Unknown)
 open Cedar.Spec (Attr EntityUID Error Result)
 
 /--
@@ -224,7 +224,7 @@ theorem evals_to_concrete_then_operand_evals_to_concrete {x₁ : Partial.Expr} {
   If `Partial.getAttr` returns a concrete value, then it returns the same value
   after any substitution of unknowns in `entities`
 -/
-theorem getAttr_subst_preserves_evaluation_to_value {v₁ : Spec.Value} {attr : Attr} {entities : Partial.Entities} {subsmap : Map Unknown Partial.Value}
+theorem getAttr_subst_preserves_evaluation_to_value {v₁ : Spec.Value} {attr : Attr} {entities : Partial.Entities} {subsmap : Subsmap}
   (wf : entities.WellFormed) :
   Partial.getAttr v₁ attr entities = .ok (.value v) →
   Partial.getAttr v₁ attr (entities.subst subsmap) = .ok (.value v)
@@ -255,7 +255,7 @@ theorem getAttr_subst_preserves_evaluation_to_value {v₁ : Spec.Value} {attr : 
   If `Partial.evaluateGetAttr` returns a concrete value, then it returns the
   same value after any substitution of unknowns in `entities`
 -/
-theorem evaluateGetAttr_subst_preserves_evaluation_to_value {pval₁ : Partial.Value} {attr : Attr} {entities : Partial.Entities} {subsmap : Map Unknown Partial.Value}
+theorem evaluateGetAttr_subst_preserves_evaluation_to_value {pval₁ : Partial.Value} {attr : Attr} {entities : Partial.Entities} {subsmap : Subsmap}
   (wf : entities.WellFormed) :
   Partial.evaluateGetAttr pval₁ attr entities = .ok (.value v) →
   Partial.evaluateGetAttr pval₁ attr (entities.subst subsmap) = .ok (.value v)
@@ -269,7 +269,7 @@ theorem evaluateGetAttr_subst_preserves_evaluation_to_value {pval₁ : Partial.V
   returns a concrete value, then it returns the same value after any
   substitution of unknowns
 -/
-theorem subst_preserves_evaluation_to_value {x₁ : Partial.Expr} {attr : Attr} {req req' : Partial.Request} {entities : Partial.Entities} {subsmap : Map Unknown Partial.Value}
+theorem subst_preserves_evaluation_to_value {x₁ : Partial.Expr} {attr : Attr} {req req' : Partial.Request} {entities : Partial.Entities} {subsmap : Subsmap}
   (wf : entities.WellFormed)
   (ih₁ : SubstPreservesEvaluationToConcrete x₁ req req' entities subsmap) :
   SubstPreservesEvaluationToConcrete (Partial.Expr.getAttr x₁ attr) req req' entities subsmap

--- a/cedar-lean/Cedar/Thm/Partial/Evaluation/HasAttr.lean
+++ b/cedar-lean/Cedar/Thm/Partial/Evaluation/HasAttr.lean
@@ -26,7 +26,7 @@ import Cedar.Thm.Partial.Subst
 namespace Cedar.Thm.Partial.Evaluation.HasAttr
 
 open Cedar.Data
-open Cedar.Partial (Unknown)
+open Cedar.Partial (Subsmap Unknown)
 open Cedar.Spec (Attr Error Prim Result)
 
 /--
@@ -176,7 +176,7 @@ theorem evals_to_concrete_then_operand_evals_to_concrete {x₁ : Partial.Expr} {
   The return value of `Partial.hasAttr` is not affected by substitution of
   unknowns in `entities`
 -/
-theorem hasAttr_subst_const {v₁ : Spec.Value} {attr : Attr} {entities : Partial.Entities} {subsmap : Map Unknown Partial.Value}
+theorem hasAttr_subst_const {v₁ : Spec.Value} {attr : Attr} {entities : Partial.Entities} {subsmap : Subsmap}
   (wf : entities.WellFormed) :
   Partial.hasAttr v₁ attr entities = Partial.hasAttr v₁ attr (entities.subst subsmap)
 := by
@@ -192,7 +192,7 @@ theorem hasAttr_subst_const {v₁ : Spec.Value} {attr : Attr} {entities : Partia
   If `Partial.evaluateHasAttr` returns a concrete value, then it returns the
   same value after any substitution of unknowns in `entities`
 -/
-theorem evaluateHasAttr_subst_preserves_evaluation_to_value {pval₁ : Partial.Value} {attr : Attr} {entities : Partial.Entities} {subsmap : Map Unknown Partial.Value}
+theorem evaluateHasAttr_subst_preserves_evaluation_to_value {pval₁ : Partial.Value} {attr : Attr} {entities : Partial.Entities} {subsmap : Subsmap}
   (wf : entities.WellFormed) :
   Partial.evaluateHasAttr pval₁ attr entities = .ok (.value v) →
   Partial.evaluateHasAttr pval₁ attr (entities.subst subsmap) = .ok (.value v)
@@ -206,7 +206,7 @@ theorem evaluateHasAttr_subst_preserves_evaluation_to_value {pval₁ : Partial.V
   returns a concrete value, then it returns the same value after any
   substitution of unknowns
 -/
-theorem subst_preserves_evaluation_to_value {x₁ : Partial.Expr} {attr : Attr} {req req' : Partial.Request} {entities : Partial.Entities} {subsmap : Map Unknown Partial.Value}
+theorem subst_preserves_evaluation_to_value {x₁ : Partial.Expr} {attr : Attr} {req req' : Partial.Request} {entities : Partial.Entities} {subsmap : Subsmap}
   (wf : entities.WellFormed)
   (ih₁ : SubstPreservesEvaluationToConcrete x₁ req req' entities subsmap) :
   SubstPreservesEvaluationToConcrete (Partial.Expr.hasAttr x₁ attr) req req' entities subsmap

--- a/cedar-lean/Cedar/Thm/Partial/Evaluation/Ite.lean
+++ b/cedar-lean/Cedar/Thm/Partial/Evaluation/Ite.lean
@@ -23,7 +23,7 @@ import Cedar.Thm.Partial.Evaluation.WellFormed
 namespace Cedar.Thm.Partial.Evaluation.Ite
 
 open Cedar.Data
-open Cedar.Partial (Unknown)
+open Cedar.Partial (Subsmap Unknown)
 open Cedar.Spec (Result)
 
 /--
@@ -120,7 +120,7 @@ theorem evals_to_concrete_then_operands_eval_to_concrete {x₁ x₂ x₃ : Parti
   a concrete value, then it returns the same value after any substitution of
   unknowns
 -/
-theorem subst_preserves_evaluation_to_value {x₁ x₂ x₃ : Partial.Expr} {req req' : Partial.Request} {entities : Partial.Entities} {subsmap : Map Unknown Partial.Value}
+theorem subst_preserves_evaluation_to_value {x₁ x₂ x₃ : Partial.Expr} {req req' : Partial.Request} {entities : Partial.Entities} {subsmap : Subsmap}
   (ih₁ : SubstPreservesEvaluationToConcrete x₁ req req' entities subsmap)
   (ih₂₃ :
     (Partial.evaluate x₁ req entities = .ok (.value (.prim (.bool true))) ∧ SubstPreservesEvaluationToConcrete x₂ req req' entities subsmap) ∨

--- a/cedar-lean/Cedar/Thm/Partial/Evaluation/Props.lean
+++ b/cedar-lean/Cedar/Thm/Partial/Evaluation/Props.lean
@@ -25,7 +25,7 @@ import Cedar.Thm.Partial.Evaluation.WellFormed
 namespace Cedar.Thm.Partial
 
 open Cedar.Data
-open Cedar.Partial (Unknown)
+open Cedar.Partial (Subsmap Unknown)
 
 /--
   Prop that partial evaluation and concrete evaluation of the same concrete
@@ -43,7 +43,7 @@ def EvaluatesToConcrete (expr : Partial.Expr) (request : Partial.Request) (entit
 /--
   Prop that .subst preserves evaluation to a concrete value
 -/
-def SubstPreservesEvaluationToConcrete (expr : Partial.Expr) (req req' : Partial.Request) (entities : Partial.Entities) (subsmap : Map Unknown Partial.Value) : Prop :=
+def SubstPreservesEvaluationToConcrete (expr : Partial.Expr) (req req' : Partial.Request) (entities : Partial.Entities) (subsmap : Subsmap) : Prop :=
   req.subst subsmap = some req' →
   ∀ v,
     Partial.evaluate expr req entities = .ok (.value v) →

--- a/cedar-lean/Cedar/Thm/Partial/Evaluation/Record.lean
+++ b/cedar-lean/Cedar/Thm/Partial/Evaluation/Record.lean
@@ -24,7 +24,7 @@ import Cedar.Thm.Partial.Evaluation.WellFormed
 namespace Cedar.Thm.Partial.Evaluation.Record
 
 open Cedar.Data
-open Cedar.Partial (Unknown)
+open Cedar.Partial (Subsmap Unknown)
 open Cedar.Spec (Attr Error Result)
 
 /--
@@ -220,7 +220,7 @@ theorem evals_to_concrete_then_vals_eval_to_concrete {attrs : List (Attr × Part
   list of concrete vals, then it produces the same list of concrete vals after
   any substitution of unknowns
 -/
-theorem mapM_subst_snd_preserves_evaluation_to_values {attrs : List (Attr × Partial.Expr)} {req req' : Partial.Request} {entities : Partial.Entities} {subsmap : Map Unknown Partial.Value}
+theorem mapM_subst_snd_preserves_evaluation_to_values {attrs : List (Attr × Partial.Expr)} {req req' : Partial.Request} {entities : Partial.Entities} {subsmap : Subsmap}
   (ih : ∀ kv ∈ attrs, SubstPreservesEvaluationToConcrete kv.snd req req' entities subsmap) :
   req.subst subsmap = some req' →
   ∀ (pvals : List (Attr × Partial.Value)),
@@ -309,7 +309,7 @@ private theorem mapM_pairs_snd {pvals : List (Attr × Partial.Value)} {pairs : L
   returns a concrete value, then it returns the same value after any
   substitution of unknowns
 -/
-theorem subst_preserves_evaluation_to_value {attrs : List (Attr × Partial.Expr)} {req req' : Partial.Request} {entities : Partial.Entities} {subsmap : Map Unknown Partial.Value}
+theorem subst_preserves_evaluation_to_value {attrs : List (Attr × Partial.Expr)} {req req' : Partial.Request} {entities : Partial.Entities} {subsmap : Subsmap}
   (ih : ∀ kv ∈ attrs, SubstPreservesEvaluationToConcrete kv.snd req req' entities subsmap) :
   SubstPreservesEvaluationToConcrete (Partial.Expr.record attrs) req req' entities subsmap
 := by

--- a/cedar-lean/Cedar/Thm/Partial/Evaluation/Set.lean
+++ b/cedar-lean/Cedar/Thm/Partial/Evaluation/Set.lean
@@ -26,7 +26,7 @@ import Cedar.Thm.Partial.Evaluation.WellFormed
 namespace Cedar.Thm.Partial.Evaluation.Set
 
 open Cedar.Data
-open Cedar.Partial (Unknown)
+open Cedar.Partial (Subsmap Unknown)
 open Cedar.Spec (Result)
 
 /--
@@ -146,7 +146,7 @@ theorem evals_to_concrete_then_elts_eval_to_concrete {xs : List Partial.Expr} {r
   with a list of concrete vals, then it produces the same list of concrete vals
   after any substitution of unknowns
 -/
-theorem mapM_subst_preserves_evaluation_to_values {xs : List Partial.Expr} {req req' : Partial.Request} {entities : Partial.Entities} {subsmap : Map Unknown Partial.Value}
+theorem mapM_subst_preserves_evaluation_to_values {xs : List Partial.Expr} {req req' : Partial.Request} {entities : Partial.Entities} {subsmap : Subsmap}
   (ih : ∀ x ∈ xs, SubstPreservesEvaluationToConcrete x req req' entities subsmap) :
   req.subst subsmap = some req' →
   ∀ (pvals : List Partial.Value),
@@ -204,7 +204,7 @@ theorem mapM_subst_preserves_evaluation_to_values {xs : List Partial.Expr} {req 
   a concrete value, then it returns the same value after any substitution of
   unknowns
 -/
-theorem subst_preserves_evaluation_to_value {xs : List Partial.Expr} {req req' : Partial.Request} {entities : Partial.Entities} {subsmap : Map Unknown Partial.Value}
+theorem subst_preserves_evaluation_to_value {xs : List Partial.Expr} {req req' : Partial.Request} {entities : Partial.Entities} {subsmap : Subsmap}
   (ih : ∀ x ∈ xs, SubstPreservesEvaluationToConcrete x req req' entities subsmap) :
   SubstPreservesEvaluationToConcrete (Partial.Expr.set xs) req req' entities subsmap
 := by

--- a/cedar-lean/Cedar/Thm/Partial/Evaluation/Unary.lean
+++ b/cedar-lean/Cedar/Thm/Partial/Evaluation/Unary.lean
@@ -23,7 +23,7 @@ import Cedar.Thm.Partial.Evaluation.WellFormed
 namespace Cedar.Thm.Partial.Evaluation.Unary
 
 open Cedar.Data
-open Cedar.Partial (Unknown)
+open Cedar.Partial (Subsmap Unknown)
 open Cedar.Spec (Prim UnaryOp)
 
 /--
@@ -141,7 +141,7 @@ theorem evals_to_concrete_then_operand_evals_to_concrete {x₁ : Partial.Expr} {
   returns a concrete value, then it returns the same value after any
   substitution of unknowns
 -/
-theorem subst_preserves_evaluation_to_value {x₁ : Partial.Expr} {op : UnaryOp} {req req' : Partial.Request} {entities : Partial.Entities} {subsmap : Map Unknown Partial.Value}
+theorem subst_preserves_evaluation_to_value {x₁ : Partial.Expr} {op : UnaryOp} {req req' : Partial.Request} {entities : Partial.Entities} {subsmap : Subsmap}
   (ih₁ : SubstPreservesEvaluationToConcrete x₁ req req' entities subsmap) :
   SubstPreservesEvaluationToConcrete (Partial.Expr.unaryApp op x₁) req req' entities subsmap
 := by

--- a/cedar-lean/Cedar/Thm/Partial/Evaluation/Var.lean
+++ b/cedar-lean/Cedar/Thm/Partial/Evaluation/Var.lean
@@ -26,7 +26,7 @@ import Cedar.Thm.Partial.Subst
 namespace Cedar.Thm.Partial.Evaluation.Var
 
 open Cedar.Data
-open Cedar.Partial (Unknown)
+open Cedar.Partial (Subsmap Unknown)
 open Cedar.Spec (Prim Var)
 
 /--
@@ -133,7 +133,7 @@ theorem partial_eval_wf {v : Var} {request : Partial.Request} {entities : Partia
   Lemma: If `context` has only concrete values before substitution, then it has
   only concrete values after substitution
 -/
-theorem subst_preserves_all_concrete {req req' : Partial.Request} {subsmap : Map Unknown Partial.Value}
+theorem subst_preserves_all_concrete {req req' : Partial.Request} {subsmap : Subsmap}
   (wf : req.WellFormed) :
   req.subst subsmap = some req' →
   req.context.mapMOnValues (λ v => match v with | .value v => some v | .residual _ => none) = some m →
@@ -171,7 +171,7 @@ theorem subst_preserves_all_concrete {req req' : Partial.Request} {subsmap : Map
   If evaluating a request context returns a concrete value, then it returns the
   same value after any substitution of unknowns
 -/
-theorem subst_preserves_evaluate_req_context_to_value {req req' : Partial.Request} {subsmap : Map Unknown Partial.Value}
+theorem subst_preserves_evaluate_req_context_to_value {req req' : Partial.Request} {subsmap : Subsmap}
   (wf : req.WellFormed) :
   req.subst subsmap = some req' →
   req.context.mapMOnValues (λ v => match v with | .value v => some v | .residual _ => none) = some m →
@@ -199,7 +199,7 @@ theorem subst_preserves_evaluate_req_context_to_value {req req' : Partial.Reques
   If `Partial.evaluateVar` returns a concrete value, then it returns the same
   value after any substitution of unknowns
 -/
-theorem subst_preserves_evaluateVar_to_value {var : Var} {req req' : Partial.Request} {v : Spec.Value} {subsmap : Map Unknown Partial.Value}
+theorem subst_preserves_evaluateVar_to_value {var : Var} {req req' : Partial.Request} {v : Spec.Value} {subsmap : Subsmap}
   (wf : req.WellFormed) :
   req.subst subsmap = some req' →
   Partial.evaluateVar var req = .ok (.value v) →
@@ -247,7 +247,7 @@ theorem subst_preserves_evaluateVar_to_value {var : Var} {req req' : Partial.Req
   If partial-evaluation of a `Var` returns a concrete value, then it returns the
   same value after any substitution of unknowns
 -/
-theorem subst_preserves_evaluation_to_value (var : Var) (req req' : Partial.Request) (entities : Partial.Entities) (subsmap : Map Unknown Partial.Value)
+theorem subst_preserves_evaluation_to_value (var : Var) (req req' : Partial.Request) (entities : Partial.Entities) (subsmap : Subsmap)
   (wf : req.WellFormed) :
   SubstPreservesEvaluationToConcrete (Partial.Expr.var var) req req' entities subsmap
 := by

--- a/cedar-lean/Cedar/Thm/Partial/Subst.lean
+++ b/cedar-lean/Cedar/Thm/Partial/Subst.lean
@@ -29,13 +29,13 @@ import Cedar.Thm.Partial.Evaluation.WellFormed
 namespace Cedar.Thm.Partial.Subst
 
 open Cedar.Data
-open Cedar.Partial (Unknown)
+open Cedar.Partial (Subsmap Unknown)
 open Cedar.Spec (Attr EntityUID)
 
 /--
   subst on a concrete expression is that expression
 -/
-theorem subst_concrete_expr (expr : Spec.Expr) (subsmap : Map Unknown Partial.Value) :
+theorem subst_concrete_expr (expr : Spec.Expr) (subsmap : Subsmap) :
   expr.asPartialExpr.subst subsmap = expr.asPartialExpr
 := by
   unfold Partial.Expr.subst Spec.Expr.asPartialExpr
@@ -74,7 +74,7 @@ termination_by expr
 /--
   Partial.Value.subst on a concrete value is that value
 -/
-theorem subst_concrete_value (value : Spec.Value) (subsmap : Map Unknown Partial.Value) :
+theorem subst_concrete_value (value : Spec.Value) (subsmap : Subsmap) :
   (Partial.Value.value value).subst subsmap = value
 := by
   unfold Partial.Value.subst
@@ -85,7 +85,7 @@ theorem subst_concrete_value (value : Spec.Value) (subsmap : Map Unknown Partial
 /--
   Partial.Expr.subst on a concrete value is that value
 -/
-theorem subst_concrete_value' (value : Spec.Value) (subsmap : Map Unknown Partial.Value) :
+theorem subst_concrete_value' (value : Spec.Value) (subsmap : Subsmap) :
   value.asPartialExpr.subst subsmap = value.asPartialExpr
 := by
   unfold Partial.Expr.subst Spec.Value.asPartialExpr
@@ -128,7 +128,7 @@ decreasing_by
 /--
   Partial.Value.subst preserves well-formedness
 -/
-theorem val_subst_preserves_wf {v : Partial.Value} {subsmap : Map Unknown Partial.Value} :
+theorem val_subst_preserves_wf {v : Partial.Value} {subsmap : Subsmap} :
   v.WellFormed → (v.subst subsmap).WellFormed
 := by
   cases v <;> simp [Partial.Value.WellFormed, Partial.Value.subst]
@@ -136,7 +136,7 @@ theorem val_subst_preserves_wf {v : Partial.Value} {subsmap : Map Unknown Partia
 /--
   Partial.Request.subst preserves well-formedness
 -/
-theorem req_subst_preserves_wf {req req' : Partial.Request} {subsmap : Map Unknown Partial.Value} :
+theorem req_subst_preserves_wf {req req' : Partial.Request} {subsmap : Subsmap} :
   req.WellFormed →
   req.subst subsmap = some req' →
   req'.WellFormed
@@ -157,7 +157,7 @@ theorem req_subst_preserves_wf {req req' : Partial.Request} {subsmap : Map Unkno
 /--
   Partial.Request.subst preserves a known principal UID
 -/
-theorem req_subst_preserves_known_principal {req req' : Partial.Request} {uid : EntityUID} {subsmap : Map Unknown Partial.Value} :
+theorem req_subst_preserves_known_principal {req req' : Partial.Request} {uid : EntityUID} {subsmap : Subsmap} :
   req.principal = .known uid →
   req.subst subsmap = some req' →
   req'.principal = .known uid
@@ -173,7 +173,7 @@ theorem req_subst_preserves_known_principal {req req' : Partial.Request} {uid : 
 /--
   Partial.Request.subst preserves a known action UID
 -/
-theorem req_subst_preserves_known_action {req req' : Partial.Request} {uid : EntityUID} {subsmap : Map Unknown Partial.Value} :
+theorem req_subst_preserves_known_action {req req' : Partial.Request} {uid : EntityUID} {subsmap : Subsmap} :
   req.action = .known uid →
   req.subst subsmap = some req' →
   req'.action = .known uid
@@ -189,7 +189,7 @@ theorem req_subst_preserves_known_action {req req' : Partial.Request} {uid : Ent
 /--
   Partial.Request.subst preserves a known resource UID
 -/
-theorem req_subst_preserves_known_resource {req req' : Partial.Request} {uid : EntityUID} {subsmap : Map Unknown Partial.Value} :
+theorem req_subst_preserves_known_resource {req req' : Partial.Request} {uid : EntityUID} {subsmap : Subsmap} :
   req.resource = .known uid →
   req.subst subsmap = some req' →
   req'.resource = .known uid
@@ -205,7 +205,7 @@ theorem req_subst_preserves_known_resource {req req' : Partial.Request} {uid : E
 /--
   Partial.Request.subst preserves the keyset of `context`
 -/
-theorem req_subst_preserves_keys_of_context {req req' : Partial.Request} {subsmap : Map Unknown Partial.Value} :
+theorem req_subst_preserves_keys_of_context {req req' : Partial.Request} {subsmap : Subsmap} :
   req.subst subsmap = some req' →
   req.context.keys = req'.context.keys
 := by
@@ -219,7 +219,7 @@ theorem req_subst_preserves_keys_of_context {req req' : Partial.Request} {subsma
 /--
   Partial.Request.subst preserves concrete values in the `context`
 -/
-theorem req_subst_preserves_concrete_context_vals {req req' : Partial.Request} {k : Attr} {subsmap : Map Unknown Partial.Value} :
+theorem req_subst_preserves_concrete_context_vals {req req' : Partial.Request} {k : Attr} {subsmap : Subsmap} :
   (k, .value v) ∈ req.context.kvs →
   req.subst subsmap = some req' →
   (k, .value v) ∈ req'.context.kvs
@@ -235,7 +235,7 @@ theorem req_subst_preserves_concrete_context_vals {req req' : Partial.Request} {
 /--
   Partial.EntityData.subst preserves well-formedness
 -/
-theorem entitydata_subst_preserves_wf {ed : Partial.EntityData} (subsmap : Map Unknown Partial.Value) :
+theorem entitydata_subst_preserves_wf {ed : Partial.EntityData} (subsmap : Subsmap) :
   ed.WellFormed → (ed.subst subsmap).WellFormed
 := by
   unfold Partial.EntityData.WellFormed Partial.EntityData.subst
@@ -252,7 +252,7 @@ theorem entitydata_subst_preserves_wf {ed : Partial.EntityData} (subsmap : Map U
 /--
   Partial.Entities.subst preserves well-formedness
 -/
-theorem entities_subst_preserves_wf {entities : Partial.Entities} (subsmap : Map Unknown Partial.Value) :
+theorem entities_subst_preserves_wf {entities : Partial.Entities} (subsmap : Subsmap) :
   entities.WellFormed → (entities.subst subsmap).WellFormed
 := by
   unfold Partial.Entities.WellFormed Partial.Entities.subst
@@ -268,7 +268,7 @@ theorem entities_subst_preserves_wf {entities : Partial.Entities} (subsmap : Map
 /--
   Partial.EntityData.subst preserves .ancestors
 -/
-theorem entitydata_subst_preserves_ancestors (ed : Partial.EntityData) (subsmap : Map Unknown Partial.Value) :
+theorem entitydata_subst_preserves_ancestors (ed : Partial.EntityData) (subsmap : Subsmap) :
   ed.ancestors = (ed.subst subsmap).ancestors
 := by
   simp [Partial.EntityData.subst]
@@ -276,7 +276,7 @@ theorem entitydata_subst_preserves_ancestors (ed : Partial.EntityData) (subsmap 
 /--
   Partial.EntityData.subst preserves .contains on .attrs
 -/
-theorem entitydata_subst_preserves_contains_on_attrs (ed : Partial.EntityData) (attr : Attr) (subsmap : Map Unknown Partial.Value)
+theorem entitydata_subst_preserves_contains_on_attrs (ed : Partial.EntityData) (attr : Attr) (subsmap : Subsmap)
   (wf : ed.WellFormed) :
   ed.attrs.contains attr = (ed.subst subsmap).attrs.contains attr
 := by
@@ -308,7 +308,7 @@ theorem entitydata_subst_preserves_contains_on_attrs (ed : Partial.EntityData) (
 /--
   Partial.EntityData.subst preserves concrete attribute values
 -/
-theorem entitydata_subst_preserves_concrete_attrs {ed : Partial.EntityData} (subsmap : Map Unknown Partial.Value) :
+theorem entitydata_subst_preserves_concrete_attrs {ed : Partial.EntityData} (subsmap : Subsmap) :
   (k, .value v) ∈ ed.attrs.kvs → (k, .value v) ∈ (ed.subst subsmap).attrs.kvs
 := by
   unfold Partial.EntityData.subst
@@ -319,7 +319,7 @@ theorem entitydata_subst_preserves_concrete_attrs {ed : Partial.EntityData} (sub
 /--
   Partial.Entities.subst preserves .ancestorsOrEmpty
 -/
-theorem entities_subst_preserves_ancestorsOrEmpty (entities : Partial.Entities) (uid : EntityUID) (subsmap : Map Unknown Partial.Value) :
+theorem entities_subst_preserves_ancestorsOrEmpty (entities : Partial.Entities) (uid : EntityUID) (subsmap : Subsmap) :
   entities.ancestorsOrEmpty uid = (entities.subst subsmap).ancestorsOrEmpty uid
 := by
   unfold Partial.Entities.subst Partial.Entities.ancestorsOrEmpty
@@ -332,7 +332,7 @@ theorem entities_subst_preserves_ancestorsOrEmpty (entities : Partial.Entities) 
 /--
   Partial.Entities.subst preserves concrete attribute values
 -/
-theorem entities_subst_preserves_concrete_attrs {entities : Partial.Entities} {uid : EntityUID} (subsmap : Map Unknown Partial.Value) :
+theorem entities_subst_preserves_concrete_attrs {entities : Partial.Entities} {uid : EntityUID} (subsmap : Subsmap) :
   entities.attrs uid = .ok attrs →
   (k, .value v) ∈ attrs.kvs →
   ∃ attrs', (entities.subst subsmap).attrs uid = .ok attrs' ∧ (k, .value v) ∈ attrs'.kvs
@@ -352,7 +352,7 @@ theorem entities_subst_preserves_concrete_attrs {entities : Partial.Entities} {u
 /--
   Partial.Entities.subst preserves `Map.contains` for the attrs maps
 -/
-theorem entities_subst_preserves_contains_on_attrsOrEmpty (entities : Partial.Entities) (uid : EntityUID) (attr : Attr) (subsmap : Map Unknown Partial.Value)
+theorem entities_subst_preserves_contains_on_attrsOrEmpty (entities : Partial.Entities) (uid : EntityUID) (attr : Attr) (subsmap : Subsmap)
   (wf : entities.WellFormed) :
   (entities.attrsOrEmpty uid).contains attr = ((entities.subst subsmap).attrsOrEmpty uid).contains attr
 := by


### PR DESCRIPTION
Instead of using `Map Unknown Partial.Value` everywhere, it will be more convenient in the future to have a dedicated `Subsmap` type.  This is a non-functional change, just a pure refactor.


