### PR TITLE
Adds modelling of condition clauses

### DIFF
--- a/cedar-lean/Cedar/Spec/Policy.lean
+++ b/cedar-lean/Cedar/Spec/Policy.lean
@@ -55,8 +55,8 @@ inductive ActionScope where
 abbrev PolicyID := String
 
 inductive ConditionKind where
-  | When
-  | Unless
+  | when
+  | unless
 
 structure Condition where
   kind : ConditionKind
@@ -112,8 +112,8 @@ def ActionScope.toExpr : ActionScope → Expr
 
 def Condition.toExpr (c : Condition) : Expr :=
   match c.kind with
-  | .When => c.body
-  | .Unless => Expr.unaryApp .not c.body
+  | .when => c.body
+  | .unless => Expr.unaryApp .not c.body
 
 -- Conditions are evaluated top to bottom, and short circuit
 def conditionsToExpr (cs : Conditions) : Expr :=

--- a/cedar-lean/Cedar/Spec/Policy.lean
+++ b/cedar-lean/Cedar/Spec/Policy.lean
@@ -116,7 +116,7 @@ def Condition.toExpr (c : Condition) : Expr :=
   | .unless => Expr.unaryApp .not c.body
 
 -- Conditions are evaluated top to bottom, and short circuit
-def conditionsToExpr (cs : Conditions) : Expr :=
+def Conditions.toExpr (cs : Conditions) : Expr :=
   List.foldr (λ c expr => .and (c.toExpr) expr ) (Expr.lit $ Prim.bool true ) cs
 
 def Policy.toExpr (p : Policy) : Expr :=
@@ -126,7 +126,7 @@ def Policy.toExpr (p : Policy) : Expr :=
       p.actionScope.toExpr
       (.and
         p.resourceScope.toExpr
-        (conditionsToExpr p.condition)))
+        p.condition.toExpr))
 
 def Scope.bound : Scope → Option EntityUID
   | .eq uid      => .some uid

--- a/cedar-lean/Cedar/Spec/Template.lean
+++ b/cedar-lean/Cedar/Spec/Template.lean
@@ -55,7 +55,7 @@ structure Template where
   principalScope : PrincipalScopeTemplate
   actionScope : ActionScope
   resourceScope : ResourceScopeTemplate
-  condition : Expr
+  condition : Conditions
 
 abbrev Templates := Map TemplateID Template
 

--- a/cedar-lean/Cedar/Thm/Authorization/Authorizer.lean
+++ b/cedar-lean/Cedar/Thm/Authorization/Authorizer.lean
@@ -541,7 +541,7 @@ theorem error_implies_scope_satisfied {policy : Policy} {request : Request} {ent
       exfalso
       clear h₂
       unfold producesNonBool at h₅
-      have h₄ := and_produces_bool_or_error policy.resourceScope.toExpr (conditionsToExpr policy.condition) request entities
+      have h₄ := and_produces_bool_or_error policy.resourceScope.toExpr policy.condition.toExpr request entities
       split at h₄ <;> simp at h₄
       case _ h₆ => simp [h₆] at h₅
       case _ h₆ => simp [h₆] at h₅
@@ -554,7 +554,7 @@ theorem error_implies_scope_satisfied {policy : Policy} {request : Request} {ent
     -- in this case, evaluating (action ∧ resource ∧ condition) produced a non-boolean
     exfalso
     unfold producesNonBool at h₄
-    generalize (Expr.and policy.resourceScope.toExpr (conditionsToExpr policy.condition)) = resource_and_condition at h₂ h₄
+    generalize (Expr.and policy.resourceScope.toExpr policy.condition.toExpr) = resource_and_condition at h₂ h₄
     have h₅ := and_produces_bool_or_error policy.actionScope.toExpr resource_and_condition request entities
     split at h₅ <;> simp at h₅
     case _ h₆ => simp [h₆] at h₄

--- a/cedar-lean/Cedar/Thm/Authorization/Authorizer.lean
+++ b/cedar-lean/Cedar/Thm/Authorization/Authorizer.lean
@@ -541,7 +541,7 @@ theorem error_implies_scope_satisfied {policy : Policy} {request : Request} {ent
       exfalso
       clear h₂
       unfold producesNonBool at h₅
-      have h₄ := and_produces_bool_or_error policy.resourceScope.toExpr policy.condition request entities
+      have h₄ := and_produces_bool_or_error policy.resourceScope.toExpr (conditionsToExpr policy.condition) request entities
       split at h₄ <;> simp at h₄
       case _ h₆ => simp [h₆] at h₅
       case _ h₆ => simp [h₆] at h₅
@@ -554,7 +554,7 @@ theorem error_implies_scope_satisfied {policy : Policy} {request : Request} {ent
     -- in this case, evaluating (action ∧ resource ∧ condition) produced a non-boolean
     exfalso
     unfold producesNonBool at h₄
-    generalize (Expr.and policy.resourceScope.toExpr policy.condition) = resource_and_condition at h₂ h₄
+    generalize (Expr.and policy.resourceScope.toExpr (conditionsToExpr policy.condition)) = resource_and_condition at h₂ h₄
     have h₅ := and_produces_bool_or_error policy.actionScope.toExpr resource_and_condition request entities
     split at h₅ <;> simp at h₅
     case _ h₆ => simp [h₆] at h₄

--- a/cedar-lean/DiffTest/Parser.lean
+++ b/cedar-lean/DiffTest/Parser.lean
@@ -404,7 +404,7 @@ def jsonToActionScope (json : Lean.Json) : ParseResult ActionScope := do
 -- conditions structure
 def jsonToConditions (json : Lean.Json) : ParseResult Conditions := do
   let expr ← jsonToExpr json
-  .ok $ [{ kind := .When,  body := expr }]
+  .ok $ [{ kind := .when,  body := expr }]
 
 def jsonToTemplate (json : Lean.Json) : ParseResult Template := do
   let effect ← getJsonField json "effect" >>= jsonToEffect

--- a/cedar-lean/DiffTest/Parser.lean
+++ b/cedar-lean/DiffTest/Parser.lean
@@ -399,18 +399,12 @@ def jsonToActionScope (json : Lean.Json) : ParseResult ActionScope := do
     .ok (.actionScope (.eq euid))
   | tag => .error s!"jsonToActionScope: unknown tag {tag}"
 
-def jsonToCondition (json : Lean.Json) : ParseResult Condition := do
-  let kind ← json.getObjVal? "kind"
-  let expr ← json.getObjVal? "body" >>= jsonToExpr
-  match kind with
-  | "when" => .ok $ { kind := .When, body := expr  }
-  | "unless" => .ok $ { kind := .Unless, body := expr }
-  | _ => .error s!"Bad condition tag. Expected either `when` or `unless`"
-
+-- This is a hack, as the current JSON loses this information.
+-- When we switch this interface to use the EST, we will get the actual
+-- conditions structure
 def jsonToConditions (json : Lean.Json) : ParseResult Conditions := do
-  let members ← jsonToArray json
-  let arr' ← members.sequenceMap jsonToCondition
-  .ok $ arr'.toList
+  let expr ← jsonToExpr json
+  .ok $ [{ kind := .When,  body := expr }]
 
 def jsonToTemplate (json : Lean.Json) : ParseResult Template := do
   let effect ← getJsonField json "effect" >>= jsonToEffect


### PR DESCRIPTION
*Issue #, if available:*
N/A
*Description of changes:*
The lean model doesn't capture the details of `when`/`unless` clauses (Including order of evaluation/short-circuiting). 
This is a miss as it's something implementations will need to get correct. 
This PR adds `when`/`unless` clauses and the proper algorithm for transforming them into expressions.
The JSON format we currently use to test the Rust impl does not support `when`/`unless` clauses (and can't be adapted too, as it's the serde serialization of a struct that has already lost that information). So we just interpret the expression past from Rust as a single `when` clause. When we switch to using ESTs for this testing, we will get the full structure.
