### PR TITLE
Optimize `add_binding` function in `common-type-resolution` fuzz target

### DIFF
--- a/cedar-policy-generators/src/schema.rs
+++ b/cedar-policy-generators/src/schema.rs
@@ -466,9 +466,7 @@ impl Bindings {
             id
         };
 
-        self.ids.insert(
-            new_id.clone().to_smolstr()
-        );
+        self.ids.insert(new_id.clone().to_smolstr());
         if let Some(binding_for_ty) = self.bindings.get_mut(&ty) {
             binding_for_ty.push(new_id);
         } else {


### PR DESCRIPTION
*Issue #, if available:*

Fixes a slow-unit that got stuck in  the `while self.ids.contains(&new_id)` loop trying to find an unused ident, taking 18931ms. Fixed so that it doesn't need to call the parser every time it checks if an indent is already used. Unit now takes 200ms.

*Description of changes:*


