### PR TITLE
Remove validity issue for schema generation

### DIFF
--- a/cedar-policy-generators/src/schema.rs
+++ b/cedar-policy-generators/src/schema.rs
@@ -810,7 +810,7 @@ impl Schema {
         let mut resource_types = HashSet::new();
         // optionally return a list of entity types and add them to `tys` at the same time
         let pick_entity_types = |tys: &mut HashSet<Name>, u: &mut Unstructured<'_>| {
-            // Pre-select the number of entity types (minimum 1), then randomly select that many indices 
+            // Pre-select the number of entity types (minimum 1), then randomly select that many indices
             let num = u.int_in_range(1..=entity_types.len()).unwrap();
             let mut indices: Vec<usize> = (0..entity_types.len()).collect();
             let mut selected_indices = Vec::with_capacity(num);
@@ -842,8 +842,10 @@ impl Schema {
                     name.clone(),
                     ActionType {
                         applies_to: {
-                            let mut picked_resource_types = pick_entity_types(&mut resource_types, u)?;
-                            let mut picked_principal_types = pick_entity_types(&mut principal_types, u)?;
+                            let mut picked_resource_types =
+                                pick_entity_types(&mut resource_types, u)?;
+                            let mut picked_principal_types =
+                                pick_entity_types(&mut principal_types, u)?;
                             // If we already have resource_types and principal_types, randomly make them empty
                             if principal_and_resource_types_exist {
                                 if u.ratio(1, 8)? {

--- a/cedar-policy-generators/src/schema.rs
+++ b/cedar-policy-generators/src/schema.rs
@@ -810,8 +810,8 @@ impl Schema {
         let mut resource_types = HashSet::new();
         // optionally return a list of entity types and add them to `tys` at the same time
         let pick_entity_types = |tys: &mut HashSet<Name>, u: &mut Unstructured<'_>| {
-            // Pre-select the number of entity types to select (minimum 1), then take a random selection of that size
-            let num = u.int_in_range(1..=entity_types.len()).unwrap() as usize;
+            // Pre-select the number of entity types (minimum 1), then randomly select that many indices 
+            let num = u.int_in_range(1..=entity_types.len()).unwrap();
             let mut indices: Vec<usize> = (0..entity_types.len()).collect();
             let mut selected_indices = Vec::with_capacity(num);
 
@@ -842,22 +842,22 @@ impl Schema {
                     name.clone(),
                     ActionType {
                         applies_to: {
-                            let mut resource_types = pick_entity_types(&mut resource_types, u)?;
-                            let mut principal_types = pick_entity_types(&mut principal_types, u)?;
-                            // If we already have resource_types or principal_types, flip a coin to remove some
+                            let mut picked_resource_types = pick_entity_types(&mut resource_types, u)?;
+                            let mut picked_principal_types = pick_entity_types(&mut principal_types, u)?;
+                            // If we already have resource_types and principal_types, randomly make them empty
                             if principal_and_resource_types_exist {
                                 if u.ratio(1, 8)? {
-                                    resource_types = None;
+                                    picked_resource_types = None;
                                 }
                                 if u.ratio(1, 8)? {
-                                    principal_types = None;
+                                    picked_principal_types = None;
                                 }
                             } else {
                                 principal_and_resource_types_exist = true;
                             }
                             let apply_spec = Some(ApplySpec {
-                                resource_types: resource_types,
-                                principal_types: principal_types,
+                                resource_types: picked_resource_types,
+                                principal_types: picked_principal_types,
                                 context: arbitrary_attrspec(&settings, &entity_type_names, u)?,
                             });
                             apply_spec


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fixes an issue relating to input generation validity in the `Schema` generation that resulted in many `arbitrary` execution errors. Removes generation of unsupported principal/resource entities that actions can apply to (as per [RFC 55](https://github.com/cedar-policy/rfcs/blob/main/text/0055-remove-unspecified.md), unspecified will no longer be supported.)

Changes generation of empty lists when populating `appliesTo` for actions.

Before:
![validity](https://github.com/cedar-policy/cedar-spec/assets/3836748/95647399-fb7e-49c4-8bad-a0779a346760)

After:
![validity_newgen](https://github.com/cedar-policy/cedar-spec/assets/3836748/f8026727-d136-4a06-9771-4825b969fca3)