### PR TITLE
updates for cedar#1027

### DIFF
--- a/cedar-policy-generators/src/expr.rs
+++ b/cedar-policy-generators/src/expr.rs
@@ -566,7 +566,7 @@ impl<'a> ExprGenerator<'a> {
                                             // This does not use an explicit namespace because entity types
                                             // implicitly use the schema namespace if an explicit one is not
                                             // provided.
-                                            name: ast::Name::from(entity_name.clone()).into(),
+                                            name: ast::Name::from(entity_name.clone()),
                                         }
                                     ),
                                     max_depth - 1,

--- a/cedar-policy-generators/src/request.rs
+++ b/cedar-policy-generators/src/request.rs
@@ -74,7 +74,7 @@ impl std::fmt::Display for Request {
             "(principal : {}, action: {}, resource: {})",
             self.principal, self.action, self.resource
         )?;
-        let mut context = self.context.iter().unwrap().peekable();
+        let mut context = self.context.clone().into_iter().peekable();
         if context.peek().is_some() {
             writeln!(f, "\nWith context: {{")?;
             for (attr, val) in context {

--- a/cedar-policy-generators/src/schema.rs
+++ b/cedar-policy-generators/src/schema.rs
@@ -826,7 +826,7 @@ impl Schema {
         for i in 0..entity_types.len() {
             for name in &entity_type_ids[(i + 1)..] {
                 if u.ratio::<u8>(1, 2)? {
-                    let etype = ast::Name::from(name.clone()).into();
+                    let etype = ast::Name::from(name.clone());
                     entity_types[i].1.member_of_types.push(etype);
                 }
             }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Updates to match [cedar#1027](https://github.com/cedar-policy/cedar/pull/1027) (which changed `Context::iter` into `Context::into_iter`). Also applied a couple clippy suggestions.