### PR TITLE
Update Lean Char Parsing from Cedar PR#1047

### DIFF
--- a/cedar-lean/DiffTest/Util.lean
+++ b/cedar-lean/DiffTest/Util.lean
@@ -80,15 +80,12 @@ def jsonToInt64 (json : Json) : ParseResult Int64 := do
     | .none => .error s!"jsonToInt64: not a signed 64-bit integer {num.mantissa}"
   | n => .error s!"jsonToInt64: number has exponent {n}"
 
-def jsonToChar (json : Json) : ParseResult Char := do
-  let num ← jsonToNum json
-  match num.exponent with
-  | 0 =>
-    let nat := num.mantissa.toNat
-    if nat.isValidChar
-    then .ok (Char.ofNat nat)
-    else .error s!"jsonToChar: cannot convert to character {nat}"
-  | n => .error s!"jsonToChar: cannot convert to character {n}"
+def jsonToChar (json: Json) : ParseResult Char :=
+  match json.getStr? with
+  | .ok s => match s.data with
+    | [c] => .ok c
+    | _ => .error s!"jsonToChar: Expected single character"
+  | .error e => .error s!"jsonToChar: {e}\n{json.pretty}"
 
 def getSingleElement (kvs : RBNode String (λ _ => Json)) : String × Json :=
   kvs.fold (init := ("",Json.null)) (λ _ k v => (k,v))


### PR DESCRIPTION
## Description of changes
Parse characters not as a number but as the internal character representation of the string.

This requires Cedar PR [#1047](https://github.com/cedar-policy/cedar/pull/1047)

I have tested this change with both the corpus integration tests as well as the eval-type-directed fuzz target


## Issue #, if available
Cedar [#1042](https://github.com/cedar-policy/cedar/issues/1042)

