### PR TITLE
fix ci

### DIFF
--- a/.github/workflows/build_and_test_drt_reusable.yml
+++ b/.github/workflows/build_and_test_drt_reusable.yml
@@ -74,3 +74,4 @@ jobs:
     with:
       cedar_spec_ref: ${{ inputs.cedar_spec_ref }}
       cedar_policy_ref: ${{ inputs.cedar_policy_ref }}
+      cedar_integration_tests_ref: ${{ inputs.cedar_policy_ref }} # match the `cedar` version

--- a/.github/workflows/build_and_test_drt_reusable.yml
+++ b/.github/workflows/build_and_test_drt_reusable.yml
@@ -68,10 +68,3 @@ jobs:
       - name: cargo test (cedar-drt/fuzz/)
         working-directory: ./cedar-spec/cedar-drt/fuzz
         run: source ~/.profile && source ../set_env_vars.sh && cargo test -- --nocapture
-
-  run-integration-tests:
-    uses: ./.github/workflows/run_integration_tests_reusable.yml
-    with:
-      cedar_spec_ref: ${{ inputs.cedar_spec_ref }}
-      cedar_policy_ref: ${{ inputs.cedar_policy_ref }}
-      cedar_integration_tests_ref: ${{ inputs.cedar_policy_ref }} # match the `cedar` version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,3 +61,11 @@ jobs:
         with:
           push: false
           tags: cedar-drt:latest
+
+  run-integration-tests:
+    needs: get-branch-name
+    uses: ./.github/workflows/run_integration_tests_reusable.yml
+    with:
+      cedar_spec_ref: ${{ github.ref }}
+      cedar_policy_ref: ${{ needs.get-branch-name.outputs.branch_name }}
+      cedar_integration_tests_ref: ${{ needs.get-branch-name.outputs.branch_name }}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Removes the integration tests from `build_and_test_drt_reusable.yml`, which is used in the `cedar` repository CI. The `cedar` CI already runs the integration tests, so it doesn't seem useful to re-run them using Lean.

The integration tests will still be run through Lean as part of PRs to the `cedar-spec` repository.

This should fix downstream CI for https://github.com/cedar-policy/cedar/pull/1110


