### PR TITLE
adjust property test in json-schema-roundtrip

### DIFF
--- a/cedar-drt/fuzz/fuzz_targets/convert-schema-cedar-to-json.rs
+++ b/cedar-drt/fuzz/fuzz_targets/convert-schema-cedar-to-json.rs
@@ -36,7 +36,7 @@ fuzz_target!(|src: String| {
             serde_json::to_value(parsed.clone()).expect("Failed to convert Cedar schema to JSON");
         let json_parsed = json_schema::Fragment::from_json_value(json)
             .expect("Failed to parse converted JSON schema");
-        if let Err(msg) = equivalence_check(parsed.clone(), json_parsed.clone()) {
+        if let Err(msg) = equivalence_check(&parsed, &json_parsed) {
             println!("Schema: {src}");
             println!(
                 "{}",

--- a/cedar-drt/fuzz/fuzz_targets/convert-schema-json-to-cedar.rs
+++ b/cedar-drt/fuzz/fuzz_targets/convert-schema-json-to-cedar.rs
@@ -30,21 +30,21 @@ fuzz_target!(|src: String| {
         if TryInto::<ValidatorSchema>::try_into(parsed.clone()).is_err() {
             return;
         }
-        let ceadr_src = parsed
+        let cedar_src = parsed
             .to_cedarschema()
             .expect("Failed to convert the JSON schema into a Cedar schema");
-        let (ceadr_parsed, _) = json_schema::Fragment::<RawName>::from_cedarschema_str(
-            &ceadr_src,
+        let (cedar_parsed, _) = json_schema::Fragment::<RawName>::from_cedarschema_str(
+            &cedar_src,
             Extensions::all_available(),
         )
         .expect("Failed to parse converted Cedar schema");
-        if let Err(msg) = equivalence_check(parsed.clone(), ceadr_parsed.clone()) {
+        if let Err(msg) = equivalence_check(&parsed, &cedar_parsed) {
             println!("Schema: {src}");
             println!(
                 "{}",
                 SimpleDiff::from_str(
                     &format!("{:#?}", parsed),
-                    &format!("{:#?}", ceadr_parsed),
+                    &format!("{:#?}", cedar_parsed),
                     "Parsed JSON",
                     "Cedar Round tripped"
                 )

--- a/cedar-drt/fuzz/fuzz_targets/json-schema-roundtrip.rs
+++ b/cedar-drt/fuzz/fuzz_targets/json-schema-roundtrip.rs
@@ -21,7 +21,7 @@ use cedar_policy_core::{ast, extensions::Extensions};
 use cedar_policy_generators::{
     schema::downgrade_frag_to_raw, schema::Schema, settings::ABACSettings,
 };
-use cedar_policy_validator::{json_schema, RawName};
+use cedar_policy_validator::json_schema;
 use libfuzzer_sys::arbitrary::{self, Arbitrary, Unstructured};
 use serde::Serialize;
 use std::collections::HashMap;
@@ -69,13 +69,13 @@ fuzz_target!(|i: Input| {
     let raw_schema = downgrade_frag_to_raw(i.schema);
     let json = serde_json::to_value(raw_schema.clone()).unwrap();
     let json_ast = json_schema::Fragment::from_json_value(json).unwrap();
-    if let Err(e) = equivalence_check(raw_schema, json_ast) {
+    if let Err(e) = equivalence_check(&raw_schema, &json_ast) {
         panic!("JSON roundtrip failed: {e}\nOrig:\n```\n{raw_schema}\n```\nRoundtripped:\n```\n{json_ast}\n```");
     }
     let src = json_ast.to_cedarschema().unwrap();
     let (final_ast, _) =
         json_schema::Fragment::from_cedarschema_str(&src, Extensions::all_available()).unwrap();
-    if let Err(e) = equivalence_check(raw_schema, final_ast) {
+    if let Err(e) = equivalence_check(&raw_schema, &final_ast) {
         panic!("Cedar roundtrip failed: {e}\nSrc:\n```\n{src}\n```");
     }
 });

--- a/cedar-drt/fuzz/fuzz_targets/json-schema-roundtrip.rs
+++ b/cedar-drt/fuzz/fuzz_targets/json-schema-roundtrip.rs
@@ -66,18 +66,16 @@ impl<'a> Arbitrary<'a> for Input {
 }
 
 fuzz_target!(|i: Input| {
-    let json = serde_json::to_value(i.schema.clone()).unwrap();
-    let json_ast: json_schema::Fragment<RawName> =
-        json_schema::Fragment::from_json_value(json).unwrap();
-    assert_eq!(
-        json_ast,
-        downgrade_frag_to_raw(i.schema.clone()),
-        "JSON roundtrip failed"
-    );
+    let raw_schema = downgrade_frag_to_raw(i.schema);
+    let json = serde_json::to_value(raw_schema.clone()).unwrap();
+    let json_ast = json_schema::Fragment::from_json_value(json).unwrap();
+    if let Err(e) = equivalence_check(raw_schema, json_ast) {
+        panic!("JSON roundtrip failed: {e}\nOrig:\n```\n{raw_schema}\n```\nRoundtripped:\n```\n{json_ast}\n```");
+    }
     let src = json_ast.to_cedarschema().unwrap();
     let (final_ast, _) =
         json_schema::Fragment::from_cedarschema_str(&src, Extensions::all_available()).unwrap();
-    if let Err(e) = equivalence_check(downgrade_frag_to_raw(i.schema), final_ast) {
-        panic!("Cedar roundtrip failed: {}\nSrc:\n```\n{}\n```", e, src);
+    if let Err(e) = equivalence_check(raw_schema, final_ast) {
+        panic!("Cedar roundtrip failed: {e}\nSrc:\n```\n{src}\n```");
     }
 });

--- a/cedar-drt/fuzz/fuzz_targets/schema-roundtrip.rs
+++ b/cedar-drt/fuzz/fuzz_targets/schema-roundtrip.rs
@@ -75,8 +75,8 @@ fuzz_target!(|i: Input| {
     let (parsed, _) =
         json_schema::Fragment::from_cedarschema_str(&src, Extensions::all_available())
             .expect("Failed to parse converted human readable schema");
-    let downgraded = downgrade_frag_to_raw(i.schema.clone());
-    if let Err(msg) = equivalence_check(downgraded.clone(), parsed.clone()) {
+    let downgraded = downgrade_frag_to_raw(i.schema);
+    if let Err(msg) = equivalence_check(&downgraded, &parsed) {
         println!("Schema: {src}");
         println!(
             "{}",


### PR DESCRIPTION
Adjusts the `json-schema-roundtrip` target to use `equivalence_check` rather than `assert_eq` in another place.  (For instance, we don't want to require that source locations are identical in the roundtripped schema, which `assert_eq` was requiring.)  Also some other minor refactoring while I'm here -- e.g., there is now only one call to `downgrade_frag_to_raw()`.