### PR TITLE
permissive validation soundness (too), permissive more expressive than strict

### DIFF
--- a/cedar-drt/fuzz/fuzz_targets/validation-pbt-type-directed.rs
+++ b/cedar-drt/fuzz/fuzz_targets/validation-pbt-type-directed.rs
@@ -107,9 +107,9 @@ impl<'a> Arbitrary<'a> for FuzzTargetInput {
 }
 
 /// helper function that just tells us whether a policyset passes validation
-fn passes_validation(validator: &Validator, policyset: &ast::PolicySet) -> bool {
+fn passes_validation(validator: &Validator, policyset: &ast::PolicySet, mode: ValidationMode) -> bool {
     validator
-        .validate(policyset, ValidationMode::default())
+        .validate(policyset, mode)
         .validation_passed()
 }
 
@@ -125,7 +125,9 @@ fuzz_target!(|input: FuzzTargetInput| {
             let mut policyset = ast::PolicySet::new();
             let policy: ast::StaticPolicy = input.policy.into();
             policyset.add_static(policy.clone()).unwrap();
-            if passes_validation(&validator, &policyset) {
+            let passes_strict = passes_validation(&validator, &policyset, ValidationMode::Strict);
+            let passes_permissive = passes_validation(&validator, &policyset, ValidationMode::Permissive);
+            if passes_permissive {
                 // policy successfully validated, let's make sure we don't get any
                 // dynamic type errors
                 let authorizer = Authorizer::new();
@@ -172,6 +174,13 @@ fuzz_target!(|input: FuzzTargetInput| {
                         "validated policy produced unexpected errors {unexpected_errs:?}!\npolicies:\n{policyset}\nentities:\n{entities}\nschema:\n{schemafile_string}\nrequest:\n{q}\n",
                     )
                 }
+            }
+            else {
+                assert_eq!(
+                    false,
+                    passes_strict,
+                    "policy fails permissive validation but passes strict validation!\npolicies:\n{policyset}\nentities:\n{entities}\nschema:\n{schemafile_string}\n",
+                );
             }
         }
     }

--- a/cedar-drt/fuzz/fuzz_targets/validation-pbt-type-directed.rs
+++ b/cedar-drt/fuzz/fuzz_targets/validation-pbt-type-directed.rs
@@ -107,10 +107,12 @@ impl<'a> Arbitrary<'a> for FuzzTargetInput {
 }
 
 /// helper function that just tells us whether a policyset passes validation
-fn passes_validation(validator: &Validator, policyset: &ast::PolicySet, mode: ValidationMode) -> bool {
-    validator
-        .validate(policyset, mode)
-        .validation_passed()
+fn passes_validation(
+    validator: &Validator,
+    policyset: &ast::PolicySet,
+    mode: ValidationMode,
+) -> bool {
+    validator.validate(policyset, mode).validation_passed()
 }
 
 // The main fuzz target. This is for PBT on the validator
@@ -126,7 +128,8 @@ fuzz_target!(|input: FuzzTargetInput| {
             let policy: ast::StaticPolicy = input.policy.into();
             policyset.add_static(policy.clone()).unwrap();
             let passes_strict = passes_validation(&validator, &policyset, ValidationMode::Strict);
-            let passes_permissive = passes_validation(&validator, &policyset, ValidationMode::Permissive);
+            let passes_permissive =
+                passes_validation(&validator, &policyset, ValidationMode::Permissive);
             if passes_permissive {
                 // policy successfully validated, let's make sure we don't get any
                 // dynamic type errors
@@ -174,8 +177,7 @@ fuzz_target!(|input: FuzzTargetInput| {
                         "validated policy produced unexpected errors {unexpected_errs:?}!\npolicies:\n{policyset}\nentities:\n{entities}\nschema:\n{schemafile_string}\nrequest:\n{q}\n",
                     )
                 }
-            }
-            else {
+            } else {
                 assert_eq!(
                     false,
                     passes_strict,

--- a/cedar-drt/fuzz/fuzz_targets/validation-pbt.rs
+++ b/cedar-drt/fuzz/fuzz_targets/validation-pbt.rs
@@ -306,10 +306,12 @@ impl<'a> Arbitrary<'a> for FuzzTargetInput {
 }
 
 /// helper function that just tells us whether a policyset passes validation
-fn passes_validation(validator: &Validator, policyset: &ast::PolicySet, mode: ValidationMode) -> bool {
-    validator
-        .validate(policyset, mode)
-        .validation_passed()
+fn passes_validation(
+    validator: &Validator,
+    policyset: &ast::PolicySet,
+    mode: ValidationMode,
+) -> bool {
+    validator.validate(policyset, mode).validation_passed()
 }
 
 // The main fuzz target. This is for PBT on the validator
@@ -333,7 +335,8 @@ fuzz_target!(|input: FuzzTargetInput| {
             let policy: ast::StaticPolicy = input.policy.into();
             policyset.add_static(policy.clone()).unwrap();
             let passes_strict = passes_validation(&validator, &policyset, ValidationMode::Strict);
-            let passes_permissive = passes_validation(&validator, &policyset, ValidationMode::Permissive);
+            let passes_permissive =
+                passes_validation(&validator, &policyset, ValidationMode::Permissive);
             if passes_permissive {
                 checkpoint(LOG_FILENAME_VALIDATION_PASS);
                 let suffix = if passes_strict { "vyes" } else { "vpermissive" };

--- a/cedar-drt/fuzz/fuzz_targets/validation-pbt.rs
+++ b/cedar-drt/fuzz/fuzz_targets/validation-pbt.rs
@@ -306,9 +306,9 @@ impl<'a> Arbitrary<'a> for FuzzTargetInput {
 }
 
 /// helper function that just tells us whether a policyset passes validation
-fn passes_validation(validator: &Validator, policyset: &ast::PolicySet) -> bool {
+fn passes_validation(validator: &Validator, policyset: &ast::PolicySet, mode: ValidationMode) -> bool {
     validator
-        .validate(policyset, ValidationMode::default())
+        .validate(policyset, mode)
         .validation_passed()
 }
 
@@ -332,11 +332,14 @@ fuzz_target!(|input: FuzzTargetInput| {
             let mut policyset = ast::PolicySet::new();
             let policy: ast::StaticPolicy = input.policy.into();
             policyset.add_static(policy.clone()).unwrap();
-            if passes_validation(&validator, &policyset) {
+            let passes_strict = passes_validation(&validator, &policyset, ValidationMode::Strict);
+            let passes_permissive = passes_validation(&validator, &policyset, ValidationMode::Permissive);
+            if passes_permissive {
                 checkpoint(LOG_FILENAME_VALIDATION_PASS);
-                maybe_log_schemastats(schemafile.as_ref(), "vyes");
-                maybe_log_hierarchystats(&input.hierarchy, "vyes");
-                maybe_log_policystats(&policy, "vyes");
+                let suffix = if passes_strict { "vyes" } else { "vpermissive" };
+                maybe_log_schemastats(schemafile.as_ref(), suffix);
+                maybe_log_hierarchystats(&input.hierarchy, suffix);
+                maybe_log_policystats(&policy, suffix);
                 // policy successfully validated, let's make sure we don't get any
                 // dynamic type errors
                 let authorizer = Authorizer::new();
@@ -387,6 +390,11 @@ fuzz_target!(|input: FuzzTargetInput| {
                 maybe_log_schemastats(schemafile.as_ref(), "vno");
                 maybe_log_hierarchystats(&input.hierarchy, "vno");
                 maybe_log_policystats(&policy, "vno");
+                assert_eq!(
+                    false,
+                    passes_strict,
+                    "policy fails permissive validation but passes strict validation!\npolicies:\n{policyset}\nentities:\n{entities}\nschema:\n{schemafile_string}\n",
+                );
             }
         }
     }


### PR DESCRIPTION
*Description of changes:* Extended the validation-pbt targets to also invoke permissive validation, and to test that whenever strict validation succeeds, permissive validation should succeed also.

Resolves #373 