### PR TITLE
Linter script to check import of top-level proofs

### DIFF
--- a/cedar-lean/Cedar/Thm.lean
+++ b/cedar-lean/Cedar/Thm.lean
@@ -14,6 +14,7 @@
  limitations under the License.
 -/
 
+import Cedar.Thm.Data
 import Cedar.Thm.Authorization
 import Cedar.Thm.Slicing
 import Cedar.Thm.Typechecking

--- a/cedar-lean/lakefile.lean
+++ b/cedar-lean/lakefile.lean
@@ -39,3 +39,23 @@ lean_exe CedarUnitTests where
 
 lean_exe Cli where
   root := `Cli.Main
+
+/--
+Check that Cedar.Thm imports all top level proofs.
+
+USAGE:
+  lake run checkThm
+  lake lint
+-/
+@[lint_driver]
+script checkThm do
+  let thm ← IO.FS.readFile ⟨"Cedar/Thm.lean"⟩
+  let dir ← System.FilePath.readDir ⟨"Cedar/Thm/"⟩
+  for entry in dir.toList do
+    let fn := entry.fileName
+    if fn.endsWith ".lean" then
+      let ln := s!"import Cedar.Thm.{fn.dropRight 5}"
+      if thm.replace ln "" == thm then
+        IO.println s!"Cedar.Thm does not import Cedar/Thm/{fn}"
+        return 1
+  return 0


### PR DESCRIPTION

*Issue #, if available:*

*Description of changes:*

This PR adds a simple linting script to `lakefile` to check that `Cedar.Thm` imports all top-level files in `Cedar/Thm/`, which contain entry points to our top-level proofs.

We've forgotten to import some proofs in the past, which causes them not to built / checked by `lake build`.

The linter is invoked with `lake lint`.  It returns 0 if all imports are present, and it prints the missing import and returns 1 when it finds the first missing import.