### PR TITLE
generate entity tags in entity data

### DIFF
--- a/cedar-drt/fuzz/fuzz_targets/rbac.rs
+++ b/cedar-drt/fuzz/fuzz_targets/rbac.rs
@@ -134,7 +134,7 @@ impl<'a> Arbitrary<'a> for FuzzTargetInput {
         let hierarchy = RBACHierarchy(
             HierarchyGenerator {
                 mode: HierarchyGeneratorMode::Arbitrary {
-                    attributes_mode: AttributesMode::NoAttributes,
+                    attributes_mode: AttributesMode::NoAttributesOrTags,
                 },
                 uid_gen_mode: EntityUIDGenMode::default(),
                 num_entities: cedar_policy_generators::hierarchy::NumEntities::RangePerEntityType(


### PR DESCRIPTION
Generates entity data containing tags.  Not yet included is, generating schemas whose entity types can have tags; that will be in a separate PR.


