### PR TITLE
Fix integration testing

### DIFF
--- a/cedar-lean/DiffTest/Parser.lean
+++ b/cedar-lean/DiffTest/Parser.lean
@@ -515,10 +515,11 @@ partial def jsonToEntityTypeEntry (json : Lean.Json) : ParseResult JsonEntitySch
   let descendants_json ← getJsonField json "descendants" >>= jsonToArray
   let descendants ← List.mapM jsonToName descendants_json.toList
   let attrs ← getJsonField json "attributes" >>= (getJsonField · "attrs") >>= jsonToRecordType
-  let tags ← -- the "tags" field may be absent
+  let tags ← -- the "tags" field must be present
     match getJsonField json "tags" with
+    | .ok .null => .ok .none
     | .ok jty  => (jsonToCedarType jty).map .some
-    | .error _ => .ok .none
+    | _ => .error "`tags` field must exist"
   .ok {
     descendants := Set.make descendants,
     attrs := attrs,


### PR DESCRIPTION
*Issue #, if available:*
The Rust implementation always emits a `tags` field for entity types.

*Description of changes:*


