### PR TITLE
bugfix equivalence check

### DIFF
--- a/cedar-drt/fuzz/fuzz_targets/convert-schema-json-to-cedar.rs
+++ b/cedar-drt/fuzz/fuzz_targets/convert-schema-json-to-cedar.rs
@@ -39,7 +39,8 @@ fuzz_target!(|src: String| {
         )
         .expect("Failed to parse converted Cedar schema");
         if let Err(msg) = equivalence_check(&parsed, &cedar_parsed) {
-            println!("Schema: {src}");
+            println!("Original JSON schema: {src}");
+            println!("Converted to Cedar format:\n{cedar_src}");
             println!(
                 "{}",
                 SimpleDiff::from_str(


### PR DESCRIPTION
Consider `CommonTypeRef` and `EntityOrCommon` equivalent if they have the same type-name.  (They could resolve to different types in theory, but they actually can't because of RFC 70.)


