### PR TITLE
Fail DRT build quickly if lean build dir isn't present

### DIFF
--- a/cedar-drt/build.rs
+++ b/cedar-drt/build.rs
@@ -15,10 +15,16 @@
  */
 
 use std::env;
+use std::path::Path;
 fn main() {
     let lean_dir = env::var("LEAN_LIB_DIR").expect(
         "`LEAN_LIB_DIR` environment variable is not set! Try running `source set_env_vars.sh`",
     );
+    // We'll need to link against some files found here later, and it's nicer to
+    // fail quickly with a helpful error message.
+    if !Path::new("../cedar-lean/.lake/build/lib").exists() {
+        panic!("Lean build directory does not exist! Try running `( cd ../cedar-lean && ../cedar-drt/build_lean_lib.sh )`")
+    }
     println!("cargo:rustc-link-search=native=../cedar-lean/.lake/build/lib");
     println!("cargo:rustc-link-search=native={lean_dir}");
     println!(

--- a/cedar-drt/build.rs
+++ b/cedar-drt/build.rs
@@ -16,7 +16,7 @@
 
 use std::env;
 use std::path::Path;
-const LEAN_BUILD_DIR : &'static str ="../cedar-lean/.lake/build/lib";
+const LEAN_BUILD_DIR: &'static str = "../cedar-lean/.lake/build/lib";
 fn main() {
     let lean_dir = env::var("LEAN_LIB_DIR").expect(
         "`LEAN_LIB_DIR` environment variable is not set! Try running `source set_env_vars.sh`",

--- a/cedar-drt/build.rs
+++ b/cedar-drt/build.rs
@@ -16,19 +16,20 @@
 
 use std::env;
 use std::path::Path;
+const LEAN_BUILD_DIR : &'static str ="../cedar-lean/.lake/build/lib";
 fn main() {
     let lean_dir = env::var("LEAN_LIB_DIR").expect(
         "`LEAN_LIB_DIR` environment variable is not set! Try running `source set_env_vars.sh`",
     );
     // We'll need to link against some files found here later, and it's nicer to
     // fail quickly with a helpful error message.
-    if !Path::new("../cedar-lean/.lake/build/lib").exists() {
+    if !Path::new(LEAN_BUILD_DIR).exists() {
         panic!("Lean build directory does not exist! Try running `( cd ../cedar-lean && ../cedar-drt/build_lean_lib.sh )`")
     }
-    println!("cargo:rustc-link-search=native=../cedar-lean/.lake/build/lib");
+    println!("cargo:rustc-link-search=native={LEAN_BUILD_DIR}");
     println!("cargo:rustc-link-search=native={lean_dir}");
     println!(
         "cargo:rustc-link-search=native=../cedar-lean/.lake/packages/batteries/.lake/build/lib"
     );
-    println!("cargo:rerun-if-changed=../cedar-lean/.lake/build/lib");
+    println!("cargo:rerun-if-changed={LEAN_BUILD_DIR}");
 }


### PR DESCRIPTION
Trying to improve on another papercut in the DRT build process. Add this to remind myself that I need to build the lean library.
