### PR TITLE
various cleanups in Protobuf

### DIFF
--- a/cedar-lean/Protobuf/Enum.lean
+++ b/cedar-lean/Protobuf/Enum.lean
@@ -38,7 +38,7 @@ def parseEnum (α : Type) [ProtoEnum α] : BParsec α := do
 
 instance [ProtoEnum α] : Field α := {
   parse := (parseEnum α)
-  checkWireType := fun w => WireType.VARINT = w
+  checkWireType := (· = WireType.VARINT)
   merge := Field.Merge.override
 }
 

--- a/cedar-lean/Protobuf/Map.lean
+++ b/cedar-lean/Protobuf/Map.lean
@@ -96,7 +96,7 @@ def parse [Inhabited KeyT] [Inhabited ValueT] [Field KeyT] [Field ValueT] : BPar
 
 instance {α β : Type} [Inhabited α] [Inhabited β] [Field α] [Field β] : Field (Map α β) := {
   parse := parse
-  checkWireType := fun (w : WireType) => WireType.LEN = w
+  checkWireType := (· = WireType.LEN)
   merge := Field.Merge.concatenate
 }
 end Map

--- a/cedar-lean/Protobuf/Message.lean
+++ b/cedar-lean/Protobuf/Message.lean
@@ -90,7 +90,7 @@ def interpret! [Inhabited α] [Message α] (b : ByteArray) : α :=
 
 instance [Inhabited α] [Message α] : Field α := {
   parse := parseWithLen
-  checkWireType := fun (w : WireType) => WireType.LEN = w
+  checkWireType := (· = WireType.LEN)
   merge := merge
 }
 

--- a/cedar-lean/Protobuf/Packed.lean
+++ b/cedar-lean/Protobuf/Packed.lean
@@ -81,13 +81,13 @@ def parse (α : Type) [Field α] : BParsec (Array α) := do
   let len_size ← Len.parseSize
   BParsec.foldl
     Field.parse
-    (fun arr => fun element => arr.push element)
+    (λ arr element => arr.push element)
     len_size
     #[]
 
 instance [Field α] : Field (Packed α) := {
   parse := (parse α)
-  checkWireType := fun (w : WireType) => WireType.LEN = w
+  checkWireType := (· = WireType.LEN)
   merge := Field.Merge.concatenate
 }
 


### PR DESCRIPTION
- refactors `BParsec.ParseResult` from an `inductive` where the `pos` field was duplicated across variants, to a `structure` that also gets to make use of the built-in `Except` type
- redefines `BParsec.run!` in terms of `BParsec.run`, and improves the panic message
- defines a new helper `BParsec.inspect` and redefines a lot of existing helpers using it.  (also uses it elsewhere in other files)
- redefines `BParsec.eof` and `utf8DecodeChar` using `do` notation for clarity
- adjusts proofs for all of the above changes


