### PR TITLE
remove most of the panics and panic-indexing from Protobuf module

### DIFF
--- a/cedar-lean/Protobuf/BParsec.lean
+++ b/cedar-lean/Protobuf/BParsec.lean
@@ -104,14 +104,20 @@ def run! [Inhabited α] (p : BParsec α) (ba : ByteArray) : α :=
 
 -- Iterator wrappers
 
-/-- Advance the iterator -/
+/-- Advance the iterator one byte, discarding it -/
 @[inline]
 def next : BParsec Unit := λ pos =>
   { pos := pos.next, res := .ok () }
 
+/-- Advance the iterator `n` bytes, discarding them -/
 @[inline]
 def forward (n : Nat) : BParsec Unit := λ pos =>
   { pos := pos.forward n, res := .ok () }
+
+/-- Advance the iterator one byte, returning it, or `None` if the iterator was empty -/
+@[inline]
+def nextByte : BParsec (Option UInt8) := λ pos =>
+  { pos := pos.next, res := .ok pos.data[pos.pos]? }
 
 /-- Return some computation on the current iterator state, without changing the state -/
 @[inline]
@@ -130,6 +136,7 @@ def remaining : BParsec Nat := inspect ByteArray.ByteIterator.remaining
 @[inline]
 def empty : BParsec Bool := inspect ByteArray.ByteIterator.empty
 
+/-- Get the current iterator position, as a `Nat` -/
 @[inline]
 def pos : BParsec Nat := inspect ByteArray.ByteIterator.pos
 


### PR DESCRIPTION
In several places we were first checking-for-empty and then panic-indexing to get the next byte.  Refactored this to use a new helper `nextByte` that returns `Option`.  Also overhauled `utf8DecodeChar` to actually consume the bytes as it goes, rather than the previous behavior of use-but-not-consume them and return an integer indicating how much the iterator needs to be advanced.  Overhauled the proof of `utf8DecodeChar.progress` to now prove that it progresses the iterator, rather than returns a positive integer.

