### PR TITLE
`isEmpty` method

### DIFF
--- a/.github/workflows/run_integration_tests_reusable.yml
+++ b/.github/workflows/run_integration_tests_reusable.yml
@@ -60,12 +60,8 @@ jobs:
       - name: Build Lean libraries
         working-directory: ./cedar-spec/cedar-lean
         run: source ~/.profile && ../cedar-drt/build_lean_lib.sh
-      - name: Debug with upterm session
-        uses: lhotari/action-upterm@v1
-        with:
-          limit-access-to-users: cdisselkoen
-          wait-timeout-minutes: 4 ## If no one connects after 4 minutes, shut down the server
       - name: Run integration tests
         working-directory: ./cedar-spec/cedar-drt
         shell: bash
         run: source ~/.profile && source set_env_vars.sh && cargo test --features "integration-testing" -- --nocapture
+

--- a/.github/workflows/run_integration_tests_reusable.yml
+++ b/.github/workflows/run_integration_tests_reusable.yml
@@ -60,8 +60,12 @@ jobs:
       - name: Build Lean libraries
         working-directory: ./cedar-spec/cedar-lean
         run: source ~/.profile && ../cedar-drt/build_lean_lib.sh
+      - name: Debug with upterm session
+        uses: lhotari/action-upterm@v1
+        with:
+          limit-access-to-users: cdisselkoen
+          wait-timeout-minutes: 4 ## If no one connects after 4 minutes, shut down the server
       - name: Run integration tests
         working-directory: ./cedar-spec/cedar-drt
         shell: bash
         run: source ~/.profile && source set_env_vars.sh && cargo test --features "integration-testing" -- --nocapture
-

--- a/cedar-lean/Cedar/Spec/Evaluator.lean
+++ b/cedar-lean/Cedar/Spec/Evaluator.lean
@@ -33,6 +33,7 @@ def intOrErr : Option Int64 → Result Value
 def apply₁ : UnaryOp → Value → Result Value
   | .not,     .prim (.bool b)        => .ok !b
   | .neg,     .prim (.int i)         => intOrErr i.neg?
+  | .isEmpty, .set s                 => .ok s.isEmpty
   | .like p,  .prim (.string s)      => .ok (wildcardMatch s p)
   | .is ety,  .prim (.entityUID uid) => .ok (ety == uid.ty)
   | _, _                             => .error .typeError

--- a/cedar-lean/Cedar/Spec/Expr.lean
+++ b/cedar-lean/Cedar/Spec/Expr.lean
@@ -36,6 +36,7 @@ inductive Var where
 inductive UnaryOp where
   | not
   | neg
+  | isEmpty
   | like (p : Pattern)
   | is (ety : EntityType)
 

--- a/cedar-lean/Cedar/Validation/Typechecker.lean
+++ b/cedar-lean/Cedar/Validation/Typechecker.lean
@@ -112,6 +112,7 @@ def typeOfUnaryApp (op : UnaryOp) (ty : CedarType) : ResultType :=
   match op, ty with
   | .not, .bool x          => ok (.bool x.not)
   | .neg, .int             => ok .int
+  | .isEmpty, .set _       => ok (.bool .anyBool)
   | .like _, .string       => ok (.bool .anyBool)
   | .is ety₁, .entity ety₂ => ok (.bool (if ety₁ = ety₂ then .tt else .ff))
   | _, _                   => err (.unexpectedType ty)

--- a/cedar-lean/CedarProto/Expr.lean
+++ b/cedar-lean/CedarProto/Expr.lean
@@ -291,6 +291,7 @@ namespace Proto.ExprKind.UnaryApp
 inductive Op where
   | not
   | neg
+  | isEmpty
 deriving Inhabited
 
 namespace Op
@@ -299,6 +300,7 @@ def fromInt (n : Int) : Except String Op :=
   match n with
     | 0 => .ok .not
     | 1 => .ok .neg
+    | 2 => .ok .isEmpty
     | n => .error s!"Field {n} does not exist in enum"
 
 instance : Inhabited Op where
@@ -316,6 +318,7 @@ def mergeOp (result : ExprKind.UnaryApp) (x : Op) : ExprKind.UnaryApp :=
   | .unaryApp _ expr => match x with
     | .not => .unaryApp .not expr
     | .neg => .unaryApp .neg expr
+    | .isEmpty => .unaryApp .isEmpty expr
   | _ => panic!("Expected ExprKind.UnaryApp to be of constructor .unaryApp")
 
 @[inline]

--- a/cedar-lean/DiffTest/Parser.lean
+++ b/cedar-lean/DiffTest/Parser.lean
@@ -86,6 +86,7 @@ def jsonToUnaryOp (json : Lean.Json) : ParseResult UnaryOp := do
   match op with
   | "Not" => .ok .not
   | "Neg" => .ok .neg
+  | "IsEmpty" => .ok .isEmpty
   | op => .error s!"jsonToUnaryOp: unknown operator {op}"
 
 def jsonToPatElem (json : Lean.Json) : ParseResult PatElem := do

--- a/cedar-policy-generators/src/expr.rs
+++ b/cedar-policy-generators/src/expr.rs
@@ -150,6 +150,9 @@ impl<'a> ExprGenerator<'a> {
                         self.generate_expr(max_depth - 1, u)?,
                         self.generate_expr(max_depth - 1, u)?,
                     )),
+                    1 => Ok(ast::Expr::is_empty(
+                        self.generate_expr(max_depth - 1, u)?,
+                    )),
                     2 => {
                         if self.settings.enable_like {
                             Ok(ast::Expr::like(
@@ -484,6 +487,14 @@ impl<'a> ExprGenerator<'a> {
                                 max_depth - 1,
                                 u,
                             )?,
+                            self.generate_expr_for_type(
+                                &Type::set_of(u.arbitrary()?),
+                                max_depth - 1,
+                                u,
+                            )?,
+                        )),
+                        // isEmpty()
+                        1 => Ok(ast::Expr::is_empty(
                             self.generate_expr_for_type(
                                 &Type::set_of(u.arbitrary()?),
                                 max_depth - 1,


### PR DESCRIPTION
Adding the `isEmpty` method (introduced by cedar-policy/cedar#1358) to the Lean and DRT.  For the DRT, the only change necessary was adjusting policy generators to be capable of generating `.isEmpty()` expressions.  For Lean, the evaluator and typechecker had to be adjusted to handle the new operator.


