### PR TITLE
ignore the `run_all_tests` test in benchmark.rs

### DIFF
--- a/cedar-drt/tests/benchmark.rs
+++ b/cedar-drt/tests/benchmark.rs
@@ -169,7 +169,7 @@ fn print_summary(auth_times: HashMap<&str, Vec<f64>>, val_times: HashMap<&str, V
           // note that actual Lean functionality on the corpus tests is tested
           // by a test called `integration_tests_on_def_impl()`, in
           // integration_tests.rs.
-fn run_all_tests() {
+fn print_timing_results() {
     let rust_impl = RustEngine::new();
     let lean_impl = LeanDefinitionalEngine::new();
 

--- a/cedar-drt/tests/benchmark.rs
+++ b/cedar-drt/tests/benchmark.rs
@@ -164,6 +164,11 @@ fn print_summary(auth_times: HashMap<&str, Vec<f64>>, val_times: HashMap<&str, V
 }
 
 #[test]
+#[ignore] // doesn't test anything, just prints timing results -- run this on
+          // demand but not in CI.
+          // note that actual Lean functionality on the corpus tests is tested
+          // by a test called `integration_tests_on_def_impl()`, in
+          // integration_tests.rs.
 fn run_all_tests() {
     let rust_impl = RustEngine::new();
     let lean_impl = LeanDefinitionalEngine::new();


### PR DESCRIPTION
This test doesn't actually test anything for correctness, it just prints timing results.  We don't need to run it by default in CI.  So, this PR adds the `#[ignore]` attribute.  The test can still be run on demand, and CI will still ensure it builds.


