### PR TITLE
Update `logos` to v0.15.0 in `cedar-drt-inner`

### DIFF
--- a/cedar-drt/fuzz/Cargo.toml
+++ b/cedar-drt/fuzz/Cargo.toml
@@ -29,7 +29,7 @@ clap = { version = "4.0", features = ["derive"], optional = true }
 rand_chacha = { version = "0.3", optional = true }
 similar-asserts = "1.5.0"
 thiserror = "2.0"
-logos = "0.14.0"
+logos = "0.15.0"
 prost = "0.13"
 itertools = "0.13.0"
 


### PR DESCRIPTION
Upgrades `logos` to v0.15.0 in the `cedar-drt-inner` package.

This mirrors the change being applied to the main `cedar` project in https://github.com/cedar-policy/cedar/pull/1364. The CI in that PR is currently failing because it pulls two different versions for `logos` and related crates, which turn out to be incompatible (see [this CI run](https://github.com/cedar-policy/cedar/actions/runs/12244716569/job/34157053589?pr=1364)):

```
   Compiling logos v0.15.0
   [...]
   Compiling logos v0.14.2
   Compiling cedar-policy-formatter v4.3.0 (/home/runner/work/cedar/cedar/cedar-spec/cedar/cedar-policy-formatter)
   Compiling cedar-policy-generators v4.0.0 (/home/runner/work/cedar/cedar/cedar-spec/cedar-policy-generators)
   Compiling cedar-policy v4.3.0 (/home/runner/work/cedar/cedar/cedar-spec/cedar/cedar-policy)
   Compiling cedar-testing v4.3.0 (/home/runner/work/cedar/cedar/cedar-spec/cedar/cedar-testing)
error[E0599]: no variant or associated item named `lexer` found for enum `Token` in the current scope
  --> fuzz_targets/formatter.rs:90:12
   |
90 |     Token::lexer(p)
   |            ^^^^^ variant or associated item not found in `Token`
   |
note: there are multiple different versions of crate `logos` in the dependency graph
  --> /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/logos-0.15.0/src/lib.rs:44:1
   |
44 |   pub trait Logos<'source>: Sized {
   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this is the trait that is needed
...
64 | /     fn lexer(source: &'source Self::Source) -> Lexer<'source, Self>
65 | |     where
66 | |         Self::Extras: Default,
   | |______________________________- the associated function is available for `Token` here
   |
  ::: fuzz_targets/formatter.rs:30:5
   |
30 |   use logos::Logos;
   |       ------------ `Logos` imported here doesn't correspond to the right version of crate `logos`
   |
  ::: /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/logos-0.14.2/src/lib.rs:44:1
   |
44 |   pub trait Logos<'source>: Sized {
   |   ------------------------------- this is the trait that was imported
help: there is an associated function `lex` with a similar name
   |
90 |     Token::lex(p)
   |            ~~~

warning: unused import: `logos::Logos`
  --> fuzz_targets/formatter.rs:30:5
   |
30 | use logos::Logos;
   |     ^^^^^^^^^^^^
   |
   = note: `#[warn(unused_imports)]` on by default

For more information about this error, try `rustc --explain E0599`.
warning: `cedar-drt-inner` (bin "formatter") generated 1 warning
error: could not compile `cedar-drt-inner` (bin "formatter") due to 1 previous error; 1 warning emitted
warning: build failed, waiting for other jobs to finish...
```

Using `logos` v0.15.0 in this repo should unblock the upgrade in other one - I've tested this manually.

