### PR TITLE
Add dependabot updates for Rust DRT packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directories:
+      - "/cedar-drt"
+      - "/cedar-drt/fuzz"
+      - "/cedar-policy-generators"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 1
+    # Update all explicitly defined dependencies
+    allow:
+      - dependency-type: "all"
+    # Group all updates into one pull request
+    groups:
+      rust-dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
Not sure how I can test that this works. I pretty much copy-pasted from the `cedar` repo

Fix #491 