### PR TITLE
Try to ignore path dependencies for depndabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,13 @@ updates:
     # Update all explicitly defined dependencies
     allow:
       - dependency-type: "all"
+    ignore:
+      - dependency-name: "cedar-policy"
+      - dependency-name: "cedar-policy-core"
+      - dependency-name: "cedar-policy-validator"
+      - dependency-name: "cedar-policy-formatter"
+      - dependency-name: "cedar-testing"
+
     # Group all updates into one pull request
     groups:
       rust-dependencies:


### PR DESCRIPTION
Depndabot failed because it couldn't find the dependencies. They're path dependencies that we assume will be in `./cedar`, but that's not populated for dependabot. Don't know if this will work. AFAIK the only way to check is merging