### PR TITLE
[CedarProto] introduce ignore, and other small refactors

### DIFF
--- a/cedar-lean/CedarProto/ActionConstraint.lean
+++ b/cedar-lean/CedarProto/ActionConstraint.lean
@@ -76,7 +76,7 @@ def parseField (t : Proto.Tag) : BParsec (MergeFn ActionScope.In) := do
       pure (mergeEuids · x)
     | _ =>
       t.wireType.skip
-      pure id
+      pure ignore
 
 instance : Message ActionScope.In := {
   parseField := parseField
@@ -108,7 +108,7 @@ def parseField (t : Proto.Tag) : BParsec (MergeFn ActionScope.Eq) := do
       pure (mergeEuid · x)
     | _ =>
       t.wireType.skip
-      pure id
+      pure ignore
 
 instance : Message ActionScope.Eq := {
   parseField := parseField
@@ -166,7 +166,7 @@ def parseField (t : Proto.Tag) : BParsec (MergeFn ActionScope) := do
       pure (mergeEq · x)
     | _ =>
       t.wireType.skip
-      pure id
+      pure ignore
 
 instance : Message ActionScope := {
   parseField := parseField

--- a/cedar-lean/CedarProto/AuthorizationRequest.lean
+++ b/cedar-lean/CedarProto/AuthorizationRequest.lean
@@ -71,7 +71,7 @@ def parseField (t : Proto.Tag) : BParsec (MergeFn AuthorizationRequest) := do
       pure (mergeEntities · x)
     | _ =>
       t.wireType.skip
-      pure id
+      pure ignore
 
 instance : Message AuthorizationRequest := {
   parseField := parseField

--- a/cedar-lean/CedarProto/Context.lean
+++ b/cedar-lean/CedarProto/Context.lean
@@ -51,7 +51,7 @@ def parseField (t : Proto.Tag) : BParsec (MergeFn Context) := do
       pure (mergeValue · x)
     | _ =>
       t.wireType.skip
-      pure id
+      pure ignore
 
 instance : Message Context := {
   parseField := parseField

--- a/cedar-lean/CedarProto/Entities.lean
+++ b/cedar-lean/CedarProto/Entities.lean
@@ -55,7 +55,7 @@ def parseField (t : Proto.Tag) : BParsec (MergeFn EntitiesProto) := do
     -- Ignoring 3 | mode
     | _ =>
       t.wireType.skip
-      pure id
+      pure ignore
 
 instance : Message EntitiesProto := {
   parseField := parseField

--- a/cedar-lean/CedarProto/Entity.lean
+++ b/cedar-lean/CedarProto/Entity.lean
@@ -91,7 +91,7 @@ def parseField (t : Proto.Tag) : BParsec (MergeFn EntityProto) := do
       pure (mergeTags · x)
     | _ =>
       t.wireType.skip
-      pure id
+      pure ignore
 
 instance : Message EntityProto := {
   parseField := parseField

--- a/cedar-lean/CedarProto/EntityReference.lean
+++ b/cedar-lean/CedarProto/EntityReference.lean
@@ -80,7 +80,7 @@ def parseField (t : Proto.Tag) : BParsec (MergeFn EntityUIDOrSlot) := do
       pure (mergeEuid · x)
     | _ =>
       t.wireType.skip
-      pure id
+      pure ignore
 
 instance : Message EntityUIDOrSlot := {
   parseField := parseField

--- a/cedar-lean/CedarProto/EntityType.lean
+++ b/cedar-lean/CedarProto/EntityType.lean
@@ -50,7 +50,7 @@ def parseField (t : Proto.Tag) : BParsec (MergeFn EntityTypeProto) := do
       pure (mergeName · x)
     | _ =>
       t.wireType.skip
-      pure id
+      pure ignore
 
 instance : Message EntityTypeProto := {
   parseField := parseField

--- a/cedar-lean/CedarProto/EntityUID.lean
+++ b/cedar-lean/CedarProto/EntityUID.lean
@@ -61,7 +61,7 @@ def parseField (t : Proto.Tag) : BParsec (MergeFn EntityUID) := do
       pure (mergeEid · x)
     | _ =>
       t.wireType.skip
-      pure id
+      pure ignore
 
 instance : Message EntityUID := {
   parseField := parseField

--- a/cedar-lean/CedarProto/EntityUIDEntry.lean
+++ b/cedar-lean/CedarProto/EntityUIDEntry.lean
@@ -45,7 +45,7 @@ def parseField (t : Proto.Tag) : BParsec (MergeFn EntityUIDEntry) := do
       pure (mergeEuid · x)
     | _ =>
       t.wireType.skip
-      pure id
+      pure ignore
 
 instance : Message EntityUIDEntry := {
   parseField := parseField

--- a/cedar-lean/CedarProto/Expr.lean
+++ b/cedar-lean/CedarProto/Expr.lean
@@ -97,7 +97,7 @@ def parseField (t : Proto.Tag) : BParsec (MergeFn Prim) := do
       pure (merge_euid · x)
     | _ =>
       t.wireType.skip
-      pure id
+      pure ignore
 
 instance : Message Prim := {
   parseField := parseField
@@ -540,13 +540,13 @@ def parseField (t : Proto.Tag) : BParsec (MergeFn PatElem) := do
   match t.fieldNum with
     | 1 =>
       let x : Ty ← Field.guardedParse t
-      pure (λ s => mergeTy s x)
+      pure (mergeTy · x)
     | 2 =>
       let x : String ← Field.guardedParse t
-      pure (λ s => mergeC s x)
+      pure (mergeC · x)
     | _ =>
       t.wireType.skip
-      pure id
+      pure ignore
 
 instance : Message PatElem := {
   parseField := parseField
@@ -754,7 +754,7 @@ partial def Proto.ExprKind.If.parseField (t : Proto.Tag) : BParsec (Proto.ExprKi
       pure (Proto.ExprKind.If.mergeElseExpr · x)
     | _ =>
       t.wireType.skip
-      pure id
+      pure ignore
 
 partial def Proto.ExprKind.And.parseField (t : Proto.Tag) : BParsec (Proto.ExprKind.And → Proto.ExprKind.And) := do
   have : Message Expr := { parseField := Expr.parseField, merge := Expr.merge }
@@ -767,7 +767,7 @@ partial def Proto.ExprKind.And.parseField (t : Proto.Tag) : BParsec (Proto.ExprK
       pure (Proto.ExprKind.And.mergeRight · x)
     | _ =>
       t.wireType.skip
-      pure id
+      pure ignore
 
 partial def Proto.ExprKind.Or.parseField (t : Proto.Tag) : BParsec (Proto.ExprKind.Or → Proto.ExprKind.Or) := do
   have : Message Expr := { parseField := Expr.parseField, merge := Expr.merge }
@@ -780,7 +780,7 @@ partial def Proto.ExprKind.Or.parseField (t : Proto.Tag) : BParsec (Proto.ExprKi
       pure (Proto.ExprKind.Or.mergeRight · x)
     | _ =>
       t.wireType.skip
-      pure id
+      pure ignore
 
 partial def Proto.ExprKind.UnaryApp.parseField (t : Proto.Tag) : BParsec (Proto.ExprKind.UnaryApp → Proto.ExprKind.UnaryApp) := do
   have : Message Expr := { parseField := Expr.parseField, merge := Expr.merge }
@@ -793,7 +793,7 @@ partial def Proto.ExprKind.UnaryApp.parseField (t : Proto.Tag) : BParsec (Proto.
       pure (Proto.ExprKind.UnaryApp.mergeArg · x)
     | _ =>
       t.wireType.skip
-      pure id
+      pure ignore
 
 partial def Proto.ExprKind.BinaryApp.parseField (t : Proto.Tag) : BParsec (Proto.ExprKind.BinaryApp → Proto.ExprKind.BinaryApp) := do
   have : Message Expr := { parseField := Expr.parseField, merge := Expr.merge }
@@ -809,7 +809,7 @@ partial def Proto.ExprKind.BinaryApp.parseField (t : Proto.Tag) : BParsec (Proto
       pure (λ s => Proto.ExprKind.BinaryApp.mergeRight s x)
     | _ =>
       t.wireType.skip
-      pure (λ s => s)
+      pure ignore
 
 partial def Proto.ExprKind.ExtensionFunctionApp.parseField (t : Proto.Tag) : BParsec (Proto.ExprKind.ExtensionFunctionApp → Proto.ExprKind.ExtensionFunctionApp) := do
   have : Message Expr := { parseField := Expr.parseField, merge := Expr.merge }
@@ -822,7 +822,7 @@ partial def Proto.ExprKind.ExtensionFunctionApp.parseField (t : Proto.Tag) : BPa
       pure (Proto.ExprKind.ExtensionFunctionApp.mergeArgs · x)
     | _ =>
       t.wireType.skip
-      pure id
+      pure ignore
 
 partial def Proto.ExprKind.GetAttr.parseField (t : Proto.Tag) : BParsec (Proto.ExprKind.GetAttr → Proto.ExprKind.GetAttr) := do
   have : Message Expr := { parseField := Expr.parseField, merge := Expr.merge }
@@ -835,7 +835,7 @@ partial def Proto.ExprKind.GetAttr.parseField (t : Proto.Tag) : BParsec (Proto.E
       pure (Proto.ExprKind.GetAttr.mergeAttr · x)
     | _ =>
       t.wireType.skip
-      pure id
+      pure ignore
 
 partial def Proto.ExprKind.HasAttr.parseField (t : Proto.Tag) : BParsec (Proto.ExprKind.HasAttr → Proto.ExprKind.HasAttr) := do
   have : Message Expr := { parseField := Expr.parseField, merge := Expr.merge }
@@ -848,7 +848,7 @@ partial def Proto.ExprKind.HasAttr.parseField (t : Proto.Tag) : BParsec (Proto.E
       pure (Proto.ExprKind.HasAttr.mergeAttr · x)
     | _ =>
       t.wireType.skip
-      pure id
+      pure ignore
 
 partial def Proto.ExprKind.Like.parseField (t : Proto.Tag) : BParsec (Proto.ExprKind.Like → Proto.ExprKind.Like) := do
   have : Message Expr := { parseField := Expr.parseField, merge := Expr.merge }
@@ -861,7 +861,7 @@ partial def Proto.ExprKind.Like.parseField (t : Proto.Tag) : BParsec (Proto.Expr
       pure (Proto.ExprKind.Like.mergePattern · x)
     | _ =>
       t.wireType.skip
-      pure id
+      pure ignore
 
 partial def Proto.ExprKind.Is.parseField (t : Proto.Tag) : BParsec (Proto.ExprKind.Is → Proto.ExprKind.Is) := do
   have : Message Expr := { parseField := Expr.parseField, merge := Expr.merge }
@@ -874,7 +874,7 @@ partial def Proto.ExprKind.Is.parseField (t : Proto.Tag) : BParsec (Proto.ExprKi
       pure (Proto.ExprKind.Is.mergeEt · x)
     | _ =>
       t.wireType.skip
-      pure id
+      pure ignore
 
 partial def Proto.ExprKind.Set.parseField (t : Proto.Tag) : BParsec (Proto.ExprKind.Set → Proto.ExprKind.Set) := do
   have : Message Expr := { parseField := Expr.parseField, merge := Expr.merge }
@@ -884,7 +884,7 @@ partial def Proto.ExprKind.Set.parseField (t : Proto.Tag) : BParsec (Proto.ExprK
       pure (Proto.ExprKind.Set.mergeElems · x)
     | _ =>
       t.wireType.skip
-      pure id
+      pure ignore
 
 partial def Proto.ExprKind.Record.parseField (t : Proto.Tag) : BParsec (Proto.ExprKind.Record → Proto.ExprKind.Record) := do
   have : Message Expr := { parseField := Expr.parseField, merge := Expr.merge }
@@ -894,7 +894,7 @@ partial def Proto.ExprKind.Record.parseField (t : Proto.Tag) : BParsec (Proto.Ex
       pure (Proto.ExprKind.Record.mergeItems · x)
     | _ =>
       t.wireType.skip
-      pure id
+      pure ignore
 
 partial def Proto.ExprKind.parseField (t : Proto.Tag) : BParsec (Proto.ExprKind → Proto.ExprKind) := do
   have : Message Proto.ExprKind.If := { parseField := Proto.ExprKind.If.parseField, merge := Proto.ExprKind.If.merge }
@@ -956,7 +956,7 @@ partial def Proto.ExprKind.parseField (t : Proto.Tag) : BParsec (Proto.ExprKind 
       pure (Proto.ExprKind.mergeRecord · x)
     | _ =>
       t.wireType.skip
-      pure id
+      pure ignore
 
 partial def Expr.parseField (t : Proto.Tag) : BParsec (Expr → Expr) := do
   have : Message Proto.ExprKind := { parseField := Proto.ExprKind.parseField, merge := Proto.ExprKind.merge }
@@ -966,7 +966,7 @@ partial def Expr.parseField (t : Proto.Tag) : BParsec (Expr → Expr) := do
       pure (Expr.mergeExprKind · x)
     | _ =>
       t.wireType.skip
-      pure id
+      pure ignore
 
 end
 

--- a/cedar-lean/CedarProto/LiteralPolicy.lean
+++ b/cedar-lean/CedarProto/LiteralPolicy.lean
@@ -80,7 +80,7 @@ def parseField (t : Proto.Tag) : BParsec (MergeFn TemplateLinkedPolicy) := do
       pure (mergeResourceEuid · x)
     | _ =>
       t.wireType.skip
-      pure (λ s => s)
+      pure ignore
 
 instance : Message TemplateLinkedPolicy := {
   parseField := parseField

--- a/cedar-lean/CedarProto/LiteralPolicySet.lean
+++ b/cedar-lean/CedarProto/LiteralPolicySet.lean
@@ -60,7 +60,7 @@ def parseField (t : Proto.Tag) : BParsec (MergeFn LiteralPolicySet) := do
       pure (mergeLinks · x)
     | _ =>
       t.wireType.skip
-      pure id
+      pure ignore
 
 instance : Message LiteralPolicySet := {
   parseField := parseField

--- a/cedar-lean/CedarProto/Name.lean
+++ b/cedar-lean/CedarProto/Name.lean
@@ -57,7 +57,7 @@ def parseField (t : Proto.Tag) : BParsec (MergeFn Name) := do
       pure (mergePath · x)
     | _ =>
       t.wireType.skip
-      pure (λ s => s)
+      pure ignore
 
 instance : Message Name := {
   parseField := parseField

--- a/cedar-lean/CedarProto/PrincipalConstraint.lean
+++ b/cedar-lean/CedarProto/PrincipalConstraint.lean
@@ -44,7 +44,7 @@ def parseField (t : Proto.Tag) : BParsec (MergeFn PrincipalScopeTemplate) := do
       pure (mergeConstraint · x)
     | _ =>
       t.wireType.skip
-      pure id
+      pure ignore
 
 instance : Message PrincipalScopeTemplate := {
   parseField := parseField

--- a/cedar-lean/CedarProto/PrincipalOrResourceConstraint.lean
+++ b/cedar-lean/CedarProto/PrincipalOrResourceConstraint.lean
@@ -72,7 +72,7 @@ def parseField (t : Proto.Tag) : BParsec (MergeFn ScopeTemplate.In) := do
       pure (mergeER · x)
     | _ =>
       t.wireType.skip
-      pure id
+      pure ignore
 
 instance : Message ScopeTemplate.In := {
   parseField := parseField
@@ -105,7 +105,7 @@ def parseField (t : Proto.Tag) : BParsec (MergeFn ScopeTemplate.Eq) := do
       pure (mergeER · x)
     | _ =>
       t.wireType.skip
-      pure id
+      pure ignore
 
 instance : Message ScopeTemplate.Eq := {
   parseField := parseField
@@ -138,7 +138,7 @@ def parseField (t : Proto.Tag) : BParsec (MergeFn ScopeTemplate.Is) := do
       pure (mergeET · x)
     | _ =>
       t.wireType.skip
-      pure id
+      pure ignore
 
 instance : Message ScopeTemplate.Is := {
   parseField := parseField
@@ -182,7 +182,7 @@ def parseField (t : Proto.Tag) : BParsec (MergeFn ScopeTemplate.IsIn) := do
       pure (mergeET · x)
     | _ =>
       t.wireType.skip
-      pure id
+      pure ignore
 
 instance : Message ScopeTemplate.IsIn := {
   parseField := parseField
@@ -278,7 +278,7 @@ def parseField (t : Proto.Tag) : BParsec (MergeFn ScopeTemplate) := do
       pure (mergeIsIn · x)
     | _ =>
       t.wireType.skip
-      pure id
+      pure ignore
 
 instance : Message ScopeTemplate := {
   parseField := parseField

--- a/cedar-lean/CedarProto/Request.lean
+++ b/cedar-lean/CedarProto/Request.lean
@@ -85,7 +85,7 @@ def parseField (t : Proto.Tag) : BParsec (MergeFn Request) := do
       pure (mergeContext · x)
     | _ =>
       t.wireType.skip
-      pure id
+      pure ignore
 
 instance : Message Request := {
   parseField := parseField

--- a/cedar-lean/CedarProto/ResourceConstraint.lean
+++ b/cedar-lean/CedarProto/ResourceConstraint.lean
@@ -45,7 +45,7 @@ def parseField (t : Proto.Tag) : BParsec (MergeFn ResourceScopeTemplate) := do
       pure (mergeConstraint · x)
     | _ =>
       t.wireType.skip
-      pure id
+      pure ignore
 
 instance : Message ResourceScopeTemplate := {
   parseField := parseField

--- a/cedar-lean/CedarProto/TemplateBody.lean
+++ b/cedar-lean/CedarProto/TemplateBody.lean
@@ -134,7 +134,7 @@ def parseField (t : Proto.Tag) : BParsec (MergeFn Template) := do
       pure (mergeConditions · x)
     | _ =>
       t.wireType.skip
-      pure id
+      pure ignore
 
 instance : Message Template := {
   parseField := parseField

--- a/cedar-lean/CedarProto/Type.lean
+++ b/cedar-lean/CedarProto/Type.lean
@@ -133,7 +133,7 @@ def parseField (t : Tag) : BParsec (MergeFn Entity) := do
       pure (mergeE · x)
     | _ =>
       t.wireType.skip
-      pure id
+      pure ignore
 
 instance : Message Entity := {
   parseField := parseField
@@ -165,7 +165,7 @@ def parseField (t : Tag) : BParsec (MergeFn ActionEntity) := do
       pure (mergeName · x)
     | _ =>
       t.wireType.skip
-      pure id
+      pure ignore
 
 instance : Message ActionEntity := {
   parseField := parseField
@@ -326,7 +326,7 @@ partial def RecordType.parseField (t : Tag) : BParsec (RecordType → RecordType
       pure (RecordType.mergeAttrs · x)
     | _ =>
       t.wireType.skip
-      pure id
+      pure ignore
 
 partial def QualifiedType.parseField (t : Tag) : BParsec (QualifiedType → QualifiedType) := do
   have : Message CedarType := { parseField := CedarType.parseField, merge := CedarType.merge}
@@ -339,7 +339,7 @@ partial def QualifiedType.parseField (t : Tag) : BParsec (QualifiedType → Qual
       pure (QualifiedType.mergeIsRequired · x)
     | _ =>
       t.wireType.skip
-      pure id
+      pure ignore
 
 partial def Proto.EntityRecordKind.parseField (t : Tag) : BParsec (Proto.EntityRecordKind → Proto.EntityRecordKind) := do
   have : Message Proto.EntityRecordKind.Record := { parseField := Proto.EntityRecordKind.Record.parseField, merge := Proto.EntityRecordKind.Record.merge }
@@ -355,7 +355,7 @@ partial def Proto.EntityRecordKind.parseField (t : Tag) : BParsec (Proto.EntityR
       pure (Proto.EntityRecordKind.mergeEntity · x)
     | _ =>
       t.wireType.skip
-      pure id
+      pure ignore
 
 partial def Proto.EntityRecordKind.Record.parseField (t : Tag) : BParsec (Proto.EntityRecordKind.Record → Proto.EntityRecordKind.Record) := do
   have : Message RecordType := { parseField := RecordType.parseField, merge := RecordType.merge }
@@ -365,7 +365,7 @@ partial def Proto.EntityRecordKind.Record.parseField (t : Tag) : BParsec (Proto.
       pure (Proto.EntityRecordKind.Record.mergeAttributes · x)
     | _ =>
       t.wireType.skip
-      pure id
+      pure ignore
 
 partial def CedarType.parseField (t : Tag) : BParsec (CedarType → CedarType) := do
   have : Message CedarType := {parseField := CedarType.parseField, merge := CedarType.merge }
@@ -385,7 +385,7 @@ partial def CedarType.parseField (t : Tag) : BParsec (CedarType → CedarType) :
       pure (CedarType.mergeName · x)
     | _ =>
       t.wireType.skip
-      pure id
+      pure ignore
 end
 
 namespace RecordType

--- a/cedar-lean/CedarProto/ValidationRequest.lean
+++ b/cedar-lean/CedarProto/ValidationRequest.lean
@@ -69,7 +69,7 @@ def parseField (t : Tag) : BParsec (MergeFn ValidationRequest) := do
       pure (mergePolicies · x)
     | _ =>
       t.wireType.skip
-      pure id
+      pure ignore
 
 instance : Message ValidationRequest := {
   parseField := parseField

--- a/cedar-lean/CedarProto/ValidatorActionId.lean
+++ b/cedar-lean/CedarProto/ValidatorActionId.lean
@@ -81,7 +81,7 @@ def parseField (t : Tag) : BParsec (MergeFn ValidatorActionId) := do
       pure (mergeContext · x)
     | _ =>
       t.wireType.skip
-      pure id
+      pure ignore
 
 instance : Message ValidatorActionId := {
   parseField := parseField

--- a/cedar-lean/CedarProto/ValidatorApplySpec.lean
+++ b/cedar-lean/CedarProto/ValidatorApplySpec.lean
@@ -61,7 +61,7 @@ def parseField (t : Tag) : BParsec (MergeFn ValidatorApplySpec) := do
       pure (mergeRas · x)
     | _ =>
       t.wireType.skip
-      pure id
+      pure ignore
 
 instance : Message ValidatorApplySpec := {
   parseField := parseField

--- a/cedar-lean/CedarProto/ValidatorEntityType.lean
+++ b/cedar-lean/CedarProto/ValidatorEntityType.lean
@@ -49,7 +49,7 @@ def parseField (t : Tag) : BParsec (MergeFn TagMessage) := do
       pure λ { optional_type := old_ty } => { optional_type := Field.merge old_ty ty }
     | _ =>
       t.wireType.skip
-      pure id
+      pure ignore
 
 @[inline]
 def merge (x y : TagMessage) : TagMessage :=
@@ -113,7 +113,7 @@ def parseField (t : Tag) : BParsec (MergeFn ValidatorEntityType) := do
       pure (mergeTags · x)
     | _ =>
       t.wireType.skip
-      pure id
+      pure ignore
 
 instance : Message ValidatorEntityType := {
   parseField := parseField

--- a/cedar-lean/CedarProto/ValidatorSchema.lean
+++ b/cedar-lean/CedarProto/ValidatorSchema.lean
@@ -135,7 +135,7 @@ def parseField (t : Tag) : BParsec (MergeFn ValidatorSchema) := do
       pure (mergeActionIds · x)
     | _ =>
       t.wireType.skip
-      pure id
+      pure ignore
 
 instance : Message ValidatorSchema := {
   parseField := parseField

--- a/cedar-lean/UnitTest/Proto.lean
+++ b/cedar-lean/UnitTest/Proto.lean
@@ -65,7 +65,7 @@ def parseField (t : Tag) : BParsec (MergeFn HardCodeStruct) := do
       pure (merge_6 · x)
     | _ =>
       t.wireType.skip
-      pure id
+      pure ignore
 
 instance : Message HardCodeStruct := {
   parseField := parseField


### PR DESCRIPTION
Introduces a `MergeFn` called `ignore` solely for readability purposes.  Avoids name collisions with `id` for types that have fields named `id`.  A few other small refactors, mostly in Protobuf/Message.lean.



