### PR TITLE
Refactor models and proofs to use Lean's Int64.

### DIFF
--- a/cedar-lean/Cedar/Spec/Evaluator.lean
+++ b/cedar-lean/Cedar/Spec/Evaluator.lean
@@ -26,7 +26,7 @@ namespace Cedar.Spec
 open Cedar.Data
 open Error
 
-def intOrErr : Option Data.Int64 → Result Value
+def intOrErr : Option Int64 → Result Value
   | .some i => .ok (.prim (.int i))
   | .none   => .error .arithBoundsError
 

--- a/cedar-lean/Cedar/Spec/Ext/Datetime.lean
+++ b/cedar-lean/Cedar/Spec/Ext/Datetime.lean
@@ -38,7 +38,7 @@ open Cedar.Data
 
   A duration may be negative. Negative duration strings must begin with `-`.
 -/
-abbrev Duration := Data.Int64
+abbrev Duration := Int64
 
 namespace Datetime
 
@@ -49,11 +49,10 @@ def MILLISECONDS_PER_DAY: Int := 86400000
 
 ----- Definitions -----
 
-def duration? (i : Int) : Option Duration :=
-  Int64.mk? i
+abbrev duration? := Int64.ofInt?
 
 def durationUnits? (n: Nat) (suffix: String) : Option Duration :=
-  match Int64.mk? n with
+  match Int64.ofInt? n with
   | none => none
   | some i =>
     match suffix with

--- a/cedar-lean/Cedar/Spec/Ext/Decimal.lean
+++ b/cedar-lean/Cedar/Spec/Ext/Decimal.lean
@@ -32,14 +32,14 @@ We restrict the number of the digits after the decimal point to 4.
 
 def DECIMAL_DIGITS : Nat := 4
 
-abbrev Decimal := Data.Int64
+abbrev Decimal := Int64
 
 namespace Decimal
 
 ----- Definitions -----
 
 def decimal? (i : Int) : Option Decimal :=
-  Int64.mk? i
+  Int64.ofInt? i
 
 def parse (str : String) : Option Decimal :=
   match str.split (· = '.') with
@@ -60,7 +60,7 @@ def parse (str : String) : Option Decimal :=
 
 instance : ToString Decimal where
   toString (d : Decimal) : String :=
-    let neg   := if d < (0 : Int) then "-" else ""
+    let neg   := if d < 0 then "-" else ""
     let d     := d.natAbs
     let left  := d / (Nat.pow 10 DECIMAL_DIGITS)
     let right := d % (Nat.pow 10 DECIMAL_DIGITS)

--- a/cedar-lean/Cedar/Spec/Value.lean
+++ b/cedar-lean/Cedar/Spec/Value.lean
@@ -58,7 +58,7 @@ instance : ToString EntityUID where
 
 inductive Prim where
   | bool (b : Bool)
-  | int (i : Data.Int64)
+  | int (i : Int64)
   | string (s : String)
   | entityUID (uid : EntityUID)
 
@@ -88,7 +88,7 @@ def Value.asString : Value →  Result String
   | .prim (.string s) => .ok s
   | _ => .error Error.typeError
 
-def Value.asInt : Value →  Result Data.Int64
+def Value.asInt : Value →  Result Int64
   | .prim (.int i) => .ok i
   | _ => .error Error.typeError
 
@@ -99,7 +99,7 @@ def Result.as {α} (β) [Coe α (Result β)] : Result α → Result β
 instance : Coe Bool Value where
   coe b := .prim (.bool b)
 
-instance : Coe Data.Int64 Value where
+instance : Coe Int64 Value where
   coe i := .prim (.int i)
 
 instance : Coe String Value where
@@ -123,7 +123,7 @@ instance : Coe (Map Attr Value) Value where
 instance : Coe Value (Result Bool) where
   coe v := v.asBool
 
-instance : Coe Value (Result Data.Int64) where
+instance : Coe Value (Result Int64) where
   coe v := v.asInt
 
 instance : Coe Value (Result String) where

--- a/cedar-lean/Cedar/Thm/Data/LT.lean
+++ b/cedar-lean/Cedar/Thm/Data/LT.lean
@@ -133,10 +133,7 @@ instance Ext.strictLT : StrictLT Ext where
     cases a <;> cases b <;> simp [LT.lt, Ext.lt] <;>
     rename_i x₁ x₂ <;> intro h₁
     case decimal =>
-      have h₂ := Data.Int64.strictLT.asymmetric x₁ x₂
-      simp [LT.lt] at h₂
-      cases h₃ : Data.Int64.lt x₁ x₂ <;>
-      simp [h₃] at h₁ h₂ ; simp [h₂]
+      exact Int64.strictLT.asymmetric x₁ x₂ h₁
     case ipaddr =>
       have h₂ := IPNet.strictLT.asymmetric x₁ x₂
       simp [LT.lt] at h₂
@@ -146,11 +143,7 @@ instance Ext.strictLT : StrictLT Ext where
     cases a <;> cases b <;> cases c <;> simp [LT.lt, Ext.lt] <;>
     rename_i x₁ x₂ x₃ <;> intro h₁ h₂
     case decimal =>
-      have h₃ := Data.Int64.strictLT.transitive x₁ x₂ x₃
-      simp [LT.lt] at h₃
-      cases h₄ : Data.Int64.lt x₁ x₂ <;> simp [h₄] at *
-      cases h₅ : Data.Int64.lt x₂ x₃ <;> simp [h₅] at *
-      simp [h₃]
+      exact Int64.strictLT.transitive x₁ x₂ x₃ h₁ h₂
     case ipaddr =>
       have h₃ := IPNet.strictLT.transitive x₁ x₂ x₃
       simp [LT.lt] at h₃
@@ -161,9 +154,7 @@ instance Ext.strictLT : StrictLT Ext where
     cases a <;> cases b <;> simp [LT.lt, Ext.lt] <;>
     rename_i x₁ x₂ <;> intro h₁
     case decimal =>
-      have h₂ := Data.Int64.strictLT.connected x₁ x₂
-      simp [LT.lt, h₁] at h₂
-      rcases h₂ with h₂ | h₂ <;> simp [h₂]
+      exact Int64.strictLT.connected x₁ x₂ h₁
     case ipaddr =>
       have h₂ := IPNet.strictLT.connected x₁ x₂
       simp [LT.lt, h₁] at h₂
@@ -261,7 +252,7 @@ theorem Prim.lt_asymm {a b : Prim} :
   cases a <;> cases b <;> simp [LT.lt] <;>
   simp [Prim.lt]
   case bool b₁ b₂          => exact Bool.strictLT.asymmetric b₁ b₂
-  case int i₁ i₂           => exact (Data.Int64.strictLT.asymmetric i₁ i₂)
+  case int i₁ i₂           => exact (Int64.strictLT.asymmetric i₁ i₂)
   case string s₁ s₂        => exact (String.strictLT.asymmetric s₁ s₂)
   case entityUID uid₁ uid₂ => exact (EntityUID.strictLT.asymmetric uid₁ uid₂)
 
@@ -271,7 +262,7 @@ theorem Prim.lt_trans {a b c : Prim} :
   cases a <;> cases b <;> cases c <;> simp [LT.lt] <;>
   simp [Prim.lt]
   case bool b₁ b₂ b₃            => exact (Bool.strictLT.transitive b₁ b₂ b₃)
-  case int i₁ i₂ i₃             => exact (Data.Int64.strictLT.transitive i₁ i₂ i₃)
+  case int i₁ i₂ i₃             => exact (Int64.strictLT.transitive i₁ i₂ i₃)
   case string s₁ s₂ s₃          => exact (String.strictLT.transitive s₁ s₂ s₃)
   case entityUID uid₁ uid₂ uid₃ => exact (EntityUID.strictLT.transitive uid₁ uid₂ uid₃)
 
@@ -281,7 +272,7 @@ theorem Prim.lt_conn {a b : Prim} :
   cases a <;> cases b <;> simp [LT.lt] <;>
   simp [Prim.lt]
   case bool b₁ b₂          => exact (Bool.strictLT.connected b₁ b₂)
-  case int i₁ i₂           => exact (Data.Int64.strictLT.connected i₁ i₂)
+  case int i₁ i₂           => exact (Int64.strictLT.connected i₁ i₂)
   case string s₁ s₂        => exact (String.strictLT.connected s₁ s₂)
   case entityUID uid₁ uid₂ => exact (EntityUID.strictLT.connected uid₁ uid₂)
 

--- a/cedar-lean/CedarProto/ActionConstraint.lean
+++ b/cedar-lean/CedarProto/ActionConstraint.lean
@@ -13,7 +13,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -/
-import Cedar
+import Cedar.Spec
 import Protobuf.Enum
 
 -- Message Dependencies

--- a/cedar-lean/CedarProto/AuthorizationRequest.lean
+++ b/cedar-lean/CedarProto/AuthorizationRequest.lean
@@ -13,7 +13,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -/
-import Cedar
+import Cedar.Spec
 
 -- Message Dependencies
 import CedarProto.Request

--- a/cedar-lean/CedarProto/Context.lean
+++ b/cedar-lean/CedarProto/Context.lean
@@ -13,7 +13,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -/
-import Cedar
+import Cedar.Spec
 import Protobuf.Message
 import Protobuf.Map
 import Protobuf.String

--- a/cedar-lean/CedarProto/Entities.lean
+++ b/cedar-lean/CedarProto/Entities.lean
@@ -13,7 +13,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -/
-import Cedar
+import Cedar.Spec
 
 -- Message Dependencies
 import CedarProto.Entity

--- a/cedar-lean/CedarProto/Entity.lean
+++ b/cedar-lean/CedarProto/Entity.lean
@@ -13,7 +13,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -/
-import Cedar
+import Cedar.Spec
 
 -- Message Dependencies
 import CedarProto.EntityUID

--- a/cedar-lean/CedarProto/EntityReference.lean
+++ b/cedar-lean/CedarProto/EntityReference.lean
@@ -13,7 +13,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -/
-import Cedar
+import Cedar.Spec
 import Protobuf.Enum
 
 -- Message Dependencies

--- a/cedar-lean/CedarProto/EntityType.lean
+++ b/cedar-lean/CedarProto/EntityType.lean
@@ -13,7 +13,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -/
-import Cedar
+import Cedar.Spec
 import Protobuf.Message
 
 -- Message Dependencies

--- a/cedar-lean/CedarProto/EntityUID.lean
+++ b/cedar-lean/CedarProto/EntityUID.lean
@@ -13,7 +13,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -/
-import Cedar
+import Cedar.Spec
 import Protobuf.Message
 import Protobuf.String
 

--- a/cedar-lean/CedarProto/EntityUIDEntry.lean
+++ b/cedar-lean/CedarProto/EntityUIDEntry.lean
@@ -13,7 +13,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -/
-import Cedar
+import Cedar.Spec
 import Protobuf.Message
 import Protobuf.String
 

--- a/cedar-lean/CedarProto/Expr.lean
+++ b/cedar-lean/CedarProto/Expr.lean
@@ -14,7 +14,8 @@
  limitations under the License.
 -/
 
-import Cedar
+import Cedar.Spec
+import Cedar.Data.Int64
 import Protobuf.Message
 import Protobuf.Enum
 import Protobuf.Map
@@ -45,17 +46,17 @@ def merge_bool (p : Prim) (b2 : Bool) : Prim :=
 @[inline]
 def merge_int (_ : Prim) (pi : Proto.Int64) : Prim :=
   have i : Int := pi
-  if H1 : i < Cedar.Data.INT64_MIN then
+  if H1 : i < Int64.MIN then
     panic!("Integer less than INT64_MIN")
-  else if H2 : i > Cedar.Data.INT64_MAX then
+  else if H2 : i > Int64.MAX then
     panic!("Integer greater than INT64_MAX")
   else
-    have h1 : Cedar.Data.INT64_MIN ≤ i ∧ i ≤ Cedar.Data.INT64_MAX := by
+    have h1 : Int64.MIN ≤ i ∧ i ≤ Int64.MAX := by
       unfold Proto.Int64 at *
       omega
 
     -- Override semantics
-    Prim.int (Cedar.Data.Int64.mk i h1)
+    Prim.int (Int64.ofIntChecked i h1)
 
 @[inline]
 def merge_string (p : Prim) (s2 : String) : Prim :=
@@ -74,7 +75,7 @@ def merge (p1 : Prim) (p2 : Prim) : Prim :=
   match p2 with
     | .bool b2 => merge_bool p1 b2
     | .int i2 =>
-      let i2₁ : Int := i2
+      let i2₁ : Int := i2.toInt
       let i2₂ : Proto.Int64 := i2₁
       merge_int p1 i2₂
     | .string s2 => merge_string p1 s2

--- a/cedar-lean/CedarProto/LiteralPolicy.lean
+++ b/cedar-lean/CedarProto/LiteralPolicy.lean
@@ -13,7 +13,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -/
-import Cedar
+import Cedar.Spec
 
 -- Message Dependencies
 import CedarProto.EntityUID

--- a/cedar-lean/CedarProto/LiteralPolicySet.lean
+++ b/cedar-lean/CedarProto/LiteralPolicySet.lean
@@ -13,7 +13,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -/
-import Cedar
+import Cedar.Spec
 
 -- Message Dependencies
 import CedarProto.TemplateBody

--- a/cedar-lean/CedarProto/Name.lean
+++ b/cedar-lean/CedarProto/Name.lean
@@ -13,7 +13,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -/
-import Cedar
+import Cedar.Spec
 import Protobuf.Message
 import Protobuf.String
 

--- a/cedar-lean/CedarProto/PrincipalConstraint.lean
+++ b/cedar-lean/CedarProto/PrincipalConstraint.lean
@@ -13,7 +13,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -/
-import Cedar
+import Cedar.Spec
 
 -- Message Dependencies
 import CedarProto.PrincipalOrResourceConstraint

--- a/cedar-lean/CedarProto/PrincipalOrResourceConstraint.lean
+++ b/cedar-lean/CedarProto/PrincipalOrResourceConstraint.lean
@@ -13,7 +13,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -/
-import Cedar
+import Cedar.Spec
 
 -- Message Dependencies
 import CedarProto.EntityReference

--- a/cedar-lean/CedarProto/Request.lean
+++ b/cedar-lean/CedarProto/Request.lean
@@ -13,7 +13,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -/
-import Cedar
+import Cedar.Spec
 import Protobuf.Message
 import Protobuf.String
 

--- a/cedar-lean/CedarProto/ResourceConstraint.lean
+++ b/cedar-lean/CedarProto/ResourceConstraint.lean
@@ -13,7 +13,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -/
-import Cedar
+import Cedar.Spec
 
 -- Message Dependencies
 import CedarProto.PrincipalOrResourceConstraint

--- a/cedar-lean/CedarProto/TemplateBody.lean
+++ b/cedar-lean/CedarProto/TemplateBody.lean
@@ -13,7 +13,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -/
-import Cedar
+import Cedar.Spec
 
 -- Message Dependencies
 import CedarProto.Expr

--- a/cedar-lean/CedarProto/Type.lean
+++ b/cedar-lean/CedarProto/Type.lean
@@ -13,7 +13,8 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -/
-import Cedar
+import Cedar.Spec
+import Cedar.Validation
 import Protobuf.Enum
 import Protobuf.Message
 import Protobuf.Map

--- a/cedar-lean/CedarProto/ValidationRequest.lean
+++ b/cedar-lean/CedarProto/ValidationRequest.lean
@@ -13,7 +13,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -/
-import Cedar
+import Cedar.Spec
 import Protobuf.Message
 import Protobuf.String
 

--- a/cedar-lean/CedarProto/ValidatorActionId.lean
+++ b/cedar-lean/CedarProto/ValidatorActionId.lean
@@ -13,7 +13,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -/
-import Cedar
+import Cedar.Spec
 import Protobuf.Message
 import Protobuf.String
 

--- a/cedar-lean/CedarProto/ValidatorApplySpec.lean
+++ b/cedar-lean/CedarProto/ValidatorApplySpec.lean
@@ -13,7 +13,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -/
-import Cedar
+import Cedar.Spec
 import Protobuf.Message
 import Protobuf.String
 

--- a/cedar-lean/CedarProto/ValidatorEntityType.lean
+++ b/cedar-lean/CedarProto/ValidatorEntityType.lean
@@ -13,7 +13,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -/
-import Cedar
+import Cedar.Spec
 import Protobuf.Message
 import Protobuf.String
 

--- a/cedar-lean/CedarProto/ValidatorSchema.lean
+++ b/cedar-lean/CedarProto/ValidatorSchema.lean
@@ -13,7 +13,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -/
-import Cedar
+import Cedar.Spec
 import Protobuf.Message
 import Protobuf.String
 

--- a/cedar-lean/CedarProto/Value.lean
+++ b/cedar-lean/CedarProto/Value.lean
@@ -13,7 +13,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -/
-import Cedar
+import Cedar.Spec
 import Protobuf.Message
 
 -- Message Dependencies

--- a/cedar-lean/DiffTest/Util.lean
+++ b/cedar-lean/DiffTest/Util.lean
@@ -71,11 +71,11 @@ def jsonToNum (json : Json) : ParseResult JsonNumber :=
   | .ok n => .ok n
   | .error e => .error s!"jsonToNum: {e}\n{json.pretty}"
 
-def jsonToInt64 (json : Json) : ParseResult Cedar.Data.Int64 := do
+def jsonToInt64 (json : Json) : ParseResult Int64 := do
   let num ← jsonToNum json
   match num.exponent with
   | 0 =>
-    match Int64.mk? num.mantissa with
+    match Int64.ofInt? num.mantissa with
     | .some i64 => .ok i64
     | .none => .error s!"jsonToInt64: not a signed 64-bit integer {num.mantissa}"
   | n => .error s!"jsonToInt64: number has exponent {n}"

--- a/cedar-lean/UnitTest/CedarProto.lean
+++ b/cedar-lean/UnitTest/CedarProto.lean
@@ -88,7 +88,7 @@ def tests := [
     testDeserializeProtodata "UnitTest/CedarProto-test-data/true.protodata"
       (Cedar.Spec.Expr.lit (.bool true)),
     testDeserializeProtodata "UnitTest/CedarProto-test-data/345.protodata"
-      (Cedar.Spec.Expr.lit (.int (Cedar.Data.Int64.mk 345 (by decide)))),
+      (Cedar.Spec.Expr.lit (.int (Int64.ofIntChecked 345 (by decide)))),
     testDeserializeProtodata "UnitTest/CedarProto-test-data/emptystring.protodata"
       (Cedar.Spec.Expr.lit (.string "")),
     testDeserializeProtodata "UnitTest/CedarProto-test-data/thisiscedar.protodata"
@@ -103,13 +103,13 @@ def tests := [
       (Cedar.Spec.Expr.set []),
     testDeserializeProtodata "UnitTest/CedarProto-test-data/set.protodata"
       (Cedar.Spec.Expr.set [
-        .lit (.int (Cedar.Data.Int64.mk (-2) (by decide))),
+        .lit (.int (Int64.ofIntChecked (-2) (by decide))),
         .lit (.string "minustwo"),
       ]),
     testDeserializeProtodata "UnitTest/CedarProto-test-data/nested_set.protodata"
       (Cedar.Spec.Expr.set [
-        .set [ .lit (.int (Cedar.Data.Int64.mk 1 (by decide))), .lit (.int (Cedar.Data.Int64.mk 2 (by decide))) ],
-        .set [ .lit (.int (Cedar.Data.Int64.mk 3 (by decide))), .getAttr (.var .principal) "foo" ],
+        .set [ .lit (.int (Int64.ofIntChecked 1 (by decide))), .lit (.int (Int64.ofIntChecked 2 (by decide))) ],
+        .set [ .lit (.int (Int64.ofIntChecked 3 (by decide))), .getAttr (.var .principal) "foo" ],
         .lit (.bool false),
       ]),
     testDeserializeProtodata "UnitTest/CedarProto-test-data/emptyrecord.protodata"
@@ -117,15 +117,15 @@ def tests := [
     testDeserializeProtodata' "UnitTest/CedarProto-test-data/record.protodata"
       Cedar.Spec.Expr.mkWf
       (.record [
-        ("eggs", .lit (.int (Cedar.Data.Int64.mk 7 (by decide)))),
-        ("ham", .lit (.int (Cedar.Data.Int64.mk 3 (by decide)))),
+        ("eggs", .lit (.int (Int64.ofIntChecked 7 (by decide)))),
+        ("ham", .lit (.int (Int64.ofIntChecked 3 (by decide)))),
       ]),
     testDeserializeProtodata' "UnitTest/CedarProto-test-data/nested_record.protodata"
       Cedar.Spec.Expr.mkWf
       (.record [
         ("eggs", .set [ .lit (.string "this is"), .lit (.string "a set") ]),
         ("ham", .record [
-          ("a", .lit (.int (Cedar.Data.Int64.mk 0 (by decide)))),
+          ("a", .lit (.int (Int64.ofIntChecked 0 (by decide)))),
           ("b", .lit (.bool false)),
         ]),
       ]),
@@ -146,19 +146,19 @@ def tests := [
         (.unaryApp .not (.getAttr (.var .principal) "foo"))
         (.unaryApp .not (.binaryApp .eq
           (.unaryApp .neg (.getAttr (.var .principal) "bar"))
-          (.lit (.int (Cedar.Data.Int64.mk 3 (by decide))))
+          (.lit (.int (Int64.ofIntChecked 3 (by decide))))
         ))
       ),
     testDeserializeProtodata "UnitTest/CedarProto-test-data/plus_and_minus_and_times.protodata"
       (Cedar.Spec.Expr.binaryApp .sub
-        (.binaryApp .add (.lit (.int (Cedar.Data.Int64.mk 32 (by decide)))) (.getAttr (.var .context) "count"))
-        (.binaryApp .mul (.lit (.int (Cedar.Data.Int64.mk 7 (by decide)))) (.lit (.int (Cedar.Data.Int64.mk 4 (by decide)))))
+        (.binaryApp .add (.lit (.int (Int64.ofIntChecked 32 (by decide)))) (.getAttr (.var .context) "count"))
+        (.binaryApp .mul (.lit (.int (Int64.ofIntChecked 7 (by decide)))) (.lit (.int (Int64.ofIntChecked 4 (by decide)))))
       ),
     testDeserializeProtodata "UnitTest/CedarProto-test-data/contains.protodata"
       (Cedar.Spec.Expr.binaryApp .contains
         (.set [
-          (.lit (.int (Cedar.Data.Int64.mk 2 (by decide)))),
-          (.lit (.int (Cedar.Data.Int64.mk 3 (by decide)))),
+          (.lit (.int (Int64.ofIntChecked 2 (by decide)))),
+          (.lit (.int (Int64.ofIntChecked 3 (by decide)))),
           (.lit (.entityUID (mkUid [] "User" "alice"))),
         ])
         (.getAttr (.var .context) "foo")
@@ -182,7 +182,7 @@ def tests := [
         (.getAttr
           (.getAttr
             (.ite
-              (.binaryApp .less (.getAttr (.var .context) "foo") (.lit (.int (Cedar.Data.Int64.mk 3 (by decide)))))
+              (.binaryApp .less (.getAttr (.var .context) "foo") (.lit (.int (Int64.ofIntChecked 3 (by decide)))))
               (.getAttr (.var .principal) "foo")
               (.getAttr (.var .principal) "bar")
             )
@@ -240,7 +240,7 @@ def tests := [
             kind := .when
             body := .unaryApp .not (.binaryApp .lessEq
               (.getAttr (.var .resource) "eligibility")
-              (.lit (.int (Cedar.Data.Int64.mk 2 (by decide))))
+              (.lit (.int (Int64.ofIntChecked 2 (by decide))))
             )
           }]
         },
@@ -255,7 +255,7 @@ def tests := [
             body := .binaryApp .eq
               (.binaryApp .sub
                 (.getAttr (.var .context) "foo")
-                (.lit (.int (Cedar.Data.Int64.mk 7 (by decide))))
+                (.lit (.int (Int64.ofIntChecked 7 (by decide))))
               )
               (.getAttr (.var .context) "bar")
           }]
@@ -321,8 +321,8 @@ def tests := [
         data := {
           attrs := Map.make [
             ("foo", .set (Set.make [
-              (.prim (.int (Cedar.Data.Int64.mk 1 (by decide)))),
-              (.prim (.int (Cedar.Data.Int64.mk (-1) (by decide)))),
+              (.prim (.int (Int64.ofIntChecked 1 (by decide)))),
+              (.prim (.int (Int64.ofIntChecked (-1) (by decide)))),
             ])),
             ("bar", .prim (.bool false)),
           ]


### PR DESCRIPTION
This PR refactors Cedar's models and proofs to use Lean's new Int64 datatype.


