### PR TITLE
Fix protobuf parsing for unrecognized extension functions

### DIFF
--- a/cedar-drt/fuzz/src/lib.rs
+++ b/cedar-drt/fuzz/src/lib.rs
@@ -249,7 +249,9 @@ pub fn run_val_test(
         TestResult::Failure(err) => {
             // TODO(#175): For now, ignore cases where the Lean code returned an error due to
             // an unknown extension function.
-            if !err.contains("unknown extension function") && !err.contains("unknown extension type") {
+            if !err.contains("unknown extension function")
+                && !err.contains("unknown extension type")
+            {
                 panic!(
                     "Unexpected error\nPolicies:\n{}\nSchema:\n{:?}\nError: {err}",
                     &policies, schema

--- a/cedar-drt/fuzz/src/lib.rs
+++ b/cedar-drt/fuzz/src/lib.rs
@@ -84,7 +84,7 @@ pub fn run_pe_test(
         TestResult::Failure(err) => {
             // TODO(#175): Ignore cases where the definitional code returned an error due to
             // an unknown extension function.
-            if err.contains("jsonToExtFun: unknown extension function") {
+            if err.contains("unknown extension function") {
                 return;
             }
             // No other errors are expected
@@ -139,7 +139,7 @@ pub fn run_eval_test(
         TestResult::Failure(err) => {
             // TODO(#175): Ignore cases where the definitional code returned an error due to
             // an unknown extension function.
-            if err.contains("jsonToExtFun: unknown extension function") {
+            if err.contains("unknown extension function") {
                 return;
             }
             // No other errors are expected
@@ -176,7 +176,7 @@ pub fn run_auth_test(
         TestResult::Failure(err) => {
             // TODO(#175): For now, ignore cases where the Lean code returned an error due to
             // an unknown extension function.
-            if err.contains("jsonToExtFun: unknown extension function") {
+            if err.contains("unknown extension function") {
                 rust_res
             } else {
                 panic!(
@@ -249,7 +249,7 @@ pub fn run_val_test(
         TestResult::Failure(err) => {
             // TODO(#175): For now, ignore cases where the Lean code returned an error due to
             // an unknown extension function.
-            if !err.contains("jsonToExtFun: unknown extension function") {
+            if !err.contains("unknown extension function") && !err.contains("unknown extension type") {
                 panic!(
                     "Unexpected error\nPolicies:\n{}\nSchema:\n{:?}\nError: {err}",
                     &policies, schema

--- a/cedar-drt/src/lean_impl.rs
+++ b/cedar-drt/src/lean_impl.rs
@@ -38,7 +38,7 @@ use lean_sys::{
     lean_alloc_sarray, lean_dec, lean_dec_ref, lean_finalize_thread,
     lean_initialize_runtime_module_locked, lean_initialize_thread, lean_io_mark_end_initialization,
     lean_io_mk_world, lean_io_result_is_ok, lean_io_result_show_error, lean_sarray_object,
-    lean_string_cstr,
+    lean_set_exit_on_panic, lean_string_cstr,
 };
 use log::info;
 use miette::miette;
@@ -167,6 +167,8 @@ impl LeanDefinitionalEngine {
                     panic!("Failed to initialize Lean");
                 }
                 lean_io_mark_end_initialization();
+                // If we don't explicitly set this, Lean does not abort after hitting a panic
+                lean_set_exit_on_panic(true);
             };
         });
         unsafe { lean_initialize_thread() };

--- a/cedar-lean/CedarProto/ActionConstraint.lean
+++ b/cedar-lean/CedarProto/ActionConstraint.lean
@@ -73,7 +73,7 @@ def parseField (t : Proto.Tag) : BParsec (MergeFn ActionScope.In) := do
   match t.fieldNum with
     | 1 =>
       let x : Repeated EntityUID ← Field.guardedParse t
-      pure (mergeEuids · x)
+      pure (pure $ mergeEuids · x)
     | _ =>
       t.wireType.skip
       pure ignore
@@ -105,7 +105,7 @@ def parseField (t : Proto.Tag) : BParsec (MergeFn ActionScope.Eq) := do
   match t.fieldNum with
     | 1 =>
       let x : EntityUID ← Field.guardedParse t
-      pure (mergeEuid · x)
+      pure (pure $ mergeEuid · x)
     | _ =>
       t.wireType.skip
       pure ignore
@@ -157,13 +157,13 @@ def parseField (t : Proto.Tag) : BParsec (MergeFn ActionScope) := do
   match t.fieldNum with
     | 1 =>
       let x : Proto.ActionScope.Ty ← Field.guardedParse t
-      pure (mergeTy · x)
+      pure (pure $ mergeTy · x)
     | 2 =>
       let x : Proto.ActionScope.In ← Field.guardedParse t
-      pure (mergeIn · x)
+      pure (pure $ mergeIn · x)
     | 3 =>
       let x : Proto.ActionScope.Eq ← Field.guardedParse t
-      pure (mergeEq · x)
+      pure (pure $ mergeEq · x)
     | _ =>
       t.wireType.skip
       pure ignore

--- a/cedar-lean/CedarProto/AuthorizationRequest.lean
+++ b/cedar-lean/CedarProto/AuthorizationRequest.lean
@@ -62,13 +62,13 @@ def parseField (t : Proto.Tag) : BParsec (MergeFn AuthorizationRequest) := do
   match t.fieldNum with
     | 1 =>
       let x : Request ← Field.guardedParse t
-      pure (mergeRequest · x)
+      pure (pure $ mergeRequest · x)
     | 2 =>
       let x : Policies ← Field.guardedParse t
-      pure (mergePolicies · x)
+      pure (pure $ mergePolicies · x)
     | 3 =>
       let x : Entities ← Field.guardedParse t
-      pure (mergeEntities · x)
+      pure (pure $ mergeEntities · x)
     | _ =>
       t.wireType.skip
       pure ignore

--- a/cedar-lean/CedarProto/Context.lean
+++ b/cedar-lean/CedarProto/Context.lean
@@ -48,7 +48,7 @@ def parseField (t : Proto.Tag) : BParsec (MergeFn Context) := do
   match t.fieldNum with
     | 1 =>
       let x : Value ← Field.guardedParse t
-      pure (mergeValue · x)
+      pure (pure $ mergeValue · x)
     | _ =>
       t.wireType.skip
       pure ignore

--- a/cedar-lean/CedarProto/Entities.lean
+++ b/cedar-lean/CedarProto/Entities.lean
@@ -51,7 +51,7 @@ def parseField (t : Proto.Tag) : BParsec (MergeFn EntitiesProto) := do
   match t.fieldNum with
     | 1 =>
       let x : Repeated EntityProto ← Field.guardedParse t
-      pure (mergeEntities · x)
+      pure (pure $ mergeEntities · x)
     -- Ignoring 3 | mode
     | _ =>
       t.wireType.skip

--- a/cedar-lean/CedarProto/Entity.lean
+++ b/cedar-lean/CedarProto/Entity.lean
@@ -79,16 +79,16 @@ def parseField (t : Proto.Tag) : BParsec (MergeFn EntityProto) := do
   match t.fieldNum with
     | 1 =>
       let x : EntityUID ← Field.guardedParse t
-      pure (mergeUid · x)
+      pure (pure $ mergeUid · x)
     | 2 =>
       let x : Proto.Map String Value ← Field.guardedParse t
-      pure (mergeAttrs · x)
+      pure (pure $ mergeAttrs · x)
     | 3 =>
       let x : Repeated EntityUID ← Field.guardedParse t
-      pure (mergeAncestors · x)
+      pure (pure $ mergeAncestors · x)
     | 4 =>
       let x : Proto.Map String Value ← Field.guardedParse t
-      pure (mergeTags · x)
+      pure (pure $ mergeTags · x)
     | _ =>
       t.wireType.skip
       pure ignore

--- a/cedar-lean/CedarProto/EntityReference.lean
+++ b/cedar-lean/CedarProto/EntityReference.lean
@@ -74,10 +74,10 @@ def parseField (t : Proto.Tag) : BParsec (MergeFn EntityUIDOrSlot) := do
   match t.fieldNum with
     | 1 =>
       let x : Proto.EntityReferenceType ← Field.guardedParse t
-      pure (mergeTy · x)
+      pure (pure $ mergeTy · x)
     | 2 =>
       let x : EntityUID ← Field.guardedParse t
-      pure (mergeEuid · x)
+      pure (pure $ mergeEuid · x)
     | _ =>
       t.wireType.skip
       pure ignore

--- a/cedar-lean/CedarProto/EntityType.lean
+++ b/cedar-lean/CedarProto/EntityType.lean
@@ -47,7 +47,7 @@ def parseField (t : Proto.Tag) : BParsec (MergeFn EntityTypeProto) := do
   match t.fieldNum with
     | 1 =>
       let x : Name ← Field.guardedParse t
-      pure (mergeName · x)
+      pure (pure $ mergeName · x)
     | _ =>
       t.wireType.skip
       pure ignore

--- a/cedar-lean/CedarProto/EntityUID.lean
+++ b/cedar-lean/CedarProto/EntityUID.lean
@@ -55,10 +55,10 @@ def parseField (t : Proto.Tag) : BParsec (MergeFn EntityUID) := do
   match t.fieldNum with
     | 1 =>
       let x : EntityTypeProto ← Field.guardedParse t
-      pure (mergeTy · x)
+      pure (pure $ mergeTy · x)
     | 2 =>
       let x : String ← Field.guardedParse t
-      pure (mergeEid · x)
+      pure (pure $ mergeEid · x)
     | _ =>
       t.wireType.skip
       pure ignore

--- a/cedar-lean/CedarProto/EntityUIDEntry.lean
+++ b/cedar-lean/CedarProto/EntityUIDEntry.lean
@@ -42,7 +42,7 @@ def parseField (t : Proto.Tag) : BParsec (MergeFn EntityUIDEntry) := do
   match t.fieldNum with
     | 1 =>
       let x : EntityUID ← Field.guardedParse t
-      pure (mergeEuid · x)
+      pure (pure $ mergeEuid · x)
     | _ =>
       t.wireType.skip
       pure ignore

--- a/cedar-lean/CedarProto/Expr.lean
+++ b/cedar-lean/CedarProto/Expr.lean
@@ -86,16 +86,16 @@ def parseField (t : Proto.Tag) : BParsec (MergeFn Prim) := do
   match t.fieldNum with
     | 1 =>
       let x : Bool ← Field.guardedParse t
-      pure (merge_bool · x)
+      pure (pure $ merge_bool · x)
     | 2 =>
       let x : Proto.Int64 ← Field.guardedParse t
-      pure (merge_int · x)
+      pure (pure $ merge_int · x)
     | 3 =>
       let x : String ← Field.guardedParse t
-      pure (merge_string · x)
+      pure (pure $ merge_string · x)
     | 4 =>
       let x : EntityUID ← Field.guardedParse t
-      pure (merge_euid · x)
+      pure (pure $ merge_euid · x)
     | _ =>
       t.wireType.skip
       pure ignore
@@ -422,21 +422,21 @@ end Proto.ExprKind.BinaryApp
 
 namespace Proto.ExprKind.ExtensionFunctionApp
 @[inline]
-def mergeName (result : ExprKind.ExtensionFunctionApp) (xfn : Name) : ExprKind.ExtensionFunctionApp :=
+def mergeName (result : ExprKind.ExtensionFunctionApp) (xfn : Name) : BParsec ExprKind.ExtensionFunctionApp :=
   match result with
   | .call _ es => match xfn.id with
-    | "decimal" => .call .decimal es
-    | "lessThan" => .call .lessThan es
-    | "lessThanOrEqual" => .call .lessThanOrEqual es
-    | "greaterThan" => .call .greaterThan es
-    | "greaterThanOrEqual" => .call .greaterThanOrEqual es
-    | "ip" => .call .ip es
-    | "isIpv4" => .call .isIpv4 es
-    | "isIpv6" => .call .isIpv6 es
-    | "isLoopback" => .call .isLoopback es
-    | "isMulticast" => .call .isMulticast es
-    | "isInRange" => .call .isInRange es
-    | xfn => panic! s!"mergeName: unknown extension function {xfn}"
+    | "decimal" => pure $ .call .decimal es
+    | "lessThan" => pure $ .call .lessThan es
+    | "lessThanOrEqual" => pure $ .call .lessThanOrEqual es
+    | "greaterThan" => pure $ .call .greaterThan es
+    | "greaterThanOrEqual" => pure $ .call .greaterThanOrEqual es
+    | "ip" => pure $ .call .ip es
+    | "isIpv4" => pure $ .call .isIpv4 es
+    | "isIpv6" => pure $ .call .isIpv6 es
+    | "isLoopback" => pure $ .call .isLoopback es
+    | "isMulticast" => pure $ .call .isMulticast es
+    | "isInRange" => pure $ .call .isInRange es
+    | xfn => throw s!"mergeName: unknown extension function {xfn}"
   | _ => panic!("Expected ExprKind.ExtensionFunctionApp to have constructor .call")
 
 @[inline]
@@ -541,10 +541,10 @@ def parseField (t : Proto.Tag) : BParsec (MergeFn PatElem) := do
   match t.fieldNum with
     | 1 =>
       let x : Ty ← Field.guardedParse t
-      pure (mergeTy · x)
+      pure (pure $ mergeTy · x)
     | 2 =>
       let x : String ← Field.guardedParse t
-      pure (mergeC · x)
+      pure (pure $ mergeC · x)
     | _ =>
       t.wireType.skip
       pure ignore
@@ -741,78 +741,78 @@ end Expr
 -- where many of the constructors depend on Expr
 mutual
 
-partial def Proto.ExprKind.If.parseField (t : Proto.Tag) : BParsec (Proto.ExprKind.If → Proto.ExprKind.If) := do
+partial def Proto.ExprKind.If.parseField (t : Proto.Tag) : BParsec (MergeFn Proto.ExprKind.If) := do
   have : Message Expr := { parseField := Expr.parseField, merge := Expr.merge }
   match t.fieldNum with
     | 1 =>
       let x : Expr ← Field.guardedParse t
-      pure (Proto.ExprKind.If.mergeTestExpr · x)
+      pure (pure $ Proto.ExprKind.If.mergeTestExpr · x)
     | 2 =>
       let x : Expr ← Field.guardedParse t
-      pure (Proto.ExprKind.If.mergeThenExpr · x)
+      pure (pure $ Proto.ExprKind.If.mergeThenExpr · x)
     | 3 =>
       let x : Expr ← Field.guardedParse t
-      pure (Proto.ExprKind.If.mergeElseExpr · x)
+      pure (pure $ Proto.ExprKind.If.mergeElseExpr · x)
     | _ =>
       t.wireType.skip
       pure ignore
 
-partial def Proto.ExprKind.And.parseField (t : Proto.Tag) : BParsec (Proto.ExprKind.And → Proto.ExprKind.And) := do
+partial def Proto.ExprKind.And.parseField (t : Proto.Tag) : BParsec (MergeFn Proto.ExprKind.And) := do
   have : Message Expr := { parseField := Expr.parseField, merge := Expr.merge }
   match t.fieldNum with
     | 1 =>
       let x : Expr ← Field.guardedParse t
-      pure (Proto.ExprKind.And.mergeLeft · x)
+      pure (pure $ Proto.ExprKind.And.mergeLeft · x)
     | 2 =>
       let x : Expr ← Field.guardedParse t
-      pure (Proto.ExprKind.And.mergeRight · x)
+      pure (pure $ Proto.ExprKind.And.mergeRight · x)
     | _ =>
       t.wireType.skip
       pure ignore
 
-partial def Proto.ExprKind.Or.parseField (t : Proto.Tag) : BParsec (Proto.ExprKind.Or → Proto.ExprKind.Or) := do
+partial def Proto.ExprKind.Or.parseField (t : Proto.Tag) : BParsec (MergeFn Proto.ExprKind.Or) := do
   have : Message Expr := { parseField := Expr.parseField, merge := Expr.merge }
   match t.fieldNum with
     | 1 =>
       let x : Expr ← Field.guardedParse t
-      pure (Proto.ExprKind.Or.mergeLeft · x)
+      pure (pure $ Proto.ExprKind.Or.mergeLeft · x)
     | 2 =>
       let x : Expr ← Field.guardedParse t
-      pure (Proto.ExprKind.Or.mergeRight · x)
+      pure (pure $ Proto.ExprKind.Or.mergeRight · x)
     | _ =>
       t.wireType.skip
       pure ignore
 
-partial def Proto.ExprKind.UnaryApp.parseField (t : Proto.Tag) : BParsec (Proto.ExprKind.UnaryApp → Proto.ExprKind.UnaryApp) := do
+partial def Proto.ExprKind.UnaryApp.parseField (t : Proto.Tag) : BParsec (MergeFn Proto.ExprKind.UnaryApp) := do
   have : Message Expr := { parseField := Expr.parseField, merge := Expr.merge }
   match t.fieldNum with
     | 1 =>
       let x : Proto.ExprKind.UnaryApp.Op ← Field.guardedParse t
-      pure (Proto.ExprKind.UnaryApp.mergeOp · x)
+      pure (pure $ Proto.ExprKind.UnaryApp.mergeOp · x)
     | 2 =>
       let x : Expr ← Field.guardedParse t
-      pure (Proto.ExprKind.UnaryApp.mergeArg · x)
+      pure (pure $ Proto.ExprKind.UnaryApp.mergeArg · x)
     | _ =>
       t.wireType.skip
       pure ignore
 
-partial def Proto.ExprKind.BinaryApp.parseField (t : Proto.Tag) : BParsec (Proto.ExprKind.BinaryApp → Proto.ExprKind.BinaryApp) := do
+partial def Proto.ExprKind.BinaryApp.parseField (t : Proto.Tag) : BParsec (MergeFn Proto.ExprKind.BinaryApp) := do
   have : Message Expr := { parseField := Expr.parseField, merge := Expr.merge }
   match t.fieldNum with
     | 1 =>
       let x : Proto.ExprKind.BinaryApp.Op ← Field.guardedParse t
-      pure (λ s => Proto.ExprKind.BinaryApp.mergeOp s x)
+      pure (pure $ Proto.ExprKind.BinaryApp.mergeOp · x)
     | 2 =>
       let x : Expr ← Field.guardedParse t
-      pure (λ s => Proto.ExprKind.BinaryApp.mergeLeft s x)
+      pure (pure $ Proto.ExprKind.BinaryApp.mergeLeft · x)
     | 3 =>
       let x : Expr ← Field.guardedParse t
-      pure (λ s => Proto.ExprKind.BinaryApp.mergeRight s x)
+      pure (pure $ Proto.ExprKind.BinaryApp.mergeRight · x)
     | _ =>
       t.wireType.skip
       pure ignore
 
-partial def Proto.ExprKind.ExtensionFunctionApp.parseField (t : Proto.Tag) : BParsec (Proto.ExprKind.ExtensionFunctionApp → Proto.ExprKind.ExtensionFunctionApp) := do
+partial def Proto.ExprKind.ExtensionFunctionApp.parseField (t : Proto.Tag) : BParsec (MergeFn Proto.ExprKind.ExtensionFunctionApp) := do
   have : Message Expr := { parseField := Expr.parseField, merge := Expr.merge }
   match t.fieldNum with
     | 1 =>
@@ -820,84 +820,84 @@ partial def Proto.ExprKind.ExtensionFunctionApp.parseField (t : Proto.Tag) : BPa
       pure (Proto.ExprKind.ExtensionFunctionApp.mergeName · x)
     | 2 =>
       let x : Repeated Expr ← Field.guardedParse t
-      pure (Proto.ExprKind.ExtensionFunctionApp.mergeArgs · x)
+      pure (pure $ Proto.ExprKind.ExtensionFunctionApp.mergeArgs · x)
     | _ =>
       t.wireType.skip
       pure ignore
 
-partial def Proto.ExprKind.GetAttr.parseField (t : Proto.Tag) : BParsec (Proto.ExprKind.GetAttr → Proto.ExprKind.GetAttr) := do
+partial def Proto.ExprKind.GetAttr.parseField (t : Proto.Tag) : BParsec (MergeFn Proto.ExprKind.GetAttr) := do
   have : Message Expr := { parseField := Expr.parseField, merge := Expr.merge }
   match t.fieldNum with
     | 1 =>
       let x : Expr ← Field.guardedParse t
-      pure (Proto.ExprKind.GetAttr.mergeExpr · x)
+      pure (pure $ Proto.ExprKind.GetAttr.mergeExpr · x)
     | 2 =>
       let x : String ← Field.guardedParse t
-      pure (Proto.ExprKind.GetAttr.mergeAttr · x)
+      pure (pure $ Proto.ExprKind.GetAttr.mergeAttr · x)
     | _ =>
       t.wireType.skip
       pure ignore
 
-partial def Proto.ExprKind.HasAttr.parseField (t : Proto.Tag) : BParsec (Proto.ExprKind.HasAttr → Proto.ExprKind.HasAttr) := do
+partial def Proto.ExprKind.HasAttr.parseField (t : Proto.Tag) : BParsec (MergeFn Proto.ExprKind.HasAttr) := do
   have : Message Expr := { parseField := Expr.parseField, merge := Expr.merge }
   match t.fieldNum with
     | 1 =>
       let x : Expr ← Field.guardedParse t
-      pure (Proto.ExprKind.HasAttr.mergeExpr · x)
+      pure (pure $ Proto.ExprKind.HasAttr.mergeExpr · x)
     | 2 =>
       let x : String ← Field.guardedParse t
-      pure (Proto.ExprKind.HasAttr.mergeAttr · x)
+      pure (pure $ Proto.ExprKind.HasAttr.mergeAttr · x)
     | _ =>
       t.wireType.skip
       pure ignore
 
-partial def Proto.ExprKind.Like.parseField (t : Proto.Tag) : BParsec (Proto.ExprKind.Like → Proto.ExprKind.Like) := do
+partial def Proto.ExprKind.Like.parseField (t : Proto.Tag) : BParsec (MergeFn Proto.ExprKind.Like) := do
   have : Message Expr := { parseField := Expr.parseField, merge := Expr.merge }
   match t.fieldNum with
     | 1 =>
       let x : Expr ← Field.guardedParse t
-      pure (Proto.ExprKind.Like.mergeExpr · x)
+      pure (pure $ Proto.ExprKind.Like.mergeExpr · x)
     | 2 =>
       let x : Repeated PatElem ← Field.guardedParse t
-      pure (Proto.ExprKind.Like.mergePattern · x)
+      pure (pure $ Proto.ExprKind.Like.mergePattern · x)
     | _ =>
       t.wireType.skip
       pure ignore
 
-partial def Proto.ExprKind.Is.parseField (t : Proto.Tag) : BParsec (Proto.ExprKind.Is → Proto.ExprKind.Is) := do
+partial def Proto.ExprKind.Is.parseField (t : Proto.Tag) : BParsec (MergeFn Proto.ExprKind.Is) := do
   have : Message Expr := { parseField := Expr.parseField, merge := Expr.merge }
   match t.fieldNum with
     | 1 =>
       let x : Expr ← Field.guardedParse t
-      pure (Proto.ExprKind.Is.mergeExpr · x)
+      pure (pure $ Proto.ExprKind.Is.mergeExpr · x)
     | 2 =>
       let x : EntityTypeProto ← Field.guardedParse t
-      pure (Proto.ExprKind.Is.mergeEt · x)
+      pure (pure $ Proto.ExprKind.Is.mergeEt · x)
     | _ =>
       t.wireType.skip
       pure ignore
 
-partial def Proto.ExprKind.Set.parseField (t : Proto.Tag) : BParsec (Proto.ExprKind.Set → Proto.ExprKind.Set) := do
+partial def Proto.ExprKind.Set.parseField (t : Proto.Tag) : BParsec (MergeFn Proto.ExprKind.Set) := do
   have : Message Expr := { parseField := Expr.parseField, merge := Expr.merge }
   match t.fieldNum with
     | 1 =>
       let x : Repeated Expr ← Field.guardedParse t
-      pure (Proto.ExprKind.Set.mergeElems · x)
+      pure (pure $ Proto.ExprKind.Set.mergeElems · x)
     | _ =>
       t.wireType.skip
       pure ignore
 
-partial def Proto.ExprKind.Record.parseField (t : Proto.Tag) : BParsec (Proto.ExprKind.Record → Proto.ExprKind.Record) := do
+partial def Proto.ExprKind.Record.parseField (t : Proto.Tag) : BParsec (MergeFn Proto.ExprKind.Record) := do
   have : Message Expr := { parseField := Expr.parseField, merge := Expr.merge }
   match t.fieldNum with
     | 1 =>
       let x : Proto.Map String Expr ← Field.guardedParse t
-      pure (Proto.ExprKind.Record.mergeItems · x)
+      pure (pure $ Proto.ExprKind.Record.mergeItems · x)
     | _ =>
       t.wireType.skip
       pure ignore
 
-partial def Proto.ExprKind.parseField (t : Proto.Tag) : BParsec (Proto.ExprKind → Proto.ExprKind) := do
+partial def Proto.ExprKind.parseField (t : Proto.Tag) : BParsec (MergeFn Proto.ExprKind) := do
   have : Message Proto.ExprKind.If := { parseField := Proto.ExprKind.If.parseField, merge := Proto.ExprKind.If.merge }
   have : Message Proto.ExprKind.And := { parseField := Proto.ExprKind.And.parseField, merge := Proto.ExprKind.And.merge }
   have : Message Proto.ExprKind.Or := { parseField := Proto.ExprKind.Or.parseField, merge := Proto.ExprKind.Or.merge }
@@ -915,56 +915,56 @@ partial def Proto.ExprKind.parseField (t : Proto.Tag) : BParsec (Proto.ExprKind 
   match t.fieldNum with
     | 1 =>
       let x : Prim ← Field.guardedParse t
-      pure (Proto.ExprKind.mergePrim · x)
+      pure (pure $ Proto.ExprKind.mergePrim · x)
     | 2 =>
       let x : Var ← Field.guardedParse t
-      pure (Proto.ExprKind.mergeVar · x)
+      pure (pure $ Proto.ExprKind.mergeVar · x)
     | 4 =>
       let x : Proto.ExprKind.If ← Field.guardedParse t
-      pure (Proto.ExprKind.mergeIf · x)
+      pure (pure $ Proto.ExprKind.mergeIf · x)
     | 5 =>
       let x : Proto.ExprKind.And ← Field.guardedParse t
-      pure (Proto.ExprKind.mergeAnd · x)
+      pure (pure $ Proto.ExprKind.mergeAnd · x)
     | 6 =>
       let x : Proto.ExprKind.Or ← Field.guardedParse t
-      pure (Proto.ExprKind.mergeOr · x)
+      pure (pure $ Proto.ExprKind.mergeOr · x)
     | 7 =>
       let x : Proto.ExprKind.UnaryApp ← Field.guardedParse t
-      pure (Proto.ExprKind.mergeUApp · x)
+      pure (pure $ Proto.ExprKind.mergeUApp · x)
     | 8 =>
       let x : Proto.ExprKind.BinaryApp ← Field.guardedParse t
-      pure (Proto.ExprKind.mergeBApp · x)
+      pure (pure $ Proto.ExprKind.mergeBApp · x)
     | 9 =>
       let x : Proto.ExprKind.ExtensionFunctionApp ← Field.guardedParse t
-      pure (Proto.ExprKind.mergeExtApp · x)
+      pure (pure $ Proto.ExprKind.mergeExtApp · x)
     | 10 =>
       let x : Proto.ExprKind.GetAttr ← Field.guardedParse t
-      pure (Proto.ExprKind.mergeGetAttr · x)
+      pure (pure $ Proto.ExprKind.mergeGetAttr · x)
     | 11 =>
       let x : Proto.ExprKind.HasAttr ← Field.guardedParse t
-      pure (Proto.ExprKind.mergeHasAttr · x)
+      pure (pure $ Proto.ExprKind.mergeHasAttr · x)
     | 12 =>
       let x : Proto.ExprKind.Like ← Field.guardedParse t
-      pure (Proto.ExprKind.mergeLike · x)
+      pure (pure $ Proto.ExprKind.mergeLike · x)
     | 13 =>
       let x : Proto.ExprKind.Is ← Field.guardedParse t
-      pure (Proto.ExprKind.mergeIs · x)
+      pure (pure $ Proto.ExprKind.mergeIs · x)
     | 14 =>
       let x : Proto.ExprKind.Set ← Field.guardedParse t
-      pure (Proto.ExprKind.mergeSet · x)
+      pure (pure $ Proto.ExprKind.mergeSet · x)
     | 15 =>
       let x : Proto.ExprKind.Record ← Field.guardedParse t
-      pure (Proto.ExprKind.mergeRecord · x)
+      pure (pure $ Proto.ExprKind.mergeRecord · x)
     | _ =>
       t.wireType.skip
       pure ignore
 
-partial def Expr.parseField (t : Proto.Tag) : BParsec (Expr → Expr) := do
+partial def Expr.parseField (t : Proto.Tag) : BParsec (MergeFn Expr) := do
   have : Message Proto.ExprKind := { parseField := Proto.ExprKind.parseField, merge := Proto.ExprKind.merge }
   match t.fieldNum with
     | 1 =>
       let x : Proto.ExprKind ← Field.guardedParse t
-      pure (Expr.mergeExprKind · x)
+      pure (pure $ Expr.mergeExprKind · x)
     | _ =>
       t.wireType.skip
       pure ignore

--- a/cedar-lean/CedarProto/LiteralPolicy.lean
+++ b/cedar-lean/CedarProto/LiteralPolicy.lean
@@ -68,16 +68,16 @@ def parseField (t : Proto.Tag) : BParsec (MergeFn TemplateLinkedPolicy) := do
   match t.fieldNum with
     | 1 =>
       let x : String ← Field.guardedParse t
-      pure (mergeTemplateId · x)
+      pure (pure $ mergeTemplateId · x)
     | 2 =>
       let x : String ← Field.guardedParse t
-      pure (mergeId · x)
+      pure (pure $ mergeId · x)
     | 4 =>
       let x : EntityUID ← Field.guardedParse t
-      pure (mergePrincipalEuid · x)
+      pure (pure $ mergePrincipalEuid · x)
     | 5 =>
       let x : EntityUID ← Field.guardedParse t
-      pure (mergeResourceEuid · x)
+      pure (pure $ mergeResourceEuid · x)
     | _ =>
       t.wireType.skip
       pure ignore

--- a/cedar-lean/CedarProto/LiteralPolicySet.lean
+++ b/cedar-lean/CedarProto/LiteralPolicySet.lean
@@ -54,10 +54,10 @@ def parseField (t : Proto.Tag) : BParsec (MergeFn LiteralPolicySet) := do
   match t.fieldNum with
     | 1 =>
       let x : Proto.Map String Template ← Field.guardedParse t
-      pure (mergeTemplates · x)
+      pure (pure $ mergeTemplates · x)
     | 2 =>
       let x : Proto.Map String TemplateLinkedPolicy ← Field.guardedParse t
-      pure (mergeLinks · x)
+      pure (pure $ mergeLinks · x)
     | _ =>
       t.wireType.skip
       pure ignore

--- a/cedar-lean/CedarProto/Name.lean
+++ b/cedar-lean/CedarProto/Name.lean
@@ -51,13 +51,14 @@ def parseField (t : Proto.Tag) : BParsec (MergeFn Name) := do
   match t.fieldNum with
     | 1 =>
       let x : String ← Field.guardedParse t
-      pure (mergeId · x)
+      pure (pure $ mergeId · x)
     | 2 =>
       let x : Repeated String ← Field.guardedParse t
-      pure (mergePath · x)
+      pure (pure $ mergePath · x)
     | _ =>
       t.wireType.skip
       pure ignore
+
 
 instance : Message Name := {
   parseField := parseField

--- a/cedar-lean/CedarProto/PrincipalConstraint.lean
+++ b/cedar-lean/CedarProto/PrincipalConstraint.lean
@@ -41,7 +41,7 @@ def parseField (t : Proto.Tag) : BParsec (MergeFn PrincipalScopeTemplate) := do
   match t.fieldNum with
     | 1 =>
       let x : ScopeTemplate ← Field.guardedParse t
-      pure (mergeConstraint · x)
+      pure (pure $ mergeConstraint · x)
     | _ =>
       t.wireType.skip
       pure ignore

--- a/cedar-lean/CedarProto/PrincipalOrResourceConstraint.lean
+++ b/cedar-lean/CedarProto/PrincipalOrResourceConstraint.lean
@@ -69,7 +69,7 @@ def parseField (t : Proto.Tag) : BParsec (MergeFn ScopeTemplate.In) := do
   match t.fieldNum with
     | 1 =>
       let x : EntityUIDOrSlot ← Field.guardedParse t
-      pure (mergeER · x)
+      pure (pure $ mergeER · x)
     | _ =>
       t.wireType.skip
       pure ignore
@@ -102,7 +102,7 @@ def parseField (t : Proto.Tag) : BParsec (MergeFn ScopeTemplate.Eq) := do
   match t.fieldNum with
     | 1 =>
       let x : EntityUIDOrSlot ← Field.guardedParse t
-      pure (mergeER · x)
+      pure (pure $ mergeER · x)
     | _ =>
       t.wireType.skip
       pure ignore
@@ -135,7 +135,7 @@ def parseField (t : Proto.Tag) : BParsec (MergeFn ScopeTemplate.Is) := do
   match t.fieldNum with
     | 1 =>
       let x : EntityTypeProto ← Field.guardedParse t
-      pure (mergeET · x)
+      pure (pure $ mergeET · x)
     | _ =>
       t.wireType.skip
       pure ignore
@@ -176,10 +176,10 @@ def parseField (t : Proto.Tag) : BParsec (MergeFn ScopeTemplate.IsIn) := do
   match t.fieldNum with
     | 1 =>
       let x : EntityUIDOrSlot ← Field.guardedParse t
-      pure (mergeER · x)
+      pure (pure $ mergeER · x)
     | 2 =>
       let x : EntityTypeProto ← Field.guardedParse t
-      pure (mergeET · x)
+      pure (pure $ mergeET · x)
     | _ =>
       t.wireType.skip
       pure ignore
@@ -263,19 +263,19 @@ def parseField (t : Proto.Tag) : BParsec (MergeFn ScopeTemplate) := do
   match t.fieldNum with
     | 1 =>
       let x : Proto.ScopeTemplate.Ty ← Field.guardedParse t
-      pure (mergeTy · x)
+      pure (pure $ mergeTy · x)
     | 2 =>
       let x : Proto.ScopeTemplate.In ← Field.guardedParse t
-      pure (mergeIn · x)
+      pure (pure $ mergeIn · x)
     | 3 =>
       let x : Proto.ScopeTemplate.Eq ← Field.guardedParse t
-      pure (mergeEq · x)
+      pure (pure $ mergeEq · x)
     | 4 =>
       let x : Proto.ScopeTemplate.Is ← Field.guardedParse t
-      pure (mergeIs · x)
+      pure (pure $ mergeIs · x)
     | 5 =>
       let x : Proto.ScopeTemplate.IsIn ← Field.guardedParse t
-      pure (mergeIsIn · x)
+      pure (pure $ mergeIsIn · x)
     | _ =>
       t.wireType.skip
       pure ignore

--- a/cedar-lean/CedarProto/Request.lean
+++ b/cedar-lean/CedarProto/Request.lean
@@ -73,16 +73,16 @@ def parseField (t : Proto.Tag) : BParsec (MergeFn Request) := do
   match t.fieldNum with
     | 1 =>
       let x : EntityUIDEntry ← Field.guardedParse t
-      pure (mergePrincipal · x)
+      pure (pure $ mergePrincipal · x)
     | 2 =>
       let x : EntityUIDEntry ← Field.guardedParse t
-      pure (mergeAction · x)
+      pure (pure $ mergeAction · x)
     | 3 =>
       let x : EntityUIDEntry ← Field.guardedParse t
-      pure (mergeResource · x)
+      pure (pure $ mergeResource · x)
     | 4 =>
       let x : Context ← Field.guardedParse t
-      pure (mergeContext · x)
+      pure (pure $ mergeContext · x)
     | _ =>
       t.wireType.skip
       pure ignore

--- a/cedar-lean/CedarProto/ResourceConstraint.lean
+++ b/cedar-lean/CedarProto/ResourceConstraint.lean
@@ -42,7 +42,7 @@ def parseField (t : Proto.Tag) : BParsec (MergeFn ResourceScopeTemplate) := do
   match t.fieldNum with
     | 1 =>
       let x : ScopeTemplate ← Field.guardedParse t
-      pure (mergeConstraint · x)
+      pure (pure $ mergeConstraint · x)
     | _ =>
       t.wireType.skip
       pure ignore

--- a/cedar-lean/CedarProto/TemplateBody.lean
+++ b/cedar-lean/CedarProto/TemplateBody.lean
@@ -119,19 +119,19 @@ def parseField (t : Proto.Tag) : BParsec (MergeFn Template) := do
     -- NOTE: Doesn't look like id gets utilized in this message
     | 4 =>
       let x : Effect ← Field.guardedParse t
-      pure (mergeEffect · x)
+      pure (pure $ mergeEffect · x)
     | 5 =>
       let x : PrincipalScopeTemplate ← Field.guardedParse t
-      pure (mergePrincipalScope · x)
+      pure (pure $ mergePrincipalScope · x)
     | 6 =>
       let x : ActionScope ← Field.guardedParse t
-      pure (mergeActionScope · x)
+      pure (pure $ mergeActionScope · x)
     | 7 =>
       let x : ResourceScopeTemplate ← Field.guardedParse t
-      pure (mergeResourceScope · x)
+      pure (pure $ mergeResourceScope · x)
     | 8 =>
       let x : Conditions ← Field.guardedParse t
-      pure (mergeConditions · x)
+      pure (pure $ mergeConditions · x)
     | _ =>
       t.wireType.skip
       pure ignore

--- a/cedar-lean/CedarProto/ValidationRequest.lean
+++ b/cedar-lean/CedarProto/ValidationRequest.lean
@@ -63,10 +63,10 @@ def parseField (t : Tag) : BParsec (MergeFn ValidationRequest) := do
   match t.fieldNum with
     | 1 =>
       let x : Schema ← Field.guardedParse t
-      pure (mergeSchema · x)
+      pure (pure $ mergeSchema · x)
     | 2 =>
       let x : Spec.Policies ← Field.guardedParse t
-      pure (mergePolicies · x)
+      pure (pure $ mergePolicies · x)
     | _ =>
       t.wireType.skip
       pure ignore

--- a/cedar-lean/CedarProto/ValidatorActionId.lean
+++ b/cedar-lean/CedarProto/ValidatorActionId.lean
@@ -72,13 +72,13 @@ def parseField (t : Tag) : BParsec (MergeFn ValidatorActionId) := do
   match t.fieldNum with
     | 2 =>
       let x : ValidatorApplySpec ← Field.guardedParse t
-      pure (mergeAppliesTo · x)
+      pure (pure $ mergeAppliesTo · x)
     | 3 =>
       let x : Repeated Spec.EntityUID ← Field.guardedParse t
-      pure (mergeDescendants · x)
+      pure (pure $ mergeDescendants · x)
     | 4 =>
       let x : CedarType ← Field.guardedParse t
-      pure (mergeContext · x)
+      pure (pure $ mergeContext · x)
     | _ =>
       t.wireType.skip
       pure ignore

--- a/cedar-lean/CedarProto/ValidatorApplySpec.lean
+++ b/cedar-lean/CedarProto/ValidatorApplySpec.lean
@@ -55,10 +55,10 @@ def parseField (t : Tag) : BParsec (MergeFn ValidatorApplySpec) := do
   match t.fieldNum with
     | 1 =>
       let x : Repeated Spec.EntityTypeProto ← Field.guardedParse t
-      pure (mergePas · x)
+      pure (pure $ mergePas · x)
     | 2 =>
       let x : Repeated Spec.EntityTypeProto ← Field.guardedParse t
-      pure (mergeRas · x)
+      pure (pure $ mergeRas · x)
     | _ =>
       t.wireType.skip
       pure ignore

--- a/cedar-lean/CedarProto/ValidatorEntityType.lean
+++ b/cedar-lean/CedarProto/ValidatorEntityType.lean
@@ -46,7 +46,7 @@ def parseField (t : Tag) : BParsec (MergeFn TagMessage) := do
   match t.fieldNum with
     | 1 =>
       let ty : CedarType ← Field.guardedParse t
-      pure λ { optional_type := old_ty } => { optional_type := Field.merge old_ty ty }
+      pure λ { optional_type := old_ty } => pure { optional_type := Field.merge old_ty ty }
     | _ =>
       t.wireType.skip
       pure ignore
@@ -104,13 +104,13 @@ def parseField (t : Tag) : BParsec (MergeFn ValidatorEntityType) := do
   match t.fieldNum with
     | 2 =>
       let x : Repeated Spec.EntityTypeProto ← Field.guardedParse t
-      pure (mergeDescendants · x)
+      pure (pure $ mergeDescendants · x)
     | 3 =>
       let x : RecordType ← Field.guardedParse t
-      pure (mergeAttributes · x)
+      pure (pure $ mergeAttributes · x)
     | 5 =>
       let x : TagMessage ← Field.guardedParse t
-      pure (mergeTags · x)
+      pure (pure $ mergeTags · x)
     | _ =>
       t.wireType.skip
       pure ignore

--- a/cedar-lean/CedarProto/ValidatorSchema.lean
+++ b/cedar-lean/CedarProto/ValidatorSchema.lean
@@ -129,10 +129,10 @@ def parseField (t : Tag) : BParsec (MergeFn ValidatorSchema) := do
   match t.fieldNum with
     | 1 =>
       let x : EntityTypeWithTypesMap ← Field.guardedParse t
-      pure (mergeEntityTypes · x)
+      pure (pure $ mergeEntityTypes · x)
     | 2 =>
       let x : EntityUidWithActionsIdMap ← Field.guardedParse t
-      pure (mergeActionIds · x)
+      pure (pure $ mergeActionIds · x)
     | _ =>
       t.wireType.skip
       pure ignore

--- a/cedar-lean/Protobuf/Message.lean
+++ b/cedar-lean/Protobuf/Message.lean
@@ -58,7 +58,7 @@ private def parseMessageHelper [Inhabited α] [Message α] (remaining : Nat) (re
 
   let startPos ← BParsec.pos
   let tag ← Tag.parse
-  let f : (α → BParsec α) ← parseField tag
+  let f : MergeFn α ← parseField tag
   let endPos ← BParsec.pos
   let newResult ← f result
 

--- a/cedar-lean/Protobuf/Message.lean
+++ b/cedar-lean/Protobuf/Message.lean
@@ -25,13 +25,13 @@ Protobuf Message class
 
 namespace Proto
 
-def MergeFn (α : Type) : Type := (α → α)
+def MergeFn (α : Type) : Type := (α → BParsec α)
 
 /--
   a MergeFn which ignores the newly parsed data and just takes the previous
   value as-is
 -/
-def ignore {α : Type} : MergeFn α := id
+def ignore {α : Type} : MergeFn α := pure
 
 class Message (α : Type) [Inhabited α] where
   /--
@@ -58,9 +58,9 @@ private def parseMessageHelper [Inhabited α] [Message α] (remaining : Nat) (re
 
   let startPos ← BParsec.pos
   let tag ← Tag.parse
-  let f : MergeFn α ← parseField tag
+  let f : (α → BParsec α) ← parseField tag
   let endPos ← BParsec.pos
-  let newResult := f result
+  let newResult ← f result
 
   let elementSize := (endPos - startPos)
   if elementSize = 0 then

--- a/cedar-lean/UnitTest/Proto.lean
+++ b/cedar-lean/UnitTest/Proto.lean
@@ -62,7 +62,7 @@ def parseField (t : Tag) : BParsec (MergeFn HardCodeStruct) := do
   match t.fieldNum with
     | 6 =>
       let x : Packed UInt32 ← Field.guardedParse t
-      pure (merge_6 · x)
+      pure (pure $ merge_6 · x)
     | _ =>
       t.wireType.skip
       pure ignore


### PR DESCRIPTION
* Change protobuf parsing to return an error result instead of panicking on unknown extension functions
* Update fuzz targets to look for these error messages rather than errors messages that were specific to JSON parsing
* Call `lean_set_exit_on_panic` when initializing the lean runtime so that any other panics will actually cause tests to fail

This should fix the remaining issues in `abac-type-directed` and `validation-drt-type-directed` targets
