### PR TITLE
Disable additional attributes for proto roundtrip target

### DIFF
--- a/cedar-drt/fuzz/fuzz_targets/protobuf-roundtrip.rs
+++ b/cedar-drt/fuzz/fuzz_targets/protobuf-roundtrip.rs
@@ -47,7 +47,7 @@ const SETTINGS: ABACSettings = ABACSettings {
     enable_extensions: true,
     max_depth: 7,
     max_width: 7,
-    enable_additional_attributes: true,
+    enable_additional_attributes: false,
     enable_like: true,
     enable_action_groups_and_attrs: true,
     enable_arbitrary_func_call: false,


### PR DESCRIPTION
This target hasn't been running in our nightly tests, and a quick local run found a failure when it generated a schema this in it

