### PR TITLE
Lean: Add parsing for `datetime` in the `datetime` extension

### DIFF
--- a/cedar-lean/Cedar/Spec/Ext/Datetime.lean
+++ b/cedar-lean/Cedar/Spec/Ext/Datetime.lean
@@ -28,11 +28,16 @@ namespace Datetime
 /--
   A datetime value is measured in milliseconds and constructed from a datetime string.
   A datetime string must be of one of the forms:
-  - `YYYY-MM-DD` (date only)
-  - `YYYY-MM-DDThh:mm:ssZ` (UTC)
-  - `YYYY-MM-DDThh:mm:ss.SSSZ` (UTC with millisecond precision)
-  - `YYYY-MM-DDThh:mm:ss(+|-)hhmm` (With timezone offset in hours and minutes)
-  - `YYYY-MM-DDThh:mm:ss.SSS(+|-)hhmm` (With timezone offset in hours and minutes and millisecond precision)
+    - `YYYY-MM-DD` (date only)
+    - `YYYY-MM-DDThh:mm:ssZ` (UTC)
+    - `YYYY-MM-DDThh:mm:ss.SSSZ` (UTC with millisecond precision)
+    - `YYYY-MM-DDThh:mm:ss(+|-)hhmm` (With timezone offset in hours and minutes)
+    - `YYYY-MM-DDThh:mm:ss.SSS(+|-)hhmm` (With timezone offset in hours and minutes and millisecond precision)
+
+  Regardless of the timezone, offset is always normalized to UTC.
+
+  The datetime type does not provide a way to create a datetime from a Unix timestamp.
+  One of the readable formats listed above must be used instead.
 -/
 abbrev Datetime := Int64
 
@@ -59,24 +64,6 @@ def parse (str: String) : Option Datetime :=
   | Except.ok val => datetime? val.toTimestamp.toMillisecondsSinceUnixEpoch.toInt
   | _ => none
 
-#eval DateOnly.parse "2022-10-10"
-#eval DateUTC.parse "2022-10-10T00:00:00Z"
-#eval DateUTCWithMillis.parse "2022-10-10T03:35:00.001Z"
-#eval DateWithOffset.parse "2022-10-10T03:35:00+0500"
-#eval DateWithOffsetAndMillis.parse "2022-10-10T03:35:00.000+0500"
-
-#eval parse "2022-10-10"
-#eval parse "2022-10-10T00:00:00Z"
-#eval parse "2022-10-10T03:35:00.001Z"
-#eval parse "2022-10-10T03:35:00+0500"
-#eval parse "2022-10-10T03:35:00.000+0500"
-
-#eval "2022-10-10".length
-#eval "2022-10-10T00:00:00Z".length
-#eval "2022-10-10T03:35:00.001Z".length
-#eval "2022-10-10T03:35:00+05:00".length
-#eval "2022-10-10T03:35:00.000+05:00".length
--- #eval (parse "1969-12-31") == (Int64.ofInt (-86400000 :Int))
 /--
   A duration value is measured in milliseconds and constructed from a duration string.
   A duration string is a concatenated sequence of quantity-unit pairs where the quantity

--- a/cedar-lean/Cedar/Spec/Ext/Datetime.lean
+++ b/cedar-lean/Cedar/Spec/Ext/Datetime.lean
@@ -49,20 +49,14 @@ def DateWithOffsetAndMillis : Std.Time.GenericFormat .any := datespec("uuuu-MM-d
 
 abbrev datetime? := Int64.ofInt?
 
-def parse (str: String) : Option Datetime :=
-  let parseFun := match str.length with
-  | 10 => DateOnly.parse
-  | 20 => DateUTC.parse
-  | 24 => if str.get? ⟨23⟩ == some 'Z'
-          then DateUTCWithMillis.parse
-          else DateWithOffset.parse
-  | 28 => DateWithOffsetAndMillis.parse
-  | _ => (fun _ => Except.error "invalid string length")
-
-  let datetime := parseFun str
-  match datetime with
-  | Except.ok val => datetime? val.toTimestamp.toMillisecondsSinceUnixEpoch.toInt
-  | _ => none
+def parse (str: String) : Option Datetime := do
+  let val :=
+    DateOnly.parse str <|>
+    DateUTC.parse str <|>
+    DateUTCWithMillis.parse str <|>
+    DateWithOffset.parse str <|>
+    DateWithOffsetAndMillis.parse str
+  datetime? (← val.toOption).toTimestamp.toMillisecondsSinceUnixEpoch.toInt
 
 /--
   A duration value is measured in milliseconds and constructed from a duration string.

--- a/cedar-lean/Cedar/Spec/Ext/Datetime.lean
+++ b/cedar-lean/Cedar/Spec/Ext/Datetime.lean
@@ -66,9 +66,9 @@ def parse (str: String) : Option Datetime := do
     DateWithOffsetAndMillis.parse str
 
   let zoned_time ← val.toOption
-  if zoned_time.timezone.offset.second.val.natAbs > MAX_OFFSET_SECONDS
-  then none
-  else datetime? zoned_time.toTimestamp.toMillisecondsSinceUnixEpoch.toInt
+  if zoned_time.timezone.offset.second.val.natAbs < MAX_OFFSET_SECONDS
+  then datetime? zoned_time.toTimestamp.toMillisecondsSinceUnixEpoch.toInt
+  else none
 
 #eval parse "2016-12-31T00:00:00+2400"
 #eval parse "2016-12-31T00:00:00+2401"

--- a/cedar-lean/Cedar/Spec/Ext/Datetime.lean
+++ b/cedar-lean/Cedar/Spec/Ext/Datetime.lean
@@ -52,11 +52,11 @@ def DateWithOffsetAndMillis : Std.Time.GenericFormat .any := datespec("uuuu-MM-d
 
 abbrev datetime? := Int64.ofInt?
 
-def date_contains_leap_seconds (str: String) : Bool :=
+def dateContainsLeapSeconds (str: String) : Bool :=
   str.length >= 20 && str.get? ⟨17⟩ == some '6' && str.get? ⟨18⟩ == some '0'
 
 def parse (str: String) : Option Datetime := do
-  if date_contains_leap_seconds str then failure
+  if dateContainsLeapSeconds str then failure
   let val :=
     DateOnly.parse str <|>
     DateUTC.parse str <|>
@@ -64,9 +64,9 @@ def parse (str: String) : Option Datetime := do
     DateWithOffset.parse str <|>
     DateWithOffsetAndMillis.parse str
 
-  let zoned_time ← val.toOption
-  if zoned_time.timezone.offset.second.val.natAbs < MAX_OFFSET_SECONDS
-  then datetime? zoned_time.toTimestamp.toMillisecondsSinceUnixEpoch.toInt
+  let zonedTime ← val.toOption
+  if zonedTime.timezone.offset.second.val.natAbs < MAX_OFFSET_SECONDS
+  then datetime? zonedTime.toTimestamp.toMillisecondsSinceUnixEpoch.toInt
   else none
 
 /--

--- a/cedar-lean/Cedar/Spec/Ext/Datetime.lean
+++ b/cedar-lean/Cedar/Spec/Ext/Datetime.lean
@@ -17,7 +17,6 @@
 import Cedar.Data.Int64
 import Std.Time
 import Std.Time.Format
-import Init.Data.Int.Basic
 
 /-! This file defines Cedar datetime values and functions. -/
 
@@ -69,11 +68,6 @@ def parse (str: String) : Option Datetime := do
   if zoned_time.timezone.offset.second.val.natAbs < MAX_OFFSET_SECONDS
   then datetime? zoned_time.toTimestamp.toMillisecondsSinceUnixEpoch.toInt
   else none
-
-#eval parse "2016-12-31T00:00:00+2400"
-#eval parse "2016-12-31T00:00:00+2401"
-#eval parse "2016-12-31T00:00:00-2400"
-#eval parse "2016-12-31T00:00:60-2400"
 
 /--
   A duration value is measured in milliseconds and constructed from a duration string.

--- a/cedar-lean/Cedar/Spec/Ext/Datetime.lean
+++ b/cedar-lean/Cedar/Spec/Ext/Datetime.lean
@@ -114,7 +114,7 @@ deriving instance Repr for Duration
 
 abbrev duration := Duration.parse
 
-abbrev Datetime := Std.Time.Timestamp
+abbrev Datetime := Int64
 
 -- /-
 --   * `YYYY-MM-DD` (date only)
@@ -140,7 +140,7 @@ def parse (str: String) : Option Datetime :=
 
   let datetime := parseFun str
   match datetime with
-  | Except.ok val => some val.toTimestamp
+  | Except.ok val => Int64.ofInt? val.toTimestamp.toMillisecondsSinceUnixEpoch.toInt
   | _ => none
 
 #eval DateOnly.parse "2022-10-10"
@@ -150,6 +150,7 @@ def parse (str: String) : Option Datetime :=
 #eval DateWithOffsetAndMillis.parse "2022-10-10T03:35:00.000+05:00"
 
 #eval parse "2022-10-10"
+#eval (parse "1969-12-31") == (Int64.ofInt (-86400000 :Int))
 #eval parse "2022-10-10T00:00:00Z"
 #eval parse "2022-10-10T03:35:00.001Z"
 #eval parse "2022-10-10T03:35:00+05:00"

--- a/cedar-lean/UnitTest/Datetime.lean
+++ b/cedar-lean/UnitTest/Datetime.lean
@@ -23,22 +23,6 @@ namespace UnitTest.Datetime
 
 open Cedar.Spec.Ext.Datetime
 
-theorem testDatetime01 : toString ((parse "2022-10-10").get!) = "1665360000000" := by native_decide
-theorem testDatetime02 : toString ((parse "1969-12-31").get!) = "-86400000" := by native_decide
--- Commented out tests following this comment are impacted by a bug we
--- encountered in Lean. Enable them when the bug has been fixed. More
--- details in https://github.com/cedar-policy/cedar-spec/issues/525
--- theorem testDatetime03 : toString ((parse "1969-12-31T23:59:59.001Z").get!) = "-999" := by native_decide
--- theorem testDatetime04 : toString ((parse "1969-12-31T23:59:59.999Z").get!) = "-1" := by native_decide
-theorem testDatetime05 : toString ((parse "1969-12-31T23:59:59Z").get!) = "-1000" := by native_decide
-theorem testDatetime06 : toString ((parse "2024-10-15").get!) = "1728950400000" := by native_decide
-theorem testDatetime07 : toString ((parse "2024-10-15T11:38:02Z").get!) = "1728992282000" := by native_decide
-theorem testDatetime08 : toString ((parse "2024-10-15T11:38:02.101Z").get!) = "1728992282101" := by native_decide
-theorem testDatetime09 : toString ((parse "2024-10-15T11:38:02.101-1134").get!) = "1729033922101" := by native_decide
-theorem testDatetime10 : toString ((parse "2024-10-15T11:38:02.101+1134").get!) = "1728950642101" := by native_decide
-theorem testDatetime11 : toString ((parse "2024-10-15T11:38:02+1134").get!) = "1728950642000" := by native_decide
-theorem testDatetime12 : toString ((parse "2024-10-15T11:38:02-1134").get!) = "1729033922000" := by native_decide
-
 private def testValidDatetime (str : String) (rep : Int) : TestCase IO :=
   test str ⟨λ _ => checkEq (parse str) (datetime? rep)⟩
 

--- a/cedar-lean/UnitTest/Datetime.lean
+++ b/cedar-lean/UnitTest/Datetime.lean
@@ -162,6 +162,6 @@ def tests := [testsForValidDatetimeStrings, testsForInvalidDatetimeStrings,
               testsForValidDurationStrings, testsForInvalidDurationStrings]
 
 -- Uncomment for interactive debugging
-#eval TestSuite.runAll tests
+-- #eval TestSuite.runAll tests
 
 end UnitTest.Datetime

--- a/cedar-lean/UnitTest/Datetime.lean
+++ b/cedar-lean/UnitTest/Datetime.lean
@@ -89,21 +89,6 @@ def testsForInvalidDatetimeStrings :=
     testInvalidDatetime "2016-12-31T00:00:00+9999" "invalid offset range",
   ]
 
-theorem testDuration01 : toString ((Duration.parse "1ms").get!) = "1" := by native_decide
-theorem testDuration02 : toString ((Duration.parse "1s").get!) = "1000" := by native_decide
-theorem testDuration03 : toString ((Duration.parse "1m").get!) = "60000" := by native_decide
-theorem testDuration04 : toString ((Duration.parse "1h").get!) = "360000" := by native_decide
-theorem testDuration05 : toString ((Duration.parse "1d").get!) = "86400000" := by native_decide
-theorem testDuration06 : toString ((Duration.parse "1d2h3m4s5ms").get!) = "87304005" := by native_decide
-theorem testDuration07 : toString ((Duration.parse "2d12h").get!) = "177120000" := by native_decide
-theorem testDuration08 : toString ((Duration.parse "3m30s").get!) = "210000" := by native_decide
-theorem testDuration09 : toString ((Duration.parse "1h30m45s").get!) = "2205000" := by native_decide
-theorem testDuration10 : toString ((Duration.parse "2d5h20m").get!) = "175800000" := by native_decide
-theorem testDuration11 : toString ((Duration.parse "-1d12h").get!) = "-90720000" := by native_decide
-theorem testDuration12 : toString ((Duration.parse "-3h45m").get!) = "-3780000" := by native_decide
-theorem testDuration13 : toString ((Duration.parse "1d1ms").get!) = "86400001" := by native_decide
-theorem testDuration14 : toString ((Duration.parse "59m59s999ms").get!) = "3599999" := by native_decide
-theorem testDuration15 : toString ((Duration.parse "23h59m59s999ms").get!) = "11879999" := by native_decide
 theorem testDuration16 : toString ((Duration.parse "0d0h0m0s0ms").get!) = "0" := by native_decide
 
 private def testValidDuration (str : String) (rep : Int) : TestCase IO :=
@@ -135,7 +120,8 @@ def testsForValidDurationStrings :=
     testValidDuration "-3h45m" (-3780000),
     testValidDuration "1d1ms" 86400001,
     testValidDuration "59m59s999ms" 3599999,
-    testValidDuration "23h59m59s999ms" 11879999
+    testValidDuration "23h59m59s999ms" 11879999,
+    testValidDuration "0d0h0m0s0ms" 0
   ]
 
 private def testInvalidDuration (str : String) (msg : String) : TestCase IO :=

--- a/cedar-lean/UnitTest/Datetime.lean
+++ b/cedar-lean/UnitTest/Datetime.lean
@@ -23,79 +23,111 @@ namespace UnitTest.Datetime
 
 open Cedar.Spec.Ext.Datetime
 
-theorem test1 : toString ((Duration.parse "1ms").get!) = "1" := by native_decide
-theorem test2 : toString ((Duration.parse "1s").get!) = "1000" := by native_decide
-theorem test3 : toString ((Duration.parse "1m").get!) = "60000" := by native_decide
-theorem test4 : toString ((Duration.parse "1h").get!) = "360000" := by native_decide
-theorem test5 : toString ((Duration.parse "1d").get!) = "86400000" := by native_decide
-theorem test6 : toString ((Duration.parse "1d2h3m4s5ms").get!) = "87304005" := by native_decide
-theorem test7 : toString ((Duration.parse "2d12h").get!) = "177120000" := by native_decide
-theorem test8 : toString ((Duration.parse "3m30s").get!) = "210000" := by native_decide
-theorem test9 : toString ((Duration.parse "1h30m45s").get!) = "2205000" := by native_decide
-theorem test10 : toString ((Duration.parse "2d5h20m").get!) = "175800000" := by native_decide
-theorem test11 : toString ((Duration.parse "-1d12h").get!) = "-90720000" := by native_decide
-theorem test12 : toString ((Duration.parse "-3h45m").get!) = "-3780000" := by native_decide
-theorem test13 : toString ((Duration.parse "1d1ms").get!) = "86400001" := by native_decide
-theorem test14 : toString ((Duration.parse "59m59s999ms").get!) = "3599999" := by native_decide
-theorem test15 : toString ((Duration.parse "23h59m59s999ms").get!) = "11879999" := by native_decide
-theorem test16 : toString ((Duration.parse "0d0h0m0s0ms").get!) = "0" := by native_decide
 
-private def testValid (str : String) (rep : Int) : TestCase IO :=
+theorem testDatetime1 : toString ((parse "2022-10-10").get!) = "1665360000000" := by native_decide
+theorem testDatetime2 : toString ((parse "1969-12-31").get!) = "-86400000" := by native_decide
+
+private def testValidDatetime (str : String) (rep : Int) : TestCase IO :=
+  test str ⟨λ _ => checkEq (parse str) (datetime? rep)⟩
+
+def testsForValidDatetimeStrings :=
+  suite "Datetime.parse for valid strings"
+  [
+    testValidDatetime "1970-01-01" 0,
+    testValidDatetime "2024-10-15" 1728950400000,
+    testValidDatetime "2024-10-15T11:38:02Z" 1728992282000,
+    testValidDatetime "2024-10-15T11:38:02.101Z" 1728992282101,
+    testValidDatetime "2024-10-15T11:38:02.101-1134" 1729033922101,
+    testValidDatetime "2024-10-15T11:38:02.101+1134" 1728950642101,
+    testValidDatetime "2024-10-15T11:38:02+1134" 1728950642000,
+    testValidDatetime "2024-10-15T11:38:02-1134" 1729033922000,
+    testValidDatetime "2016-12-31T23:59:60Z" 1483228800000, -- the last leap second
+    testValidDatetime "2017-01-01" 1483228800000, -- same date without leap second
+  ]
+
+private def testInvalidDatetime (str : String) (msg : String) : TestCase IO :=
+  test s!"{str} [{msg}]" ⟨λ _ => checkEq (Duration.parse str) .none⟩
+
+def testsForInvalidDatetimeStrings :=
+  suite "Datetime.parse for invalid strings"
+  [
+    testInvalidDatetime "1970-01-00" "does not exist",
+  ]
+
+theorem testDuration1 : toString ((Duration.parse "1ms").get!) = "1" := by native_decide
+theorem testDuration2 : toString ((Duration.parse "1s").get!) = "1000" := by native_decide
+theorem testDuration3 : toString ((Duration.parse "1m").get!) = "60000" := by native_decide
+theorem testDuration4 : toString ((Duration.parse "1h").get!) = "360000" := by native_decide
+theorem testDuration5 : toString ((Duration.parse "1d").get!) = "86400000" := by native_decide
+theorem testDuration6 : toString ((Duration.parse "1d2h3m4s5ms").get!) = "87304005" := by native_decide
+theorem testDuration7 : toString ((Duration.parse "2d12h").get!) = "177120000" := by native_decide
+theorem testDuration8 : toString ((Duration.parse "3m30s").get!) = "210000" := by native_decide
+theorem testDuration9 : toString ((Duration.parse "1h30m45s").get!) = "2205000" := by native_decide
+theorem testDuration10 : toString ((Duration.parse "2d5h20m").get!) = "175800000" := by native_decide
+theorem testDuration11 : toString ((Duration.parse "-1d12h").get!) = "-90720000" := by native_decide
+theorem testDuration12 : toString ((Duration.parse "-3h45m").get!) = "-3780000" := by native_decide
+theorem testDuration13 : toString ((Duration.parse "1d1ms").get!) = "86400001" := by native_decide
+theorem testDuration14 : toString ((Duration.parse "59m59s999ms").get!) = "3599999" := by native_decide
+theorem testDuration15 : toString ((Duration.parse "23h59m59s999ms").get!) = "11879999" := by native_decide
+theorem testDuration16 : toString ((Duration.parse "0d0h0m0s0ms").get!) = "0" := by native_decide
+
+private def testValidDuration (str : String) (rep : Int) : TestCase IO :=
   test str ⟨λ _ => checkEq (Duration.parse str) (duration? rep)⟩
 
 def testsForValidDurationStrings :=
   suite "Duration.parse for valid strings"
   [
-    testValid "0ms" 0,
-    testValid "0d0s" 0,
-    testValid "1ms" 1,
-    testValid "1s" 1000,
-    testValid "1m" 60000,
-    testValid "1h" 360000,
-    testValid "1d" 86400000,
-    testValid "12s340ms" 12340,
-    testValid "1s234ms" 1234,
-    testValid "-1s" (-1000),
-    testValid "-4s200ms" (-4200),
-    testValid "-9s876ms" (-9876),
-    testValid "106751d23h47m16s854ms" 9223297516854,
-    testValid "-106751d23h47m16s854ms" (-9223297516854),
-    testValid "1d2h3m4s5ms" 87304005,
-    testValid "2d12h" 177120000,
-    testValid "3m30s" 210000,
-    testValid "1h30m45s" 2205000,
-    testValid "2d5h20m" 175800000,
-    testValid "-1d12h" (-90720000),
-    testValid "-3h45m" (-3780000),
-    testValid "1d1ms" 86400001,
-    testValid "59m59s999ms" 3599999,
-    testValid "23h59m59s999ms" 11879999
+    testValidDuration "0ms" 0,
+    testValidDuration "0d0s" 0,
+    testValidDuration "1ms" 1,
+    testValidDuration "1s" 1000,
+    testValidDuration "1m" 60000,
+    testValidDuration "1h" 360000,
+    testValidDuration "1d" 86400000,
+    testValidDuration "12s340ms" 12340,
+    testValidDuration "1s234ms" 1234,
+    testValidDuration "-1s" (-1000),
+    testValidDuration "-4s200ms" (-4200),
+    testValidDuration "-9s876ms" (-9876),
+    testValidDuration "106751d23h47m16s854ms" 9223297516854,
+    testValidDuration "-106751d23h47m16s854ms" (-9223297516854),
+    testValidDuration "1d2h3m4s5ms" 87304005,
+    testValidDuration "2d12h" 177120000,
+    testValidDuration "3m30s" 210000,
+    testValidDuration "1h30m45s" 2205000,
+    testValidDuration "2d5h20m" 175800000,
+    testValidDuration "-1d12h" (-90720000),
+    testValidDuration "-3h45m" (-3780000),
+    testValidDuration "1d1ms" 86400001,
+    testValidDuration "59m59s999ms" 3599999,
+    testValidDuration "23h59m59s999ms" 11879999
   ]
 
-private def testInvalid (str : String) (msg : String) : TestCase IO :=
+private def testInvalidDuration (str : String) (msg : String) : TestCase IO :=
   test s!"{str} [{msg}]" ⟨λ _ => checkEq (Duration.parse str) .none⟩
 
 def testsForInvalidDurationStrings :=
   suite "Duration.parse for invalid strings"
   [
-    testInvalid "" "empty string",
-    testInvalid "d" "unit but no amount",
-    testInvalid "1d-1s" "invalid use of -",
-    testInvalid "1d2h3m4s5ms6" "trailing amount",
-    testInvalid "1x2m3s" "invalid unit",
-    testInvalid "1.23s" "amounts must be integral",
-    testInvalid "1s1d" "invalid order",
-    testInvalid "1s1s" "repeated units",
-    testInvalid "1d2h3m4s5ms " "trailing space",
-    testInvalid " 1d2h3m4s5ms" "leading space",
-    testInvalid "1d9223372036854775807ms" "overflow",
-    testInvalid "1d92233720368547758071ms" "overflow ms",
-    testInvalid "9223372036854776s1ms" "overflow s"
+    testInvalidDuration "" "empty string",
+    testInvalidDuration "d" "unit but no amount",
+    testInvalidDuration "1d-1s" "invalid use of -",
+    testInvalidDuration "1d2h3m4s5ms6" "trailing amount",
+    testInvalidDuration "1x2m3s" "invalid unit",
+    testInvalidDuration "1.23s" "amounts must be integral",
+    testInvalidDuration "1s1d" "invalid order",
+    testInvalidDuration "1s1s" "repeated units",
+    testInvalidDuration "1d2h3m4s5ms " "trailing space",
+    testInvalidDuration " 1d2h3m4s5ms" "leading space",
+    testInvalidDuration "1d9223372036854775807ms" "overflow",
+    testInvalidDuration "1d92233720368547758071ms" "overflow ms",
+    testInvalidDuration "9223372036854776s1ms" "overflow s"
   ]
 
-def tests := [testsForValidDurationStrings, testsForInvalidDurationStrings]
+def tests := [testsForValidDatetimeStrings, testsForInvalidDatetimeStrings,
+              testsForValidDurationStrings, testsForInvalidDurationStrings]
 
 -- Uncomment for interactive debugging
--- #eval TestSuite.runAll tests
+#eval TestSuite.runAll tests
 
 end UnitTest.Datetime

--- a/cedar-lean/UnitTest/Datetime.lean
+++ b/cedar-lean/UnitTest/Datetime.lean
@@ -23,14 +23,21 @@ namespace UnitTest.Datetime
 
 open Cedar.Spec.Ext.Datetime
 
-theorem testDatetime1 : toString ((parse "2022-10-10").get!) = "1665360000000" := by native_decide
-theorem testDatetime2 : toString ((parse "1969-12-31").get!) = "-86400000" := by native_decide
-theorem testDatetime3 : toString ((parse "2024-10-15T11:38:02Z").get!) = "1728992282000" := by native_decide
-theorem testDatetime4 : toString ((parse "2024-10-15T11:38:02.101Z").get!) = "1728992282101" := by native_decide
-theorem testDatetime5 : toString ((parse "2024-10-15T11:38:02.101-1134").get!) = "1729033922101" := by native_decide
-theorem testDatetime6 : toString ((parse "2024-10-15T11:38:02.101+1134").get!) = "1728950642101" := by native_decide
-theorem testDatetime7 : toString ((parse "2024-10-15T11:38:02+1134").get!) = "1728950642000" := by native_decide
-theorem testDatetime8 : toString ((parse "2024-10-15T11:38:02-1134").get!) = "1729033922000" := by native_decide
+theorem testDatetime01 : toString ((parse "2022-10-10").get!) = "1665360000000" := by native_decide
+theorem testDatetime02 : toString ((parse "1969-12-31").get!) = "-86400000" := by native_decide
+-- Commented out tests following this comment are impacted by a bug we
+-- encountered in Lean. Enable them when the bug has been fixed. More
+-- details in https://github.com/cedar-policy/cedar-spec/issues/525
+-- theorem testDatetime03 : toString ((parse "1969-12-31T23:59:59.001Z").get!) = "-999" := by native_decide
+-- theorem testDatetime04 : toString ((parse "1969-12-31T23:59:59.999Z").get!) = "-1" := by native_decide
+theorem testDatetime05 : toString ((parse "1969-12-31T23:59:59Z").get!) = "-1000" := by native_decide
+theorem testDatetime06 : toString ((parse "2024-10-15").get!) = "1728950400000" := by native_decide
+theorem testDatetime07 : toString ((parse "2024-10-15T11:38:02Z").get!) = "1728992282000" := by native_decide
+theorem testDatetime08 : toString ((parse "2024-10-15T11:38:02.101Z").get!) = "1728992282101" := by native_decide
+theorem testDatetime09 : toString ((parse "2024-10-15T11:38:02.101-1134").get!) = "1729033922101" := by native_decide
+theorem testDatetime10 : toString ((parse "2024-10-15T11:38:02.101+1134").get!) = "1728950642101" := by native_decide
+theorem testDatetime11 : toString ((parse "2024-10-15T11:38:02+1134").get!) = "1728950642000" := by native_decide
+theorem testDatetime12 : toString ((parse "2024-10-15T11:38:02-1134").get!) = "1729033922000" := by native_decide
 
 private def testValidDatetime (str : String) (rep : Int) : TestCase IO :=
   test str ⟨λ _ => checkEq (parse str) (datetime? rep)⟩
@@ -38,7 +45,8 @@ private def testValidDatetime (str : String) (rep : Int) : TestCase IO :=
 def testsForValidDatetimeStrings :=
   suite "Datetime.parse for valid strings"
   [
-    testValidDatetime "1970-01-01" 0,
+    testValidDatetime "2022-10-10" 1665360000000,
+    testValidDatetime "1969-12-31" (-86400000 : Int),
     testValidDatetime "1969-12-31T23:59:59Z" (-1000 : Int),
     -- Commented out tests following this comment are impacted by a bug we
     -- encountered in Lean. Enable them when the bug has been fixed. More
@@ -97,15 +105,15 @@ def testsForInvalidDatetimeStrings :=
     testInvalidDatetime "2016-12-31T00:00:00+9999" "invalid offset range",
   ]
 
-theorem testDuration1 : toString ((Duration.parse "1ms").get!) = "1" := by native_decide
-theorem testDuration2 : toString ((Duration.parse "1s").get!) = "1000" := by native_decide
-theorem testDuration3 : toString ((Duration.parse "1m").get!) = "60000" := by native_decide
-theorem testDuration4 : toString ((Duration.parse "1h").get!) = "360000" := by native_decide
-theorem testDuration5 : toString ((Duration.parse "1d").get!) = "86400000" := by native_decide
-theorem testDuration6 : toString ((Duration.parse "1d2h3m4s5ms").get!) = "87304005" := by native_decide
-theorem testDuration7 : toString ((Duration.parse "2d12h").get!) = "177120000" := by native_decide
-theorem testDuration8 : toString ((Duration.parse "3m30s").get!) = "210000" := by native_decide
-theorem testDuration9 : toString ((Duration.parse "1h30m45s").get!) = "2205000" := by native_decide
+theorem testDuration01 : toString ((Duration.parse "1ms").get!) = "1" := by native_decide
+theorem testDuration02 : toString ((Duration.parse "1s").get!) = "1000" := by native_decide
+theorem testDuration03 : toString ((Duration.parse "1m").get!) = "60000" := by native_decide
+theorem testDuration04 : toString ((Duration.parse "1h").get!) = "360000" := by native_decide
+theorem testDuration05 : toString ((Duration.parse "1d").get!) = "86400000" := by native_decide
+theorem testDuration06 : toString ((Duration.parse "1d2h3m4s5ms").get!) = "87304005" := by native_decide
+theorem testDuration07 : toString ((Duration.parse "2d12h").get!) = "177120000" := by native_decide
+theorem testDuration08 : toString ((Duration.parse "3m30s").get!) = "210000" := by native_decide
+theorem testDuration09 : toString ((Duration.parse "1h30m45s").get!) = "2205000" := by native_decide
 theorem testDuration10 : toString ((Duration.parse "2d5h20m").get!) = "175800000" := by native_decide
 theorem testDuration11 : toString ((Duration.parse "-1d12h").get!) = "-90720000" := by native_decide
 theorem testDuration12 : toString ((Duration.parse "-3h45m").get!) = "-3780000" := by native_decide


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This PR adds parsing for `datetime` strings in the `datetime` extension. See [RFC 80: datetime extension](https://cedar-policy.github.io/rfcs/0080-datetime-extension.html), its [Rust implementation](https://github.com/cedar-policy/cedar/pull/1276), and #471 which added parsing for `duration` in Lean.

The parsing procedure in this PR leverages the new datetime functionality in Lean 4 (see https://github.com/leanprover/lean4/pull/4904). The `datespec` macro, which allows users to define custom formats, is used here to define the five datetime formats specified in the RFC. As a consequence, **this implementation can handle some cases (e.g., leap seconds) which the Rust implementation does not handle at the moment**. I've marked such cases with a comment `TODO: LEAN-RUST DIFF` so they are easier to locate in the PR, and I'm hoping that the discussion in this PR helps me understand what cases we need to artificially reject in order to achieve parity with the Rust implementation.

When writing tests for dates before 1970, I noticed some confusing results. The folks working on Lean 4 have confirmed to me in private that there are some bugs in such dates, and they're working on fixes now. See the test marked with `TODO: Bug in dates before 1970` for an example.