### PR TITLE
Derive serialize for protobuf fuzz target input

### DIFF
--- a/cedar-drt/fuzz/fuzz_targets/protobuf-roundtrip.rs
+++ b/cedar-drt/fuzz/fuzz_targets/protobuf-roundtrip.rs
@@ -18,6 +18,7 @@
 
 use libfuzzer_sys::arbitrary::{self, MaxRecursionReached};
 use prost::Message;
+use serde::Serialize;
 
 use crate::arbitrary::Arbitrary;
 use crate::arbitrary::Unstructured;
@@ -32,8 +33,9 @@ use cedar_policy_generators::{
     settings::ABACSettings,
 };
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Serialize)]
 struct FuzzTargetInput {
+    #[serde(skip)]
     request: ABACRequest,
     policy: ABACPolicy,
     entities: Entities,


### PR DESCRIPTION
Not clear why this is required and a local build works fine without it, but it looks like the it's the reason our nightly test run failed, and most of the other inputs structs are serialize

*Issue #, if available:*

*Description of changes:*


