### PR TITLE
Lean: APIs for the `datetime` extension

### DIFF
--- a/cedar-lean/Cedar/Spec/Ext/Datetime.lean
+++ b/cedar-lean/Cedar/Spec/Ext/Datetime.lean
@@ -158,4 +158,27 @@ deriving instance Repr for Duration
 
 abbrev duration := Duration.parse
 
+def offset (datetime: Datetime) (duration: Duration) : Option Datetime :=
+  datetime.add? duration
+
+def durationSince (datetime other: Datetime) : Option Duration :=
+  datetime.sub? other
+
+def toDate (datetime: Datetime) : Option Datetime :=
+  let millisPerDayI64 := Int64.ofIntChecked MILLISECONDS_PER_DAY (by decide)
+  if datetime >= 0
+  then millisPerDayI64 * (datetime.div millisPerDayI64)
+  else if datetime.mod millisPerDayI64 == 0
+       then datetime
+       else ((datetime.div millisPerDayI64) - 1) * millisPerDayI64
+
+def toTime (datetime: Datetime) : Duration :=
+  let millisPerDayI64 := Int64.ofIntChecked MILLISECONDS_PER_DAY (by decide)
+  if datetime >= 0
+  then datetime.mod millisPerDayI64
+  else let rem := datetime.mod millisPerDayI64
+       if rem == 0
+       then rem
+       else rem + millisPerDayI64
+
 end Datetime

--- a/cedar-lean/UnitTest/Datetime.lean
+++ b/cedar-lean/UnitTest/Datetime.lean
@@ -145,8 +145,65 @@ def testsForInvalidDurationStrings :=
     testInvalidDuration "9223372036854776s1ms" "overflow s"
   ]
 
+private def testOffset (date₁ date₂ : String) (dur : Duration) : TestCase IO :=
+  test s!"{date₁} + {dur} -> {date₂}" ⟨λ _ => checkEq (offset (parse date₁).get! dur) (parse date₂)⟩
+
+def testsForOffset :=
+  suite "offset tests"
+  [
+    testOffset "2024-10-15" "2024-10-15" 0,
+    testOffset "2024-10-15" "2024-10-15T00:00:00.001Z" 1,
+    testOffset "2024-10-15" "2024-10-15T00:00:01Z" 1000,
+    testOffset "2024-10-15" "2024-10-14T23:59:59Z" (-1000 : Duration),
+    testOffset "2024-10-15" "2024-10-15T00:00:00-0001" 60000,
+  ]
+
+private def testDurationSince (date₁ date₂ : String) (dur : Duration) : TestCase IO :=
+  test s!"durationSince {date₁} {date₂} = {dur}" ⟨λ _ => checkEq (durationSince (parse date₁).get! (parse date₂).get!) dur⟩
+
+def testsForDurationSince :=
+  suite "durationSince tests"
+  [
+    testDurationSince "2024-10-15" "2024-10-15" 0,
+    testDurationSince "2024-10-15T00:00:00.001Z" "2024-10-15" 1,
+    testDurationSince "2024-10-15T00:00:01Z" "2024-10-15" 1000,
+    testDurationSince "2024-10-14T23:59:59Z" "2024-10-15" (-1000 : Duration),
+    testDurationSince "2024-10-15T00:00:00-0001" "2024-10-15" 60000,
+  ]
+
+private def testToDate (date₁ date₂ : String) : TestCase IO :=
+  test s!"toDate {date₁} = {date₂}" ⟨λ _ => checkEq (toDate (parse date₁).get!) (parse date₂).get!⟩
+
+def testsForToDate :=
+  suite "toDate tests"
+  [
+    testToDate "2024-10-15" "2024-10-15",
+    testToDate "2024-10-15T00:00:01Z" "2024-10-15",
+    testToDate "2024-10-15T23:59:59Z" "2024-10-15",
+    testToDate "2024-10-15T23:59:00-0001" "2024-10-16",
+    testToDate "1969-12-31" "1969-12-31",
+    testToDate "1969-12-31T23:59:59Z" "1969-12-31",
+  ]
+
+private def testToTime (date₁ : String) (dur : Duration) : TestCase IO :=
+  test s!"toTime {date₁} = {dur}" ⟨λ _ => checkEq (toTime (parse date₁).get!) dur⟩
+
+def testsForToTime :=
+  suite "toTime tests"
+  [
+    testToTime "2024-10-15" 0,
+    testToTime "2024-10-15T00:00:00.001Z" 1,
+    testToTime "2024-10-15T00:00:01Z" 1000,
+    testToTime "2024-10-15T23:59:59Z" 86399000,
+    testToTime "2024-10-15T23:59:00-0001" 0,
+    testToTime "1969-12-31" 0,
+    testToTime "1969-12-31T23:59:59Z" 86399000,
+    testToTime "1969-12-31T12:00:00Z" 43200000
+  ]
+
 def tests := [testsForValidDatetimeStrings, testsForInvalidDatetimeStrings,
-              testsForValidDurationStrings, testsForInvalidDurationStrings]
+              testsForValidDurationStrings, testsForInvalidDurationStrings,
+              testsForOffset, testsForDurationSince, testsForToDate, testsForToTime]
 
 -- Uncomment for interactive debugging
 -- #eval TestSuite.runAll tests


### PR DESCRIPTION
*Description of changes:* Adds the following "methods" associated to the `datetime` type, as specified in [the RFC for the `datetime` extension](https://cedar-policy.github.io/rfcs/0080-datetime-extension.html):
- `.offset(duration)` returns a new `datetime`, offset by duration.
- `.durationSince(DT2)` returns the difference between `DT` and `DT2` as a `duration`.
- `.toDate()` returns a new `datetime`, truncating to the day, such that printing the `datetime` would have `00:00:00` as the time.
- `.toTime()` returns a new `duration`, removing the days, such that only milliseconds since `.toDate()` are left.

We also include some unit tests for each method.



