### PR TITLE
fail directly when lean --print-libdir returns no output

### DIFF
--- a/cedar-drt/set_env_vars.sh
+++ b/cedar-drt/set_env_vars.sh
@@ -19,6 +19,10 @@ if ! command -v lean &> /dev/null; then
     return 1
 else
     export LEAN_LIB_DIR=$(lean --print-libdir)
+    if [ -z "$LEAN_LIB_DIR" ] then
+        echo "lean --print-libdir returned no output"
+        return 1
+    fi
     export LD_LIBRARY_PATH=${LD_LIBRARY_PATH+$LD_LIBRARY_PATH:}$(lean --print-libdir)
     export DYLD_LIBRARY_PATH=${DYLD_LIBRARY_PATH+$DYLD_LIBRARY_PATH:}$(lean --print-libdir)
 

--- a/cedar-drt/set_env_vars.sh
+++ b/cedar-drt/set_env_vars.sh
@@ -20,7 +20,7 @@ if ! command -v lean &> /dev/null; then
 else
     export LEAN_LIB_DIR=$(lean --print-libdir)
     if [ -z "$LEAN_LIB_DIR" ]; then
-        echo "lean --print-libdir returned no output"
+        echo "error: `lean --print-libdir` returned no output"
         return 1
     fi
     export LD_LIBRARY_PATH=${LD_LIBRARY_PATH+$LD_LIBRARY_PATH:}$(lean --print-libdir)

--- a/cedar-drt/set_env_vars.sh
+++ b/cedar-drt/set_env_vars.sh
@@ -20,7 +20,7 @@ if ! command -v lean &> /dev/null; then
 else
     export LEAN_LIB_DIR=$(lean --print-libdir)
     if [ -z "$LEAN_LIB_DIR" ]; then
-        echo "error: `lean --print-libdir` returned no output"
+        echo "error: lean --print-libdir returned no output"
         return 1
     fi
     export LD_LIBRARY_PATH=${LD_LIBRARY_PATH+$LD_LIBRARY_PATH:}$(lean --print-libdir)

--- a/cedar-drt/set_env_vars.sh
+++ b/cedar-drt/set_env_vars.sh
@@ -19,7 +19,7 @@ if ! command -v lean &> /dev/null; then
     return 1
 else
     export LEAN_LIB_DIR=$(lean --print-libdir)
-    if [ -z "$LEAN_LIB_DIR" ] then
+    if [ -z "$LEAN_LIB_DIR" ]; then
         echo "lean --print-libdir returned no output"
         return 1
     fi


### PR DESCRIPTION
Test for the case where `lean --print-libdir` returns no output, and fail directly if so.  Currently, we instead set `LD_PRELOAD` to `/lib/glibc/libm.so` which is unlikely to exist, which causes more confusing errors.


