### PR TITLE
Updates to fuzzer to fix changes from entity_removal feature in cedar

### DIFF
--- a/cedar-drt/fuzz/src/lib.rs
+++ b/cedar-drt/fuzz/src/lib.rs
@@ -439,6 +439,7 @@ fn test_run_auth_test() {
         EntityUID::with_eid_and_type("User", "alice").unwrap(),
         alice_attributes,
         std::collections::HashSet::new(),
+        std::collections::HashSet::new(),
         std::iter::empty(),
         &Extensions::all_available(),
     )
@@ -447,11 +448,13 @@ fn test_run_auth_test() {
         EntityUID::with_eid_and_type("Action", "view").unwrap(),
         [],
         std::collections::HashSet::new(),
+        std::collections::HashSet::new(),
         [],
     );
     let entity_vacation = Entity::new_with_attr_partial_value(
         EntityUID::with_eid_and_type("Photo", "vacation").unwrap(),
         [],
+        std::collections::HashSet::new(),
         std::collections::HashSet::new(),
         [],
     );

--- a/cedar-policy-generators/src/hierarchy.rs
+++ b/cedar-policy-generators/src/hierarchy.rs
@@ -671,6 +671,7 @@ impl<'a, 'u> HierarchyGenerator<'a, 'u> {
                 let entity = ast::Entity::new(
                     uid.clone(),
                     attrs,
+                    std::collections::HashSet::new(),
                     parents.into_iter().collect(),
                     tags,
                     &self.extensions,


### PR DESCRIPTION
Updates to fuzzer to address the change in entity representation that were introduced to support entity_removal feature.

