### PR TITLE
Add more datastructure lemmas and Cedar.Slice

### DIFF
--- a/cedar-lean/Cedar/Data/List.lean
+++ b/cedar-lean/Cedar/Data/List.lean
@@ -93,4 +93,7 @@ def mapM₃ {m : Type u → Type v} [Monad m] {γ : Type u} [SizeOf α] [SizeOf 
   (xs : List (α × β)) (f : { x : α × β // sizeOf x.snd < 1 + (1 + sizeOf xs) } → m γ) : m (List γ) :=
   xs.attach₃.mapM f
 
+def mapUnion {α β} [Union α] [EmptyCollection α] (f : β → α) (bs : List β) : α :=
+  bs.foldl (λ a b => a ∪ f b) ∅
+
 end List

--- a/cedar-lean/Cedar/Thm.lean
+++ b/cedar-lean/Cedar/Thm.lean
@@ -16,6 +16,6 @@
 
 import Cedar.Thm.Data
 import Cedar.Thm.Authorization
-import Cedar.Thm.Slicing
+import Cedar.Thm.PolicySlice
 import Cedar.Thm.Typechecking
 import Cedar.Thm.Validation

--- a/cedar-lean/Cedar/Thm/Authorization/PolicySlice.lean
+++ b/cedar-lean/Cedar/Thm/Authorization/PolicySlice.lean
@@ -1,0 +1,118 @@
+/-
+ Copyright Cedar Contributors
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-/
+
+import Cedar.Slice.PolicySlice
+import Cedar.Thm.Authorization.Authorizer
+
+/-! This file contains definitions relevant to slicing. -/
+
+namespace Cedar.Thm
+
+open Cedar.Spec Cedar.Slice Cedar.Data
+
+/--
+A policy slice is a subset of a collection of policies.  This slice is sound for
+a given request and entities if every policy in the collection that is not in
+the slice is also not satisfied with respect to the request and entities, and
+doesn't produce an error when evaluated.
+-/
+def IsSoundPolicySlice (req : Request) (entities : Entities) (slice policies : Policies) : Prop :=
+  slice ⊆ policies ∧
+  ∀ policy ∈ policies,
+    policy ∉ slice →
+    ¬ satisfied policy req entities ∧ ¬ hasError policy req entities
+
+/--
+A bound is sound for a given policy if the bound is satisfied for every request
+and entities for which the policy is satisfied or for which the policy produces
+an error.
+-/
+def IsSoundPolicyBound (bound : PolicyBound) (policy : Policy) : Prop :=
+  ∀ (request : Request) (entities : Entities),
+  (satisfied policy request entities →
+  satisfiedBound bound request entities) ∧
+  (hasError policy request entities →
+  satisfiedBound bound request entities)
+
+/--
+A bound analysis is sound if it produces sound bounds for all policies.
+-/
+def IsSoundBoundAnalysis (ba : BoundAnalysis) : Prop :=
+  ∀ (policy : Policy), IsSoundPolicyBound (ba policy) policy
+
+theorem sound_policy_slice_is_equisatisfied (effect : Effect) {request : Request} {entities : Entities} {slice policies : Policies} :
+  IsSoundPolicySlice request entities slice policies →
+  slice.filterMap (satisfiedWithEffect effect · request entities) ≡
+  policies.filterMap (satisfiedWithEffect effect · request entities)
+:= by
+  intro h
+  unfold IsSoundPolicySlice at h
+  have ⟨h₁, h₂⟩ := h; clear h
+  simp [List.Equiv]
+  simp [List.subset_def]
+  apply And.intro <;>
+  intros pid policy h₃ h₄ <;>
+  exists policy <;>
+  simp [h₄]
+  case left =>
+    simp [List.subset_def] at h₁
+    specialize h₁ h₃
+    exact h₁
+  case right =>
+    by_contra h₅
+    specialize h₂ policy h₃ h₅
+    simp [h₂, satisfiedWithEffect] at h₄
+
+theorem satisfiedPolicies_eq_for_sound_policy_slice (effect : Effect) {request : Request} {entities : Entities} {slice policies : Policies} :
+  IsSoundPolicySlice request entities slice policies →
+  satisfiedPolicies effect slice request entities = satisfiedPolicies effect policies request entities
+:= by
+  intro h
+  unfold satisfiedPolicies
+  rw [Set.make_make_eqv]
+  exact sound_policy_slice_is_equisatisfied effect h
+
+theorem sound_policy_slice_is_equierror {request : Request} {entities : Entities} {slice policies : Policies} :
+  IsSoundPolicySlice request entities slice policies →
+  slice.filter (hasError · request entities) ≡ policies.filter (hasError · request entities)
+:= by
+  intro h
+  unfold IsSoundPolicySlice at h
+  have ⟨h₁, h₂⟩ := h; clear h
+  simp [List.Equiv, List.subset_def]
+  rw [List.subset_def] at h₁
+  apply And.intro <;>
+  intro policy h₄ h₅ <;>
+  apply And.intro
+  · exact h₁ h₄
+  · exact h₅
+  · by_contra h₆
+    specialize h₂ policy h₄ h₆
+    exact h₂.right h₅
+  · exact h₅
+
+theorem errorPolicies_eq_for_sound_policy_slice {request : Request} {entities : Entities} {slice policies : Policies} :
+  IsSoundPolicySlice request entities slice policies →
+  errorPolicies slice request entities = errorPolicies policies request entities
+:= by
+  intro h
+  repeat rw [alternate_errorPolicies_equiv_errorPolicies]
+  unfold alternateErrorPolicies
+  rw [Set.make_make_eqv]
+  apply List.map_equiv
+  exact sound_policy_slice_is_equierror h
+
+end Cedar.Thm

--- a/cedar-lean/Cedar/Thm/Data/MapUnion.lean
+++ b/cedar-lean/Cedar/Thm/Data/MapUnion.lean
@@ -1,0 +1,306 @@
+/-
+ Copyright Cedar Contributors
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-/
+
+import Cedar.Thm.Data.List
+import Cedar.Thm.Data.Option
+import Cedar.Thm.Data.Set
+
+/-!
+# Lemmas about List.mapUnion operator
+-/
+
+/-! ### List.mapUnion applied to lists of lists -/
+
+namespace List
+
+theorem mapUnion_pmap_subtype
+  [Union β] [EmptyCollection β]
+  {p : α → Prop}
+  (f : α → β)
+  (as : List α)
+  (h : ∀ a, a ∈ as → p a) :
+    List.mapUnion (λ x : { a : α // p a } => f x.val) (List.pmap Subtype.mk as h)
+    =
+    List.mapUnion f as
+:= by
+  simp only [mapUnion]
+  rw [foldl_pmap_subtype λ a b => a ∪ f b]
+
+private theorem mem_foldl_union_iff_mem_or_exists {α β} [DecidableEq α] {f : β → List α} {xs : List β} {init : List α} {a : α} :
+  a ∈ List.foldl (λ as b => as ∪ f b) init xs ↔ (a ∈ init ∨ ∃ s ∈ xs, a ∈ f s)
+:= by
+  induction xs generalizing init
+  case nil =>
+    simp only [List.foldl_nil, List.not_mem_nil, false_and, exists_false, or_false]
+  case cons hd tl ih =>
+    simp only [List.foldl_cons, List.mem_cons, exists_eq_or_imp]
+    specialize @ih (init ∪ f hd)
+    constructor <;> intro h
+    case mp =>
+      replace ih := ih.mp h
+      rw [List.mem_union_iff, or_assoc] at ih
+      exact ih
+    case mpr =>
+      rw [← or_assoc, ← List.mem_union_iff] at h
+      exact ih.mpr h
+
+theorem mem_mapUnion_iff_mem_exists {α β} [DecidableEq α] {f : β → List α} {xs : List β} :
+  ∀ e, e ∈ xs.mapUnion f ↔ ∃ s ∈ xs, e ∈ f s
+:= by
+  intro e
+  simp only [List.mapUnion, EmptyCollection.emptyCollection]
+  cases xs
+  case nil =>
+    simp only [foldl_nil, not_mem_nil, false_and, exists_false]
+  case cons xhd xtl ih =>
+    simp only [foldl_cons, nil_union, mem_cons, exists_eq_or_imp]
+    exact mem_foldl_union_iff_mem_or_exists
+
+end List
+
+/-! ### List.mapUnion applied to lists of sets -/
+
+namespace Cedar.Data.Set
+
+theorem mapUnion_wf {α β} [LT α] [StrictLT α] [DecidableLT α] {f : β → Set α} {xs : List β} :
+  (xs.mapUnion f).WellFormed
+:= by
+  simp only [List.mapUnion]
+  generalize h : (∅ : Set α) = a
+  have ha : a.WellFormed := by
+    subst h
+    simp only [EmptyCollection.emptyCollection]
+    exact Set.empty_wf
+  clear h
+  induction xs generalizing a
+  case nil =>
+    simp only [ha, List.foldl_nil]
+  case cons xhd xtl ih =>
+    simp only [List.foldl_cons]
+    exact ih _ (Set.union_wf _ _)
+
+private theorem mem_foldl_union_iff_mem_or_exists {α β} [LT α] [StrictLT α] [DecidableLT α] {f : β → Set α} {xs : List β} {init : Set α} {a : α} :
+  a ∈ List.foldl (λ as b => as ∪ f b) init xs ↔ (a ∈ init ∨ ∃ s ∈ xs, a ∈ f s)
+:= by
+  induction xs generalizing init
+  case nil =>
+    simp only [List.foldl_nil, List.not_mem_nil, false_and, exists_false, or_false]
+  case cons hd tl ih =>
+    simp only [List.foldl_cons, List.mem_cons, exists_eq_or_imp]
+    specialize @ih (init ∪ f hd)
+    constructor <;> intro h
+    case mp =>
+      replace ih := ih.mp h
+      rw [Set.mem_union_iff_mem_or, or_assoc] at ih
+      exact ih
+    case mpr =>
+      rw [← or_assoc, ← Set.mem_union_iff_mem_or] at h
+      exact ih.mpr h
+
+theorem mem_mapUnion_iff_mem_exists {α β} [LT α] [StrictLT α] [DecidableLT α] {f : β → Set α} {xs : List β} :
+  ∀ e, e ∈ xs.mapUnion f ↔ ∃ s ∈ xs, e ∈ f s
+:= by
+  intro e
+  simp only [List.mapUnion, EmptyCollection.emptyCollection]
+  cases xs
+  case nil =>
+    simp only [List.foldl_nil, empty_no_elts, List.not_mem_nil,
+      false_and, exists_false]
+  case cons hd tl =>
+    have h : e ∈ f hd ↔ e ∈ (empty ∪ f hd) := by
+      simp only [mem_union_iff_mem_or, empty_no_elts, false_or]
+    simp only [List.foldl_cons, List.mem_cons, exists_eq_or_imp, h, mem_foldl_union_iff_mem_or_exists]
+
+theorem mem_mem_implies_mem_mapUnion {α β} [LT α] [StrictLT α] [DecidableLT α] {f : β → Set α} {xs : List β} {e : α} {s : β} :
+  e ∈ f s → s ∈ xs → e ∈ xs.mapUnion f
+:= by
+  intro he hs
+  rw [mem_mapUnion_iff_mem_exists]
+  exists s
+
+theorem mem_implies_subset_mapUnion {α β} [LT α] [StrictLT α] [DecidableLT α] [DecidableEq α] (f : β → Set α) {xs : List β} {s : β} :
+  s ∈ xs → f s ⊆ xs.mapUnion f
+:= by
+  simp only [subset_def]
+  intro hs a ha
+  exact mem_mem_implies_mem_mapUnion ha hs
+
+theorem mapUnion_filterMap {α β γ} [LT α] [StrictLT α] [DecidableLT α] [DecidableEq α] {f : β → Set α} {g : γ → Option β} {xs : List γ} :
+  (xs.filterMap g).mapUnion f =
+  xs.mapUnion λ x => (g x).mapD f Set.empty
+:= by
+  simp only [List.mapUnion]
+  generalize h : (∅ : Set α) = a
+  have ha : a ∪ Set.empty = a := by
+    subst h
+    exact Set.union_idempotent Set.empty_wf
+  clear h
+  induction xs generalizing a
+  case nil => simp only [List.filterMap_nil, List.foldl_nil]
+  case cons hd tl ih =>
+    simp only [List.filterMap_cons, List.foldl_cons]
+    cases g hd <;> simp only [List.foldl_cons]
+    case none =>
+      simp only [Option.mapD_none]
+      rw [ha]
+      exact ih a ha
+    case some y =>
+      simp only [Option.mapD_some]
+      apply ih
+      apply Set.union_empty_right (Set.union_wf _ _)
+
+theorem mapUnion_congr {α β} [LT α] [StrictLT α] [DecidableLT α] [DecidableEq α] (f g : β → Set α) {xs : List β} :
+  (∀ b ∈ xs, f b = g b) → xs.mapUnion f = xs.mapUnion g
+:= by
+  intro h
+  simp only [List.mapUnion]
+  generalize h : (∅ : Set α) = a
+  clear h
+  induction xs generalizing a
+  case nil => simp only [List.foldl_nil]
+  case cons hd tl ih =>
+    simp only [List.foldl_cons]
+    have heq := h hd (by simp only [List.mem_cons, true_or])
+    rw [heq]
+    apply ih
+    intro b htl
+    apply h
+    simp only [List.mem_cons, htl, or_true]
+
+theorem mapUnion_eq_mapUnion_id_map {α β} [LT α] [StrictLT α] [DecidableLT α] [DecidableEq α] (f : β → Set α) {xs : List β} :
+  xs.mapUnion f = (xs.map f).mapUnion id
+:= by
+  simp only [List.mapUnion]
+  generalize h : (∅ : Set α) = a
+  clear h
+  induction xs generalizing a
+  case nil => simp only [List.foldl_nil, id_eq, List.map_nil]
+  case cons hd tl ih =>
+    simp only [List.foldl_cons, id_eq, List.map_cons]
+    apply ih
+
+private theorem foldl_union_swap_front {α} [LT α] [StrictLT α] [DecidableLT α] [DecidableEq α] (x₁ x₂ : Set α) {xs : List (Set α)} {a : Set α}:
+  (x₁ :: x₂ :: xs).foldl (· ∪ ·) a = (x₂ :: x₁ :: xs).foldl (· ∪ ·) a
+:= by
+  simp only [List.foldl_cons, Set.union_assoc]
+  rw [Set.union_comm x₁]
+
+private theorem foldl_union_swap_middle {α} [LT α] [StrictLT α] [DecidableLT α] [DecidableEq α] (y : Set α) {xs ys : List (Set α)} {a : Set α}:
+  (xs ++ y :: ys).foldl (· ∪ ·) a = (y :: xs ++ ys).foldl (· ∪ ·) a
+:= by
+  cases xs
+  case nil =>
+    simp only [List.nil_append, List.foldl_cons, List.singleton_append]
+  case cons xhd xtl =>
+    rw [eq_comm, List.cons_append y, List.cons_append xhd, foldl_union_swap_front y xhd, eq_comm]
+    rw [List.foldl_cons, List.cons_append, List.foldl_cons]
+    exact foldl_union_swap_middle y
+
+private theorem foldl_union_comm {α} [LT α] [StrictLT α] [DecidableLT α] [DecidableEq α] {xs ys : List (Set α)} {a : Set α}:
+  (xs ++ ys).foldl (· ∪ ·) a = (ys ++ xs).foldl (· ∪ ·) a
+:= by
+  cases xs <;> cases ys
+  case nil.nil =>
+    simp only [List.nil_append, List.append_nil]
+  case nil.cons | cons.nil =>
+    simp only [List.append_nil, List.nil_append, List.foldl_cons]
+  case cons xhd xtl yhd ytl =>
+    rw [foldl_union_swap_middle, foldl_union_swap_middle, ← List.singleton_append, List.append_assoc,
+      List.cons_append xhd, foldl_union_swap_middle]
+    simp only [List.cons_append, List.singleton_append, List.foldl_cons, List.nil_append]
+    exact foldl_union_comm
+
+theorem mapUnion_comm {α β} [LT α] [StrictLT α] [DecidableLT α] [DecidableEq α] {f : β → Set α} {xs ys : List β} :
+  (xs ++ ys).mapUnion f = (ys ++ xs).mapUnion f
+:= by
+  rw [mapUnion_eq_mapUnion_id_map, eq_comm, mapUnion_eq_mapUnion_id_map, eq_comm]
+  simp only [List.mapUnion, id_eq, List.map_append]
+  exact foldl_union_comm
+
+private theorem foldl_union_remove_head {α} [LT α] [StrictLT α] [DecidableLT α] [DecidableEq α] (x : Set α) (xs : List (Set α)) {a : Set α}:
+  (x :: xs).foldl (· ∪ ·) a = (x :: (xs.removeAll [x])).foldl (· ∪ ·) a
+:= by
+  simp only [List.foldl_cons, List.removeAll]
+  induction xs generalizing a x
+  case nil => simp only [List.foldl_nil, List.filter_nil]
+  case cons xhd xtl ih =>
+    simp only [List.foldl_cons, List.elem_eq_mem, List.mem_singleton,
+      List.filter_cons, Bool.not_eq_true', decide_eq_false_iff_not, ite_not]
+    simp only [List.elem_eq_mem, List.mem_singleton] at ih
+    have heq : (a ∪ xhd ∪ xhd) = a ∪ xhd := by
+      rw [Set.union_comm (a ∪ xhd)]
+      apply Set.union_subset_eq (Set.union_wf _ _)
+      rw [Set.union_comm]
+      exact Set.subset_union _ _
+    split
+    case isTrue h =>
+      subst h
+      simp only [heq]
+      exact ih xhd
+    case isFalse h =>
+      simp only [List.foldl_cons]
+      rw [Set.union_comm _ xhd, ← Set.union_assoc, Set.union_comm xhd]
+      exact @ih x (a ∪ xhd)
+
+private theorem eqv_implies_foldl_union_eq {α} [LT α] [StrictLT α] [DecidableLT α] [DecidableEq α] {xs ys : List (Set α)} {a : Set α}:
+  xs ≡ ys → xs.foldl (· ∪ ·) a = ys.foldl (· ∪ ·) a
+:= by
+  intro heqv
+  cases xs <;> cases ys
+  case nil.nil =>
+    simp only [List.foldl_nil]
+  case nil.cons =>
+    replace heqv := List.Equiv.symm heqv
+    simp only [List.equiv_nil, reduceCtorEq] at heqv
+  case cons.nil =>
+    simp only [List.equiv_nil, reduceCtorEq] at heqv
+  case cons.cons xhd xtl yhd ytl =>
+    have ⟨ytl₁, ytl₂, h⟩ := List.mem_iff_append.mp (List.cons_subset.mp heqv.left).left
+    rw [h, foldl_union_comm, foldl_union_remove_head xhd xtl, List.cons_append,
+      foldl_union_remove_head xhd (ytl₂ ++ ytl₁)]
+    simp only [h] at heqv
+    replace heqv : xhd :: xtl ≡ xhd :: (ytl₂ ++ ytl₁) := by
+      apply List.Equiv.trans heqv
+      apply List.Equiv.trans (List.append_swap_equiv ytl₁ _)
+      simp only [List.cons_append, List.Equiv.refl]
+    replace heqv : xtl.removeAll [xhd] ≡ (ytl₂ ++ ytl₁).removeAll [xhd] := by
+      apply List.cons_equiv_implies_equiv xhd _ _
+      · apply List.Equiv.trans (List.Equiv.symm (List.removeAll_singleton_equiv xhd xtl))
+        apply List.Equiv.trans heqv
+        exact List.removeAll_singleton_equiv xhd (ytl₂ ++ ytl₁)
+      · exact List.mem_removeAll_singleton_of_eq xhd xtl
+      · exact List.mem_removeAll_singleton_of_eq xhd (ytl₂ ++ ytl₁)
+    simp only [List.foldl_cons]
+    exact eqv_implies_foldl_union_eq heqv
+termination_by xs.length
+decreasing_by
+  simp_wf
+  rename_i xhd xtl hxs _ _ _ _ _ _
+  simp only [hxs, List.length_cons, Nat.succ_eq_add_one]
+  have _ := List.length_removeAll_le xtl [xhd]
+  omega
+
+-- Note that the converse doesn't hold. For example, let f = g = id,
+-- xs = [{a}, {b}], and ys = [{a, b}]
+theorem map_eqv_implies_mapUnion_eq {α β γ} [LT α] [StrictLT α] [DecidableLT α] [DecidableEq α] {f : β → Set α} {g : γ → Set α} {xs : List β} {ys : List γ} :
+  xs.map f ≡ ys.map g → xs.mapUnion f = ys.mapUnion g
+:= by
+  intro hm
+  rw [mapUnion_eq_mapUnion_id_map, eq_comm, mapUnion_eq_mapUnion_id_map, eq_comm]
+  simp only [List.mapUnion, id_eq]
+  exact eqv_implies_foldl_union_eq hm
+
+end Cedar.Data.Set

--- a/cedar-lean/Cedar/Thm/Data/Option.lean
+++ b/cedar-lean/Cedar/Thm/Data/Option.lean
@@ -14,9 +14,22 @@
  limitations under the License.
 -/
 
-import Cedar.Thm.Data.Control
-import Cedar.Thm.Data.List
-import Cedar.Thm.Data.LT
-import Cedar.Thm.Data.Map
-import Cedar.Thm.Data.Set
-import Cedar.Thm.Data.MapUnion
+/-!
+# Additional Option functions and lemmas
+-/
+
+namespace Option
+
+def mapD {α β} (f : α → β) (default : β) : Option α → β
+  | .some a => f a
+  | .none   => default
+
+theorem mapD_some {α β} (f : α → β) (default : β) (a : α) :
+  (Option.some a).mapD f default = f a
+:= by simp only [mapD]
+
+theorem mapD_none {α β} (f : α → β) (default : β) :
+  Option.none.mapD f default = default
+:= by simp only [mapD]
+
+end Option

--- a/cedar-lean/Cedar/Thm/PolicySlice.lean
+++ b/cedar-lean/Cedar/Thm/PolicySlice.lean
@@ -14,9 +14,9 @@
  limitations under the License.
 -/
 
-import Cedar.Spec
+import Cedar.Slice.PolicySlice
 import Cedar.Thm.Authorization.Authorizer
-import Cedar.Thm.Authorization.Slicing
+import Cedar.Thm.Authorization.PolicySlice
 
 /-!
 This file defines what it means for a policy slice to be sound.
@@ -38,7 +38,7 @@ We prove two main theorems:
 
 namespace Cedar.Thm
 
-open Cedar.Spec
+open Cedar.Spec Cedar.Slice
 
 /--
 Policy slicing soundness: `isAuthorized` produces the same result for a sound
@@ -83,15 +83,6 @@ theorem sound_bound_analysis_produces_sound_slices (ba : BoundAnalysis) (request
     simp only [h₃, Bool.false_eq_true, imp_false, Bool.not_eq_true] at h₅ h₆
     specialize h₄ h₅
     simp only [h₄, Bool.true_eq_false] at h₆
-
-/--
-Scope-based bound analysis extracts the bound from the policy scope.
--/
-def scopeAnalysis (policy : Policy) : PolicyBound :=
-  {
-    principalBound := policy.principalScope.scope.bound,
-    resourceBound  := policy.resourceScope.scope.bound,
-  }
 
 /--
 Scope-based bounds are sound.


### PR DESCRIPTION
This PR adds more List functions and lemmas (specifically for `List.mapUnion`) that will be useful for level-based checking and slicing. 

This PR also creates a new `Cedar.Slice` module and moves existing policy slicing code into this module. The intent is to move all slicing-related code there, including level-based slicing and, eventually, manifests and manifest-based slicing.


