### PR TITLE
Update entity JSON parsing for changes to entity struct

### DIFF
--- a/cedar-lean/DiffTest/Parser.lean
+++ b/cedar-lean/DiffTest/Parser.lean
@@ -277,8 +277,9 @@ def jsonToRequest (json : Lean.Json) : ParseResult Request := do
 
 
 def jsonToEntityData (json : Lean.Json) : ParseResult EntityData := do
-  let ancestorsArr ← getJsonField json "ancestors" >>= jsonToArray
-  let ancestors ← List.mapM jsonToEuid ancestorsArr.toList
+  let parentsArr ← getJsonField json "parents" >>= jsonToArray
+  let indirectAncestorsArr ← getJsonField json "indirect_ancestors" >>= jsonToArray
+  let ancestors ← List.mapM jsonToEuid (parentsArr.toList ++ indirectAncestorsArr.toList)
   let attrsKVs ← getJsonField json "attrs" >>= jsonObjToKVList
   let attrs ← mapMValues attrsKVs jsonToValue
   let tagsKVs ← -- the "tags" field may be absent


### PR DESCRIPTION
Fixes for cedar-policy/cedar#1453

We could also have resolved this by updating relevant targets to use protobuf (#543) which does handle the changes from that PR correctly, but this fix is a quicker way to fix errors in the nightly test run.

*Issue #, if available:*

*Description of changes:*


