### PR TITLE
more elegant Protobuf.Message impl

### DIFF
--- a/cedar-lean/CedarProto/Schema.lean
+++ b/cedar-lean/CedarProto/Schema.lean
@@ -69,8 +69,8 @@ def toSchema (schema : Schema) : Validation.Schema :=
   let ancestorMap := descendantsToAncestors descendantMap
   let acts := Data.Map.make $ acts.map λ decl =>
     (decl.name, {
-      appliesToPrincipal := Data.Set.make decl.principal_types.toList
-      appliesToResource := Data.Set.make decl.resource_types.toList
+      appliesToPrincipal := Data.Set.make decl.principalTypes.toList
+      appliesToResource := Data.Set.make decl.resourceTypes.toList
       ancestors := ancestorMap.find! decl.name
       context := Data.Map.make $ decl.context.toList.map λ (k,v) => (k, v.map ProtoType.toCedarType)
     })


### PR DESCRIPTION
Introduces new utilities for making implementations of `Protobuf.Message`.

The first version of this PR applies this technique only to `ActionDecl`, for reviews/comments.  If folks like this direction, I will apply to the other structs in `CedarProto`, as applicable.