### PR TITLE
refactor out some panics in CedarProto

### DIFF
--- a/cedar-lean/Cedar/Validation/Types.lean
+++ b/cedar-lean/Cedar/Validation/Types.lean
@@ -61,6 +61,12 @@ def map {α β} (f : α → β) : Qualified α → Qualified β
   | optional a => optional (f a)
   | required a => required (f a)
 
+def transpose {α ε} : Qualified (Except ε α) → Except ε (Qualified α)
+  | optional (.ok a) => .ok (optional a)
+  | required (.ok a) => .ok (required a)
+  | optional (.error e) => .error e
+  | required (.error e) => .error e
+
 end Qualified
 
 inductive CedarType where

--- a/cedar-lean/CedarProto/Schema.lean
+++ b/cedar-lean/CedarProto/Schema.lean
@@ -49,32 +49,42 @@ private def descendantsToAncestors [LT α] [DecidableEq α] [DecidableLT α] (de
 
 namespace Schema
 
-def toSchema (schema : Schema) : Validation.Schema :=
+private def attrsToCedarType (attrs : Proto.Map String (Qualified ProtoType)) : Except String (Data.Map Spec.Attr (Qualified CedarType)) := do
+  let attrs ← attrs.toList.mapM λ (k,v) => do
+    let v ← v.map ProtoType.toCedarType |>.transpose
+    .ok (k, v)
+  .ok $ Data.Map.make attrs
+
+/-- was surprised this isn't in the stdlib -/
+def option_transpose : Option (Except ε α) → Except ε (Option α)
+  | none => .ok none
+  | some (.ok a) => .ok (some a)
+  | some (.error e) => .error e
+
+def toSchema (schema : Schema) : Except String Validation.Schema := do
   let ets := schema.ets.toList
   let descendantMap := ets.map λ decl => (decl.name, Data.Set.make decl.descendants.toList)
   let ancestorMap := descendantsToAncestors descendantMap
-  let ets := Data.Map.make $ ets.map λ decl =>
-    (decl.name,
-      if decl.enums.isEmpty then
-      .standard {
+  let ets ← ets.mapM λ decl => do
+    let ese : EntitySchemaEntry ←
+      if decl.enums.isEmpty then .ok $ .standard {
         ancestors := ancestorMap.find! decl.name
-        attrs := Data.Map.make $ decl.attrs.toList.map λ (k,v) => (k, v.map ProtoType.toCedarType)
-        tags := decl.tags.map ProtoType.toCedarType
+        attrs := ← attrsToCedarType decl.attrs
+        tags := ← option_transpose $ decl.tags.map ProtoType.toCedarType
       }
-      else
-      .enum $ Cedar.Data.Set.make decl.enums.toList
-    )
+      else .ok $ .enum $ Cedar.Data.Set.make decl.enums.toList
+    .ok (decl.name, ese)
   let acts := schema.acts.toList
   let descendantMap := acts.map λ decl => (decl.name, Data.Set.make decl.descendants.toList)
   let ancestorMap := descendantsToAncestors descendantMap
-  let acts := Data.Map.make $ acts.map λ decl =>
-    (decl.name, {
+  let acts ← acts.mapM λ decl => do
+    .ok (decl.name, {
       appliesToPrincipal := Data.Set.make decl.principalTypes.toList
       appliesToResource := Data.Set.make decl.resourceTypes.toList
       ancestors := ancestorMap.find! decl.name
-      context := Data.Map.make $ decl.context.toList.map λ (k,v) => (k, v.map ProtoType.toCedarType)
+      context := ← attrsToCedarType decl.context
     })
-  { ets, acts }
+  .ok { ets := Data.Map.make ets, acts := Data.Map.make acts }
 
 @[inline]
 def mergeEntityDecls (result : Schema) (x : Array EntityDecl) : Schema :=
@@ -143,6 +153,6 @@ def merge (x1 x2 : Schema) : Schema :=
   }
 
 deriving instance Inhabited for Schema
-instance : Field Schema := Field.fromInterField Proto.Schema.toSchema merge
+instance : Field Schema := Field.fromInterFieldFallible Proto.Schema.toSchema merge
 
 end Cedar.Validation.Schema

--- a/cedar-lean/CedarProto/Value.lean
+++ b/cedar-lean/CedarProto/Value.lean
@@ -31,23 +31,27 @@ def merge (v1 : Value) (v2 : Value) : Value :=
   | .record m1, .record m2 => Cedar.Data.Map.mk (m1.kvs ++ m2.kvs)
   | _, _ => v2 -- note this includes all the .ext cases
 
-private def extExprToValue (xfn : ExtFun) (args : List Expr) : Value :=
+private def extExprToValue (xfn : ExtFun) (args : List Expr) : Except String Value :=
   match xfn, args with
   | .decimal, [.lit (.string s)] => match Spec.Ext.Decimal.decimal s with
-    | .some v => .ext (.decimal v)
-    | .none => panic! s!"exprToValue: failed to parse decimal {s}"
+    | .some v => .ok $ .ext (.decimal v)
+    | .none => .error s!"exprToValue: failed to parse decimal {s}"
   | .ip, [.lit (.string s)] => match Spec.Ext.IPAddr.ip s with
-    | .some v => .ext (.ipaddr v)
-    | .none => panic! s!"exprToValue: failed to parse ip {s}"
-  | _, _ => panic! ("exprToValue: unexpected extension value\n" ++ toString (repr (Expr.call xfn args)))
+    | .some v => .ok $ .ext (.ipaddr v)
+    | .none => .error s!"exprToValue: failed to parse ip {s}"
+  | _, _ => .error s!"exprToValue: unexpected extension value\n{repr (Expr.call xfn args)}"
 
-private partial def exprToValue : Expr → Value
-  | .lit p => .prim p
-  | .record r => .record (Cedar.Data.Map.make (r.map λ ⟨attr, e⟩ => ⟨attr, exprToValue e⟩))
-  | .set s => .set (Cedar.Data.Set.make (s.map exprToValue))
+private partial def exprToValue : Expr → Except String Value
+  | .lit p => .ok (.prim p)
+  | .record r => do
+      let attrs ← r.mapM λ ⟨attr, e⟩ => do .ok ⟨attr, ← exprToValue e⟩
+      .ok $ .record (Cedar.Data.Map.make attrs)
+  | .set s => do
+      let elts ← s.mapM exprToValue
+      .ok $ .set (Cedar.Data.Set.make elts)
   | .call xfn args => extExprToValue xfn args
-  | _ => panic!("exprToValue: invalid input expression")
+  | e => .error s!"exprToValue: invalid input expression {repr e}"
 
-instance : Field Value := Field.fromInterField exprToValue merge
+instance : Field Value := Field.fromInterFieldFallible exprToValue merge
 
 end Cedar.Spec.Value

--- a/cedar-lean/Protobuf/BParsec.lean
+++ b/cedar-lean/Protobuf/BParsec.lean
@@ -37,6 +37,11 @@ def pure (a : α) : BParsec α := λ pos => { pos, res := .ok a }
 @[inline]
 def fail (msg : String) : BParsec α := λ pos => { pos, res := .error msg }
 
+@[inline]
+def ofExcept : Except String α → BParsec α
+  | .ok a => pure a
+  | .error e => fail e
+
 instance (α : Type) : Inhabited (BParsec α) := ⟨fail ""⟩
 
 @[inline]

--- a/cedar-lean/Protobuf/Field.lean
+++ b/cedar-lean/Protobuf/Field.lean
@@ -67,6 +67,15 @@ def fromInterField {α β : Type} [Inhabited α] [Field α] (convert : α → β
   merge := merge
 }
 
+@[inline]
+def fromInterFieldFallible {α β : Type} [Inhabited α] [Field α] (convert : α → Except String β) (merge : β → β → β) : Field β := {
+  parse := do
+    let m : α ← Field.parse
+    ofExcept $ convert m
+  expectedWireType := Field.expectedWireType α
+  merge := merge
+}
+
 end Field
 
 end Proto


### PR DESCRIPTION
Refactors out some panics in CedarProto.  Specifically, the Protobuf parser now gracefully fails (rather than panicking) when encountering:
- unknown extension type (in a schema)
- `ip()` or `decimal()` argument that fails to parse
- expression of an unsupported variant (ie not a restricted expression) where a Value is expected


