### PR TITLE
apply #555 to all of CedarProto

### DIFF
--- a/cedar-lean/Cedar/Spec/Template.lean
+++ b/cedar-lean/Cedar/Spec/Template.lean
@@ -69,7 +69,9 @@ abbrev SlotEnv := Map SlotID EntityUID
 def SlotEnv.empty : SlotEnv := Map.empty
 
 structure TemplateLinkedPolicy where
+  /-- ID of the link, which for static policies will match the `templateId` -/
   id : PolicyID
+  /-- ID of the template, which for static policies will match the `id` -/
   templateId : TemplateID
   slotEnv : SlotEnv
 deriving Repr

--- a/cedar-lean/CedarProto/ActionDecl.lean
+++ b/cedar-lean/CedarProto/ActionDecl.lean
@@ -41,7 +41,8 @@ deriving Repr, Inhabited
 namespace ActionDecl
 
 instance : Message ActionDecl := {
-  parseField (t : Tag) := do match t.fieldNum with
+  parseField (t : Tag) := do
+    match t.fieldNum with
     | 1 => parseFieldElement t name (update name)
     | 3 => parseFieldElement t descendants (update descendants)
     | 4 => parseFieldElement t context (update context)

--- a/cedar-lean/CedarProto/ActionDecl.lean
+++ b/cedar-lean/CedarProto/ActionDecl.lean
@@ -15,7 +15,7 @@
 -/
 import Cedar.Spec
 import Protobuf.Message
-import Protobuf.String
+import Protobuf.Structure
 
 -- Message Dependencies
 import CedarProto.EntityUID
@@ -23,13 +23,6 @@ import CedarProto.Expr
 import CedarProto.Type
 
 open Proto
-
-macro "update " f:Lean.Parser.Term.structInstLVal : term => `(λ x v => { x with $f := v })
-
-def parseFieldElement {α β} [Field β] (t : Tag) (f : α → β) (g : α → β → α) : BParsec (MergeFn α) := do
-  let x : β ← Field.guardedParse t
-  let merge result x := g result (Field.merge (f result) x)
-  pure (pure $ merge · x)
 
 namespace Cedar.Validation.Proto
 
@@ -41,33 +34,28 @@ structure ActionDecl where
   name : Spec.EntityUID
   descendants : Repeated Spec.EntityUID
   context : Proto.Map String (Qualified ProtoType)
-  principalTypes : Repeated Spec.Name
-  resourceTypes : Repeated Spec.Name
+  principalTypes : Repeated Spec.Proto.Name
+  resourceTypes : Repeated Spec.Proto.Name
 deriving Repr, Inhabited
 
 namespace ActionDecl
 
-@[inline]
-def merge (x y : ActionDecl) : ActionDecl :=
-  {
+instance : Message ActionDecl := {
+  parseField (t : Tag) := do match t.fieldNum with
+    | 1 => parseFieldElement t name (update name)
+    | 3 => parseFieldElement t descendants (update descendants)
+    | 4 => parseFieldElement t context (update context)
+    | 5 => parseFieldElement t principalTypes (update principalTypes)
+    | 6 => parseFieldElement t resourceTypes (update resourceTypes)
+    | _ => let _ ← t.wireType.skip ; pure ignore
+
+  merge x y := {
     name           := Field.merge x.name           y.name
     descendants    := Field.merge x.descendants    y.descendants
     context        := Field.merge x.context        y.context
     principalTypes := Field.merge x.principalTypes y.principalTypes
     resourceTypes  := Field.merge x.resourceTypes  y.resourceTypes
   }
-
-instance : Message ActionDecl := {
-  parseField (t : Tag) := do
-    match t.fieldNum with
-      | 1 => parseFieldElement t name (update name)
-      | 3 => parseFieldElement t descendants (update descendants)
-      | 4 => parseFieldElement t context (update context)
-      | 5 => parseFieldElement t principalTypes (update principalTypes)
-      | 6 => parseFieldElement t resourceTypes (update resourceTypes)
-      | _ => let _ ← t.wireType.skip ; pure ignore
-
-  merge := merge
 }
 
 end ActionDecl

--- a/cedar-lean/CedarProto/AuthorizationRequest.lean
+++ b/cedar-lean/CedarProto/AuthorizationRequest.lean
@@ -13,7 +13,10 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -/
+
 import Cedar.Spec
+import Protobuf.Message
+import Protobuf.Structure
 
 -- Message Dependencies
 import CedarProto.Request
@@ -31,51 +34,18 @@ deriving Inhabited, DecidableEq, Repr
 
 namespace AuthorizationRequest
 
-@[inline]
-def mergeRequest (result : AuthorizationRequest) (x : Request) : AuthorizationRequest :=
-  {result with
-    request := Field.merge result.request x
-  }
+instance : Message AuthorizationRequest := {
+  parseField (t : Proto.Tag) := do match t.fieldNum with
+    | 1 => parseFieldElement t request (update request)
+    | 2 => parseFieldElement t policies (update policies)
+    | 3 => parseFieldElement t entities (update entities)
+    | _ => let _ ← t.wireType.skip ; pure ignore
 
-@[inline]
-def mergeEntities (result : AuthorizationRequest) (x : Entities) : AuthorizationRequest :=
-  {result with
-    entities := Field.merge result.entities x
-  }
-
-@[inline]
-def mergePolicies (result : AuthorizationRequest) (x : Policies) : AuthorizationRequest :=
-  {result with
-    policies := Field.merge result.policies x
-  }
-
-@[inline]
-def merge (x y : AuthorizationRequest) : AuthorizationRequest :=
-  {
-    request := Field.merge x.request y.request
+  merge x y := {
+    request :=  Field.merge x.request  y.request
     entities := Field.merge x.entities y.entities
     policies := Field.merge x.policies y.policies
   }
-
-@[inline]
-def parseField (t : Proto.Tag) : BParsec (MergeFn AuthorizationRequest) := do
-  match t.fieldNum with
-    | 1 =>
-      let x : Request ← Field.guardedParse t
-      pure (pure $ mergeRequest · x)
-    | 2 =>
-      let x : Policies ← Field.guardedParse t
-      pure (pure $ mergePolicies · x)
-    | 3 =>
-      let x : Entities ← Field.guardedParse t
-      pure (pure $ mergeEntities · x)
-    | _ =>
-      t.wireType.skip
-      pure ignore
-
-instance : Message AuthorizationRequest := {
-  parseField := parseField
-  merge := merge
 }
 
 end AuthorizationRequest

--- a/cedar-lean/CedarProto/AuthorizationRequest.lean
+++ b/cedar-lean/CedarProto/AuthorizationRequest.lean
@@ -35,7 +35,8 @@ deriving Inhabited, DecidableEq, Repr
 namespace AuthorizationRequest
 
 instance : Message AuthorizationRequest := {
-  parseField (t : Proto.Tag) := do match t.fieldNum with
+  parseField (t : Proto.Tag) := do
+    match t.fieldNum with
     | 1 => parseFieldElement t request (update request)
     | 2 => parseFieldElement t policies (update policies)
     | 3 => parseFieldElement t entities (update entities)

--- a/cedar-lean/CedarProto/Entities.lean
+++ b/cedar-lean/CedarProto/Entities.lean
@@ -44,7 +44,8 @@ instance : HAppend Entities (Repeated Entity) Entities where
 namespace Entities
 
 instance : Message Entities := {
-  parseField (t : Proto.Tag) := do match t.fieldNum with
+  parseField (t : Proto.Tag) := do
+    match t.fieldNum with
     | 1 => parseFieldElement t entities (update entities)
     | _ => let _ ← t.wireType.skip ; pure ignore
 

--- a/cedar-lean/CedarProto/Entities.lean
+++ b/cedar-lean/CedarProto/Entities.lean
@@ -13,14 +13,17 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -/
+
 import Cedar.Spec
+import Protobuf.Message
+import Protobuf.Structure
 
 -- Message Dependencies
 import CedarProto.Entity
 
 open Proto
 
-namespace Cedar.Spec
+namespace Cedar.Spec.Proto
 
 -- Note that Cedar.Spec.Entities is defined as
 -- abbrev Entities := Map EntityUID EntityData
@@ -29,59 +32,49 @@ namespace Cedar.Spec
 -- we need to parse an intermediate representation EntityProto
 -- which contains that and transform it to the appropriate types.
 
-def EntitiesProto : Type := Array EntityProto
-deriving instance Inhabited for EntitiesProto
-instance : HAppend EntitiesProto EntitiesProto EntitiesProto where
-  hAppend x y :=
-    let x : Array EntityProto := x
-    let y : Array EntityProto := y
-    x ++ y
-instance : HAppend EntitiesProto (Array EntityProto) EntitiesProto where
-  hAppend x y :=
-    let x : Array EntityProto := x
-    x ++ y
+structure Entities where
+  entities : Repeated Entity
+deriving Repr, Inhabited
 
-namespace EntitiesProto
+instance : HAppend Entities Entities Entities where
+  hAppend x y := { entities := x.entities ++ y.entities }
+instance : HAppend Entities (Repeated Entity) Entities where
+  hAppend x y := { entities := x.entities ++ y }
 
-@[inline]
-def mergeEntities (result : EntitiesProto) (x : Array EntityProto) : EntitiesProto :=
-  result ++ x
+namespace Entities
 
-@[inline]
-def merge (x : EntitiesProto) (y : EntitiesProto) : EntitiesProto :=
-  x ++ y
+instance : Message Entities := {
+  parseField (t : Proto.Tag) := do match t.fieldNum with
+    | 1 => parseFieldElement t entities (update entities)
+    | _ => let _ ← t.wireType.skip ; pure ignore
 
-@[inline]
-def parseField (t : Proto.Tag) : BParsec (MergeFn EntitiesProto) := do
-  match t.fieldNum with
-    | 1 =>
-      let x : Repeated EntityProto ← Field.guardedParse t
-      pure (pure $ mergeEntities · x)
-    | _ =>
-      t.wireType.skip
-      pure ignore
-
-instance : Message EntitiesProto := {
-  parseField := parseField
-  merge := merge
+  merge := (· ++ ·)
 }
 
 @[inline]
-def toEntities (e : EntitiesProto) : Entities :=
-  Cedar.Data.Map.make (e.toList.map λ entity => ⟨entity.uid, entity.data⟩)
-
-end EntitiesProto
-
-namespace Entities
-@[inline]
-def merge (e1 : Entities) (e2 : Entities) : Entities :=
-  -- Don't sort if e1 is empty
-  match e1.kvs with
-    | [] => e2
-    | _ => Cedar.Data.Map.make (e2.kvs ++ e1.kvs)
-
-instance : Field Entities := Field.fromInterField EntitiesProto.toEntities merge
+def toEntities (e : Entities) : Spec.Entities :=
+  Data.Map.make $ e.entities.toList.map λ { uid, attrs, ancestors, tags } => (
+    uid,
+    {
+      attrs := Data.Map.make attrs.toList
+      ancestors := Data.Set.make ancestors.toList
+      tags := Data.Map.make tags.toList
+    }
+  )
 
 end Entities
+
+end Cedar.Spec.Proto
+
+namespace Cedar.Spec
+
+def Entities.merge (x y : Entities) : Entities :=
+  -- avoid sorting if either is empty
+  match x.kvs, y.kvs with
+  | [], _ => y
+  | _, [] => x
+  | _, _  => Data.Map.make (x.kvs ++ y.kvs)
+
+instance : Field Entities := Field.fromInterField Proto.Entities.toEntities Entities.merge
 
 end Cedar.Spec

--- a/cedar-lean/CedarProto/Entity.lean
+++ b/cedar-lean/CedarProto/Entity.lean
@@ -47,7 +47,8 @@ deriving Repr, Inhabited
 namespace Entity
 
 instance : Message Entity := {
-  parseField (t : Proto.Tag) := do match t.fieldNum with
+  parseField (t : Proto.Tag) := do
+    match t.fieldNum with
     | 1 => parseFieldElement t uid (update uid)
     | 2 => parseFieldElement t attrs (update attrs)
     | 3 => parseFieldElement t ancestors (update ancestors)

--- a/cedar-lean/CedarProto/EntityDecl.lean
+++ b/cedar-lean/CedarProto/EntityDecl.lean
@@ -13,9 +13,10 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -/
+
 import Cedar.Spec
 import Protobuf.Message
-import Protobuf.String
+import Protobuf.Structure
 
 -- Message Dependencies
 import CedarProto.Name
@@ -28,81 +29,32 @@ namespace Cedar.Validation.Proto
 -- Note: EntitySchemaEntry takes ancestors, so we'll create this intermediate
 -- representation. Once we gather all the entries, we will perform the transform.
 structure EntityDecl where
-  name : Spec.Name
+  name : Spec.Proto.Name
   /-- All (transitive) descendants. Assumes TC is computed before encoding into protobuf. -/
-  descendants : Array Spec.Name
+  descendants : Repeated Spec.Proto.Name
   attrs : Proto.Map String (Qualified ProtoType)
   tags : Option ProtoType
-  enums : Array String
+  enums : Repeated String
 deriving Repr, Inhabited
 
 namespace EntityDecl
 
-@[inline]
-def mergeName (result : EntityDecl) (x : Spec.Name) : EntityDecl :=
-  {result with
-    name := Field.merge result.name x
-  }
-
-@[inline]
-def mergeDescendants (result : EntityDecl) (x : Array Spec.Name) : EntityDecl :=
-  {result with
-    descendants := result.descendants ++ x
-  }
-
-@[inline]
-def mergeAttributes (result : EntityDecl) (x : Proto.Map String (Qualified ProtoType)) : EntityDecl :=
-  {result with
-    attrs := result.attrs ++ x
-  }
-
-@[inline]
-def mergeTags (result : EntityDecl) (x : ProtoType) : EntityDecl :=
-  {result with
-    tags := Field.merge result.tags (some x)
-  }
-
-@[inline]
-def mergeEnums (result : EntityDecl) (x : Array String) : EntityDecl :=
-  {result with
-    enums := result.enums ++ x
-  }
-
-@[inline]
-def merge (x y : EntityDecl) : EntityDecl :=
-  {
-    name := Field.merge x.name y.name
-    descendants := y.descendants ++ x.descendants
-    attrs := x.attrs ++ y.attrs
-    tags := Field.merge x.tags y.tags
-    enums := x.enums ++ y.enums
-  }
-
-@[inline]
-def parseField (t : Tag) : BParsec (MergeFn EntityDecl) := do
-  match t.fieldNum with
-    | 1 =>
-      let x : Spec.Name ← Field.guardedParse t
-      pure (pure $ mergeName · x)
-    | 2 =>
-      let x : Repeated Spec.Name ← Field.guardedParse t
-      pure (pure $ mergeDescendants · x)
-    | 3 =>
-      let x : Proto.Map String (Qualified ProtoType) ← Field.guardedParse t
-      pure (pure $ mergeAttributes · x)
-    | 5 =>
-      let x : ProtoType ← Field.guardedParse t
-      pure (pure $ mergeTags · x)
-    | 6 =>
-      let x : Repeated String ← Field.guardedParse t
-      pure (pure $ mergeEnums · x)
-    | _ =>
-      t.wireType.skip
-      pure ignore
-
 instance : Message EntityDecl := {
-  parseField := parseField
-  merge := merge
+  parseField (t : Tag) := do match t.fieldNum with
+    | 1 => parseFieldElement t name (update name)
+    | 2 => parseFieldElement t descendants (update descendants)
+    | 3 => parseFieldElement t attrs (update attrs)
+    | 5 => parseFieldElement t tags (update tags)
+    | 6 => parseFieldElement t enums (update enums)
+    | _ => let _ ← t.wireType.skip ; pure ignore
+
+  merge x y := {
+    name        := Field.merge x.name        y.name
+    descendants := Field.merge x.descendants y.descendants
+    attrs       := Field.merge x.attrs       y.attrs
+    tags        := Field.merge x.tags        y.tags
+    enums       := Field.merge x.enums       y.enums
+  }
 }
 
 end EntityDecl

--- a/cedar-lean/CedarProto/EntityDecl.lean
+++ b/cedar-lean/CedarProto/EntityDecl.lean
@@ -40,7 +40,8 @@ deriving Repr, Inhabited
 namespace EntityDecl
 
 instance : Message EntityDecl := {
-  parseField (t : Tag) := do match t.fieldNum with
+  parseField (t : Tag) := do
+    match t.fieldNum with
     | 1 => parseFieldElement t name (update name)
     | 2 => parseFieldElement t descendants (update descendants)
     | 3 => parseFieldElement t attrs (update attrs)

--- a/cedar-lean/CedarProto/EntityUID.lean
+++ b/cedar-lean/CedarProto/EntityUID.lean
@@ -13,61 +13,28 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -/
+
 import Cedar.Spec
 import Protobuf.Message
-import Protobuf.String
+import Protobuf.Structure
 
 -- Message Dependencies
 import CedarProto.Name
 
 open Proto
 
-namespace Cedar.Spec
-
--- Note that Cedar.Spec.EntityUID is defined as
--- structure EntityUID where
---   ty : EntityType
---   eid : String
-
-namespace EntityUID
-
-@[inline]
-def mergeTy (result : EntityUID) (ty : Name) : EntityUID :=
-  {result with
-    ty := Field.merge result.ty ty
-  }
-
-@[inline]
-def mergeEid (result : EntityUID) (eid : String) : EntityUID :=
-  {result with
-    eid := Field.merge result.eid eid
-  }
-
-@[inline]
-def merge (x1 : EntityUID) (x2 : EntityUID) : EntityUID :=
-  {x1 with
-    ty := Field.merge x1.ty x2.ty
-    eid := Field.merge x1.eid x2.eid
-  }
-
-@[inline]
-def parseField (t : Proto.Tag) : BParsec (MergeFn EntityUID) := do
-  match t.fieldNum with
-    | 1 =>
-      let x : Name ← Field.guardedParse t
-      pure (pure $ mergeTy · x)
-    | 2 =>
-      let x : String ← Field.guardedParse t
-      pure (pure $ mergeEid · x)
-    | _ =>
-      t.wireType.skip
-      pure ignore
+namespace Cedar.Spec.EntityUID
 
 instance : Message EntityUID := {
-  parseField := parseField
-  merge := merge
+  parseField (t : Proto.Tag) := do match t.fieldNum with
+    | 1 => parseFieldElement t ty (update ty)
+    | 2 => parseFieldElement t eid (update eid)
+    | _ => let _ ← t.wireType.skip ; pure ignore
+
+  merge x y := {
+    ty  := Field.merge x.ty  y.ty
+    eid := Field.merge x.eid y.eid
+  }
 }
 
-end EntityUID
-
-end Cedar.Spec
+end Cedar.Spec.EntityUID

--- a/cedar-lean/CedarProto/EntityUID.lean
+++ b/cedar-lean/CedarProto/EntityUID.lean
@@ -26,7 +26,8 @@ open Proto
 namespace Cedar.Spec.EntityUID
 
 instance : Message EntityUID := {
-  parseField (t : Proto.Tag) := do match t.fieldNum with
+  parseField (t : Proto.Tag) := do
+    match t.fieldNum with
     | 1 => parseFieldElement t ty (update ty)
     | 2 => parseFieldElement t eid (update eid)
     | _ => let _ ← t.wireType.skip ; pure ignore

--- a/cedar-lean/CedarProto/Name.lean
+++ b/cedar-lean/CedarProto/Name.lean
@@ -31,7 +31,8 @@ deriving Repr, Inhabited
 namespace Name
 
 instance : Message Name := {
-  parseField (t : Proto.Tag) := do match t.fieldNum with
+  parseField (t : Proto.Tag) := do
+    match t.fieldNum with
     | 1 => parseFieldElement t id (update id)
     | 2 => parseFieldElement t path (update path)
     | _ => let _ ← t.wireType.skip ; pure ignore

--- a/cedar-lean/CedarProto/Name.lean
+++ b/cedar-lean/CedarProto/Name.lean
@@ -57,7 +57,7 @@ def Name.merge (x y : Name) : Name := {
   path := x.path ++ y.path
 }
 
-def EntityType.merge (x y : EntityType) : EntityType := Name.merge x y
+def EntityType.merge := Name.merge
 
 instance : Field Name := Field.fromInterField Proto.Name.toName Name.merge
 instance : Field EntityType := Field.fromInterField (λ n => n) EntityType.merge

--- a/cedar-lean/CedarProto/Name.lean
+++ b/cedar-lean/CedarProto/Name.lean
@@ -13,56 +13,52 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -/
+
 import Cedar.Spec
 import Protobuf.Message
 import Protobuf.String
+import Protobuf.Structure
 
 open Proto
 
-namespace Cedar.Spec.Name
+namespace Cedar.Spec.Proto
 
--- Note that Cedar.Spec.Name is defined as
--- structure Name where
---   id : String
---   path : List String
--- deriving Inhabited, Repr, DecidableEq
+structure Name where
+  id : String
+  path : Repeated String
+deriving Repr, Inhabited
 
-@[inline]
-def mergeId (result : Name) (x : String) : Name :=
-  {result with
-    id := Field.merge result.id x
-  }
-
-@[inline]
-def mergePath (result : Name) (path_elem : Repeated String) : Name :=
-  {result with
-    path := result.path ++ path_elem.toList
-  }
-
-@[inline]
-def merge (x y : Name) : Name :=
-  {
-    id := Field.merge x.id y.id
-    path := x.path ++ y.path
-  }
-
-@[inline]
-def parseField (t : Proto.Tag) : BParsec (MergeFn Name) := do
-  match t.fieldNum with
-    | 1 =>
-      let x : String ← Field.guardedParse t
-      pure (pure $ mergeId · x)
-    | 2 =>
-      let x : Repeated String ← Field.guardedParse t
-      pure (pure $ mergePath · x)
-    | _ =>
-      t.wireType.skip
-      pure ignore
-
+namespace Name
 
 instance : Message Name := {
-  parseField := parseField
-  merge := merge
+  parseField (t : Proto.Tag) := do match t.fieldNum with
+    | 1 => parseFieldElement t id (update id)
+    | 2 => parseFieldElement t path (update path)
+    | _ => let _ ← t.wireType.skip ; pure ignore
+
+  merge x y := {
+    id   := Field.merge x.id   y.id
+    path := Field.merge x.path y.path
+  }
 }
 
-end Cedar.Spec.Name
+def toName : Name -> Spec.Name
+  | { id, path } => { id, path := path.toList }
+
+end Name
+
+end Cedar.Spec.Proto
+
+namespace Cedar.Spec
+
+def Name.merge (x y : Name) : Name := {
+  id := Field.merge x.id y.id
+  path := x.path ++ y.path
+}
+
+def EntityType.merge (x y : EntityType) : EntityType := Name.merge x y
+
+instance : Field Name := Field.fromInterField Proto.Name.toName Name.merge
+instance : Field EntityType := Field.fromInterField (λ n => n) EntityType.merge
+
+end Cedar.Spec

--- a/cedar-lean/CedarProto/Name.lean
+++ b/cedar-lean/CedarProto/Name.lean
@@ -60,6 +60,6 @@ def Name.merge (x y : Name) : Name := {
 def EntityType.merge := Name.merge
 
 instance : Field Name := Field.fromInterField Proto.Name.toName Name.merge
-instance : Field EntityType := Field.fromInterField (λ n => n) EntityType.merge
+instance : Field EntityType := Field.fromInterField id EntityType.merge
 
 end Cedar.Spec

--- a/cedar-lean/CedarProto/Policy.lean
+++ b/cedar-lean/CedarProto/Policy.lean
@@ -13,86 +13,78 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -/
+
 import Cedar.Spec
+import Protobuf.Message
+import Protobuf.Structure
 
 -- Message Dependencies
 import CedarProto.EntityUID
 
 open Proto
 
-namespace Cedar.Spec
+namespace Cedar.Spec.Proto
 
-namespace TemplateLinkedPolicy
+structure Policy where
+  templateId : String
+  linkId : Option String
+  isTemplateLink : Bool
+  principalEuid : Option EntityUID
+  resourceEuid : Option EntityUID
+deriving Repr, Inhabited
 
--- Note that Cedar.Spec.TemplateLinkedPolicy is defined as
--- structure TemplateLinkedPolicy where
---   id : PolicyID
---   templateId : TemplateID
---   slotEnv : SlotEnv
-deriving instance Inhabited for TemplateLinkedPolicy
+namespace Policy
 
+instance : Message Policy := {
+  parseField (t : Proto.Tag) := do match t.fieldNum with
+    | 1 => parseFieldElement t templateId (update templateId)
+    | 2 => parseFieldElement t linkId (update linkId)
+    | 3 => parseFieldElement t isTemplateLink (update isTemplateLink)
+    | 4 => parseFieldElement t principalEuid (update principalEuid)
+    | 5 => parseFieldElement t resourceEuid (update resourceEuid)
+    | _ => let _ ← t.wireType.skip ; pure ignore
 
-@[inline]
-def mergeId (result : TemplateLinkedPolicy) (x : String) : TemplateLinkedPolicy :=
-  {result with
-    id := Field.merge result.id x
+  merge x y := {
+    templateId     := Field.merge x.templateId     y.templateId
+    linkId         := Field.merge x.linkId         y.linkId
+    isTemplateLink := Field.merge x.isTemplateLink y.isTemplateLink
+    principalEuid  := Field.merge x.principalEuid  y.principalEuid
+    resourceEuid   := Field.merge x.resourceEuid   y.resourceEuid
   }
-
-@[inline]
-def mergeTemplateId (result : TemplateLinkedPolicy) (x : String) : TemplateLinkedPolicy :=
-  {result with
-    templateId := Field.merge result.templateId x
-  }
-
-@[inline]
-def mergePrincipalEuid (result : TemplateLinkedPolicy) (x : EntityUID) : TemplateLinkedPolicy :=
-  {result with
-    slotEnv := Cedar.Data.Map.mk (("?principal", x) :: result.slotEnv.kvs)
-  }
-
-@[inline]
-def mergeResourceEuid (result : TemplateLinkedPolicy) (x : EntityUID) : TemplateLinkedPolicy :=
-  {result with
-    slotEnv := Cedar.Data.Map.mk (("?resource", x) :: result.slotEnv.kvs)
-  }
-
-@[inline]
-def merge (x : TemplateLinkedPolicy) (y : TemplateLinkedPolicy) : TemplateLinkedPolicy :=
-  {
-    id := Field.merge x.id y.id
-    templateId := Field.merge x.id y.id
-    slotEnv := Cedar.Data.Map.mk (x.slotEnv.kvs ++ y.slotEnv.kvs)
-  }
-
-def parseField (t : Proto.Tag) : BParsec (MergeFn TemplateLinkedPolicy) := do
-  match t.fieldNum with
-    | 1 =>
-      let x : String ← Field.guardedParse t
-      pure (pure $ mergeTemplateId · x)
-    | 2 =>
-      let x : String ← Field.guardedParse t
-      pure (pure $ mergeId · x)
-    | 4 =>
-      let x : EntityUID ← Field.guardedParse t
-      pure (pure $ mergePrincipalEuid · x)
-    | 5 =>
-      let x : EntityUID ← Field.guardedParse t
-      pure (pure $ mergeResourceEuid · x)
-    | _ =>
-      t.wireType.skip
-      pure ignore
-
-instance : Message TemplateLinkedPolicy := {
-  parseField := parseField
-  merge := merge
 }
 
-@[inline]
-def mkWf (t : TemplateLinkedPolicy) : TemplateLinkedPolicy :=
-  {t with
-    slotEnv := Cedar.Data.Map.make t.slotEnv.kvs
+def toTemplateLinkedPolicy (p : Policy) : Spec.TemplateLinkedPolicy :=
+  {
+    templateId := p.templateId
+    id := if p.isTemplateLink then
+      match p.linkId with | some id => id | none => panic!("template link should have a linkId")
+    else
+      p.templateId -- for static policies, the id is the template id
+    slotEnv := Data.Map.make $ match p.principalEuid, p.resourceEuid with
+      | some p, some r => [("?principal", p), ("?resource", r)]
+      | some p, none   => [("?principal", p)]
+      | none,   some r => [("?resource", r)]
+      | none,   none   => []
   }
 
-end TemplateLinkedPolicy
+end Policy
+
+end Cedar.Spec.Proto
+
+namespace Cedar.Spec
+
+deriving instance Inhabited for TemplateLinkedPolicy
+
+def TemplateLinkedPolicy.merge (x y : TemplateLinkedPolicy) : TemplateLinkedPolicy := {
+  templateId := Field.merge x.templateId y.templateId
+  id := Field.merge x.id y.id
+  slotEnv := match x.slotEnv.kvs, y.slotEnv.kvs with
+    -- avoid sort if either are empty
+    | [], _ => y.slotEnv
+    | _, [] => x.slotEnv
+    | xkvs, ykvs  => Data.Map.make $ xkvs ++ ykvs
+}
+
+instance : Field TemplateLinkedPolicy := Field.fromInterField (Proto.Policy.toTemplateLinkedPolicy) TemplateLinkedPolicy.merge
 
 end Cedar.Spec

--- a/cedar-lean/CedarProto/Policy.lean
+++ b/cedar-lean/CedarProto/Policy.lean
@@ -36,7 +36,8 @@ deriving Repr, Inhabited
 namespace Policy
 
 instance : Message Policy := {
-  parseField (t : Proto.Tag) := do match t.fieldNum with
+  parseField (t : Proto.Tag) := do
+    match t.fieldNum with
     | 1 => parseFieldElement t templateId (update templateId)
     | 2 => parseFieldElement t linkId (update linkId)
     | 3 => parseFieldElement t isTemplateLink (update isTemplateLink)

--- a/cedar-lean/CedarProto/PolicySet.lean
+++ b/cedar-lean/CedarProto/PolicySet.lean
@@ -13,7 +13,11 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -/
+
 import Cedar.Spec
+import Protobuf.Map
+import Protobuf.Message
+import Protobuf.Structure
 
 -- Message Dependencies
 import CedarProto.TemplateBody
@@ -21,7 +25,7 @@ import CedarProto.Policy
 
 open Proto
 
-namespace Cedar.Spec
+namespace Cedar.Spec.Proto
 
 structure PolicySet where
   templates : Proto.Map String Template
@@ -63,28 +67,30 @@ def parseField (t : Proto.Tag) : BParsec (MergeFn PolicySet) := do
       pure ignore
 
 instance : Message PolicySet := {
-  parseField := parseField
-  merge := merge
+  parseField (t : Proto.Tag) := do match t.fieldNum with
+    | 1 => parseFieldElement t templates (update templates)
+    | 2 => parseFieldElement t links (update links)
+    | _ => let _ ← t.wireType.skip ; pure ignore
+
+  merge x y := {
+    templates := Field.merge x.templates y.templates
+    links     := Field.merge x.links     y.links
+  }
 }
+
+def toPolicies : PolicySet → Spec.Policies
+  | { templates, links } =>
+    let templates := Data.Map.make templates.toList
+    match link? templates (links.toList.map Prod.snd) with
+    | .ok policies => policies
+    | .error e => panic!(s!"toPolicies: failed to link templates: {e}\n  templates: {repr templates}\n  links: {repr links.toList}")
 
 end PolicySet
 
+end Cedar.Spec.Proto
 
-namespace Policies
+namespace Cedar.Spec
 
-@[inline]
-def fromPolicySet (x : PolicySet) : Policies :=
-  let templates := Cedar.Data.Map.make x.templates.toList
-  let links := x.links.map (λ ⟨id, p⟩ => (p.mergeId id).mkWf)
-  match link? templates links.toList with
-  | .ok policies => policies
-  | .error e => panic!(s!"fromPolicySet: failed to link templates: {e}\n  templates: {repr templates}\n  links: {repr links.toList}}")
+instance : Field Policies := Field.fromInterField Proto.PolicySet.toPolicies (· ++ ·)
 
-@[inline]
-private def merge (x y : Policies) : Policies :=
-  x ++ y
-
-instance : Field Policies := Field.fromInterField fromPolicySet merge
-
-end Policies
 end Cedar.Spec

--- a/cedar-lean/CedarProto/PolicySet.lean
+++ b/cedar-lean/CedarProto/PolicySet.lean
@@ -67,7 +67,8 @@ def parseField (t : Proto.Tag) : BParsec (MergeFn PolicySet) := do
       pure ignore
 
 instance : Message PolicySet := {
-  parseField (t : Proto.Tag) := do match t.fieldNum with
+  parseField (t : Proto.Tag) := do
+    match t.fieldNum with
     | 1 => parseFieldElement t templates (update templates)
     | 2 => parseFieldElement t links (update links)
     | _ => let _ ← t.wireType.skip ; pure ignore

--- a/cedar-lean/CedarProto/PrincipalOrResourceConstraint.lean
+++ b/cedar-lean/CedarProto/PrincipalOrResourceConstraint.lean
@@ -118,7 +118,7 @@ instance : Inhabited ScopeTemplate.Is where
   default := .is default
 
 @[inline]
-def mergeET (result : ScopeTemplate.Is) (e2 : Name) : ScopeTemplate.Is :=
+def mergeET (result : ScopeTemplate.Is) (e2 : Spec.Name) : ScopeTemplate.Is :=
   match result with
     | .is e1 => .is (Field.merge e1 e2)
     | _ => panic!("ScopeTemplate.Is expected ScopeTemplate constructor to be set to .is")
@@ -134,7 +134,7 @@ def merge (x1 x2 : ScopeTemplate.Is) : ScopeTemplate.Is :=
 def parseField (t : Proto.Tag) : BParsec (MergeFn ScopeTemplate.Is) := do
   match t.fieldNum with
     | 1 =>
-      let x : Name ← Field.guardedParse t
+      let x : Spec.Name ← Field.guardedParse t
       pure (pure $ mergeET · x)
     | _ =>
       t.wireType.skip
@@ -157,7 +157,7 @@ def mergeER (result : ScopeTemplate.IsIn) (er2 : EntityUIDOrSlot) : ScopeTemplat
     | _ => panic!("ScopeTemplate.IsIn expected ScopeTemplate constructor to be set to .isMem")
 
 @[inline]
-def mergeET (result : ScopeTemplate.IsIn) (et2 : Name) : ScopeTemplate.IsIn :=
+def mergeET (result : ScopeTemplate.IsIn) (et2 : Spec.Name) : ScopeTemplate.IsIn :=
   match result with
     | .isMem et1 er => .isMem (Field.merge et1 et2) er
     | _ => panic!("ScopeTemplate.IsIn expected ScopeTemplate constructor to be set to .isMem")
@@ -178,7 +178,7 @@ def parseField (t : Proto.Tag) : BParsec (MergeFn ScopeTemplate.IsIn) := do
       let x : EntityUIDOrSlot ← Field.guardedParse t
       pure (pure $ mergeER · x)
     | 2 =>
-      let x : Name ← Field.guardedParse t
+      let x : Spec.Name ← Field.guardedParse t
       pure (pure $ mergeET · x)
     | _ =>
       t.wireType.skip

--- a/cedar-lean/CedarProto/Request.lean
+++ b/cedar-lean/CedarProto/Request.lean
@@ -15,7 +15,7 @@
 -/
 import Cedar.Spec
 import Protobuf.Message
-import Protobuf.String
+import Protobuf.Structure
 
 -- Message Dependencies
 import CedarProto.EntityUID
@@ -24,81 +24,61 @@ import CedarProto.Value
 
 open Proto
 
-namespace Cedar.Spec
+namespace Cedar.Spec.Proto
 
--- Note that Cedar.Spec.Request is defined as
--- structure Request where
---   principal : EntityUID
---   action : EntityUID
---   resource : EntityUID
---   context : Map Attr Value
+structure Request where
+  principal : EntityUID
+  action : EntityUID
+  resource : EntityUID
+  context : Expr
+deriving Repr, Inhabited
 
 namespace Request
 
-@[inline]
-def mergePrincipal (result : Request) (x : EntityUID) : Request :=
-  {result with
-    principal := Field.merge result.principal x
-  }
-
-@[inline]
-def mergeAction (result : Request) (x : EntityUID) : Request :=
-  {result with
-    action := Field.merge result.action x
-  }
-
-@[inline]
-def mergeResource (result : Request) (x : EntityUID) : Request :=
-  {result with
-    resource := Field.merge result.resource x
-  }
-
-@[inline]
-def mergeContext (result : Request) (x : Value) : Request :=
-  match x with
-  | .record pairs =>
-    {result with
-      context := Data.Map.make (result.context.kvs ++ pairs.kvs)
-    }
-  | _ => panic!("Context is not of correct type")
-
-@[inline]
-def merge (x : Request) (y : Request) : Request :=
-  {
-    principal := Field.merge x.principal y.principal
-    action := Field.merge x.action y.action
-    resource := Field.merge x.resource y.resource
-    context :=
-      -- Avoid a sort if x1 is empty
-      match x.context.kvs with
-        | [] => y.context
-        | _ => Data.Map.make (y.context.kvs ++ x.context.kvs)
-  }
-
-@[inline]
-def parseField (t : Proto.Tag) : BParsec (MergeFn Request) := do
-  match t.fieldNum with
-    | 1 =>
-      let x : EntityUID ← Field.guardedParse t
-      pure (pure $ mergePrincipal · x)
-    | 2 =>
-      let x : EntityUID ← Field.guardedParse t
-      pure (pure $ mergeAction · x)
-    | 3 =>
-      let x : EntityUID ← Field.guardedParse t
-      pure (pure $ mergeResource · x)
-    | 4 =>
-      let x : Value ← Field.guardedParse t
-      pure (pure $ mergeContext · x)
-    | _ =>
-      t.wireType.skip
-      pure ignore
-
 instance : Message Request := {
-  parseField := parseField
-  merge := merge
+  parseField (t : Proto.Tag) := do match t.fieldNum with
+    | 1 => parseFieldElement t principal (update principal)
+    | 2 => parseFieldElement t action (update action)
+    | 3 => parseFieldElement t resource (update resource)
+    | 4 => parseFieldElement t context (update context)
+    | _ => let _ ← t.wireType.skip ; pure ignore
+
+  merge x y := {
+    principal := Field.merge x.principal y.principal
+    action    := Field.merge x.action    y.action
+    resource  := Field.merge x.resource  y.resource
+    context   := Field.merge x.context   y.context
+  }
 }
 
+def toRequest : Request → Spec.Request
+  | { principal, action, resource, context } =>
+    {
+      principal
+      action
+      resource
+      context := match context with
+        | .record pairs => Data.Map.make $ pairs.map λ (k,v) => (k, Spec.Value.exprToValue v)
+        | _ => panic!("expected context to be a record")
+    }
+
 end Request
+
+end Cedar.Spec.Proto
+
+namespace Cedar.Spec
+
+def Request.merge (x y : Request) : Request := {
+  principal := Field.merge x.principal y.principal
+  action    := Field.merge x.action    y.action
+  resource  := Field.merge x.resource  y.resource
+  context   := match x.context.kvs, y.context.kvs with
+  -- avoid sort if either is empty
+  | [], _ => y.context
+  | _, [] => x.context
+  | xkvs, ykvs => Data.Map.make $ xkvs ++ ykvs
+}
+
+instance : Field Request := Field.fromInterField Proto.Request.toRequest Request.merge
 
 end Cedar.Spec

--- a/cedar-lean/CedarProto/Request.lean
+++ b/cedar-lean/CedarProto/Request.lean
@@ -36,7 +36,8 @@ deriving Repr, Inhabited
 namespace Request
 
 instance : Message Request := {
-  parseField (t : Proto.Tag) := do match t.fieldNum with
+  parseField (t : Proto.Tag) := do
+    match t.fieldNum with
     | 1 => parseFieldElement t principal (update principal)
     | 2 => parseFieldElement t action (update action)
     | 3 => parseFieldElement t resource (update resource)

--- a/cedar-lean/CedarProto/Schema.lean
+++ b/cedar-lean/CedarProto/Schema.lean
@@ -50,7 +50,8 @@ private def descendantsToAncestors [LT α] [DecidableEq α] [DecidableLT α] (de
 namespace Schema
 
 instance : Message Schema := {
-  parseField (t : Tag) := do match t.fieldNum with
+  parseField (t : Tag) := do
+    match t.fieldNum with
     | 1 => parseFieldElement t ets (update ets)
     | 2 => parseFieldElement t acts (update acts)
     | _ => let _ ← t.wireType.skip ; pure ignore

--- a/cedar-lean/CedarProto/ValidationRequest.lean
+++ b/cedar-lean/CedarProto/ValidationRequest.lean
@@ -13,9 +13,10 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -/
+
 import Cedar.Spec
 import Protobuf.Message
-import Protobuf.String
+import Protobuf.Structure
 
 -- Message Dependencies
 import CedarProto.Schema

--- a/cedar-lean/Protobuf.lean
+++ b/cedar-lean/Protobuf.lean
@@ -22,6 +22,7 @@ import Protobuf.Message
 import Protobuf.Packed
 import Protobuf.Proofs
 import Protobuf.String
+import Protobuf.Structure
 import Protobuf.Structures
 import Protobuf.Varint
 import Protobuf.WireType

--- a/cedar-lean/Protobuf/Structure.lean
+++ b/cedar-lean/Protobuf/Structure.lean
@@ -1,0 +1,39 @@
+/-
+ Copyright Cedar Contributors
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-/
+
+import Protobuf.Field
+import Protobuf.Message
+import Protobuf.Structures
+import Batteries.Data.UInt
+
+open Proto
+
+macro "update " f:Lean.Parser.Term.structInstLVal : term => `(λ x v => { x with $f := v })
+
+/--
+Helper function for defining `parseField` for a structure (Protobuf message).
+For example, for a struct with fields `name` and `value`,
+```
+  parseField (t : Tag) := do match t.fieldNum with
+     | 1 => parseFieldElement t name (update name)
+     | 2 => parseFieldElement t value (update value)
+     | _ => let _ ← t.wireType.skip ; pure ignore
+```
+-/
+def parseFieldElement {α β} [Field β] (t : Tag) (f : α → β) (g : α → β → α) : BParsec (MergeFn α) := do
+  let x : β ← Field.guardedParse t
+  let merge result x := g result (Field.merge (f result) x)
+  pure (pure $ merge · x)

--- a/cedar-lean/Protobuf/Structure.lean
+++ b/cedar-lean/Protobuf/Structure.lean
@@ -27,7 +27,8 @@ macro "update " f:Lean.Parser.Term.structInstLVal : term => `(λ x v => { x with
 Helper function for defining `parseField` for a structure (Protobuf message).
 For example, for a struct with fields `name` and `value`,
 ```
-  parseField (t : Tag) := do match t.fieldNum with
+  parseField (t : Tag) := do
+     match t.fieldNum with
      | 1 => parseFieldElement t name (update name)
      | 2 => parseFieldElement t value (update value)
      | _ => let _ ← t.wireType.skip ; pure ignore

--- a/cedar-lean/UnitTest/CedarProto.lean
+++ b/cedar-lean/UnitTest/CedarProto.lean
@@ -198,7 +198,7 @@ def tests := [
         (.call .decimal [.lit (.string "3.1416")]),
       ]),
     testDeserializeProtodata' "UnitTest/CedarProto-test-data/rbac.protodata"
-      Cedar.Spec.Policies.fromPolicySet
+      Cedar.Spec.Proto.PolicySet.toPolicies
       [{
         id := "policy0"
         effect := .permit
@@ -208,7 +208,7 @@ def tests := [
         condition := [{ kind := .when, body := .lit (.bool true) }]
       }],
     testDeserializeProtodata' "UnitTest/CedarProto-test-data/abac.protodata"
-      Cedar.Spec.Policies.fromPolicySet
+      Cedar.Spec.Proto.PolicySet.toPolicies
       [{
         id := "policy0"
         effect := .permit
@@ -227,7 +227,7 @@ def tests := [
         ]
       }],
     testDeserializeProtodata' "UnitTest/CedarProto-test-data/policyset.protodata"
-      (Cedar.Spec.Policies.sortByPolicyId ∘ Cedar.Spec.Policies.fromPolicySet)
+      (Cedar.Spec.Policies.sortByPolicyId ∘ Cedar.Spec.Proto.PolicySet.toPolicies)
       [
         {
           id := "linkedpolicy"
@@ -288,11 +288,11 @@ def tests := [
         },
       ],
     testDeserializeProtodata' "UnitTest/CedarProto-test-data/policyset_just_templates.protodata"
-      (Cedar.Spec.Policies.sortByPolicyId ∘ Cedar.Spec.Policies.fromPolicySet)
+      (Cedar.Spec.Policies.sortByPolicyId ∘ Cedar.Spec.Proto.PolicySet.toPolicies)
       -- when it's just a template, it gets dropped in the Lean `Cedar.Spec.Policies` representation
       [],
     testDeserializeProtodata' "UnitTest/CedarProto-test-data/policyset_one_static_policy.protodata"
-      (Cedar.Spec.Policies.sortByPolicyId ∘ Cedar.Spec.Policies.fromPolicySet)
+      (Cedar.Spec.Policies.sortByPolicyId ∘ Cedar.Spec.Proto.PolicySet.toPolicies)
       [
         {
           id := ""
@@ -306,18 +306,18 @@ def tests := [
           }]
         }
       ],
-    testDeserializeProtodata "UnitTest/CedarProto-test-data/request.protodata"
-      ({
+    testDeserializeProtodata' "UnitTest/CedarProto-test-data/request.protodata"
+      Cedar.Spec.Proto.Request.toRequest
+      {
         principal := mkUid [] "User" "alice"
         action := mkUid [] "Action" "access"
         resource := mkUid [] "Folder" "data"
         context := Map.make [ ("foo", .prim (.bool true)) ]
-      } : Cedar.Spec.Request),
+      },
     testDeserializeProtodata' "UnitTest/CedarProto-test-data/entity.protodata"
-      Cedar.Spec.EntityProto.mkWf
-      ({
-        uid := mkUid ["A"] "B" "C"
-        data := {
+      (λ eproto => Cedar.Spec.Proto.Entities.toEntities ({ entities := #[eproto] }))
+      ((Map.make [
+        (mkUid ["A"] "B" "C", {
           attrs := Map.make [
             ("foo", .set (Set.make [
               (.prim (.int (Int64.ofIntChecked 1 (by decide)))),
@@ -333,10 +333,10 @@ def tests := [
             ("tag1", .prim (.string "val1")),
             ("tag2", .prim (.string "val2")),
           ]
-        }
-      }),
+        })
+      ])),
     testDeserializeProtodata' "UnitTest/CedarProto-test-data/entities.protodata"
-      Cedar.Spec.EntitiesProto.toEntities
+      Cedar.Spec.Proto.Entities.toEntities
       ((Map.make [
         (mkUid [] "ABC" "123", { attrs := Map.empty, ancestors := Set.empty, tags := Map.empty }),
         (mkUid [] "DEF" "234", { attrs := Map.empty, ancestors := Set.empty, tags := Map.empty }),


### PR DESCRIPTION
Continues the changes in #555, but for all of `CedarProto`, resulting in a significant reduction in boilerplate, and hopefully significantly reduced opportunity for mistakes in said boilerplate.

In order to take better advantage of the new functions, refactors a couple types from (complicated manual implementation of `Message` for a type in `Cedar.Spec`) to (definition of a new structure type in `Proto` namespace which mirrors the protobuf definition, plus a conversion from that struct to the `Cedar.Spec` type).  This is probably easier to maintain in the future anyway, because it means that our `Proto` structs more closely match the Protobuf definitions, and if the Protobuf definitions change, the updates needed to the new code here should be straightforward.


