### PR TITLE
use Protobuf for additional DRT targets

### DIFF
--- a/cedar-drt/fuzz/fuzz_targets/protobuf-roundtrip.rs
+++ b/cedar-drt/fuzz/fuzz_targets/protobuf-roundtrip.rs
@@ -22,7 +22,7 @@ use serde::Serialize;
 
 use crate::arbitrary::Arbitrary;
 use crate::arbitrary::Unstructured;
-use cedar_drt::{AuthorizationRequestMsg, OwnedAuthorizationRequestMsg};
+use cedar_drt::{AuthorizationRequest, OwnedAuthorizationRequest};
 use cedar_drt_inner::{fuzz_target, schemas::Equiv};
 use cedar_policy::proto;
 use cedar_policy_core::{
@@ -99,7 +99,7 @@ fuzz_target!(|input: FuzzTargetInput| {
     let s_policy: ast::StaticPolicy = input.policy.into();
     let mut policies: ast::PolicySet = ast::PolicySet::new();
     policies.add(s_policy.into()).expect("Failed to add policy");
-    roundtrip_authz_request_msg(AuthorizationRequestMsg {
+    roundtrip_authz_request_msg(AuthorizationRequest {
         request: &input.request.into(),
         policies: &policies,
         entities: &input.entities,
@@ -107,19 +107,19 @@ fuzz_target!(|input: FuzzTargetInput| {
     roundtrip_schema(input.schema);
 });
 
-fn roundtrip_authz_request_msg(auth_request: AuthorizationRequestMsg) {
+fn roundtrip_authz_request_msg(auth_request: AuthorizationRequest) {
     // AST -> Protobuf
-    let auth_request_proto = cedar_drt::proto::AuthorizationRequestMsg::from(&auth_request);
+    let auth_request_proto = cedar_drt::proto::AuthorizationRequest::from(&auth_request);
 
     // Protobuf -> Bytes
     let buf = auth_request_proto.encode_to_vec();
 
     // Bytes -> Protobuf
-    let roundtripped_proto = cedar_drt::proto::AuthorizationRequestMsg::decode(&buf[..])
-        .expect("Failed to deserialize AuthorizationRequestMsg from proto");
+    let roundtripped_proto = cedar_drt::proto::AuthorizationRequest::decode(&buf[..])
+        .expect("Failed to deserialize AuthorizationRequest from proto");
 
     // Protobuf -> AST
-    let roundtripped = OwnedAuthorizationRequestMsg::from(roundtripped_proto);
+    let roundtripped = OwnedAuthorizationRequest::from(roundtripped_proto);
 
     // Checking request equality (ignores loc field)
     assert_eq!(

--- a/cedar-drt/fuzz/src/lib.rs
+++ b/cedar-drt/fuzz/src/lib.rs
@@ -315,10 +315,9 @@ pub fn run_req_val_test(
     });
     info!("{}{}", RUST_REQ_VALIDATION_MSG, rust_auth_dur.as_nanos());
 
-    let definitional_res = custom_impl.validate_request(&schema, &request);
-    match definitional_res {
-        TestResult::Failure(_) => {
-            panic!("request validation test: failed to parse");
+    match custom_impl.validate_request(&schema, &request) {
+        TestResult::Failure(e) => {
+            panic!("failed to execute request validation: {e}");
         }
         TestResult::Success(definitional_res) => {
             if rust_res.is_ok() {
@@ -354,10 +353,9 @@ pub fn run_ent_val_test(
         )
     });
     info!("{}{}", RUST_ENT_VALIDATION_MSG, rust_auth_dur.as_nanos());
-    let definitional_res = custom_impl.validate_entities(&schema, &entities);
-    match definitional_res {
-        TestResult::Failure(_) => {
-            panic!("entity validation test: failed to parse");
+    match custom_impl.validate_entities(&schema, &entities) {
+        TestResult::Failure(e) => {
+            panic!("failed to execute entity validation: {e}");
         }
         TestResult::Success(definitional_res) => {
             if rust_res.is_ok() {

--- a/cedar-drt/protobuf_schema/Messages.proto
+++ b/cedar-drt/protobuf_schema/Messages.proto
@@ -3,14 +3,31 @@ package cedar_drt;
 import "core.proto";
 import "validator.proto";
 
-message AuthorizationRequestMsg {
+message AuthorizationRequest {
     cedar_policy_core.Request request = 1;
     cedar_policy_core.PolicySet policies = 2;
     cedar_policy_core.Entities entities = 3;
 }
 
-message ValidationRequestMsg {
+message ValidationRequest {
     cedar_policy_validator.Schema schema = 1;
     cedar_policy_core.PolicySet policies = 2;
     cedar_policy_validator.ValidationMode mode = 3;
+}
+
+message EvaluationRequest {
+    cedar_policy_core.Expr expr = 1;
+    cedar_policy_core.Request request = 2;
+    cedar_policy_core.Entities entities = 3;
+    cedar_policy_core.Expr expected = 4;
+}
+
+message EntityValidationRequest {
+    cedar_policy_validator.Schema schema = 1;
+    cedar_policy_core.Entities entities = 2;
+}
+
+message RequestValidationRequest {
+    cedar_policy_validator.Schema schema = 1;
+    cedar_policy_core.Request request = 2;
 }

--- a/cedar-drt/src/definitional_request_types.rs
+++ b/cedar-drt/src/definitional_request_types.rs
@@ -25,15 +25,15 @@ pub mod proto {
     include!(concat!(env!("OUT_DIR"), "/cedar_drt.rs"));
 }
 
-#[derive(Clone, Debug, Serialize)]
-pub struct AuthorizationRequestMsg<'a> {
+#[derive(Clone, Debug)]
+pub struct AuthorizationRequest<'a> {
     pub request: &'a ast::Request,
     pub policies: &'a ast::PolicySet,
     pub entities: &'a Entities,
 }
 
-impl From<&AuthorizationRequestMsg<'_>> for proto::AuthorizationRequestMsg {
-    fn from(v: &AuthorizationRequestMsg<'_>) -> Self {
+impl From<&AuthorizationRequest<'_>> for proto::AuthorizationRequest {
+    fn from(v: &AuthorizationRequest<'_>) -> Self {
         Self {
             request: Some(cedar_policy::proto::models::Request::from(v.request)),
             policies: Some(cedar_policy::proto::models::PolicySet::from(v.policies)),
@@ -42,17 +42,17 @@ impl From<&AuthorizationRequestMsg<'_>> for proto::AuthorizationRequestMsg {
     }
 }
 
-// Converting `AuthorizationRequestMsg` from proto to non-proto structures is
+// Converting `AuthorizationRequest` from proto to non-proto structures is
 // only required for some roundtrip tests
 #[derive(Clone, Debug)]
-pub struct OwnedAuthorizationRequestMsg {
+pub struct OwnedAuthorizationRequest {
     pub request: ast::Request,
     pub policies: ast::PolicySet,
     pub entities: Entities,
 }
 
-impl From<proto::AuthorizationRequestMsg> for OwnedAuthorizationRequestMsg {
-    fn from(v: proto::AuthorizationRequestMsg) -> Self {
+impl From<proto::AuthorizationRequest> for OwnedAuthorizationRequest {
+    fn from(v: proto::AuthorizationRequest) -> Self {
         Self {
             request: ast::Request::from(&v.request.unwrap_or_default()),
             policies: ast::PolicySet::try_from(&v.policies.unwrap_or_default())
@@ -62,15 +62,15 @@ impl From<proto::AuthorizationRequestMsg> for OwnedAuthorizationRequestMsg {
     }
 }
 
-#[derive(Clone, Debug, Serialize)]
-pub struct ValidationRequestMsg<'a> {
+#[derive(Clone, Debug)]
+pub struct ValidationRequest<'a> {
     pub schema: &'a ValidatorSchema,
     pub policies: &'a ast::PolicySet,
     pub mode: ValidationMode,
 }
 
-impl From<&ValidationRequestMsg<'_>> for proto::ValidationRequestMsg {
-    fn from(v: &ValidationRequestMsg<'_>) -> Self {
+impl From<&ValidationRequest<'_>> for proto::ValidationRequest {
+    fn from(v: &ValidationRequest<'_>) -> Self {
         Self {
             schema: Some(cedar_policy::proto::models::Schema::from(v.schema)),
             policies: Some(cedar_policy::proto::models::PolicySet::from(v.policies)),
@@ -79,14 +79,7 @@ impl From<&ValidationRequestMsg<'_>> for proto::ValidationRequestMsg {
     }
 }
 
-#[derive(Debug, Serialize)]
-pub struct AuthorizationRequest<'a> {
-    pub request: &'a ast::Request,
-    pub policies: &'a ast::PolicySet,
-    pub entities: &'a Entities,
-}
-
-#[derive(Debug, Serialize)]
+#[derive(Clone, Debug)]
 pub struct EvaluationRequest<'a> {
     pub request: &'a ast::Request,
     pub entities: &'a Entities,
@@ -94,7 +87,18 @@ pub struct EvaluationRequest<'a> {
     pub expected: Option<&'a ast::Expr>,
 }
 
-#[derive(Debug, Serialize)]
+impl From<&EvaluationRequest<'_>> for proto::EvaluationRequest {
+    fn from(v: &EvaluationRequest<'_>) -> Self {
+        Self {
+            expr: Some(cedar_policy::proto::models::Expr::from(v.expr)),
+            request: Some(cedar_policy::proto::models::Request::from(v.request)),
+            entities: Some(cedar_policy::proto::models::Entities::from(v.entities)),
+            expected: v.expected.map(cedar_policy::proto::models::Expr::from),
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Clone)]
 pub struct PartialEvaluationRequest<'a> {
     pub request: &'a ast::Request,
     pub entities: &'a Entities,
@@ -102,28 +106,39 @@ pub struct PartialEvaluationRequest<'a> {
     pub expected: Option<ExprOrValue>,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Clone)]
 pub struct PartialAuthorizationRequest<'a> {
     pub request: &'a ast::Request,
     pub entities: &'a Entities,
     pub policies: &'a ast::PolicySet,
 }
 
-#[derive(Debug, Serialize)]
-pub struct ValidationRequest<'a> {
-    pub schema: &'a ValidatorSchema,
-    pub policies: &'a ast::PolicySet,
-    pub mode: ValidationMode,
-}
-
-#[derive(Debug, Serialize)]
+#[derive(Debug, Clone)]
 pub struct RequestValidationRequest<'a> {
     pub schema: &'a ValidatorSchema,
     pub request: &'a ast::Request,
 }
 
-#[derive(Debug, Serialize)]
+impl From<&RequestValidationRequest<'_>> for proto::RequestValidationRequest {
+    fn from(v: &RequestValidationRequest<'_>) -> Self {
+        Self {
+            schema: Some(cedar_policy::proto::models::Schema::from(v.schema)),
+            request: Some(cedar_policy::proto::models::Request::from(v.request)),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
 pub struct EntityValidationRequest<'a> {
     pub schema: &'a ValidatorSchema,
     pub entities: &'a Entities,
+}
+
+impl From<&EntityValidationRequest<'_>> for proto::EntityValidationRequest {
+    fn from(v: &EntityValidationRequest<'_>) -> Self {
+        Self {
+            schema: Some(cedar_policy::proto::models::Schema::from(v.schema)),
+            entities: Some(cedar_policy::proto::models::Entities::from(v.entities)),
+        }
+    }
 }

--- a/cedar-drt/tests/integration_tests.rs
+++ b/cedar-drt/tests/integration_tests.rs
@@ -126,15 +126,15 @@ fn protobuf_roundtrip() {
 
         for request in requests {
             // Construct Message
-            let request_msg = AuthorizationRequestMsg {
+            let request_msg = AuthorizationRequest {
                 request: &request,
                 policies: &policies,
                 entities: &entities,
             };
 
             // Perform a roundtrip serialize/de-serialize from protobuf and AST
-            let request_msg_proto = proto::AuthorizationRequestMsg::from(&request_msg);
-            let request_msg_rt = OwnedAuthorizationRequestMsg::from(request_msg_proto);
+            let request_msg_proto = proto::AuthorizationRequest::from(&request_msg);
+            let request_msg_rt = OwnedAuthorizationRequest::from(request_msg_proto);
 
             // Checking request equality (ignores loc field)
             assert_eq!(
@@ -163,14 +163,14 @@ fn protobuf_roundtrip() {
             // Time protobuf serialization from AST -> bytes
             let (request_msg_proto, proto_serialize_dur): (Vec<u8>, Duration) =
                 time_function(|| {
-                    proto::AuthorizationRequestMsg::from(&request_msg).encode_to_vec()
+                    proto::AuthorizationRequest::from(&request_msg).encode_to_vec()
                 });
 
             // Time protobuf deserialization from bytes -> AST
             let (_request_msg_rt, proto_deserialize_dur) = time_function(|| {
-                OwnedAuthorizationRequestMsg::from(
-                    proto::AuthorizationRequestMsg::decode(&request_msg_proto[..])
-                        .expect("Failed to deserialize AuthorizationRequestMsg proto"),
+                OwnedAuthorizationRequest::from(
+                    proto::AuthorizationRequest::decode(&request_msg_proto[..])
+                        .expect("Failed to deserialize AuthorizationRequest proto"),
                 )
             });
 

--- a/cedar-drt/tests/integration_tests.rs
+++ b/cedar-drt/tests/integration_tests.rs
@@ -162,9 +162,7 @@ fn protobuf_roundtrip() {
 
             // Time protobuf serialization from AST -> bytes
             let (request_msg_proto, proto_serialize_dur): (Vec<u8>, Duration) =
-                time_function(|| {
-                    proto::AuthorizationRequest::from(&request_msg).encode_to_vec()
-                });
+                time_function(|| proto::AuthorizationRequest::from(&request_msg).encode_to_vec());
 
             // Time protobuf deserialization from bytes -> AST
             let (_request_msg_rt, proto_deserialize_dur) = time_function(|| {

--- a/cedar-drt/tests/integration_tests.rs
+++ b/cedar-drt/tests/integration_tests.rs
@@ -104,8 +104,6 @@ fn protobuf_roundtrip() {
     let mut proto_serialize_durs: Vec<f64> = vec![];
     let mut proto_serialize_sizes: Vec<f64> = vec![];
     let mut proto_deserialize_durs: Vec<f64> = vec![];
-    let mut json_serialize_durs: Vec<f64> = vec![];
-    let mut json_serialize_sizes: Vec<f64> = vec![];
 
     for test in tests {
         // Load test from JSON file
@@ -180,20 +178,6 @@ fn protobuf_roundtrip() {
                     as f64,
             );
             proto_deserialize_durs.push(proto_deserialize_dur.as_micros() as f64);
-
-            // Time JSON serialization to a string
-            let (request_json, json_serialize_dur) = time_function(|| {
-                serde_json::to_string(&AuthorizationRequest {
-                    request: &request,
-                    policies: &policies,
-                    entities: &entities,
-                })
-                .expect("Failed to seralize Authorization request")
-            });
-
-            // Log JSON serialization time and size of string
-            json_serialize_durs.push(json_serialize_dur.as_micros() as f64);
-            json_serialize_sizes.push(request_json.len() as f64);
         }
     }
 
@@ -219,16 +203,4 @@ fn protobuf_roundtrip() {
     let std_proto_deserialize_dur = d_proto_deserialize_durs.std_dev().unwrap();
     println!("Protobuf Mean Deserialization Time {mean_proto_deserialize_dur} micros");
     println!("Protobuf Std Deserialization Time {std_proto_deserialize_dur} micros\n");
-
-    let d_json_serialize_durs = Data::new(json_serialize_durs);
-    let mean_json_serialize_dur = d_json_serialize_durs.mean().unwrap();
-    let std_json_serialize_dur = d_json_serialize_durs.std_dev().unwrap();
-    println!("JSON Mean Serialization Time {mean_json_serialize_dur} micros");
-    println!("JSON Std Serialization Time {std_json_serialize_dur} micros\n");
-
-    let d_json_serialize_sizes = Data::new(json_serialize_sizes);
-    let mean_json_serialize_size = d_json_serialize_sizes.mean().unwrap();
-    let std_json_serialize_size = d_json_serialize_sizes.std_dev().unwrap();
-    println!("JSON Mean Serialization Size {mean_json_serialize_size} bytes");
-    println!("JSON Std Serialization Size {std_json_serialize_size} bytes");
 }

--- a/cedar-lean/CedarProto.lean
+++ b/cedar-lean/CedarProto.lean
@@ -22,12 +22,15 @@ import CedarProto.Entity
 import CedarProto.EntityDecl
 import CedarProto.EntityReference
 import CedarProto.EntityUID
+import CedarProto.EntityValidationRequest
+import CedarProto.EvaluationRequest
 import CedarProto.Expr
 import CedarProto.Name
 import CedarProto.Policy
 import CedarProto.PolicySet
 import CedarProto.PrincipalOrResourceConstraint
 import CedarProto.Request
+import CedarProto.RequestValidationRequest
 import CedarProto.Schema
 import CedarProto.TemplateBody
 import CedarProto.Type

--- a/cedar-lean/CedarProto/EntityValidationRequest.lean
+++ b/cedar-lean/CedarProto/EntityValidationRequest.lean
@@ -1,0 +1,51 @@
+/-
+ Copyright Cedar Contributors
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-/
+
+import Cedar.Spec
+import Protobuf.Message
+import Protobuf.Structure
+
+-- Message Dependencies
+import CedarProto.Schema
+import CedarProto.Entities
+
+
+open Proto
+
+namespace Cedar.Validation.Proto
+
+structure EntityValidationRequest where
+  schema : Validation.Schema
+  entities : Cedar.Spec.Entities
+deriving Repr, Inhabited
+
+namespace EntityValidationRequest
+
+instance : Message EntityValidationRequest where
+  parseField (t : Tag) := do
+    match t.fieldNum with
+    | 1 => parseFieldElement t schema (update schema)
+    | 2 => parseFieldElement t entities (update entities)
+    | _ => let _ ← t.wireType.skip ; pure ignore
+
+  merge x y := {
+    schema   := Field.merge x.schema   y.schema
+    entities := Field.merge x.entities y.entities
+  }
+
+end EntityValidationRequest
+
+end Cedar.Validation.Proto

--- a/cedar-lean/CedarProto/EvaluationRequest.lean
+++ b/cedar-lean/CedarProto/EvaluationRequest.lean
@@ -1,0 +1,56 @@
+/-
+ Copyright Cedar Contributors
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-/
+
+import Cedar.Spec
+import Protobuf.Message
+import Protobuf.Structure
+
+-- Message Dependencies
+import CedarProto.Request
+import CedarProto.Entities
+import CedarProto.Expr
+
+open Proto
+
+namespace Cedar.Spec
+structure EvaluationRequest where
+  expr : Expr
+  request : Request
+  entities : Entities
+  expected : Option Value
+deriving Inhabited, DecidableEq, Repr
+
+namespace EvaluationRequest
+
+instance : Message EvaluationRequest where
+  parseField (t : Proto.Tag) := do
+    match t.fieldNum with
+    | 1 => parseFieldElement t expr (update expr)
+    | 2 => parseFieldElement t request (update request)
+    | 3 => parseFieldElement t entities (update entities)
+    | 4 => parseFieldElement t expected (update expected)
+    | _ => let _ ← t.wireType.skip ; pure ignore
+
+  merge x y := {
+    expr     := Field.merge x.expr     y.expr
+    request  := Field.merge x.request  y.request
+    entities := Field.merge x.entities y.entities
+    expected := Field.merge x.expected y.expected
+  }
+
+end EvaluationRequest
+
+end Cedar.Spec

--- a/cedar-lean/CedarProto/RequestValidationRequest.lean
+++ b/cedar-lean/CedarProto/RequestValidationRequest.lean
@@ -1,0 +1,51 @@
+/-
+ Copyright Cedar Contributors
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-/
+
+import Cedar.Spec
+import Protobuf.Message
+import Protobuf.Structure
+
+-- Message Dependencies
+import CedarProto.Schema
+import CedarProto.Request
+
+
+open Proto
+
+namespace Cedar.Validation.Proto
+
+structure RequestValidationRequest where
+  schema : Validation.Schema
+  request : Cedar.Spec.Request
+deriving Repr, Inhabited
+
+namespace RequestValidationRequest
+
+instance : Message RequestValidationRequest where
+  parseField (t : Tag) := do
+    match t.fieldNum with
+    | 1 => parseFieldElement t schema (update schema)
+    | 2 => parseFieldElement t request (update request)
+    | _ => let _ ← t.wireType.skip ; pure ignore
+
+  merge x y := {
+    schema  := Field.merge x.schema  y.schema
+    request := Field.merge x.request y.request
+  }
+
+end RequestValidationRequest
+
+end Cedar.Validation.Proto

--- a/cedar-lean/Cli/Main.lean
+++ b/cedar-lean/Cli/Main.lean
@@ -55,14 +55,16 @@ unsafe def main (args : List String) : IO Unit :=
         IO.println response
       | "evaluate" =>
         let request ← IO.FS.readFile filename
+        -- does not use evaluateDRT, because that just takes an `expected`
+        -- and returns true/false whether the result matched expected
         let response := evaluate request
         IO.println s!"{repr response}"
       | "validateRequest" =>
-        let request ← IO.FS.readFile filename
+        let request ← IO.FS.readBinFile filename
         let response := validateRequestDRT request
         IO.println response
       | "validateEntities" =>
-        let request ← IO.FS.readFile filename
+        let request ← IO.FS.readBinFile filename
         let response := validateEntitiesDRT request
         IO.println response
       | _ => printUsage s!"Invalid command `{command}` (expected `authorize`, `validate`, `validateRequest`, `validateEntities`, or `evaluate`)"

--- a/cedar-lean/Protobuf/Structures.lean
+++ b/cedar-lean/Protobuf/Structures.lean
@@ -25,9 +25,6 @@ Various Protobuf Structures, likely will reorganize later
 
 namespace Proto
 
-structure MessageSchema where
-  schema : Std.HashMap Nat PType
-
 structure Tag where
   fieldNum : Nat
   wireType : WireType
@@ -72,7 +69,7 @@ def parse : BParsec Tag := do
                     else if wt_uint = 3 then pure WireType.SGROUP
                     else if wt_uint = 4 then pure WireType.EGROUP
                     else if wt_uint = 5 then pure WireType.I32
-                    else throw "Unexcepted Wire Type"
+                    else throw "Unexpected Wire Type"
   have field_num := element >>> 3
   pure (Tag.mk field_num.toNat wire_type)
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Uses Protobuf, rather than the undocumented internal JSON format, for the `eval-type-directed`, `entity-validation`, and `request-validation` DRT targets.  Also renames Protobuf-related structs in the DRT package to remove `Msg` suffix which is redundant.

Tested that these three targets successfully run for a least a few seconds on my machine.


