### PR TITLE
Cases for `datetime` types in `extExprToValue`

### DIFF
--- a/cedar-lean/CedarProto/Value.lean
+++ b/cedar-lean/CedarProto/Value.lean
@@ -43,6 +43,12 @@ private def extExprToValue (xfn : ExtFun) (args : List Expr) : Except String Val
   | .ip, [.lit (.string s)] => match Spec.Ext.IPAddr.ip s with
     | .some v => .ok $ .ext (.ipaddr v)
     | .none => .error s!"exprToValue: failed to parse ip {s}"
+  | .datetime, [.lit (.string s)] => match Spec.Ext.Datetime.parse s with
+    | .some v => .ok $ .ext (.datetime v)
+    | .none => .error s!"exprToValue: failed to parse datetime {s}"
+  | .duration, [.lit (.string s)] => match Spec.Ext.Datetime.Duration.parse s with
+    | .some v => .ok $ .ext (.duration v)
+    | .none => .error s!"exprToValue: failed to parse duration {s}"
   | _, _ => .error s!"exprToValue: unexpected extension value\n{repr (Expr.call xfn args)}"
 
 partial def exprToValue : Expr → Except String Value


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* We are missing cases for `datetime` types in the `extExprToValue` function. Without them, DRT crashes on at least one target with an error like:
```
Error: evaluateReq: failed to parse input: offset 95: exprToValue: unexpected extension value
Cedar.Spec.Expr.call (Cedar.Spec.ExtFun.datetime) [Cedar.Spec.Expr.lit (Cedar.Spec.Prim.string "0000-01-01")]
```


