### PR TITLE
Fix schema type conversion for extension types

### DIFF
--- a/cedar-policy-generators/src/schema.rs
+++ b/cedar-policy-generators/src/schema.rs
@@ -350,8 +350,8 @@ fn schematype_to_type(
             json_schema::TypeVariant::Extension { name } => match name.as_ref() {
                 "ipaddr" => Type::ipaddr(),
                 "decimal" => Type::decimal(),
-                "datetime" => Type::decimal(),
-                "duration" => Type::decimal(),
+                "datetime" => Type::datetime(),
+                "duration" => Type::duration(),
                 _ => panic!("unrecognized extension type: {name:?}"),
             },
         },


### PR DESCRIPTION
*Description of changes:* Fix the schema type conversion for extension types.

Noticed this while looking at the changes in #470. It's probably unrelated to current DRT failures, but better to take care of it now than later.


