### PR TITLE
Restore `Serialize` for two fuzz targets

### DIFF
--- a/cedar-drt/fuzz/fuzz_targets/protobuf-roundtrip.rs
+++ b/cedar-drt/fuzz/fuzz_targets/protobuf-roundtrip.rs
@@ -33,11 +33,16 @@ use cedar_policy_generators::{
     settings::ABACSettings,
 };
 
-#[derive(Debug, Clone)]
+use serde::Serialize;
+
+#[derive(Debug, Clone, Serialize)]
 struct FuzzTargetInput {
+    #[serde(skip)]
     request: ABACRequest,
     policy: ABACPolicy,
+    #[serde(skip)]
     entities: Entities,
+    #[serde(skip)]
     schema: cedar_policy_validator::ValidatorSchema,
 }
 

--- a/cedar-drt/fuzz/fuzz_targets/wildcard-matching.rs
+++ b/cedar-drt/fuzz/fuzz_targets/wildcard-matching.rs
@@ -20,6 +20,8 @@ use cedar_drt_inner::fuzz_target;
 use cedar_policy_core::ast::{Pattern, PatternElem};
 use libfuzzer_sys::arbitrary::{self, Arbitrary, Result, Unstructured};
 use regex::{escape, Regex};
+use serde::{Serialize, Serializer};
+use serde::ser::SerializeStruct;
 
 /// Input expected by this fuzz target:
 /// A pattern and a string that matches it
@@ -29,6 +31,24 @@ struct FuzzTargetInput {
     pub pattern: Vec<PatternElem>,
     /// generated string
     pub string: String,
+}
+
+impl Serialize for FuzzTargetInput {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut state = serializer.serialize_struct("FuzzTargetInput", 2)?;
+
+        let pattern: Vec<String> = self.pattern.iter().map(|e| match e {
+            PatternElem::Char(c) => c.to_string(),
+            PatternElem::Wildcard => "*".to_string(),
+        }).collect();
+
+        state.serialize_field("pattern", &pattern)?;
+        state.serialize_field("string", &self.string)?;
+        state.end()
+    }
 }
 
 /// A wrapper struct for valid characters:

--- a/cedar-drt/fuzz/fuzz_targets/wildcard-matching.rs
+++ b/cedar-drt/fuzz/fuzz_targets/wildcard-matching.rs
@@ -20,8 +20,8 @@ use cedar_drt_inner::fuzz_target;
 use cedar_policy_core::ast::{Pattern, PatternElem};
 use libfuzzer_sys::arbitrary::{self, Arbitrary, Result, Unstructured};
 use regex::{escape, Regex};
-use serde::{Serialize, Serializer};
 use serde::ser::SerializeStruct;
+use serde::{Serialize, Serializer};
 
 /// Input expected by this fuzz target:
 /// A pattern and a string that matches it
@@ -40,10 +40,14 @@ impl Serialize for FuzzTargetInput {
     {
         let mut state = serializer.serialize_struct("FuzzTargetInput", 2)?;
 
-        let pattern: Vec<String> = self.pattern.iter().map(|e| match e {
-            PatternElem::Char(c) => c.to_string(),
-            PatternElem::Wildcard => "*".to_string(),
-        }).collect();
+        let pattern: Vec<String> = self
+            .pattern
+            .iter()
+            .map(|e| match e {
+                PatternElem::Char(c) => c.to_string(),
+                PatternElem::Wildcard => "*".to_string(),
+            })
+            .collect();
 
         state.serialize_field("pattern", &pattern)?;
         state.serialize_field("string", &self.string)?;


### PR DESCRIPTION
*Description of changes:* Our fuzzers are built which `--features log` which in turn require the `Serialize` trait to be implemented for fuzz target inputs. https://github.com/cedar-policy/cedar/pull/1520 removed the `Serialize` implementations from many core/validator types, but CI didn't catch it because we don't test the build with `--features log`.

This PR restores `Serialize` for two fuzz targets:
 - `protobuf-roundtrip`: We use `#[serde(skip)]` for each field except `policy`. This is how it's done in other targets, and I assume `ValidatorSchema` is safe to skip because it's built from `Schema` which is skipped in other targets as well.
 - `wildcard-matching`: We implement a simple custom serializer to avoid restoring it in `cedar`.


