### PR TITLE
Lean: Definitions and theorems for `duration` converters

### DIFF
--- a/cedar-lean/Cedar/Spec/Ext/Datetime.lean
+++ b/cedar-lean/Cedar/Spec/Ext/Datetime.lean
@@ -138,7 +138,7 @@ instance : Coe Int64 Duration where
 
 def MILLISECONDS_PER_SECOND: Int := 1000
 def MILLISECONDS_PER_MINUTE: Int := 60000
-def MILLISECONDS_PER_HOUR: Int := 360000
+def MILLISECONDS_PER_HOUR: Int := 3600000
 def MILLISECONDS_PER_DAY: Int := 86400000
 
 ----- Definitions -----
@@ -231,5 +231,20 @@ def toTime (datetime: Datetime) : Duration :=
        if rem == 0
        then rem
        else (rem + millisPerDayI64)
+
+def Duration.toMilliseconds (duration: Duration) : Int64 :=
+  duration.val
+
+def Duration.toSeconds (duration: Duration) : Int64 :=
+  duration.toMilliseconds / 1000
+
+def Duration.toMinutes (duration: Duration) : Int64 :=
+  duration.toSeconds / 60
+
+def Duration.toHours (duration: Duration) : Int64 :=
+  duration.toMinutes / 60
+
+def Duration.toDays (duration: Duration) : Int64 :=
+  duration.toHours / 24
 
 end Datetime

--- a/cedar-lean/Cedar/Spec/ExtFun.lean
+++ b/cedar-lean/Cedar/Spec/ExtFun.lean
@@ -43,6 +43,11 @@ inductive ExtFun where
   | durationSince
   | toDate
   | toTime
+  | toMilliseconds
+  | toSeconds
+  | toMinutes
+  | toHours
+  | toDays
 
 def res {α} [Coe α Ext] : Option α → Result Value
   | some v => .ok v
@@ -73,6 +78,11 @@ def call : ExtFun → List Value → Result Value
     [.ext (.datetime d₁), .ext (.datetime d₂)]  => res (d₁.durationSince d₂)
   | .toDate, [.ext (.datetime dt)]              => res (dt.toDate)
   | .toTime, [.ext (.datetime dt)]              => .ok dt.toTime
+  | .toMilliseconds, [.ext (.duration dur)]     => .ok dur.toMilliseconds
+  | .toSeconds, [.ext (.duration dur)]          => .ok dur.toSeconds
+  | .toMinutes, [.ext (.duration dur)]          => .ok dur.toMinutes
+  | .toHours, [.ext (.duration dur)]            => .ok dur.toHours
+  | .toDays , [.ext (.duration dur)]            => .ok dur.toDays
   | _, _                                        => .error .typeError
 
 ----- Derivations -----

--- a/cedar-lean/Cedar/Thm/Validation/Typechecker/Call.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Typechecker/Call.lean
@@ -772,6 +772,79 @@ theorem type_of_call_ipAddr_recognizer_is_sound {xfn : ExtFun} {xs : List Expr} 
     apply bool_is_instance_of_anyBool
   }
 
+def IsDurationConverter : ExtFun → Prop
+  | .toMilliseconds
+  | .toSeconds
+  | .toMinutes
+  | .toHours
+  | .toDays => True
+  | _       => False
+
+theorem type_of_call_duration_converter_inversion {xfn : ExtFun} {xs : List Expr} {c c' : Capabilities} {env : Environment} {ty : TypedExpr}
+  (h₀ : IsDurationConverter xfn)
+  (h₁ : typeOf (Expr.call xfn xs) c env = Except.ok (ty, c')) :
+  ty.typeOf = .int ∧
+  c' = ∅ ∧
+  ∃ (x₁ : Expr) (c₁ : Capabilities),
+    xs = [x₁] ∧
+    (typeOf x₁ c env).typeOf = .ok ((.ext .duration), c₁)
+:= by
+  simp [typeOf] at h₁
+  cases h₂ : List.mapM₁ xs fun x => justType (typeOf x.val c env) <;>
+  simp [h₂] at h₁
+  rename_i tys
+  simp [typeOfCall] at h₁
+  simp [IsDurationConverter] at h₀
+  split at h₀
+  all_goals {
+    split at h₁ <;> try { contradiction }
+    all_goals {
+      simp [ok] at h₁
+      have ⟨hl₁, hr₁⟩ := h₁
+      rw [←hl₁]
+      simp only [TypedExpr.typeOf, hr₁, List.empty_eq, true_and]
+      rename_i h₃
+      cases tys <;> try simp at h₃
+      rename_i tys
+      cases tys <;> try simp at h₃
+      rw [←h₃]
+      apply typeOf_of_unary_call_inversion h₂
+    }
+  }
+
+theorem type_of_call_duration_converter_is_sound {xfn : ExtFun} {xs : List Expr} {c₁ c₂ : Capabilities} {env : Environment} {ty : TypedExpr} {request : Request} {entities : Entities}
+  (h₀ : IsDurationConverter xfn)
+  (h₁ : CapabilitiesInvariant c₁ request entities)
+  (h₂ : RequestAndEntitiesMatchEnvironment env request entities)
+  (h₃ : typeOf (Expr.call xfn xs) c₁ env = Except.ok (ty, c₂))
+  (ih : ∀ (xᵢ : Expr), xᵢ ∈ xs → TypeOfIsSound xᵢ) :
+  GuardedCapabilitiesInvariant (Expr.call xfn xs) c₂ request entities ∧
+  ∃ v, EvaluatesTo (Expr.call xfn xs) request entities v ∧ InstanceOfType v ty.typeOf
+:= by
+  have ⟨h₄, h₅, x₁, c₁', h₆, h₇⟩ := type_of_call_duration_converter_inversion h₀ h₃
+  rw [h₄]
+  subst h₅ h₆
+  apply And.intro empty_guarded_capabilities_invariant
+  simp only [EvaluatesTo, evaluate, List.mapM₁, List.attach_def, List.pmap, List.mapM_cons,
+    List.mapM_nil, pure_bind, bind_assoc]
+  have ih₁ := ih x₁
+  simp [TypeOfIsSound] at ih₁
+  split_type_of h₇ ; rename_i h₇ hl₇ hr₇
+  have ⟨_, v₁, hl₁, hr₁⟩ := ih₁ h₁ h₂ h₇
+  simp [EvaluatesTo] at hl₁
+  rcases hl₁ with hl₁ | hl₁ | hl₁ | hl₁ <;>
+  simp [hl₁] <;>
+  try { exact type_is_inhabited (.int)}
+  rw [hl₇] at hr₁
+  have ⟨ip₁, hr₁⟩ := instance_of_duration_type_is_duration hr₁
+  subst hr₁
+  simp [IsDurationConverter] at h₀
+  split at h₀ <;>
+  simp only [call, reduceCtorEq, Except.ok.injEq, false_or, exists_eq_left'] <;> try { contradiction }
+  all_goals {
+    apply InstanceOfType.instance_of_int
+  }
+
 theorem type_of_call_is_sound {xfn : ExtFun} {xs : List Expr} {c₁ c₂ : Capabilities} {env : Environment} {ty : TypedExpr} {request : Request} {entities : Entities}
   (h₁ : CapabilitiesInvariant c₁ request entities)
   (h₂ : RequestAndEntitiesMatchEnvironment env request entities)
@@ -798,5 +871,10 @@ theorem type_of_call_is_sound {xfn : ExtFun} {xs : List Expr} {c₁ c₂ : Capab
   | .durationSince      => exact type_of_call_durationSince_is_sound h₁ h₂ h₃ ih
   | .toDate             => exact type_of_call_toDate_is_sound h₁ h₂ h₃ ih
   | .toTime             => exact type_of_call_toTime_is_sound h₁ h₂ h₃ ih
+  | .toMilliseconds
+  | .toSeconds
+  | .toMinutes
+  | .toHours
+  | .toDays             => exact type_of_call_duration_converter_is_sound (by simp [IsDurationConverter]) h₁ h₂ h₃ ih
 
 end Cedar.Thm

--- a/cedar-lean/Cedar/Validation/Typechecker.lean
+++ b/cedar-lean/Cedar/Validation/Typechecker.lean
@@ -328,6 +328,11 @@ def typeOfCall (xfn : ExtFun) (tys : List TypedExpr) (xs : List Expr) : ResultTy
   | .durationSince, [.ext .datetime, .ext .datetime]    => ok (.ext .duration)
   | .toDate, [.ext .datetime]                           => ok (.ext .datetime)
   | .toTime, [.ext .datetime]                           => ok (.ext .duration)
+  | .toMilliseconds, [.ext .duration]                   => ok .int
+  | .toSeconds, [.ext .duration]                        => ok .int
+  | .toMinutes, [.ext .duration]                        => ok .int
+  | .toHours, [.ext .duration]                          => ok .int
+  | .toDays , [.ext .duration]                          => ok .int
   | _, _                                                => err (.extensionErr xs)
 
 

--- a/cedar-lean/UnitTest/Datetime.lean
+++ b/cedar-lean/UnitTest/Datetime.lean
@@ -111,7 +111,7 @@ def testsForValidDurationStrings :=
     testValidDuration "1ms" 1,
     testValidDuration "1s" 1000,
     testValidDuration "1m" 60000,
-    testValidDuration "1h" 360000,
+    testValidDuration "1h" 3600000,
     testValidDuration "1d" 86400000,
     testValidDuration "12s340ms" 12340,
     testValidDuration "1s234ms" 1234,
@@ -119,20 +119,20 @@ def testsForValidDurationStrings :=
     testValidDuration "-1s" (-1000),
     testValidDuration "-4s200ms" (-4200),
     testValidDuration "-9s876ms" (-9876),
-    testValidDuration "106751d23h47m16s854ms" 9223297516854,
-    testValidDuration "-106751d23h47m16s854ms" (-9223297516854),
+    testValidDuration "106751d23h47m16s854ms" 9223372036854,
+    testValidDuration "-106751d23h47m16s854ms" (-9223372036854),
     testValidDuration "-9223372036854775808ms" (-9223372036854775808), -- min Int64 value
     testValidDuration "9223372036854775807ms" (9223372036854775807),   -- max Int64 value
-    testValidDuration "1d2h3m4s5ms" 87304005,
-    testValidDuration "2d12h" 177120000,
+    testValidDuration "1d2h3m4s5ms" 93784005,
+    testValidDuration "2d12h" 216000000,
     testValidDuration "3m30s" 210000,
-    testValidDuration "1h30m45s" 2205000,
-    testValidDuration "2d5h20m" 175800000,
-    testValidDuration "-1d12h" (-90720000),
-    testValidDuration "-3h45m" (-3780000),
+    testValidDuration "1h30m45s" 5445000,
+    testValidDuration "2d5h20m" 192000000,
+    testValidDuration "-1d12h" (-129600000),
+    testValidDuration "-3h45m" (-13500000),
     testValidDuration "1d1ms" 86400001,
     testValidDuration "59m59s999ms" 3599999,
-    testValidDuration "23h59m59s999ms" 11879999,
+    testValidDuration "23h59m59s999ms" 86399999,
     testValidDuration "0d0h0m0s0ms" 0
   ]
 
@@ -213,9 +213,102 @@ def testsForToTime :=
     testToTime "1969-12-31T12:00:00Z" 43200000
   ]
 
+private def testToMilliseconds (str : String) (dur : Int64) : TestCase IO :=
+  test s!"toMilliseconds {str} = {dur}" ⟨λ _ => checkEq (Duration.toMilliseconds (Duration.parse str).get!) dur⟩
+
+def testsForToMilliseconds :=
+  suite "toMilliseconds tests"
+  [
+    testToMilliseconds "0ms" 0,
+    testToMilliseconds "1ms" 1,
+    testToMilliseconds "1000ms" 1000,
+    testToMilliseconds "-0ms" 0,
+    testToMilliseconds "-1ms" (-1 : Int64),
+    testToMilliseconds "1s" 1000,
+    testToMilliseconds "1m" 60000,
+    testToMilliseconds "1h" 3600000,
+    testToMilliseconds "1d" 86400000,
+    testToMilliseconds "-9223372036854775808ms" (-9223372036854775808 : Int64),
+    testToMilliseconds "9223372036854775807ms" 9223372036854775807,
+  ]
+
+private def testToSeconds (str : String) (dur : Int64) : TestCase IO :=
+  test s!"toSeconds {str} = {dur}" ⟨λ _ => checkEq (Duration.toSeconds (Duration.parse str).get!) dur⟩
+
+def testsForToSeconds :=
+  suite "toSeconds tests"
+  [
+    testToSeconds "0ms" 0,
+    testToSeconds "999ms" 0,
+    testToSeconds "1000ms" 1,
+    testToSeconds "1001ms" 1,
+    testToSeconds "-0ms" 0,
+    testToSeconds "-999ms" (0 : Int64),
+    testToSeconds "-1000ms" (-1 : Int64),
+    testToSeconds "1s" 1,
+    testToSeconds "1m" 60,
+    testToSeconds "1h" 3600,
+    testToSeconds "1d" 86400,
+  ]
+
+private def testToMinutes (str : String) (dur : Int64) : TestCase IO :=
+  test s!"toMinutes {str} = {dur}" ⟨λ _ => checkEq (Duration.toMinutes (Duration.parse str).get!) dur⟩
+
+def testsForToMinutes :=
+  suite "toMinutes tests"
+  [
+    testToMinutes "0ms" 0,
+    testToMinutes "59999ms" 0,
+    testToMinutes "60000ms" 1,
+    testToMinutes "59s" 0,
+    testToMinutes "60s" 1,
+    testToMinutes "61s" 1,
+    testToMinutes "-59999ms" 0,
+    testToMinutes "-60000ms" (-1 : Int64),
+    testToMinutes "1m" 1,
+    testToMinutes "1h" 60,
+    testToMinutes "1d" 1440,
+  ]
+
+private def testToHours (str : String) (dur : Int64) : TestCase IO :=
+  test s!"toHours {str} = {dur}" ⟨λ _ => checkEq (Duration.toHours (Duration.parse str).get!) dur⟩
+
+def testsForToHours :=
+  suite "toHours tests"
+  [
+    testToHours "0ms" 0,
+    testToHours "3599999ms" 0,
+    testToHours "3600000ms" 1,
+    testToHours "59m" 0,
+    testToHours "60m" 1,
+    testToHours "61m" 1,
+    testToHours "-3599999ms" 0,
+    testToHours "-3600000ms" (-1 : Int64),
+    testToHours "1h" 1,
+    testToHours "1d" 24,
+  ]
+
+private def testToDays (str : String) (dur : Int64) : TestCase IO :=
+  test s!"toDays {str} = {dur}" ⟨λ _ => checkEq (Duration.toDays (Duration.parse str).get!) dur⟩
+
+def testsForToDays :=
+  suite "toDays tests"
+  [
+    testToDays "0ms" 0,
+    testToDays "86399999ms" 0,
+    testToDays "86400000ms" 1,
+    testToDays "23h" 0,
+    testToDays "24h" 1,
+    testToDays "25h" 1,
+    testToDays "-86399999ms" 0,
+    testToDays "-86400000ms" (-1 : Int64),
+    testToDays "1d" 1,
+  ]
+
 def tests := [testsForValidDatetimeStrings, testsForInvalidDatetimeStrings,
               testsForValidDurationStrings, testsForInvalidDurationStrings,
-              testsForOffset, testsForDurationSince, testsForToDate, testsForToTime]
+              testsForOffset, testsForDurationSince, testsForToDate, testsForToTime,
+              testsForToMilliseconds, testsForToSeconds, testsForToMinutes, testsForToHours, testsForToDays]
 
 -- Uncomment for interactive debugging
 -- #eval TestSuite.runAll tests


### PR DESCRIPTION
*Description of changes:* #527 missed the converter "methods" associated to the `duration` type, as specified in [the RFC for the datetime extension](https://cedar-policy.github.io/rfcs/0080-datetime-extension.html):
 - `.toMilliseconds()` returns a `long` describing the number of milliseconds in this duration (the value as a long, itself)
 - `.toSeconds()` returns a `long` describing the number of seconds in this duration (`.toMilliseconds() / 1000`)
 - `.toMinutes()` returns a `long` describing the number of minutes in this duration (`.toSeconds() / 60`)
 - `.toHours()` returns a `long` describing the number of hours in this duration (`.toMinutes() / 60`)
 - `.toDays()` returns a `long` describing the number of days in this duration (`.toHours() / 24`)

We include unit tests for each method in addition to a type call theorem for all of them.

The changes also include fixes for an embarrassing mistake in the `MILLISECONDS_PER_HOUR` definition.


