### PR TITLE
Add protobuf parsing `offset` when used as a `datetime` constructor

### DIFF
--- a/cedar-lean/CedarProto/Value.lean
+++ b/cedar-lean/CedarProto/Value.lean
@@ -49,6 +49,12 @@ private def extExprToValue (xfn : ExtFun) (args : List Expr) : Except String Val
   | .duration, [.lit (.string s)] => match Spec.Ext.Datetime.Duration.parse s with
     | .some v => .ok $ .ext (.duration v)
     | .none => .error s!"exprToValue: failed to parse duration {s}"
+  | .offset, [.call xfn₁ args₁, .call xfn₂ args₂] => do
+    let arg₁ ← extExprToValue xfn₁ args₁
+    let arg₂ ← extExprToValue xfn₂ args₂
+    match arg₁, arg₂ with
+    | .ext (.datetime dt), .ext (.duration dr) => .ok ∘ .ext ∘ .datetime $ dt.val + dr.val
+    | _, _ => .error s!"exprToValue: unexpected argument to datetime offset\n{repr (Expr.call xfn args)}"
   | _, _ => .error s!"exprToValue: unexpected extension value\n{repr (Expr.call xfn args)}"
 
 partial def exprToValue : Expr → Except String Value


### PR DESCRIPTION
This PR updates protobuf value parsing to handle `offset` as an extension value constructor. The evaluator will sometimes return a value as the result of a `datetime` expression using the `offset` function as a constructor.

For example:

```console
[jkastner@ cedar]$ cedar evaluate 'datetime("0000-01-01").offset(duration("-365d"))' --principal 'P::""' --action 'A::""' --resource 'R::""'

(datetime("1970-01-01")).offset(duration("-62198755200000ms"))
```

This is necessary because `datetime` will not parse strings with any year before year zero.



