### PR TITLE
Let target `roundtrip-entities` fail fast when an attribute value is a `datetime`

### DIFF
--- a/cedar-drt/fuzz/fuzz_targets/roundtrip-entities.rs
+++ b/cedar-drt/fuzz/fuzz_targets/roundtrip-entities.rs
@@ -97,7 +97,9 @@ fuzz_target!(|input: FuzzTargetInput| {
             // 1, which involves calls to `datetime` and `offset`.
             return;
         }
-        _ => panic!("Should be able to serialize entities to JSON"),
+        Err(err) => {
+            panic!("Should be able to serialize entities to JSON, instead got error: {err}")
+        }
     };
 
     let eparser: EntityJsonParser<'_, '_, NoEntitiesSchema> = EntityJsonParser::new(

--- a/cedar-drt/fuzz/fuzz_targets/roundtrip-entities.rs
+++ b/cedar-drt/fuzz/fuzz_targets/roundtrip-entities.rs
@@ -92,8 +92,8 @@ fuzz_target!(|input: FuzzTargetInput| {
         Err(EntitiesError::Serialization(JsonSerializationError::ExtnCall2OrMoreArguments(
             err,
         ))) if err.to_string().contains("offset") => {
-	    // Serializing to JSON is expected to fail when there's a record
-	    // attribute of type `datetime`, which involves calls to `offset`.
+            // Serializing to JSON is expected to fail when there's a record
+            // attribute of type `datetime`, which involves calls to `offset`.
             // This is because years before AD 1 cannot be constructed using the
             // `datetime` function, of which the valid inputs span from AD 1 to
             // year 9999.

--- a/cedar-drt/fuzz/fuzz_targets/roundtrip-entities.rs
+++ b/cedar-drt/fuzz/fuzz_targets/roundtrip-entities.rs
@@ -89,6 +89,14 @@ fuzz_target!(|input: FuzzTargetInput| {
             // attribute `__entity`, `__expr`, or `__extn`
             return;
         }
+        Err(EntitiesError::Serialization(JsonSerializationError::ExtnCall2OrMoreArguments(
+            err,
+        ))) if err.to_string().contains("offset") => {
+            // Serializing to JSON is expected to fail when there's a record
+            // attribute of type `datetime` and it represents a time before AD
+            // 1, which involves calls to `datetime` and `offset`.
+            return;
+        }
         _ => panic!("Should be able to serialize entities to JSON"),
     };
 

--- a/cedar-drt/fuzz/fuzz_targets/roundtrip-entities.rs
+++ b/cedar-drt/fuzz/fuzz_targets/roundtrip-entities.rs
@@ -92,9 +92,11 @@ fuzz_target!(|input: FuzzTargetInput| {
         Err(EntitiesError::Serialization(JsonSerializationError::ExtnCall2OrMoreArguments(
             err,
         ))) if err.to_string().contains("offset") => {
-            // Serializing to JSON is expected to fail when there's a record
-            // attribute of type `datetime` and it represents a time before AD
-            // 1, which involves calls to `datetime` and `offset`.
+	    // Serializing to JSON is expected to fail when there's a record
+	    // attribute of type `datetime`, which involves calls to `offset`.
+            // This is because years before AD 1 cannot be constructed using the
+            // `datetime` function, of which the valid inputs span from AD 1 to
+            // year 9999.
             return;
         }
         Err(err) => {

--- a/cedar-policy-generators/src/expr.rs
+++ b/cedar-policy-generators/src/expr.rs
@@ -1191,7 +1191,7 @@ impl<'a> ExprGenerator<'a> {
                         self.arbitrary_ext_constructor_call_for_type(
                             target_type,
                             ast::Expr::val,
-                            |fn_name, arg| ast::Expr::call_extension_fn(fn_name, vec![arg]),
+                            ast::Expr::call_extension_fn,
                             u,
                         )
                     } else {
@@ -1853,7 +1853,7 @@ impl<'a> ExprGenerator<'a> {
         &self,
         target_type: &Type,
         mk_str: fn(SmolStr) -> E,
-        mk_ext: fn(ast::Name, E) -> E,
+        mk_ext: fn(ast::Name, Vec<E>) -> E,
         u: &mut Unstructured<'_>,
     ) -> Result<E> {
         let func = self
@@ -1866,20 +1866,36 @@ impl<'a> ExprGenerator<'a> {
             func_name = func.name
         );
         let name_as_ref = func.name.basename_as_ref().as_ref();
-        let arg = match name_as_ref {
-            "ip" => mk_str(self.constant_pool.arbitrary_ip_str(u)?),
-            "decimal" => mk_str(self.constant_pool.arbitrary_decimal_str(u)?),
-            "datetime" => mk_str(self.constant_pool.arbitrary_datetime_str(u)?),
-            "duration" => mk_str(self.constant_pool.arbitrary_duration_str(u)?),
+        let args = match name_as_ref {
+            "ip" => vec![mk_str(self.constant_pool.arbitrary_ip_str(u)?)],
+            "decimal" => vec![mk_str(self.constant_pool.arbitrary_decimal_str(u)?)],
+            "datetime" => vec![mk_str(self.constant_pool.arbitrary_datetime_str(u)?)],
+            "offset" => {
+                let base_datetime_str = self.constant_pool.arbitrary_datetime_str(u)?;
+                let offset_duration_str = self.constant_pool.arbitrary_duration_str(u)?;
+                vec![
+                    mk_ext(
+                        ast::Name::parse_unqualified_name("datetime")
+                            .expect("should be a valid identifier"),
+                        vec![mk_str(base_datetime_str)],
+                    ),
+                    mk_ext(
+                        ast::Name::parse_unqualified_name("duration")
+                            .expect("should be a valid identifier"),
+                        vec![mk_str(offset_duration_str)],
+                    ),
+                ]
+            }
+            "duration" => vec![mk_str(self.constant_pool.arbitrary_duration_str(u)?)],
             _ => unreachable!("unhandled extension constructor {name_as_ref}"),
         };
         assert_eq!(
-            1,
+            args.len(),
             func.parameter_types.len(),
             "Generated wrong number of args for {name_as_ref} extension constructor"
         );
 
-        Ok(mk_ext(func.name.clone(), arg))
+        Ok(mk_ext(func.name.clone(), args))
     }
 
     /// get an AttrValue of the given type which conforms to this schema
@@ -1925,10 +1941,7 @@ impl<'a> ExprGenerator<'a> {
                 self.arbitrary_ext_constructor_call_for_type(
                     target_type,
                     AttrValue::StringLit,
-                    |fn_name, arg| AttrValue::ExtFuncCall {
-                        fn_name,
-                        args: vec![arg],
-                    },
+                    |fn_name, args| AttrValue::ExtFuncCall { fn_name, args },
                     u,
                 )
             }


### PR DESCRIPTION


*Issue #, if available:*

*Description of changes:*


