### PR TITLE
remove remaining references to Unspecified entities in cedar-policy-generators

### DIFF
--- a/cedar-drt/fuzz/fuzz_targets/abac-type-directed.rs
+++ b/cedar-drt/fuzz/fuzz_targets/abac-type-directed.rs
@@ -58,7 +58,6 @@ const SETTINGS: ABACSettings = ABACSettings {
     enable_arbitrary_func_call: true,
     enable_unknowns: false,
     enable_action_in_constraints: true,
-    enable_unspecified_apply_spec: true,
 };
 
 impl<'a> Arbitrary<'a> for FuzzTargetInput {

--- a/cedar-drt/fuzz/fuzz_targets/abac.rs
+++ b/cedar-drt/fuzz/fuzz_targets/abac.rs
@@ -60,7 +60,6 @@ const SETTINGS: ABACSettings = ABACSettings {
     enable_arbitrary_func_call: true,
     enable_unknowns: false,
     enable_action_in_constraints: true,
-    enable_unspecified_apply_spec: true,
 };
 
 impl<'a> Arbitrary<'a> for FuzzTargetInput {

--- a/cedar-drt/fuzz/fuzz_targets/common-type-resolution.rs
+++ b/cedar-drt/fuzz/fuzz_targets/common-type-resolution.rs
@@ -47,7 +47,6 @@ const SETTINGS: ABACSettings = ABACSettings {
     enable_arbitrary_func_call: true,
     enable_unknowns: false,
     enable_action_in_constraints: true,
-    enable_unspecified_apply_spec: true,
 };
 
 impl<'a> Arbitrary<'a> for Input {

--- a/cedar-drt/fuzz/fuzz_targets/entity-slicing-drt-type-directed.rs
+++ b/cedar-drt/fuzz/fuzz_targets/entity-slicing-drt-type-directed.rs
@@ -59,7 +59,6 @@ const SETTINGS: ABACSettings = ABACSettings {
     enable_arbitrary_func_call: true,
     enable_unknowns: false,
     enable_action_in_constraints: true,
-    enable_unspecified_apply_spec: true,
 };
 
 impl<'a> Arbitrary<'a> for FuzzTargetInput {

--- a/cedar-drt/fuzz/fuzz_targets/entity-validation.rs
+++ b/cedar-drt/fuzz/fuzz_targets/entity-validation.rs
@@ -45,7 +45,6 @@ const SETTINGS: ABACSettings = ABACSettings {
     enable_arbitrary_func_call: true,
     enable_unknowns: false,
     enable_action_in_constraints: true,
-    enable_unspecified_apply_spec: true,
 };
 
 impl<'a> Arbitrary<'a> for FuzzTargetInput {

--- a/cedar-drt/fuzz/fuzz_targets/eval-type-directed.rs
+++ b/cedar-drt/fuzz/fuzz_targets/eval-type-directed.rs
@@ -54,7 +54,6 @@ const SETTINGS: ABACSettings = ABACSettings {
     enable_arbitrary_func_call: true,
     enable_unknowns: false,
     enable_action_in_constraints: true,
-    enable_unspecified_apply_spec: true,
 };
 
 impl<'a> Arbitrary<'a> for FuzzTargetInput {

--- a/cedar-drt/fuzz/fuzz_targets/formatter.rs
+++ b/cedar-drt/fuzz/fuzz_targets/formatter.rs
@@ -57,7 +57,6 @@ const SETTINGS: ABACSettings = ABACSettings {
     enable_arbitrary_func_call: false,
     enable_unknowns: false,
     enable_action_in_constraints: true,
-    enable_unspecified_apply_spec: true,
 };
 
 impl<'a> Arbitrary<'a> for FuzzTargetInput {

--- a/cedar-drt/fuzz/fuzz_targets/json-schema-roundtrip.rs
+++ b/cedar-drt/fuzz/fuzz_targets/json-schema-roundtrip.rs
@@ -45,7 +45,6 @@ const SETTINGS: ABACSettings = ABACSettings {
     enable_arbitrary_func_call: true,
     enable_unknowns: false,
     enable_action_in_constraints: true,
-    enable_unspecified_apply_spec: true,
 };
 
 impl<'a> Arbitrary<'a> for Input {

--- a/cedar-drt/fuzz/fuzz_targets/level-validation-drt.rs
+++ b/cedar-drt/fuzz/fuzz_targets/level-validation-drt.rs
@@ -47,7 +47,6 @@ const SETTINGS: ABACSettings = ABACSettings {
     enable_arbitrary_func_call: true,
     enable_unknowns: false,
     enable_action_in_constraints: true,
-    enable_unspecified_apply_spec: true,
 };
 
 impl<'a> Arbitrary<'a> for FuzzTargetInput {

--- a/cedar-drt/fuzz/fuzz_targets/policy-set-roundtrip.rs
+++ b/cedar-drt/fuzz/fuzz_targets/policy-set-roundtrip.rs
@@ -44,7 +44,6 @@ const SETTINGS: ABACSettings = ABACSettings {
     enable_arbitrary_func_call: false,
     enable_unknowns: false,
     enable_action_in_constraints: true,
-    enable_unspecified_apply_spec: true,
 };
 
 impl<'a> Arbitrary<'a> for FuzzTargetInput {

--- a/cedar-drt/fuzz/fuzz_targets/protobuf-roundtrip.rs
+++ b/cedar-drt/fuzz/fuzz_targets/protobuf-roundtrip.rs
@@ -54,7 +54,6 @@ const SETTINGS: ABACSettings = ABACSettings {
     enable_arbitrary_func_call: false,
     enable_unknowns: false,
     enable_action_in_constraints: true,
-    enable_unspecified_apply_spec: true,
 };
 
 impl<'a> Arbitrary<'a> for FuzzTargetInput {

--- a/cedar-drt/fuzz/fuzz_targets/request-validation.rs
+++ b/cedar-drt/fuzz/fuzz_targets/request-validation.rs
@@ -49,7 +49,6 @@ const SETTINGS: ABACSettings = ABACSettings {
     enable_arbitrary_func_call: true,
     enable_unknowns: false,
     enable_action_in_constraints: true,
-    enable_unspecified_apply_spec: true,
 };
 
 impl<'a> Arbitrary<'a> for FuzzTargetInput {

--- a/cedar-drt/fuzz/fuzz_targets/roundtrip-entities.rs
+++ b/cedar-drt/fuzz/fuzz_targets/roundtrip-entities.rs
@@ -52,7 +52,6 @@ const SETTINGS: ABACSettings = ABACSettings {
     enable_arbitrary_func_call: true,
     enable_unknowns: false,
     enable_action_in_constraints: true,
-    enable_unspecified_apply_spec: true,
 };
 
 impl<'a> Arbitrary<'a> for FuzzTargetInput {

--- a/cedar-drt/fuzz/fuzz_targets/roundtrip.rs
+++ b/cedar-drt/fuzz/fuzz_targets/roundtrip.rs
@@ -48,7 +48,6 @@ const SETTINGS: ABACSettings = ABACSettings {
     enable_arbitrary_func_call: false,
     enable_unknowns: false,
     enable_action_in_constraints: true,
-    enable_unspecified_apply_spec: true,
 };
 
 impl<'a> Arbitrary<'a> for FuzzTargetInput {

--- a/cedar-drt/fuzz/fuzz_targets/schema-roundtrip.rs
+++ b/cedar-drt/fuzz/fuzz_targets/schema-roundtrip.rs
@@ -47,7 +47,6 @@ const SETTINGS: ABACSettings = ABACSettings {
     enable_arbitrary_func_call: true,
     enable_unknowns: false,
     enable_action_in_constraints: true,
-    enable_unspecified_apply_spec: true,
 };
 
 impl<'a> Arbitrary<'a> for Input {

--- a/cedar-drt/fuzz/fuzz_targets/validation-drt-type-directed.rs
+++ b/cedar-drt/fuzz/fuzz_targets/validation-drt-type-directed.rs
@@ -45,7 +45,6 @@ const SETTINGS: ABACSettings = ABACSettings {
     enable_arbitrary_func_call: true,
     enable_unknowns: false,
     enable_action_in_constraints: true,
-    enable_unspecified_apply_spec: true,
 };
 
 impl<'a> Arbitrary<'a> for FuzzTargetInput {

--- a/cedar-drt/fuzz/fuzz_targets/validation-drt.rs
+++ b/cedar-drt/fuzz/fuzz_targets/validation-drt.rs
@@ -45,7 +45,6 @@ const SETTINGS: ABACSettings = ABACSettings {
     enable_arbitrary_func_call: true,
     enable_unknowns: false,
     enable_action_in_constraints: true,
-    enable_unspecified_apply_spec: true,
 };
 
 impl<'a> Arbitrary<'a> for FuzzTargetInput {

--- a/cedar-drt/fuzz/fuzz_targets/validation-pbt-type-directed.rs
+++ b/cedar-drt/fuzz/fuzz_targets/validation-pbt-type-directed.rs
@@ -59,7 +59,6 @@ const SETTINGS: ABACSettings = ABACSettings {
     enable_arbitrary_func_call: true,
     enable_unknowns: false,
     enable_action_in_constraints: true,
-    enable_unspecified_apply_spec: true,
 };
 
 impl<'a> Arbitrary<'a> for FuzzTargetInput {

--- a/cedar-drt/fuzz/fuzz_targets/validation-pbt.rs
+++ b/cedar-drt/fuzz/fuzz_targets/validation-pbt.rs
@@ -60,7 +60,6 @@ const SETTINGS: ABACSettings = ABACSettings {
     enable_arbitrary_func_call: true,
     enable_unknowns: false,
     enable_action_in_constraints: true,
-    enable_unspecified_apply_spec: true,
 };
 
 const LOG_FILENAME_GENERATION_START: &str = "./logs/01_generation_start.txt";

--- a/cedar-policy-generators/src/expr.rs
+++ b/cedar-policy-generators/src/expr.rs
@@ -17,7 +17,7 @@
 use crate::abac::{AttrValue, AvailableExtensionFunctions, ConstantPool, Type, UnknownPool};
 use crate::collections::HashMap;
 use crate::err::{while_doing, Error, Result};
-use crate::hierarchy::{arbitrary_specified_uid, generate_uid_with_type, Hierarchy};
+use crate::hierarchy::{generate_uid_with_type, Hierarchy};
 use crate::schema::{
     attrs_from_attrs_or_context, entity_type_name_to_schema_type, lookup_common_type,
     uid_for_action_name, Schema,
@@ -1095,9 +1095,7 @@ impl<'a> ExprGenerator<'a> {
                         // UID literal, that exists
                         11 => Ok(ast::Expr::val(self.generate_uid(u)?)),
                         // UID literal, that doesn't exist
-                        2 => Ok(ast::Expr::val(
-                            arbitrary_specified_uid(u)?,
-                        )),
+                        2 => Ok(ast::Expr::val(u.arbitrary::<ast::EntityUID>()?)),
                         // `principal`
                         6 => Ok(ast::Expr::var(ast::Var::Principal)),
                         // `action`
@@ -1734,9 +1732,8 @@ impl<'a> ExprGenerator<'a> {
                 // UID literal, that exists
                 3 => Ok(ast::Expr::val(self.generate_uid(u)?)),
                 // UID literal, that doesn't exist
-                1 => Ok(ast::Expr::val(
-                    arbitrary_specified_uid(u)?,
-                )))
+                1 => Ok(ast::Expr::val(u.arbitrary::<ast::EntityUID>()?))
+                )
             }
             Type::IPAddr | Type::Decimal | Type::DateTime | Type::Duration => {
                 unimplemented!("constant expression of type ipaddr or decimal")
@@ -2469,9 +2466,8 @@ impl<'a> ExprGenerator<'a> {
             self.constant_pool.arbitrary_string_constant(u)?,
         )),
         20 => Ok(ast::Expr::val(self.generate_uid(u)?)),
-        4 => Ok(ast::Expr::val(
-            arbitrary_specified_uid(u)?,
-        )))
+        4 => Ok(ast::Expr::val(u.arbitrary::<ast::EntityUID>()?))
+        )
     }
 
     /// get a UID of a type declared in the schema -- may be a principal,

--- a/cedar-policy-generators/src/policy.rs
+++ b/cedar-policy-generators/src/policy.rs
@@ -320,7 +320,7 @@ impl PrincipalOrResourceConstraint {
                 )
             } else {
                 // 32% Eq, 16% In, 16% Is, 16% IsIn
-                let uid = hierarchy.arbitrary_uid(u, None)?;
+                let uid = hierarchy.arbitrary_uid(u)?;
                 gen!(u,
                     2 => Ok(Self::Eq(uid)),
                     1 => Ok(Self::In(uid)),
@@ -417,13 +417,13 @@ impl ActionConstraint {
         if u.ratio(1, 10)? {
             Ok(Self::NoConstraint)
         } else if u.ratio(1, 3)? {
-            Ok(Self::Eq(hierarchy.arbitrary_uid(u, None)?))
+            Ok(Self::Eq(hierarchy.arbitrary_uid(u)?))
         } else if u.ratio(1, 2)? {
-            Ok(Self::In(hierarchy.arbitrary_uid(u, None)?))
+            Ok(Self::In(hierarchy.arbitrary_uid(u)?))
         } else {
             let mut uids = vec![];
             u.arbitrary_loop(Some(0), max_list_length, |u| {
-                uids.push(hierarchy.arbitrary_uid(u, None)?);
+                uids.push(hierarchy.arbitrary_uid(u)?);
                 Ok(std::ops::ControlFlow::Continue(()))
             })?;
             Ok(Self::InList(uids))
@@ -478,7 +478,7 @@ impl GeneratedLinkedPolicy {
         u: &mut Unstructured<'_>,
     ) -> Result<Option<EntityUID>> {
         if prc.has_slot() {
-            Ok(Some(hierarchy.arbitrary_uid(u, None)?))
+            Ok(Some(hierarchy.arbitrary_uid(u)?))
         } else {
             Ok(None)
         }

--- a/cedar-policy-generators/src/request.rs
+++ b/cedar-policy-generators/src/request.rs
@@ -44,9 +44,9 @@ impl Request {
         u: &mut Unstructured<'_>,
     ) -> arbitrary::Result<Self> {
         Ok(Self {
-            principal: hierarchy.arbitrary_uid(u, Some(ast::Var::Principal))?,
-            action: hierarchy.arbitrary_uid(u, Some(ast::Var::Action))?,
-            resource: hierarchy.arbitrary_uid(u, Some(ast::Var::Resource))?,
+            principal: hierarchy.arbitrary_uid(u)?,
+            action: hierarchy.arbitrary_uid(u)?,
+            resource: hierarchy.arbitrary_uid(u)?,
             context: ast::Context::from_pairs(context, Extensions::all_available())
                 .map_err(Error::ContextError)?,
         })

--- a/cedar-policy-generators/src/schema.rs
+++ b/cedar-policy-generators/src/schema.rs
@@ -1977,7 +1977,6 @@ mod tests {
         enable_action_groups_and_attrs: true,
         enable_arbitrary_func_call: false,
         enable_unknowns: false,
-        enable_unspecified_apply_spec: true,
         enable_action_in_constraints: true,
     };
 

--- a/cedar-policy-generators/src/settings.rs
+++ b/cedar-policy-generators/src/settings.rs
@@ -83,10 +83,6 @@ pub struct ABACSettings {
     /// Flag to enable/disable generating unknowns, exercising partial evaluation
     pub enable_unknowns: bool,
 
-    /// Flag to enable/disable unspecified entities where actions can apply
-    /// Enabling it causes `ActionType::applies_to` to match `Some(ApplySpec {resource_types: Some(_), principal_types: Some(_), context: _})`
-    pub enable_unspecified_apply_spec: bool,
-
     /// Flag to enable/disable action constraints in forms of `in` operations
     pub enable_action_in_constraints: bool,
 }


### PR DESCRIPTION
There were still some comments and code paths related to Unspecified entities, which were removed in Cedar 4.0.


