### PR TITLE
avoiding generating invalid EIDs for enum entity types

### DIFF
--- a/cedar-policy-generators/src/expr.rs
+++ b/cedar-policy-generators/src/expr.rs
@@ -2553,7 +2553,7 @@ impl<'a> ExprGenerator<'a> {
     ) -> Result<ast::EntityUID> {
         match self.hierarchy {
             None => generate_uid_with_type(ty.clone(), &self.schema.get_uid_choices(ty), u),
-            Some(hierarchy) => hierarchy.arbitrary_uid_with_type(ty, u),
+            Some(hierarchy) => hierarchy.arbitrary_uid_with_type(Some(self.schema), ty, u),
         }
     }
     /// size hint for arbitrary_uid_with_type()


### PR DESCRIPTION
*Issue #, if available:*

Makes #1550 unnecessary, I hope.

*Description of changes:*

Avoids generating invalid EIDs for enum entity types.
1) When generating a new `Hierarchy`, when generating a new EID of an enum entity type, removed the 20% coinflip to generate an invalid EID.  Now always generates a valid EID if the entity type is an enum entity type.
2) For `arbitrary_uid_with_type()` (which is used for generating the principal/resource for requests), now takes a `schema` so it can determine if the requested type is an enum entity type, and reuses the above method. Preserves the previous behavior of (with some probability) generating a UID that doesn't exist in the hierarchy, but will no longer generate one that is invalid based on a schema enum-entity declaration.


