### PR TITLE
fix bug in protobuf parsing

### DIFF
--- a/cedar-lean/CedarProto/Expr.lean
+++ b/cedar-lean/CedarProto/Expr.lean
@@ -507,6 +507,11 @@ def mergeName (result : ExprKind.ExtensionFunctionApp) (xfn : Spec.Name) : BPars
     | "durationSince" => ret .durationSince
     | "toDate" => ret .toDate
     | "toTime" => ret .toTime
+    | "toMilliseconds" => ret .toMilliseconds
+    | "toSeconds" => ret .toSeconds
+    | "toMinutes" => ret .toMinutes
+    | "toHours" => ret .toHours
+    | "toDays" => ret .toDays
     | xfn => throw s!"mergeName: unknown extension function {xfn}"
   | _ => throw "Expected ExprKind.ExtensionFunctionApp to have constructor .call"
 


### PR DESCRIPTION
*Issue #, if available:*

Found by corpus tests in https://github.com/cedar-policy/cedar-integration-tests/pull/16

*Description of changes:*

Fixes Lean protobuf parser to handle policies (expressions) containing any of these 5 additional `duration` extension functions

