### PR TITLE
Lean: Upgrade to v4.18

### DIFF
--- a/cedar-lean/Cedar/Data/Int64.lean
+++ b/cedar-lean/Cedar/Data/Int64.lean
@@ -52,8 +52,8 @@ theorem ext_iff {i₁ i₂ : Int64} : i₁ = i₂ ↔ i₁.toInt = i₂.toInt :=
   constructor <;> intro h₁
   · simp only [h₁]
   · cases i₁ ; cases i₂ ; rename_i i₁ i₂
-    simp [UInt64.toInt64]
-    simp only [toInt, BitVec.toInt_inj, Int64.toBitVec, UInt64.toBitVec_inj] at h₁
+    apply Int64.toBitVec.inj
+    simp only [toInt, BitVec.toInt_inj] at h₁
     exact h₁
 
 theorem lt_def_toInt {i₁ i₂ : Int64} : i₁ < i₂ ↔ i₁.toInt < i₂.toInt := by

--- a/cedar-lean/Cedar/Data/Int64.lean
+++ b/cedar-lean/Cedar/Data/Int64.lean
@@ -52,27 +52,27 @@ theorem ext_iff {i₁ i₂ : Int64} : i₁ = i₂ ↔ i₁.toInt = i₂.toInt :=
   constructor <;> intro h₁
   · simp only [h₁]
   · cases i₁ ; cases i₂ ; rename_i i₁ i₂
-    simp only [mk.injEq]
+    simp [UInt64.toInt64]
     simp only [toInt, BitVec.toInt_inj, Int64.toBitVec, UInt64.toBitVec_inj] at h₁
     exact h₁
 
-theorem lt_def {i₁ i₂ : Int64} : i₁ < i₂ ↔ i₁.toInt < i₂.toInt := by
+theorem lt_def_toInt {i₁ i₂ : Int64} : i₁ < i₂ ↔ i₁.toInt < i₂.toInt := by
   simp [LT.lt, Int64.lt, BitVec.slt, Int64.toInt]
 
-theorem le_def {i₁ i₂ : Int64} : i₁ ≤ i₂ ↔ i₁.toInt ≤ i₂.toInt := by
+theorem le_def_toInt {i₁ i₂ : Int64} : i₁ ≤ i₂ ↔ i₁.toInt ≤ i₂.toInt := by
   simp [LE.le, Int64.le, BitVec.sle, Int64.toInt]
 
 deriving instance Repr for Int64
 
 instance strictLT : Cedar.Data.StrictLT Int64 where
   asymmetric a b   := by
-    simp [Int64.lt_def]
+    simp [Int64.lt_def_toInt]
     omega
   transitive a b c := by
-    simp [Int64.lt_def]
+    simp [Int64.lt_def_toInt]
     omega
   connected  a b   := by
-    simp [Int64.lt_def, Int64.ext_iff]
+    simp [Int64.lt_def_toInt, Int64.ext_iff]
     omega
 
 instance : Coe Int64 Int where

--- a/cedar-lean/Cedar/Data/LT.lean
+++ b/cedar-lean/Cedar/Data/LT.lean
@@ -213,7 +213,7 @@ instance UInt32.strictLT : StrictLT UInt32 where
   transitive a b c := by apply Nat.strictLT.transitive
   connected  a b   := by
     simp only [ne_eq, UInt32.ext_iff, LT.lt, Nat.lt,
-      toNat_toBitVec_eq_toNat, Nat.succ_eq_add_one, Nat.le_eq]
+      toNat_toBitVec, Nat.succ_eq_add_one, Nat.le_eq]
     apply StrictLT.connected
 
 instance Char.strictLT : StrictLT Char where

--- a/cedar-lean/UnitTest.lean
+++ b/cedar-lean/UnitTest.lean
@@ -15,8 +15,8 @@
 -/
 
 import UnitTest.CedarProto
-import UnitTest.Decimal
 import UnitTest.Datetime
+import UnitTest.Decimal
 import UnitTest.IPAddr
 import UnitTest.Levels
 import UnitTest.Main

--- a/cedar-lean/UnitTest.lean
+++ b/cedar-lean/UnitTest.lean
@@ -16,6 +16,7 @@
 
 import UnitTest.CedarProto
 import UnitTest.Decimal
+import UnitTest.Datetime
 import UnitTest.IPAddr
 import UnitTest.Levels
 import UnitTest.Main

--- a/cedar-lean/lakefile.lean
+++ b/cedar-lean/lakefile.lean
@@ -18,9 +18,9 @@ import Lake
 open Lake DSL
 
 meta if get_config? env = some "dev" then -- dev is so not everyone has to build it
-require "leanprover" / "doc-gen4" @ git "v4.17.0"
+require "leanprover" / "doc-gen4" @ git "v4.18.0"
 
-require "leanprover-community" / "batteries" @ git "v4.17.0"
+require "leanprover-community" / "batteries" @ git "v4.18.0"
 
 package Cedar
 

--- a/cedar-lean/lean-toolchain
+++ b/cedar-lean/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:v4.17.0
+leanprover/lean4:v4.18.0


### PR DESCRIPTION
*Description of changes:* Upgrades the Lean version to 4.18, which causes the following failures:
 
```
⚠ [24/222] Replayed Cedar.Data.LT
warning: ././././Cedar/Data/LT.lean:216:6: `UInt32.toNat_toBitVec_eq_toNat` has been deprecated: use `UInt32.toNat_toBitVec` instead
✖ [84/222] Building Cedar.Data.Int64
trace: .> LEAN_PATH=././.lake/packages/batteries/.lake/build/lib/lean:././.lake/build/lib/lean /home/accorell/.elan/toolchains/leanprover--lean4---v4.18.0/bin/lean ././././Cedar/Data/Int64.lean -R ./././. -o ././.lake/build/lib/lean/Cedar/Data/Int64.olean -i ././.lake/build/lib/lean/Cedar/Data/Int64.ilean -c ././.lake/build/ir/Cedar/Data/Int64.c --json
warning: ././././Cedar/Data/Int64.lean:55:15: `Int64.mk` has been deprecated: use `UInt64.toInt64` instead
error: ././././Cedar/Data/Int64.lean:55:15: unknown constant 'Int64.mk.injEq'
error: ././././Cedar/Data/Int64.lean:55:4: simp made no progress
error: ././././Cedar/Data/Int64.lean:59:8: 'Int64.lt_def' has already been declared
error: ././././Cedar/Data/Int64.lean:62:8: 'Int64.le_def' has already been declared
error: ././././Cedar/Data/Int64.lean:70:4: omega could not prove the goal:
No usable constraints found. You may need to unfold definitions so `omega` can see linear arithmetic facts about `Nat` and `Int`, which may also involve multiplication, division, and modular remainder by constants.
error: ././././Cedar/Data/Int64.lean:73:4: omega could not prove the goal:
No usable constraints found. You may need to unfold definitions so `omega` can see linear arithmetic facts about `Nat` and `Int`, which may also involve multiplication, division, and modular remainder by constants.
error: ././././Cedar/Data/Int64.lean:76:4: omega could not prove the goal:
a possible counterexample may satisfy the constraints
  c - d ≥ 1
where
 c := b.toInt
 d := a.toInt
error: Lean exited with code 1
Some required builds logged failures:
- Cedar.Data.Int64
error: build failed
```

Some comments to make it easier to review:
* The `lt_def` and `le_def` declared in Lean 4 are defined in terms of `toBitVec` and not `toInt`, so I renamed them to `lt_def_toInt` and `le_def_toInt`.
* The `mk.injEq` theorem for `Int64` is now private, but `apply Int64.toBitVec.inj` makes `ext_iff` even simpler.
* I noticed `UnitTest.Datetime` from the UnitTests.lean file, so I added it.


