### PR TITLE
Cherry-picks (#597): Set Rust toolchain to 1.85 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM amazonlinux:2 AS prepare
 RUN yum update -y \
   && yum install -y \
   curl clang tar zip unzip python3 git xz \
-  make wget gcc gcc-c++ \
+  make wget \
   && yum clean all
 
 # Setup Rust toolchain
@@ -28,7 +28,7 @@ COPY . $CEDAR_SPEC_ROOT
 
 # Clone `cedar` repository
 WORKDIR $CEDAR_SPEC_ROOT
-RUN git clone --depth 1 https://github.com/cedar-policy/cedar
+RUN git clone --depth 1 -b release/4.3.x https://github.com/cedar-policy/cedar
 
 # Build the Lean formalization and extract to static C libraries
 WORKDIR $CEDAR_SPEC_ROOT/cedar-lean

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM amazonlinux:2 AS prepare
 RUN yum update -y \
   && yum install -y \
   curl clang tar zip unzip python3 git xz \
-  make wget \
+  make wget gcc gcc-c++ \
   && yum clean all
 
 # Setup Rust toolchain

--- a/cedar-drt/fuzz/rust-toolchain.toml
+++ b/cedar-drt/fuzz/rust-toolchain.toml
@@ -1,0 +1,4 @@
+# We pin this crate to Rust 1.85 to avoid linking failures.
+# More details in https://github.com/cedar-policy/cedar/issues/1564
+[toolchain]
+channel = "1.85"

--- a/cedar-drt/rust-toolchain.toml
+++ b/cedar-drt/rust-toolchain.toml
@@ -1,0 +1,4 @@
+# We pin this crate to Rust 1.85 to avoid linking failures.
+# More details in https://github.com/cedar-policy/cedar/issues/1564
+[toolchain]
+channel = "1.85"


### PR DESCRIPTION
Set's Rust toolchain to 1.85 to avoid an apparent linker issue introduced in Rust 1.86.

