### PR TITLE
Updates lean_sys to version 0.0.8 to fix linker errors when using rust 1.86

### DIFF
--- a/cedar-drt/Cargo.toml
+++ b/cedar-drt/Cargo.toml
@@ -12,7 +12,7 @@ cedar-policy-core = { path = "../cedar/cedar-policy-core", version = "4.*", feat
 cedar-policy-validator = { path = "../cedar/cedar-policy-validator", version = "4.*", features = ["arbitrary", "level-validate"] }
 cedar-policy-formatter = { path = "../cedar/cedar-policy-formatter", version = "4.*" }
 cedar-testing = { path = "../cedar/cedar-testing", version = "4.*", features = ["level-validate"] }
-lean-sys = { version = "0.0.7", features = ["small_allocator"], default-features = false }
+lean-sys = { version = "0.0.8", features = ["small_allocator"], default-features = false }
 miette = "7.1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/cedar-drt/fuzz/rust-toolchain.toml
+++ b/cedar-drt/fuzz/rust-toolchain.toml
@@ -1,4 +1,0 @@
-# We pin this crate to Rust 1.85 to avoid linking failures.
-# More details in https://github.com/cedar-policy/cedar/issues/1564
-[toolchain]
-channel = "1.85"

--- a/cedar-drt/rust-toolchain.toml
+++ b/cedar-drt/rust-toolchain.toml
@@ -1,4 +1,0 @@
-# We pin this crate to Rust 1.85 to avoid linking failures.
-# More details in https://github.com/cedar-policy/cedar/issues/1564
-[toolchain]
-channel = "1.85"


### PR DESCRIPTION
*Issue [#1564](https://github.com/cedar-policy/cedar/issues/1564) of [cedar](https://github.com/cedar-policy/cedar)

*Description of changes:*

Updates lean_sys (rust bindings for lean) from v0.0.7 to v0.0.8 to address linker errors in rustc 1.86.
Removes rust-toolchain files which we used to force our builds to use rust 1.85.