### PR TITLE
Cherry picks #603 to update lean_sys to version 0.0.8 to resolve linker error in rustc 1.86

### DIFF
--- a/cedar-drt/Cargo.toml
+++ b/cedar-drt/Cargo.toml
@@ -13,7 +13,7 @@ cedar-policy-core = { path = "../cedar/cedar-policy-core", version = "4.*", feat
 cedar-policy-validator = { path = "../cedar/cedar-policy-validator", version = "4.*", features = ["arbitrary", "datetime"] }
 cedar-policy-formatter = { path = "../cedar/cedar-policy-formatter", version = "4.*" }
 cedar-testing = { path = "../cedar/cedar-testing", version = "4.*" }
-lean-sys = { version = "0.0.7", features = ["small_allocator"], default-features = false }
+lean-sys = { version = "0.0.8", features = ["small_allocator"], default-features = false }
 miette = "7.1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"


### PR DESCRIPTION
Updates lean_sys (rust bindings for lean) to version 0.0.8 to resolve linker errors in rustc 1.86