### PR TITLE
chore: shake unused imports

### DIFF
--- a/cedar-lean/Cedar/Data/LT.lean
+++ b/cedar-lean/Cedar/Data/LT.lean
@@ -15,9 +15,8 @@
 -/
 
 import Init.Classical
-import Batteries.Tactic.Init
-import Batteries.Data.String
 import Batteries.Data.UInt
+import Batteries.Tactic.Init
 
 /-!
 This file contains utilities for working with strict and decidable LT relations.

--- a/cedar-lean/Cedar/Data/List.lean
+++ b/cedar-lean/Cedar/Data/List.lean
@@ -15,7 +15,6 @@
 -/
 
 import Cedar.Data.LT
-import Batteries.Data.List
 
 /-!
 This file contains utilities for working with lists that are canonical or

--- a/cedar-lean/Cedar/Data/Set.lean
+++ b/cedar-lean/Cedar/Data/Set.lean
@@ -15,8 +15,6 @@
 -/
 
 import Cedar.Data.List
-import Batteries.Data.List.Basic
-import Batteries.Data.List.Lemmas
 
 /-!
 # Canonical list-based sets

--- a/cedar-lean/Cedar/Spec/Wildcard.lean
+++ b/cedar-lean/Cedar/Spec/Wildcard.lean
@@ -14,11 +14,10 @@
  limitations under the License.
 -/
 
-import Batteries.Data.HashMap
-
+import Std.Data.HashMap
 namespace Cedar.Spec
 
-open Batteries
+open Std
 
 inductive PatElem where
   | star
@@ -57,7 +56,7 @@ def wildcardMatchIdx (text : List Char) (pattern : Pattern) (i j : Nat)
   (h₁ : i ≤ text.length)
   (h₂ : j ≤ pattern.length) : CacheM Bool
 := do
-  if let .some b := (← get).find? (i, j) then
+  if let .some b := (← get)[(i, j)]? then
     return b
   let mut r := false
   if h₃ : j = pattern.length then

--- a/cedar-lean/Cedar/Thm/Data/List/Basic.lean
+++ b/cedar-lean/Cedar/Thm/Data/List/Basic.lean
@@ -17,7 +17,6 @@
 import Cedar.Data.List
 import Cedar.Data.LT
 import Cedar.Thm.Data.Control
-import Batteries.Logic
 
 /-!
 

--- a/cedar-lean/Protobuf/String.lean
+++ b/cedar-lean/Protobuf/String.lean
@@ -18,7 +18,6 @@ import Protobuf.BParsec
 import Protobuf.Field
 import Protobuf.Structures
 import Protobuf.WireType
-import Batteries.Data.UInt
 
 /-!
 Decode UTF-8 encoded strings with ByteArray Parser Combinators

--- a/cedar-lean/Protobuf/Structure.lean
+++ b/cedar-lean/Protobuf/Structure.lean
@@ -17,7 +17,7 @@
 import Protobuf.Field
 import Protobuf.Message
 import Protobuf.Structures
-import Batteries.Data.UInt
+import Lean.Elab.Tactic.Basic
 
 open Proto
 

--- a/cedar-lean/UnitTest/Run.lean
+++ b/cedar-lean/UnitTest/Run.lean
@@ -14,7 +14,6 @@
  limitations under the License.
 -/
 
-import Batteries.Data.List
 
 /-! This file defines simple utilities for unit testing. -/
 


### PR DESCRIPTION
This PR removes unused `import` statements, or replaces them with smaller imports.