### PR TITLE
Share fuzzing code between the two validation-drt targets

### DIFF
--- a/cedar-drt/fuzz/fuzz_targets/validation-drt-type-directed.rs
+++ b/cedar-drt/fuzz/fuzz_targets/validation-drt-type-directed.rs
@@ -15,75 +15,8 @@
  */
 
 #![no_main]
-use cedar_drt::*;
-use cedar_drt_inner::*;
-use cedar_policy_core::ast;
-use cedar_policy_generators::{
-    abac::ABACPolicy, hierarchy::HierarchyGenerator, schema::Schema, settings::ABACSettings,
-};
-use libfuzzer_sys::arbitrary::{self, Arbitrary, Unstructured};
-use log::{debug, info};
-
-/// Input expected by this fuzz target
-#[derive(Debug, Clone)]
-pub struct FuzzTargetInput {
-    /// generated schema
-    pub schema: Schema,
-    /// generated policy
-    pub policy: ABACPolicy,
-}
-
-/// settings for this fuzz target
-const SETTINGS: ABACSettings = ABACSettings {
-    match_types: true,
-    enable_extensions: true,
-    max_depth: 7,
-    max_width: 7,
-    enable_additional_attributes: true,
-    enable_like: true,
-    enable_action_groups_and_attrs: true,
-    enable_arbitrary_func_call: true,
-    enable_unknowns: false,
-    enable_action_in_constraints: true,
-};
-
-impl<'a> Arbitrary<'a> for FuzzTargetInput {
-    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
-        let schema: Schema = Schema::arbitrary(SETTINGS.clone(), u)?;
-        let hierarchy = schema.arbitrary_hierarchy(u)?;
-        let policy = schema.arbitrary_policy(&hierarchy, u)?;
-        Ok(Self { schema, policy })
-    }
-
-    fn try_size_hint(
-        depth: usize,
-    ) -> arbitrary::Result<(usize, Option<usize>), arbitrary::MaxRecursionReached> {
-        Ok(arbitrary::size_hint::and_all(&[
-            Schema::arbitrary_size_hint(depth)?,
-            HierarchyGenerator::size_hint(depth),
-            Schema::arbitrary_policy_size_hint(&SETTINGS, depth),
-        ]))
-    }
-}
+use cedar_drt_inner::validation_drt;
+use libfuzzer_sys::fuzz_target;
 
 // Type-directed fuzzing of (strict) validation.
-fuzz_target!(|input: FuzzTargetInput| {
-    initialize_log();
-    let def_impl = LeanDefinitionalEngine::new();
-
-    // generate a schema
-    if let Ok(schema) = ValidatorSchema::try_from(input.schema) {
-        debug!("Schema: {:?}", schema);
-
-        // generate a policy
-        let mut policyset = ast::PolicySet::new();
-        let policy: ast::StaticPolicy = input.policy.into();
-        policyset.add_static(policy).unwrap();
-        debug!("Policies: {policyset}");
-
-        // run the policy through both validators and compare the result
-        let (_, total_dur) =
-            time_function(|| run_val_test(&def_impl, schema, &policyset, ValidationMode::Strict));
-        info!("{}{}", TOTAL_MSG, total_dur.as_nanos());
-    }
-});
+fuzz_target!(|input: validation_drt::FuzzTargetInput<true>| validation_drt::fuzz_target(input));

--- a/cedar-drt/fuzz/fuzz_targets/validation-drt.rs
+++ b/cedar-drt/fuzz/fuzz_targets/validation-drt.rs
@@ -15,75 +15,8 @@
  */
 
 #![no_main]
-use cedar_drt::*;
-use cedar_drt_inner::*;
-use cedar_policy_core::ast;
-use cedar_policy_generators::{
-    abac::ABACPolicy, hierarchy::HierarchyGenerator, schema::Schema, settings::ABACSettings,
-};
-use libfuzzer_sys::arbitrary::{self, Arbitrary, Unstructured};
-use log::{debug, info};
-
-/// Input expected by this fuzz target
-#[derive(Debug, Clone)]
-pub struct FuzzTargetInput {
-    /// generated schema
-    pub schema: Schema,
-    /// generated policy
-    pub policy: ABACPolicy,
-}
-
-/// settings for this fuzz target
-const SETTINGS: ABACSettings = ABACSettings {
-    match_types: false,
-    enable_extensions: true,
-    max_depth: 7,
-    max_width: 7,
-    enable_additional_attributes: true,
-    enable_like: true,
-    enable_action_groups_and_attrs: true,
-    enable_arbitrary_func_call: true,
-    enable_unknowns: false,
-    enable_action_in_constraints: true,
-};
-
-impl<'a> Arbitrary<'a> for FuzzTargetInput {
-    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
-        let schema: Schema = Schema::arbitrary(SETTINGS.clone(), u)?;
-        let hierarchy = schema.arbitrary_hierarchy(u)?;
-        let policy = schema.arbitrary_policy(&hierarchy, u)?;
-        Ok(Self { schema, policy })
-    }
-
-    fn try_size_hint(
-        depth: usize,
-    ) -> arbitrary::Result<(usize, Option<usize>), arbitrary::MaxRecursionReached> {
-        Ok(arbitrary::size_hint::and_all(&[
-            Schema::arbitrary_size_hint(depth)?,
-            HierarchyGenerator::size_hint(depth),
-            Schema::arbitrary_policy_size_hint(&SETTINGS, depth),
-        ]))
-    }
-}
+use cedar_drt_inner::validation_drt;
+use libfuzzer_sys::fuzz_target;
 
 // Non-type-directed fuzzing of (strict) validation.
-fuzz_target!(|input: FuzzTargetInput| {
-    initialize_log();
-    let def_impl = LeanDefinitionalEngine::new();
-
-    // generate a schema
-    if let Ok(schema) = ValidatorSchema::try_from(input.schema) {
-        debug!("Schema: {:?}", schema);
-
-        // generate a policy
-        let mut policyset = ast::PolicySet::new();
-        let policy: ast::StaticPolicy = input.policy.into();
-        policyset.add_static(policy).unwrap();
-        debug!("Policies: {policyset}");
-
-        // run the policy through both validators and compare the result
-        let (_, total_dur) =
-            time_function(|| run_val_test(&def_impl, schema, &policyset, ValidationMode::Strict));
-        info!("{}{}", TOTAL_MSG, total_dur.as_nanos());
-    }
-});
+fuzz_target!(|input: validation_drt::FuzzTargetInput<true>| validation_drt::fuzz_target(input));

--- a/cedar-drt/fuzz/fuzz_targets/validation-drt.rs
+++ b/cedar-drt/fuzz/fuzz_targets/validation-drt.rs
@@ -19,4 +19,4 @@ use cedar_drt_inner::validation_drt;
 use libfuzzer_sys::fuzz_target;
 
 // Non-type-directed fuzzing of (strict) validation.
-fuzz_target!(|input: validation_drt::FuzzTargetInput<true>| validation_drt::fuzz_target(input));
+fuzz_target!(|input: validation_drt::FuzzTargetInput<false>| validation_drt::fuzz_target(input));

--- a/cedar-drt/fuzz/src/lib.rs
+++ b/cedar-drt/fuzz/src/lib.rs
@@ -24,6 +24,7 @@ pub use dump::*;
 pub use parsing_utils::*;
 pub use prt::*;
 pub mod schemas;
+pub mod validation_drt;
 
 use cedar_policy::ffi;
 use cedar_policy::PolicyId;

--- a/cedar-drt/fuzz/src/validation_drt.rs
+++ b/cedar-drt/fuzz/src/validation_drt.rs
@@ -1,0 +1,93 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use cedar_drt::{
+    ast, initialize_log, LeanDefinitionalEngine, ValidationMode, ValidatorSchema, TOTAL_MSG,
+};
+use cedar_policy_generators::{
+    abac::ABACPolicy, hierarchy::HierarchyGenerator, schema::Schema, settings::ABACSettings,
+};
+use cedar_testing::cedar_test_impl::time_function;
+use libfuzzer_sys::arbitrary::{self, Arbitrary, Unstructured};
+use log::{debug, info};
+
+use crate::run_val_test;
+
+/// Input for validation DRT fuzz targets
+#[derive(Debug, Clone)]
+pub struct FuzzTargetInput<const TYPE_DIRECTED: bool> {
+    /// generated schema
+    pub schema: Schema,
+    /// generated policy
+    pub policy: ABACPolicy,
+}
+
+impl<const TYPE_DIRECTED: bool> FuzzTargetInput<TYPE_DIRECTED> {
+    fn settings() -> ABACSettings {
+        ABACSettings {
+            match_types: TYPE_DIRECTED,
+            enable_extensions: true,
+            max_depth: 7,
+            max_width: 7,
+            enable_additional_attributes: true,
+            enable_like: true,
+            enable_action_groups_and_attrs: true,
+            enable_arbitrary_func_call: true,
+            enable_unknowns: false,
+            enable_action_in_constraints: true,
+        }
+    }
+}
+
+impl<'a, const TYPE_DIRECTED: bool> Arbitrary<'a> for FuzzTargetInput<TYPE_DIRECTED> {
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        let schema: Schema = Schema::arbitrary(Self::settings(), u)?;
+        let hierarchy = schema.arbitrary_hierarchy(u)?;
+        let policy = schema.arbitrary_policy(&hierarchy, u)?;
+        Ok(Self { schema, policy })
+    }
+
+    fn try_size_hint(
+        depth: usize,
+    ) -> arbitrary::Result<(usize, Option<usize>), arbitrary::MaxRecursionReached> {
+        Ok(arbitrary::size_hint::and_all(&[
+            Schema::arbitrary_size_hint(depth)?,
+            HierarchyGenerator::size_hint(depth),
+            Schema::arbitrary_policy_size_hint(&Self::settings(), depth),
+        ]))
+    }
+}
+
+pub fn fuzz_target<const TYPE_DIRECTED: bool>(input: FuzzTargetInput<TYPE_DIRECTED>) {
+    initialize_log();
+    let def_impl = LeanDefinitionalEngine::new();
+
+    // generate a schema
+    if let Ok(schema) = ValidatorSchema::try_from(input.schema) {
+        debug!("Schema: {:?}", schema);
+
+        // generate a policy
+        let mut policyset = ast::PolicySet::new();
+        let policy: ast::StaticPolicy = input.policy.into();
+        policyset.add_static(policy).unwrap();
+        debug!("Policies: {policyset}");
+
+        // run the policy through both validators and compare the result
+        let (_, total_dur) =
+            time_function(|| run_val_test(&def_impl, schema, &policyset, ValidationMode::Strict));
+        info!("{}{}", TOTAL_MSG, total_dur.as_nanos());
+    }
+}


### PR DESCRIPTION
We should be able to do the same with the `abac` and `validation-pbt` targets, but the fuzz target implementations there aren't exactly the same. It looks like the difference is only in logging code, but we'd want to make sure we don't lose anything important


