### PR TITLE
Move levels soundness thm for easier discovery

### DIFF
--- a/cedar-lean/Cedar/Thm/Validation/Levels.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Levels.lean
@@ -146,17 +146,3 @@ theorem typecheck_policy_at_level_with_environments_is_sound {p : Policy} {envs 
   specialize htl env he₁
   replace ⟨_, htl⟩ := htl
   exact typecheck_policy_with_level_is_sound hs hr htl
-
-theorem validate_with_level_is_sound {ps : Policies} {schema : Schema} {n : Nat} {request : Request} {entities slice : Entities}
-  (hr : validateRequest schema request = .ok ())
-  (he : validateEntities schema entities = .ok ())
-  (hs : slice = entities.sliceAtLevel request n)
-  (htl : validateWithLevel ps schema n = .ok ()) :
-  isAuthorized request entities ps = isAuthorized request slice ps
-:= by
-  have hsound : ∀ p ∈ ps, evaluate p.toExpr request entities = evaluate p.toExpr request slice := by
-    have hre := request_and_entities_validate_implies_match_schema _ _ _ hr he
-    replace htl := List.forM_ok_implies_all_ok _ _ htl
-    intro p hp
-    exact typecheck_policy_at_level_with_environments_is_sound hs hre (htl p hp)
-  exact is_authorized_congr_evaluate hsound

--- a/cedar-lean/README.md
+++ b/cedar-lean/README.md
@@ -58,6 +58,7 @@ Definitional engine ([`Cedar/Spec/`](Cedar/Spec/))
 Definitional validator ([`Cedar/Validation/`](Cedar/Validation/))
 
 * `typeOf` returns the result of type checking an expression against a schema.
+* `checkLevel` checks that an expression does an exceed the specified maximum entity entity deference level
 
 ## Verified properties
 
@@ -76,3 +77,8 @@ Sound type checking ([`Cedar/Thm/Typechecking.lean`](Cedar/Thm/Typechecking.lean
 
 * If an expression is well-typed according to the typechecker, then either evaluation returns a value of that type, or it returns an error of type
 `entityDoesNotExist`, `extensionError`, or `arithBoundsError`. All other errors are impossible.
+
+Sound level-based entity slicing ([`Cedar/Thm/Validation/Levels.lean`](Cedar/Thm/Validation/Levels.lean))
+
+* If an expression is well-typed and does not exceed a maximum entity dereference level `n`, then, for any set of entities, the result
+  of evaluating the expression with entities sliced at level `n` is the same as evaluating the expression with the original set of entities.


### PR DESCRIPTION
Move top-level soundness theorem for level validation to the same file as the main validation soundness theorem 


also adds a mention of levels into the readme

