### PR TITLE
Adds cedar-cli: a command-line-interface for using the lean formalization of Cedar.

### DIFF
--- a/cedar-cli/Cargo.toml
+++ b/cedar-cli/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "cedar-cli"
+edition = "2021"
+version = "0.1.0"
+publish = false
+
+[dependencies]
+cedar-policy = { path="../cedar/cedar-policy/", version = "=4.4.0", features = ["protobufs", "permissive-validate"] }
+clap = { version = "4.5.36", features = ["derive"] }
+lean-sys = { version = "0.0.8", default-features = false }
+serde = "1"
+serde_json = "1.0"
+thiserror = "2.0"
+prost = "0.13"
+itertools = "0.14.0"
+miette = "7.6.0"
+prettytable-rs = "0.10"
+
+[build-dependencies]
+prost-build = "0.13"
+
+[profile.release]

--- a/cedar-cli/README.md
+++ b/cedar-cli/README.md
@@ -1,0 +1,227 @@
+# Cedar CLI
+
+This directory contains a command line interface (CLI) for interacting with the Lean formalization of Cedar. This CLI uses [`Cedar`](https://github.com/cedar-policy/cedar) to parse policies, schemas, entities, and requests and then uses the Lean formalization of Cedar to perform validation, evaluation, authorization, and analysis.
+
+## Build
+
+### Prerequisites:
+
+#### Install Lean
+For more details read about Lean's version manager [elan](https://github.com/leanprover/elan).
+
+```
+curl https://elan.lean-lang.org/elan-init.sh -sSf | sh
+```
+
+#### Install cvc5 (>= v1.0.5)
+The analysis features provided by this CLI requires a local install of [cvc5](https://github.com/cvc5/cvc5) with version [1.0.5](https://github.com/cvc5/cvc5/releases/tag/cvc5-1.0.5) or greater.
+
+Once you install cvc5. Export the following Environment variable which allows this CLI to know where cvc5 is installed. Consider adding the export to your `~/.bashrc` or `~/.profile` so that the environment variable is exported to all new terminal sessions.
+
+```
+export CVC5=<PATH-TO-CVC5-EXECUTABLE>
+```
+
+#### Install Rust
+
+This CLI is written in Rust and uses Lean's foreign function interface to call the relevant parts of the Cedar lean formalization.
+
+```
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+```
+
+#### Install Protoc
+
+This CLI uses Protobuf for serializing Cedar data structures between the Rust frontend and Lean backend of this CLI.
+
+Download and install Protobuf. The code has been tested with [Protobuf v29.3](https://github.com/protocolbuffers/protobuf/releases/tag/v29.3). If you are using Linux (on x86_64 arch) and wish to install protobuf to `/usr/local/` you can use the following instructions to install protobuf. For more information see the official [Protobuf installation page](https://github.com/protocolbuffers/protobuf#protobuf-compiler-installation).
+
+```
+curl -OL https://github.com/protocolbuffers/protobuf/releases/download/v29.3/protoc-29.3-linux-x86_64.zip
+unzip protoc-29.3-linux-x86_64.zip
+cp bin/protoc /usr/local/bin/
+cp -r include/google/ /usr/local/include/
+```
+
+### Build this CLI
+
+Use the following commands to build `cedar-cli`
+
+```
+cd cedar-spec                                       # enter the cedar-spec directory of this repository
+git clone https://github.com/cedar-policy/cedar.git # Clone Cedar locally (Required for building the CLI's protobuf messages)
+
+cd cedar-cli                                        # Enter this directory
+source set_env_vars.sh                              # Updates environment variables with Lean's library location
+./build_lean_lib.sh                                 # Build the Lean model of Cedar
+cargo install --path .                              # Build and install this CLI
+```
+
+Consider adding `source set_env_vars.sh` to your `~/.bashrc` or `~/.profile` to ensure Lean's library path is automatically exported in all new terminal sessions.
+
+If you try to run `cedar-cli` and get the error `cedar-cli: error while loading shared libraries: libleanshared.so: cannot open shared object file: No such file or directory` you need to run `source set_env_vars.sh`
+
+## Usage
+
+This CLI implements 4 high-level commands `analyze`, `evaluate`, `validate`, and `symcc`:
+
+* The `analyze` command gives access to Cedar's Analyzer for analyzing either a single policyset for warnings or comparing one policyset to another.
+* The `evaluate` command gives access to Cedar's evaluation to either evaluate a Cedar expression or authorization request.
+* The `validate` command gives access to Cedar's validation to validate a policyset, entities, an authorization request, or a set of entities.
+* The `symcc` command gives access to Cedar's Symbolic Compiler---a lower level interface to Cedar's analysis capabilities.
+
+```
+> cedar-cli --help
+Command Line Interface for Cedar Lean
+
+Usage: cedar-cli <COMMAND>
+
+Commands:
+  analyze   Run the Cedar Analyzer
+  evaluate  Evaluate a Cedar PolicySet or Expression
+  validate  Validate PolicySets, Entities, or Requests against a Schema
+  symcc    Run the Cedar Symbolic Compiler
+  help      Print this message or the help of the given subcommand(s)
+
+Options:
+  -h, --help     Print help
+  -V, --version  Print version
+```
+
+### Analysis
+
+The `analyze` command provides two sub-commands `policies` and `compare`.
+
+* The `policies` command will analyze a single policyset and present a set of findings about each policy within the policyset.
+* The `compare` command takes two policysets `source` and `target` and determines for each "type" of request if the `source` policyset is equivalent, less permissive, more permissive, or incomparable to the `target` policyset (in terms of the requests allowed by each policyset).
+
+```
+> cedar-cli analyze --help
+Run the Cedar Analyzer
+
+Usage: cedar-cli analyze <COMMAND>
+
+Commands:
+  policies  Analyze a PolicySet
+  compare   Compare the source PolicySet against the target PolicySet
+  help      Print this message or the help of the given subcommand(s)
+
+Options:
+  -j, --json-output  Whether to output the compare policy sets output in .json format
+  -h, --help  Print help
+```
+
+For both sub-commands, the CLI supports both a "human readable output" (default) and a more "machine friendly" JSON format (`--json-output`).
+
+#### Analyze Policies
+
+The `analyze policies` command presents five findings: if a policy is vacuous, if a subset of policies are redundant (i.e., are equivalent to each other), if a permit policy is shadowed by another permit policy, if a permit policy is overrident by forbid policy, or if a fordid policy is shadowed by another forbid policy. We present the findings (other than vacuousness of policies) per request type.
+
+* A policy is vacous if either (1) it applies to all requests (allows all) or (2) it applies to no requests (allows none).
+* A set of policies are redundant with each other if every policy within the set are equivalent (allows the same set of authorization requests).
+* A permit policy `src` is shadowed by a permit policy `tgt` if every request allowed by `src` is allowed by `tgt` and `src` and `tgt` are not redundant.
+* A permit policy `src` is overriden by a forbid policy `tgt` if every request allowed by `src` is denied by `tgt`.
+* A forbid policy `src` is shaddowed by a forbid policy `tgt` if every request denied by `src` is denied by `tgt` and `src` and `tgt` are not redundant.
+
+#### Analyze Compare
+
+The `analyze compare` command compares a `src` policyset to a `tgt` policyset per request "type". For each type, it determines if `src` is equivalent to `tgt`, if `src` is less permissive than `tgt`, if `src` is more permissive than `tgt`, or if `src` and `tgt` are incomparable.
+
+* `src` is equivalent to `tgt`: the set of authorizations allowed by `src` and `tgt` are identical
+* `src` is less permissive than `tgt`: the set of authorization requests allowed by `src` is a strict subset of the requests allowed by `tgt`.
+* `src` is more permissive than `tgt`: the set of authorization requests allowed by `src` is a strict superset of the requests allowed by `tgt`.
+* `src` is incomparable with `tgt`: there is no relation between the sets of authorization requests allowed by `src` and `tgt`.
+
+### Symbolic Compilation
+
+The `symcc` command provides an interface to access Cedar's Symbolic Compiler. The Symbolic compiler provides a lower level interface to Cedar's analysis capabilities. The `symcc` command has six sub-commands `check-never-errors`, `check-always-allows`, `check-always-denies`, `check-equivalent`, `check-implies`, `check-disjoint`.
+
+* `check-never-errors`: Checks if a policy will never throw an error during evaluation.
+* `check-always-allows`: Checks if a policy allows all authorization requests.
+* `check-always-denies`: Checks if a policy denies all authorization requests.
+* `check-equivalent`: Compares two policy sets `source` and `target`; Checks if `source` and `target` allow the same set of authorization requests.
+* `check-implies`: Compares two policy sets `source` and `target`; Checks if every authorization request allowed by `source` is also allowed by `target`.
+* `check-disjoint`:Compares two policy sets `source` and `target`; Checks if `source` and `taget` allow disjoint sets of authorization requests.
+
+```
+> cedar-cli symcc --help
+Run the Cedar Symbolic Compiler
+
+Usage: cedar-cli symcc <COMMAND>
+
+Commands:
+  check-never-errors   Check if the provided Policy never errors
+  check-always-allows  Check if the provided PolicySet allows all authorization requests
+  check-always-denies  Check if the provided PolicySet denies all authorization requests
+  check-equivalent     Check if the source and target PolicySets are equivalent
+  check-implies        Check if the target PolicySet authorizes all requests that the source PolicySet authorizes
+  check-disjoint       Check if the source and target PolicySets are disjoint (there is no authorization request that both PolicySets allow)
+  help                 Print this message or the help of the given subcommand(s)
+
+Options:
+  -h, --help  Print help
+```
+
+For each of the six sub-commands, you may either run the analysis (`--run-analysis`) or print out an [SMT-LIB](https://smt-lib.org/) file containing the necessary checks to run the analysis (`--print-smtlib`).
+
+Additionally, for all six sub-commands you may restrict the analyses to a specific principal type, action, or resource type.
+
+```
+Execution Modes:
+      --run-analysis  Run the SMT formula produced by the provided backend encoder via CVC5 [default]
+      --print-smtlib  Print the SMT formula produced by the provided backend
+
+Request Environment Options:
+      --principal-type <PRINCIPAL_TYPE_NAME>
+          Restrict Analysis to Request Environments for the given PrincipalType
+      --action-name <ACTION_NAME>
+          Restrict Analysis to Request Environmetns for the given Action
+      --resource-type <RESOURCE_TYPE_NAME>
+          Restrict Analysis to Request Environments for the given ResourceType
+```
+
+### Evaluation
+
+The `evaluate` command provides two sub-commands `authorize` and `evaluate`.
+* The `authorize` sub-command evaluates an authorization request.
+* The `evaluate` sub-command evalutes a cedar expression (and optionally compares the evaluated expression to a cedar value).
+
+```
+> cedar-cli evaluate --help
+Evaluate a Cedar PolicySet or Expression
+
+Usage: cedar-cli evaluate <COMMAND>
+
+Commands:
+  authorize  Check if a given PolicySet allows or denies a Request
+  evaluate   Evaluate a Cedar Expression
+  help       Print this message or the help of the given subcommand(s)
+
+Options:
+  -h, --help  Print help
+```
+
+### Validation
+
+The `validate` command provides four sub-commands `policy-set`, `level`, `request`, and `entities`.
+* The `policy-set` sub-command validates a policyset against a given Schema.
+* The `level` sub-command validates a policyset against a given Schema at a desired level (maximum reference depth of field identifiers).
+* The `request` sub-command validates an authorization request against a given Schema.
+* The `entities` sub-command validates a set of entities against a given Schema.
+
+```
+> cedar-cli validate --help
+Validate PolicySets, Entities, or Requests against a Schema
+
+Usage: cedar-cli validate <COMMAND>
+
+Commands:
+  policy-set  Validate a PolicySet against a Schema
+  level       Validate a PolicySet against a Schema using level-based validation
+  request     Validate a Request against a Schema
+  entities    Validate Entities against a Schema
+  help        Print this message or the help of the given subcommand(s)
+
+Options:
+  -h, --help  Print help
+```

--- a/cedar-cli/build.rs
+++ b/cedar-cli/build.rs
@@ -1,0 +1,45 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::path::Path;
+const CEDAR_LEAN_DIR: &str = "../cedar-lean";
+const LEAN_BUILD_DIR: &str = "../cedar-lean/.lake/build/lib";
+fn main() {
+    let lean_dir = std::env::var("LEAN_LIB_DIR").expect(
+        "`LEAN_LIB_DIR` environment variable is not set! Try running `source set_env_vars.sh`",
+    );
+    // We'll need to link against some files found here later, and it's nicer to
+    // fail quickly with a helpful error message.
+    if !Path::new(LEAN_BUILD_DIR).exists() {
+        panic!("Lean build directory does not exist! Try running `( ./build_lean_lib.sh )`")
+    }
+    println!("cargo:rustc-link-search=native={LEAN_BUILD_DIR}");
+    println!("cargo:rustc-link-search=native={lean_dir}");
+    println!(
+        "cargo:rustc-link-search=native={CEDAR_LEAN_DIR}/.lake/packages/batteries/.lake/build/lib"
+    );
+    println!("cargo:rerun-if-changed={LEAN_BUILD_DIR}");
+
+    let mut config = prost_build::Config::new();
+    config.extern_path(".cedar_policy_core", "::cedar_policy::proto::models");
+    config.extern_path(".cedar_policy_validator", "::cedar_policy::proto::models");
+    config
+        .compile_protos(
+            &["./protobuf_schema/Messages.proto"],
+            &["./protobuf_schema", "../cedar/cedar-policy/protobuf_schema"],
+        )
+        .unwrap();
+}

--- a/cedar-cli/build_lean_lib.sh
+++ b/cedar-cli/build_lean_lib.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Copyright Cedar Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Build command needed for linking Lean lib with Rust code
+cd ../cedar-lean/
+lake update
+lake build Cedar:static Protobuf:static CedarProto:static Cedar.SymCC:static CedarFFI:static SymFFI:static Batteries:static

--- a/cedar-cli/protobuf_schema/Messages.proto
+++ b/cedar-cli/protobuf_schema/Messages.proto
@@ -1,0 +1,78 @@
+syntax = "proto3";
+package cedar_symcc;
+import "core.proto";
+import "validator.proto";
+
+message Policy {
+    cedar_policy_core.TemplateBody template = 1;
+    cedar_policy_core.Policy policy = 2;
+}
+
+// Authorization / Evaluation Specific Messages
+message AuthorizationRequest {
+    cedar_policy_core.Request request = 1;
+    cedar_policy_core.PolicySet policies = 2;
+    cedar_policy_core.Entities entities = 3;
+}
+
+message EvaluationRequest {
+    cedar_policy_core.Expr expr = 1;
+    cedar_policy_core.Request request = 2;
+    cedar_policy_core.Entities entities = 3;
+}
+
+message EvaluationRequestChecked {
+    cedar_policy_core.Expr expr = 1;
+    cedar_policy_core.Request request = 2;
+    cedar_policy_core.Entities entities = 3;
+    cedar_policy_core.Expr expected = 4;
+}
+
+// Validation Specific Messages
+message EntityValidationRequest {
+    cedar_policy_validator.Schema schema = 1;
+    cedar_policy_core.Entities entities = 2;
+}
+
+message RequestValidationRequest {
+    cedar_policy_validator.Schema schema = 1;
+    cedar_policy_core.Request request = 2;
+}
+
+message ValidationRequest {
+    cedar_policy_validator.Schema schema = 1;
+    cedar_policy_core.PolicySet policies = 2;
+    cedar_policy_validator.ValidationMode mode = 3;
+}
+
+message LevelValidationRequest {
+    cedar_policy_validator.Schema schema = 1;
+    cedar_policy_core.PolicySet policies = 2;
+    int32 level = 3;
+}
+
+// SymCC Specific Messages
+message RequestEnv {
+    cedar_policy_core.Name principal = 1;
+    cedar_policy_core.EntityUid action = 2;
+    cedar_policy_core.Name resource = 3;
+}
+
+message CheckPolicyRequest {
+    Policy policy = 1;
+    cedar_policy_validator.Schema schema = 2;
+    RequestEnv request = 3;
+}
+
+message CheckPolicySetRequest {
+    cedar_policy_core.PolicySet policySet = 1;
+    cedar_policy_validator.Schema schema = 2;
+    RequestEnv request = 3;
+}
+
+message ComparePolicySetsRequest {
+    cedar_policy_core.PolicySet srcPolicySet = 1;
+    cedar_policy_core.PolicySet tgtPolicySet = 2;
+    cedar_policy_validator.Schema schema = 3;
+    RequestEnv request = 4;
+}

--- a/cedar-cli/set_env_vars.sh
+++ b/cedar-cli/set_env_vars.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# Copyright Cedar Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Set environment variables for Lean
+if ! command -v lean &> /dev/null; then
+    echo "lean executable could not be found. is lean installed?"
+    return 1
+else
+    export LEAN_LIB_DIR=$(lean --print-libdir)
+    if [ -z "$LEAN_LIB_DIR" ]; then
+        echo "error: lean --print-libdir returned no output"
+        return 1
+    fi
+    export LD_LIBRARY_PATH=${LD_LIBRARY_PATH+$LD_LIBRARY_PATH:}$(lean --print-libdir)
+    export DYLD_LIBRARY_PATH=${DYLD_LIBRARY_PATH+$DYLD_LIBRARY_PATH:}$(lean --print-libdir)
+
+    # if the version of GLIBC is too old (< 2.27), then use the version of libm.so packaged with Lean
+    # Skip this check on macOS (darwin), which may not have `ldd`
+    if [[ "$OSTYPE" != "darwin"* ]]; then
+        GLIBC_VERSION=$(ldd --version | awk '/ldd/{print $NF}')
+        if awk "BEGIN {exit !($GLIBC_VERSION < 2.27)}"; then
+            export LD_PRELOAD=${LD_PRELOAD+$LD_PRELOAD:}$(lean --print-prefix)/lib/glibc/libm.so
+        fi
+    fi
+fi

--- a/cedar-cli/src/analysis.rs
+++ b/cedar-cli/src/analysis.rs
@@ -1,0 +1,785 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+use crate::lean_ffi::LeanDefinitionalEngine;
+use crate::util::{AnalyzePolicyFindingsSer, OpenRequestEnv};
+use crate::{err::ExecError, util::RequestEnvSer};
+use cedar_policy::{Effect, Policy, PolicyId, PolicySet, RequestEnv, Schema};
+use itertools::Itertools;
+use prettytable::{Attr, Cell, Row, Table};
+use serde::Serialize;
+use std::{
+    collections::{HashMap, HashSet},
+    iter::zip,
+};
+
+/// Analyze a Cedar `PolicySet` with respect to a given Cedar `Schema` and print the findings
+pub fn analyze_policyset(
+    policy_set: PolicySet,
+    schema: Schema,
+    json_output: bool,
+) -> Result<(), ExecError> {
+    let mut policy_vacuity_results = HashMap::new();
+
+    let req_envs = OpenRequestEnv::any().to_request_envs(&schema)?;
+    let policies: Vec<&Policy> = policy_set.policies().collect();
+
+    for policy in policies.iter() {
+        let pvr = vacuity_result(policy, &schema, &req_envs)?;
+        policy_vacuity_results.insert(policy.id().clone(), pvr);
+    }
+
+    // p1 |-> [envF_1, envF_2, ..., envF_n] and p2 \in envF_i then p1 and p2 are equivalent for the ith request environment
+    let mut redundant_findings: HashMap<PolicyId, Vec<HashSet<PolicyId>>> = HashMap::new();
+    // p1 |-> [envF_1, envF_2, ..., envF_n] and p2 \in envF_i then p2 shadows p1 for the ith request environment
+    let mut permit_shadowed_by_permit_findings: HashMap<PolicyId, Vec<HashSet<PolicyId>>> =
+        HashMap::new();
+    // p1 |-> [envF_1, envF_2, ..., envF_n] and p2 \in envF_i then p2 overrides p1 for the ith request environment
+    let mut permit_overriden_by_forbid_findings: HashMap<PolicyId, Vec<HashSet<PolicyId>>> =
+        HashMap::new();
+    // p1 |-> [envF_1, envF_2, ..., envF_n] and p2 \in envF_i then p2 shadows p1 for the ith request environment
+    let mut forbid_shadowed_by_forbid_findigns: HashMap<PolicyId, Vec<HashSet<PolicyId>>> =
+        HashMap::new();
+
+    let policyset_vacuity_results = policyset_vacuous(&policy_set, &schema, &req_envs, false)?;
+
+    for [src_policy, tgt_policy] in policies.iter().array_combinations() {
+        let svr = policy_vacuity_results
+            .get(src_policy.id())
+            .expect("Vacousness of source policy not precomputed");
+        let tvr = policy_vacuity_results
+            .get(tgt_policy.id())
+            .expect("Vacousness of target policy not precomputed");
+        match (src_policy.effect(), tgt_policy.effect()) {
+            (Effect::Permit, Effect::Permit) => {
+                let shadowing_results = compute_permit_shadowing_result(
+                    src_policy, svr, tgt_policy, tvr, &schema, &req_envs,
+                )?;
+                update_findings(
+                    src_policy.id(),
+                    tgt_policy.id(),
+                    &shadowing_results,
+                    &mut redundant_findings,
+                    ShadowingResult::Equivalent,
+                );
+                update_findings(
+                    tgt_policy.id(),
+                    src_policy.id(),
+                    &shadowing_results,
+                    &mut redundant_findings,
+                    ShadowingResult::Equivalent,
+                );
+                update_findings(
+                    src_policy.id(),
+                    tgt_policy.id(),
+                    &shadowing_results,
+                    &mut permit_shadowed_by_permit_findings,
+                    ShadowingResult::TgtShadowsSrc,
+                );
+                update_findings(
+                    tgt_policy.id(),
+                    src_policy.id(),
+                    &shadowing_results,
+                    &mut permit_shadowed_by_permit_findings,
+                    ShadowingResult::SrcShadowsTgt,
+                );
+            }
+            (Effect::Permit, Effect::Forbid) => {
+                let override_results = compute_forbid_overrides_shadow_result(
+                    tgt_policy,
+                    tvr,
+                    &src_policy,
+                    svr,
+                    &schema,
+                    &req_envs,
+                )?;
+                update_findings(
+                    src_policy.id(),
+                    tgt_policy.id(),
+                    &override_results,
+                    &mut permit_overriden_by_forbid_findings,
+                    OverrideResult::Overrides,
+                );
+            }
+            (Effect::Forbid, Effect::Permit) => {
+                let override_results = compute_forbid_overrides_shadow_result(
+                    src_policy,
+                    svr,
+                    &tgt_policy,
+                    tvr,
+                    &schema,
+                    &req_envs,
+                )?;
+                update_findings(
+                    tgt_policy.id(),
+                    src_policy.id(),
+                    &override_results,
+                    &mut permit_overriden_by_forbid_findings,
+                    OverrideResult::Overrides,
+                );
+            }
+            (Effect::Forbid, Effect::Forbid) => {
+                let shadowing_results = compute_forbid_shadowing_result(
+                    src_policy, svr, tgt_policy, tvr, &schema, &req_envs,
+                )?;
+                update_findings(
+                    src_policy.id(),
+                    tgt_policy.id(),
+                    &shadowing_results,
+                    &mut redundant_findings,
+                    ShadowingResult::Equivalent,
+                );
+                update_findings(
+                    tgt_policy.id(),
+                    src_policy.id(),
+                    &shadowing_results,
+                    &mut redundant_findings,
+                    ShadowingResult::Equivalent,
+                );
+                update_findings(
+                    src_policy.id(),
+                    tgt_policy.id(),
+                    &shadowing_results,
+                    &mut forbid_shadowed_by_forbid_findigns,
+                    ShadowingResult::TgtShadowsSrc,
+                );
+                update_findings(
+                    tgt_policy.id(),
+                    src_policy.id(),
+                    &shadowing_results,
+                    &mut forbid_shadowed_by_forbid_findigns,
+                    ShadowingResult::SrcShadowsTgt,
+                );
+            }
+        }
+    }
+    let findings = AnalyzePolicyFindings::new(
+        req_envs,
+        policyset_vacuity_results,
+        policy_vacuity_results,
+        redundant_findings,
+        permit_shadowed_by_permit_findings,
+        permit_overriden_by_forbid_findings,
+        forbid_shadowed_by_forbid_findigns,
+    );
+    if json_output {
+        findings.print_json(&policy_set);
+    } else {
+        findings.print_table();
+    }
+    Ok(())
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct PerSigFindings {
+    pub(crate) req_env: RequestEnvSer,
+    pub(crate) equiv_classes: Vec<HashSet<PolicyId>>,
+    pub(crate) permit_shadowed_by_permits: HashMap<PolicyId, HashSet<PolicyId>>,
+    pub(crate) forbid_shadowed_by_forbids: HashMap<PolicyId, HashSet<PolicyId>>,
+    pub(crate) permit_overriden_by_forbids: HashMap<PolicyId, HashSet<PolicyId>>,
+}
+
+impl PerSigFindings {
+    pub(crate) fn new(
+        req_env: RequestEnv,
+        mut equiv_results: HashMap<PolicyId, HashSet<PolicyId>>,
+        permit_shadowed_by_permits: HashMap<PolicyId, HashSet<PolicyId>>,
+        forbid_shadowed_by_forbids: HashMap<PolicyId, HashSet<PolicyId>>,
+        permit_overriden_by_forbids: HashMap<PolicyId, HashSet<PolicyId>>,
+    ) -> Self {
+        let mut equiv_classes = Vec::new();
+        while !equiv_results.is_empty() {
+            // Take first (pid, redundants) from equiv_results
+            let (pid, redundants) = equiv_results
+                .iter()
+                .next()
+                .expect("(K,V) must exist because HashMap is not empty");
+
+            let mut equiv_class = redundants.clone();
+            equiv_class.insert(pid.clone());
+
+            for pid in equiv_class.iter() {
+                equiv_results.remove(pid);
+            }
+
+            if equiv_class.len() >= 2 {
+                equiv_classes.push(equiv_class);
+            }
+        }
+
+        Self {
+            req_env: RequestEnvSer::new(&req_env),
+            equiv_classes,
+            permit_shadowed_by_permits,
+            forbid_shadowed_by_forbids,
+            permit_overriden_by_forbids,
+        }
+    }
+
+    pub fn nfindings(&self) -> usize {
+        let mut ret = self.equiv_classes.len();
+        for (_, s) in self.permit_shadowed_by_permits.iter() {
+            ret += s.len();
+        }
+        for (_, s) in self.permit_overriden_by_forbids.iter() {
+            ret += s.len();
+        }
+        for (_, s) in self.forbid_shadowed_by_forbids.iter() {
+            ret += s.len();
+        }
+        ret
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct AnalyzePolicyFindings {
+    pub(crate) vacuous_result: VacuityResult,
+    pub(crate) vacuous_policies: HashMap<PolicyId, VacuityResult>,
+    pub(crate) per_sig_findings: Vec<PerSigFindings>,
+}
+
+impl AnalyzePolicyFindings {
+    pub(crate) fn new(
+        req_envs: Vec<RequestEnv>,
+        vacuous_results: Vec<VacuityResult>,
+        policy_vacuity_results: HashMap<PolicyId, Vec<VacuityResult>>,
+        redundant_findings: HashMap<PolicyId, Vec<HashSet<PolicyId>>>,
+        permit_shadowed_by_permit_findings: HashMap<PolicyId, Vec<HashSet<PolicyId>>>,
+        permit_overriden_by_forbid_findings: HashMap<PolicyId, Vec<HashSet<PolicyId>>>,
+        forbid_shadowed_by_forbid_findigns: HashMap<PolicyId, Vec<HashSet<PolicyId>>>,
+    ) -> Self {
+        let vacuous_result = vacous_finding_from_results(&vacuous_results);
+        let vacuous_policies: HashMap<PolicyId, VacuityResult> = policy_vacuity_results
+            .into_iter()
+            .map(|(pid, pvr)| (pid, vacous_finding_from_results(&pvr)))
+            .filter(|(_, pvr)| *pvr != VacuityResult::AllowsSome)
+            .collect();
+        let mut per_sig_findings = Vec::new();
+
+        for (ind, req_env) in req_envs.iter().enumerate() {
+            let mut sig_redundant_findings = HashMap::new();
+            for (pid, prr) in redundant_findings.iter() {
+                let prs = prr
+                    .get(ind)
+                    .expect("Redundancy for policy not precomputed for signature");
+                sig_redundant_findings.insert(pid.clone(), prs.clone());
+            }
+
+            let mut sig_permit_shadowed_findings = HashMap::new();
+            for (pid, ppsr) in permit_shadowed_by_permit_findings.iter() {
+                let ppss = ppsr
+                    .get(ind)
+                    .expect("Shadowing for policy not precomputed for signature");
+                sig_permit_shadowed_findings.insert(pid.clone(), ppss.clone());
+            }
+
+            let mut sig_permit_overriden_findings = HashMap::new();
+            for (pid, pofr) in permit_overriden_by_forbid_findings.iter() {
+                let pofs = pofr
+                    .get(ind)
+                    .expect("Overriding for policy not precomputed for signature");
+                sig_permit_overriden_findings.insert(pid.clone(), pofs.clone());
+            }
+
+            let mut sig_forbid_shadowed_findings = HashMap::new();
+            for (pid, fsr) in forbid_shadowed_by_forbid_findigns.iter() {
+                let fss = fsr
+                    .get(ind)
+                    .expect("Shadowing for policy not precomputed for signature");
+                sig_forbid_shadowed_findings.insert(pid.clone(), fss.clone());
+            }
+
+            let sig_findings = PerSigFindings::new(
+                req_env.clone(),
+                sig_redundant_findings,
+                sig_permit_shadowed_findings,
+                sig_permit_overriden_findings,
+                sig_forbid_shadowed_findings,
+            );
+
+            // if there was actually something for this signature
+            if sig_findings.nfindings() != 0 {
+                per_sig_findings.push(sig_findings);
+            }
+        }
+
+        Self {
+            vacuous_result,
+            vacuous_policies,
+            per_sig_findings,
+        }
+    }
+
+    pub fn print_table(&self) {
+        match self.vacuous_result {
+            VacuityResult::AllowsSome => (),
+            VacuityResult::AllowsAll => {
+                println!("Policyset is vacuous. Policyset allows all authorization requests.\n");
+            }
+            VacuityResult::AllowsNone => {
+                println!("Policyset is vacuous. Policyset denies all authorization requests.\n");
+            }
+        }
+
+        if !self.vacuous_policies.is_empty() {
+            println!("Found {} vacuous policies:", self.vacuous_policies.len());
+
+            for (pid, vr) in self.vacuous_policies.iter() {
+                match vr {
+                    VacuityResult::AllowsSome => (),
+                    VacuityResult::AllowsAll => {
+                        println!("Policy `{pid}` allows all authorization requests.")
+                    }
+                    VacuityResult::AllowsNone => {
+                        println!("Policy `{pid}` denies all authorization requests.")
+                    }
+                }
+            }
+            println!()
+        }
+
+        let n_sig_findings = self
+            .per_sig_findings
+            .iter()
+            .map(PerSigFindings::nfindings)
+            .sum::<usize>();
+
+        println!("Found {n_sig_findings} request environment specific warnings:");
+        let mut table = Table::new();
+        // Print a nice header
+        table.add_row(Row::new(vec![
+            Cell::new("PrincipalType").with_style(Attr::Bold),
+            Cell::new("ActionName").with_style(Attr::Bold),
+            Cell::new("ResourceType").with_style(Attr::Bold),
+            Cell::new("Findings").with_style(Attr::Bold),
+        ]));
+
+        for sig_finding in self.per_sig_findings.iter() {
+            let mut per_env_result_strs: Vec<String> = Vec::new();
+            for equiv_class in sig_finding.equiv_classes.iter() {
+                let result_str = format!("Redundant Policies: {}", ids_comma_sep(equiv_class));
+                per_env_result_strs.push(result_str);
+            }
+            for (pid, shadowers) in sig_finding.permit_shadowed_by_permits.iter() {
+                for spid in shadowers {
+                    let result_str = format!("Policy `{pid}` shadowed by `{spid}`");
+                    per_env_result_strs.push(result_str);
+                }
+            }
+            for (pid, overriders) in sig_finding.permit_overriden_by_forbids.iter() {
+                for opid in overriders {
+                    let result_str = format!("Policy `{pid}` shadowed by `{opid}`");
+                    per_env_result_strs.push(result_str);
+                }
+            }
+            for (pid, shadowers) in sig_finding.forbid_shadowed_by_forbids.iter() {
+                for spid in shadowers {
+                    let result_str = format!("Policy `{pid}` shadowed by `{spid}`");
+                    per_env_result_strs.push(result_str);
+                }
+            }
+            table.add_row(Row::new(vec![
+                Cell::new(&sig_finding.req_env.principal_type),
+                Cell::new(&sig_finding.req_env.action_uid),
+                Cell::new(&sig_finding.req_env.resource_type),
+                Cell::new(&per_env_result_strs.join("\n")),
+            ]));
+        }
+        table.printstd();
+    }
+
+    pub fn print_json(&self, policy_set: &PolicySet) {
+        let serializable_findings = AnalyzePolicyFindingsSer::new(self, policy_set);
+        let json = serde_json::to_string_pretty(&serializable_findings).unwrap();
+        println!("{}", json);
+    }
+}
+
+fn ids_comma_sep(pids: &HashSet<PolicyId>) -> String {
+    let mut ret = "".into();
+    for (ind, pid) in pids.iter().enumerate() {
+        if ind == 0 {
+            ret = format!("`{pid}`");
+        } else if pids.len() == 2 {
+            ret = format!("{ret} and `{pid}`");
+        } else if ind + 1 != pids.len() {
+            ret = format!("{ret}, `{pid}`");
+        } else {
+            ret = format!("`{ret}`, and `{pid}`")
+        }
+    }
+    ret
+}
+
+/// A policy can be non-vacuous or vacuous by allowing all requests or no requests
+#[derive(Clone, Copy, Debug, PartialEq, Serialize)]
+pub enum VacuityResult {
+    AllowsAll,  // For a forbid policy. Interpreted as DeniesNone
+    AllowsSome, // For a forbid policy. Interpreted as DeniesSome
+    AllowsNone, // For a forbid policy. Interpreted as DeniesAll
+}
+
+fn vacous_finding_from_results(results: &Vec<VacuityResult>) -> VacuityResult {
+    if results.iter().all(|res| *res == VacuityResult::AllowsAll) {
+        VacuityResult::AllowsAll
+    } else if results.iter().all(|res| *res == VacuityResult::AllowsNone) {
+        VacuityResult::AllowsNone
+    } else {
+        VacuityResult::AllowsSome
+    }
+}
+
+/// Is a given PolicySet vacous (per request environment)
+fn policyset_vacuous(
+    policyset: &PolicySet,
+    schema: &Schema,
+    req_envs: &Vec<RequestEnv>,
+    negate: bool, // AllowsAll becomes AllowsNone and vice versa
+) -> Result<Vec<VacuityResult>, ExecError> {
+    let mut vr = Vec::new();
+
+    let lean_context = LeanDefinitionalEngine::new();
+    for req_env in req_envs {
+        if lean_context.run_check_always_allows(policyset, schema, req_env)? {
+            if negate {
+                vr.push(VacuityResult::AllowsNone);
+            } else {
+                vr.push(VacuityResult::AllowsAll);
+            }
+        } else if lean_context.run_check_always_denies(policyset, schema, req_env)? {
+            if negate {
+                vr.push(VacuityResult::AllowsAll);
+            } else {
+                vr.push(VacuityResult::AllowsNone);
+            }
+        } else {
+            vr.push(VacuityResult::AllowsSome);
+        }
+    }
+    Ok(vr)
+}
+
+/// Auxillary function that computes the vacuitiness of a policy for each request environment
+/// For forbid policies, it computes the vacuitiness of the policy as if it were a permit policy
+fn vacuity_result(
+    policy: &Policy,
+    schema: &Schema,
+    req_envs: &Vec<RequestEnv>,
+) -> Result<Vec<VacuityResult>, ExecError> {
+    let permit_policy = force_permit(policy)?;
+    let pset = PolicySet::from_policies([permit_policy]).map_err(|err| {
+        ExecError::PolicyIntoPolicySetError {
+            error: Box::new(err),
+        }
+    })?;
+
+    match policy.effect() {
+        Effect::Forbid => policyset_vacuous(&pset, schema, req_envs, true),
+        Effect::Permit => policyset_vacuous(&pset, schema, req_envs, false),
+    }
+}
+
+/// Represents if the Src Policy is shadowed by the Tgt Policy or vice versa
+#[derive(Clone, Copy, Debug, PartialEq)]
+enum ShadowingResult {
+    Equivalent,    // Src & Tgt are non vacuous and allow the same requests
+    SrcShadowsTgt, // Src & Tgt are non vacuous and Src allows strictly more requests than Tgt
+    TgtShadowsSrc, // Src & Tgt are non vacuous and Tgt allows strictly more requests than Src
+    NoResult,      // Either Src or Tgt is vacuous or allow incomporable sets of requests
+}
+
+/// Compute Redudant and Shadowed relationship between src and tgt policies (per environment)
+fn compute_permit_shadowing_result(
+    src_policy: &Policy,
+    src_vacuous_results: &Vec<VacuityResult>,
+    tgt_policy: &Policy,
+    tgt_vacuous_results: &Vec<VacuityResult>,
+    schema: &Schema,
+    req_envs: &Vec<RequestEnv>,
+) -> Result<Vec<ShadowingResult>, ExecError> {
+    let mut results = Vec::new();
+    let src_pset = PolicySet::from_policies([src_policy.to_owned()]).map_err(|err| {
+        ExecError::PolicyIntoPolicySetError {
+            error: Box::new(err),
+        }
+    })?;
+    let tgt_pset = PolicySet::from_policies([tgt_policy.to_owned()]).map_err(|err| {
+        ExecError::PolicyIntoPolicySetError {
+            error: Box::new(err),
+        }
+    })?;
+
+    let lean_context = LeanDefinitionalEngine::new();
+    for ((src_vr, tgt_vr), req_env) in zip(zip(src_vacuous_results, tgt_vacuous_results), req_envs)
+    {
+        match (src_vr, tgt_vr) {
+            (VacuityResult::AllowsNone, _) | (_, VacuityResult::AllowsNone) => {
+                results.push(ShadowingResult::NoResult)
+            }
+            (VacuityResult::AllowsAll, VacuityResult::AllowsAll) => {
+                results.push(ShadowingResult::Equivalent)
+            }
+            (VacuityResult::AllowsAll, VacuityResult::AllowsSome) => {
+                results.push(ShadowingResult::SrcShadowsTgt)
+            }
+            (VacuityResult::AllowsSome, VacuityResult::AllowsAll) => {
+                results.push(ShadowingResult::TgtShadowsSrc)
+            }
+            (VacuityResult::AllowsSome, VacuityResult::AllowsSome) => {
+                let src_implies_tgt =
+                    lean_context.run_check_implies(&src_pset, &tgt_pset, schema, req_env)?;
+                let tgt_implies_src =
+                    lean_context.run_check_implies(&tgt_pset, &src_pset, schema, req_env)?;
+                match (src_implies_tgt, tgt_implies_src) {
+                    (true, true) => results.push(ShadowingResult::Equivalent),
+                    (true, _) => results.push(ShadowingResult::TgtShadowsSrc),
+                    (_, true) => results.push(ShadowingResult::SrcShadowsTgt),
+                    (_, _) => results.push(ShadowingResult::NoResult),
+                }
+            }
+        }
+    }
+    Ok(results)
+}
+
+/// Represents if the Forbid policy overrides the Permit policy
+#[derive(Clone, Copy, Debug, PartialEq)]
+enum OverrideResult {
+    Overrides, // Forbid policy overrides Permit policy
+    NoResult, // Either the Forbid or Permit policy is vacuous or there is a request allowed by the Permit policy that is not forbidden by the Forbid policy
+}
+
+/// Determine if forbid policy overrides permit policy (per environment)
+fn compute_forbid_overrides_shadow_result(
+    forbid_policy: &Policy,
+    forbid_vacuous_results: &Vec<VacuityResult>,
+    permit_policy: &Policy,
+    permit_vacuous_results: &Vec<VacuityResult>,
+    schema: &Schema,
+    req_envs: &Vec<RequestEnv>,
+) -> Result<Vec<OverrideResult>, ExecError> {
+    let mut results = Vec::new();
+    let forbid_pset = PolicySet::from_policies([force_permit(forbid_policy)?]).map_err(|err| {
+        ExecError::PolicyIntoPolicySetError {
+            error: Box::new(err),
+        }
+    })?;
+    let permit_pset = PolicySet::from_policies([permit_policy.to_owned()]).map_err(|err| {
+        ExecError::PolicyIntoPolicySetError {
+            error: Box::new(err),
+        }
+    })?;
+
+    let lean_context = LeanDefinitionalEngine::new();
+    for ((forbid_vr, permit_vr), req_env) in zip(
+        zip(forbid_vacuous_results, permit_vacuous_results),
+        req_envs,
+    ) {
+        match (forbid_vr, permit_vr) {
+            (VacuityResult::AllowsNone, _) | (VacuityResult::AllowsAll, _) |                                          // forbid policy is vacous: denies all or does not apply
+            (_, VacuityResult::AllowsNone) | (_, VacuityResult::AllowsAll) => results.push(OverrideResult::NoResult), // permit policy is vacous: allows all (no need to check overriding) or does not apply
+            _ => {
+                if lean_context.run_check_implies(&permit_pset, &forbid_pset, schema, req_env)? {
+                    results.push(OverrideResult::Overrides); // Every request allowed by permit is denied by forbid
+                } else {
+                    results.push(OverrideResult::NoResult);  // some request allowed by permit is not denies by forbid
+                }
+            }
+        }
+    }
+    Ok(results)
+}
+
+/// Compute Shadoing (and redudancy) relationship between src and tgt policies (per request environment)
+fn compute_forbid_shadowing_result(
+    src_policy: &Policy,
+    src_vacuous_results: &Vec<VacuityResult>,
+    tgt_policy: &Policy,
+    tgt_vacuous_results: &Vec<VacuityResult>,
+    schema: &Schema,
+    req_envs: &Vec<RequestEnv>,
+) -> Result<Vec<ShadowingResult>, ExecError> {
+    let mut results = Vec::new();
+    let src_pset = PolicySet::from_policies([force_permit(src_policy)?]).map_err(|err| {
+        ExecError::PolicyIntoPolicySetError {
+            error: Box::new(err),
+        }
+    })?;
+    let tgt_pset = PolicySet::from_policies([force_permit(tgt_policy)?]).map_err(|err| {
+        ExecError::PolicyIntoPolicySetError {
+            error: Box::new(err),
+        }
+    })?;
+    let lean_context = LeanDefinitionalEngine::new();
+    for ((src_vr, tgt_vr), req_env) in zip(zip(src_vacuous_results, tgt_vacuous_results), req_envs)
+    {
+        // Forbid vacuity results are computed on them as if they were permit policies
+        match (src_vr, tgt_vr) {
+            (VacuityResult::AllowsAll, _) | (_, VacuityResult::AllowsAll) => {
+                results.push(ShadowingResult::NoResult) // One of the two policies is vacuous
+            }
+            (VacuityResult::AllowsNone, VacuityResult::AllowsNone) => {
+                results.push(ShadowingResult::Equivalent) // Both policies deny all requests
+            }
+            (VacuityResult::AllowsNone, VacuityResult::AllowsSome) => {
+                results.push(ShadowingResult::SrcShadowsTgt) // Src policy denies all requests, Tgt denies some
+            }
+            (VacuityResult::AllowsSome, VacuityResult::AllowsNone) => {
+                results.push(ShadowingResult::TgtShadowsSrc) // Tgt policy denies all requests, Src denies some
+            }
+            (VacuityResult::AllowsSome, VacuityResult::AllowsSome) => {
+                let src_implies_tgt =
+                    lean_context.run_check_implies(&src_pset, &tgt_pset, schema, req_env)?;
+                let tgt_implies_src =
+                    lean_context.run_check_implies(&tgt_pset, &src_pset, schema, req_env)?;
+                match (src_implies_tgt, tgt_implies_src) {
+                    (true, true) => results.push(ShadowingResult::Equivalent), // Equivalent
+                    (true, _) => results.push(ShadowingResult::TgtShadowsSrc), // Tgt denies strictly more than Src
+                    (_, true) => results.push(ShadowingResult::SrcShadowsTgt), // Src denies strictly more than Tgt
+                    (_, _) => results.push(ShadowingResult::NoResult),         // Incomparable
+                }
+            }
+        }
+    }
+    Ok(results)
+}
+
+/// Converts a forbid policy into a permit policy
+fn force_permit(policy: &Policy) -> Result<Policy, ExecError> {
+    let mut json = policy
+        .to_json()
+        .map_err(|err| ExecError::InternalAnalysisError {
+            error: Box::new(err),
+        })?;
+    json["effect"] = "permit".into();
+    Policy::from_json(Some(policy.id().clone()), json).map_err(|err| {
+        ExecError::InternalAnalysisError {
+            error: Box::new(err),
+        }
+    })
+}
+
+/// if results[j] == result_filter then update the findings such that tgt_pid \in envF_i where src_pid |-> [envF_1, ..., envF_n]
+fn update_findings<T>(
+    src_pid: &PolicyId,
+    tgt_pid: &PolicyId,
+    results: &Vec<T>,
+    findings: &mut HashMap<PolicyId, Vec<HashSet<PolicyId>>>,
+    result_filter: T,
+) where
+    T: PartialEq,
+{
+    if !findings.contains_key(src_pid) {
+        findings.insert(src_pid.clone(), vec![HashSet::new(); results.len()]);
+    }
+    let src_findings = findings
+        .get_mut(src_pid)
+        .expect("Findings are unexpectedly missing");
+    for (ind, result) in results.iter().enumerate() {
+        if *result == result_filter {
+            src_findings[ind].insert(tgt_pid.clone());
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+enum PolicySetComparisonStatus {
+    MorePermissive,
+    LessPermissive,
+    Equivalent,
+    Incomparable,
+}
+
+impl PolicySetComparisonStatus {
+    fn print(self) -> String {
+        match self {
+            PolicySetComparisonStatus::MorePermissive => {
+                String::from("Source PolicySet is more permissive than Target Policy")
+            }
+            PolicySetComparisonStatus::LessPermissive => {
+                String::from("Source PolicySet is less permissive than Target Policy")
+            }
+            PolicySetComparisonStatus::Equivalent => {
+                String::from("Source PolicySet is equivalent to Target Policy")
+            }
+            PolicySetComparisonStatus::Incomparable => {
+                String::from("Source PolicySet is incomparable with Target Policy")
+            }
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct PolicySetComparisonResult {
+    req_env: RequestEnvSer,
+    status: PolicySetComparisonStatus,
+}
+
+fn print_compare_results(results: &[PolicySetComparisonResult]) {
+    let mut table = Table::new();
+    // Print a nice header
+    table.add_row(Row::new(vec![
+        Cell::new("PrincipalType").with_style(Attr::Bold),
+        Cell::new("ActionName").with_style(Attr::Bold),
+        Cell::new("ResourceType").with_style(Attr::Bold),
+        Cell::new("Result").with_style(Attr::Bold),
+    ]));
+
+    for res in results.iter() {
+        table.add_row(Row::new(vec![
+            Cell::new(&res.req_env.principal_type),
+            Cell::new(&res.req_env.action_uid),
+            Cell::new(&res.req_env.resource_type),
+            Cell::new(&res.status.clone().print()),
+        ]));
+    }
+    table.printstd();
+}
+/// Compare src policyset to tgt policyset and print results
+pub fn compare_policysets(
+    src_policyset: PolicySet,
+    tgt_policyset: PolicySet,
+    schema: Schema,
+    json_output: bool,
+) -> Result<(), ExecError> {
+    let req_envs = OpenRequestEnv::any().to_request_envs(&schema)?;
+    let lean_context = LeanDefinitionalEngine::new();
+    let comparison_results: Vec<PolicySetComparisonResult> = req_envs
+        .iter()
+        .map(|req_env| -> Result<PolicySetComparisonResult, ExecError> {
+            let fwd_implies =
+                lean_context.run_check_implies(&src_policyset, &tgt_policyset, &schema, req_env)?;
+            let bwd_implies =
+                lean_context.run_check_implies(&tgt_policyset, &src_policyset, &schema, req_env)?;
+            let status = match (fwd_implies, bwd_implies) {
+                (true, true) => PolicySetComparisonStatus::Equivalent,
+                (true, false) => PolicySetComparisonStatus::LessPermissive,
+                (false, true) => PolicySetComparisonStatus::MorePermissive,
+                (false, false) => PolicySetComparisonStatus::Incomparable,
+            };
+            Ok(PolicySetComparisonResult {
+                req_env: RequestEnvSer::new(req_env),
+                status,
+            })
+        })
+        .collect::<Result<Vec<PolicySetComparisonResult>, ExecError>>()?;
+    if json_output {
+        let json = serde_json::to_string_pretty(&comparison_results).unwrap();
+        println!("{}", json);
+    } else {
+        print_compare_results(&comparison_results);
+    }
+    Ok(())
+}

--- a/cedar-cli/src/cli_enums.rs
+++ b/cedar-cli/src/cli_enums.rs
@@ -1,0 +1,390 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+use crate::err::ExecError;
+use crate::util;
+use clap::{ArgAction, Args, Parser, Subcommand, ValueEnum};
+use serde::Serialize;
+use std::path::PathBuf;
+
+#[derive(Args, Clone, Debug, Serialize)]
+pub(crate) struct PolicyAnalysisArgs {
+    /// A file containing the Policy to be analyzed
+    #[clap(required = true)]
+    pub(crate) policy_file: PathBuf,
+    /// A file containing the schema for which the Policy is to be analyzed against
+    #[clap(required = true)]
+    pub(crate) schema_file: PathBuf,
+}
+
+#[derive(Args, Clone, Debug, Serialize)]
+pub(crate) struct PolicySetAnalysisArgs {
+    /// A file containing the PolicySet to be analyzed
+    #[clap(required = true)]
+    pub(crate) policyset_file: PathBuf,
+    /// A file containing the schema for which the PolicySet is to be analyzed against
+    #[clap(required = true)]
+    pub(crate) schema_file: PathBuf,
+    /// Whether to output the compare policy sets output in .json format
+    #[clap(long, short, action=ArgAction::SetTrue)]
+    pub(crate) json_output: bool,
+}
+
+#[derive(Args, Clone, Debug, Serialize)]
+pub(crate) struct ComparePolicySetAnalysisArgs {
+    /// A file containing the first PolicySet to be analyzed
+    #[clap(required = true)]
+    pub(crate) source_policyset_file: PathBuf,
+    /// A file containing the second PolicySet to be analyzed
+    #[clap(required = true)]
+    pub(crate) target_policyset_file: PathBuf,
+    /// A file containing the schema for which the PolicySet(s) are to be analyzed against
+    #[clap(required = true)]
+    pub(crate) schema_file: PathBuf,
+    /// Whether to output the compare policy sets output in .json format
+    #[clap(long, short, action=ArgAction::SetTrue)]
+    pub(crate) json_output: bool,
+}
+
+#[derive(Args, Clone, Debug, Serialize)]
+#[clap(next_help_heading = "Execution Modes")]
+pub(crate) struct Mode {
+    /// Run the SMT formula produced by the provided backend encoder via CVC5 [default]
+    #[arg(long, conflicts_with_all = ["print_smtlib"], global=true)]
+    run_analysis: bool,
+    /// Print the SMT formula produced by the provided backend
+    #[arg(long, conflicts_with_all = ["run_analysis"], global=true)]
+    print_smtlib: bool,
+}
+
+pub(crate) enum ModeEnum {
+    RunAnalysis,
+    PrintSMTLib,
+}
+
+impl From<Mode> for ModeEnum {
+    /// Convert from `Mode` struct which works well with clap to `ModeEnum`
+    /// which is much nicer to use and pattern-match on.
+    fn from(mode: Mode) -> Self {
+        if mode.run_analysis {
+            return ModeEnum::RunAnalysis;
+        }
+        if mode.print_smtlib {
+            return ModeEnum::PrintSMTLib;
+        }
+        ModeEnum::RunAnalysis
+    }
+}
+
+/// Need to refactor into a struct that has both options and make them conflict with each other...
+/// Then provide a translation into an Enum of this form for easier pattern matching.
+#[derive(Args, Clone, Debug, Serialize)]
+#[clap(next_help_heading = "Request Arguments (required)")]
+#[serde(rename_all = "kebab-case")]
+pub(crate) struct RequestArgs {
+    /// The requested principal
+    #[arg(
+        long,
+        value_name = "PRINCIPAL_NAME",
+        conflicts_with = "request_file",
+        required_unless_present = "request_file"
+    )]
+    principal: Option<String>,
+    /// The requested action
+    #[arg(
+        long,
+        value_name = "ACTION_ID",
+        conflicts_with = "request_file",
+        required_unless_present = "request_file"
+    )]
+    action: Option<String>,
+    /// The requested resource
+    #[arg(
+        long,
+        value_name = "RESOURCE_NAME",
+        conflicts_with = "request_file",
+        required_unless_present = "request_file"
+    )]
+    resource: Option<String>,
+    /// The context as a JSON string [default {}]
+    #[arg(long, value_name = "CONTEXT", conflicts_with_all = ["request_file", "context_file"], requires = "principal", requires = "action", requires = "resource")]
+    context: Option<String>,
+    /// A file containign the context in JSON
+    #[arg(long, value_name = "CONTEXT_FILE", conflicts_with_all = ["request_file", "context"], requires = "principal", requires = "action", requires = "resource")]
+    context_file: Option<PathBuf>,
+    /// A file containing a request (principal, action, resource, context) in JSON format
+    #[arg(long, value_name = "REQUEST_FILE", conflicts_with_all = ["principal", "action", "resource", "context", "context_file"])]
+    request_file: Option<PathBuf>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub(crate) enum ContextArg {
+    FromString { json_str: String },
+    FromFile { file_name: PathBuf },
+    Default,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub(crate) enum RequestArgsEnum {
+    FromArgs {
+        principal: String,
+        action: String,
+        resource: String,
+        context: ContextArg,
+    },
+    FromFile {
+        file_name: PathBuf,
+    },
+}
+
+impl From<RequestArgs> for RequestArgsEnum {
+    /// Convert from RequestArgs to RequestArgsEnum for a more user-friendly representation/pattern matching
+    fn from(req_args: RequestArgs) -> Self {
+        match req_args.request_file {
+            Some(fname) => Self::FromFile { file_name: fname },
+            None => {
+                let context = match (req_args.context, req_args.context_file) {
+                    (Some(ctx_str), _) => ContextArg::FromString { json_str: ctx_str },
+                    (_, Some(ctx_file)) => ContextArg::FromFile {
+                        file_name: ctx_file,
+                    },
+                    (_, _) => ContextArg::Default,
+                };
+                match (req_args.principal, req_args.action, req_args.resource) {
+                    (Some(p), Some(a), Some(r)) => Self::FromArgs {
+                        principal: p,
+                        action: a,
+                        resource: r,
+                        context: context,
+                    },
+                    (_, _, _) => panic!("Error parsing args. Principal, Action, and Resource are required if request_file is not provided"),
+                }
+            }
+        }
+    }
+}
+
+#[derive(Args, Clone, Debug, Serialize)]
+#[clap(next_help_heading = "Request Environment Options")]
+#[serde(rename_all = "kebab-case")]
+pub(crate) struct RequestEnvArgs {
+    /// Restrict Analysis to Request Environments for the given PrincipalType
+    #[arg(long, value_name = "PRINCIPAL_TYPE_NAME", global = true)]
+    principal_type: Option<String>,
+    /// Restrict Analysis to Request Environmetns for the given Action
+    #[arg(long, value_name = "ACTION_NAME", global = true)]
+    action_name: Option<String>,
+    /// Restrict Analysis to Request Environments for the given ResourceType
+    #[arg(long, value_name = "RESOURCE_TYPE_NAME", global = true)]
+    resource_type: Option<String>,
+}
+
+impl util::OpenRequestEnv {
+    /// Function to convert from the CLI struct for specifying a request type to an OpenRequest type
+    /// which converts each string to the corresponding Cedar Type (i.e., `EntityType`` or `EntityUID`).
+    pub(crate) fn from_request_args(
+        value: RequestEnvArgs,
+    ) -> Result<util::OpenRequestEnv, ExecError> {
+        util::OpenRequestEnv::new(value.principal_type, value.action_name, value.resource_type)
+    }
+}
+
+#[derive(ValueEnum, Clone, Debug, Serialize)]
+pub(crate) enum ValidationMode {
+    Strict,
+    Permissive,
+}
+
+#[derive(Clone, Debug, Serialize, Subcommand)]
+#[serde(rename_all = "kebab-case")]
+pub(crate) enum EvaluationCommands {
+    /// Check if a given PolicySet allows or denies a Request
+    Authorize {
+        /// A file containing the PolicySet to authorize against
+        #[clap(required = true)]
+        policyset_file: PathBuf,
+        /// A file containing the entities relevant for authorization
+        #[clap(required = true)]
+        entities_file: PathBuf,
+        #[clap(flatten)]
+        req_args: RequestArgs,
+    },
+    /// Evaluate a Cedar Expression
+    Evaluate {
+        /// A file contianing the expression to be evaluated
+        #[clap(required = true)]
+        input_expr_file: PathBuf,
+        /// A file containing the Entities needed for evaluation
+        #[clap(required = true)]
+        entities_file: PathBuf,
+        /// A file containing the expected output of the evaluation
+        expected_expr_file: Option<PathBuf>,
+        #[clap(flatten)]
+        req_args: RequestArgs,
+    },
+}
+
+#[derive(Clone, Debug, Serialize, Subcommand)]
+#[serde(rename_all = "kebab-case")]
+pub(crate) enum ValidationCommands {
+    /// Validate a PolicySet against a Schema
+    PolicySet {
+        /// A file containing the PolicySet to validate
+        #[clap(required = true)]
+        policyset_file: PathBuf,
+        /// A file containing the Schema to validate against
+        #[clap(required = true)]
+        schema_file: PathBuf,
+        /// Whether to use strict or permissive validation
+        #[clap(default_value = "strict")]
+        validation_mode: ValidationMode,
+    },
+    /// Validate a PolicySet against a Schema using level-based validation
+    Level {
+        /// A file containing the PolicySet to validate
+        #[clap(required = true)]
+        policyset_file: PathBuf,
+        /// A file containing the Schema to validate against
+        #[clap(required = true)]
+        schema_file: PathBuf,
+        /// The level to validate at
+        #[clap(default_value = "0")]
+        level: i32,
+    },
+    /// Validate a Request against a Schema
+    Request {
+        /// A file containing the Schema to validate against
+        #[clap(required = true)]
+        schema_file: PathBuf,
+        #[clap(flatten)]
+        req_args: RequestArgs,
+    },
+    /// Validate Entities against a Schema
+    Entities {
+        /// A file containing the Schema to validate against
+        #[clap(required = true)]
+        schema_file: PathBuf,
+        /// A file containing the Entities to validate
+        #[clap(required = true)]
+        entities_file: PathBuf,
+    },
+}
+
+#[derive(Clone, Debug, Serialize, Subcommand)]
+#[serde(rename_all = "kebab-case")]
+pub(crate) enum SymCCCommands {
+    /// Check if the provided Policy never errors
+    CheckNeverErrors {
+        #[clap(flatten)]
+        args: PolicyAnalysisArgs,
+        #[clap(flatten)]
+        mode: Mode,
+        #[clap(flatten)]
+        req_env: RequestEnvArgs,
+    },
+    /// Check if the provided PolicySet allows all authorization requests
+    CheckAlwaysAllows {
+        #[clap(flatten)]
+        args: PolicySetAnalysisArgs,
+        #[clap(flatten)]
+        mode: Mode,
+        #[clap(flatten)]
+        req_env: RequestEnvArgs,
+    },
+    /// Check if the provided PolicySet denies all authorization requests
+    CheckAlwaysDenies {
+        #[clap(flatten)]
+        args: PolicySetAnalysisArgs,
+        #[clap(flatten)]
+        mode: Mode,
+        #[clap(flatten)]
+        req_env: RequestEnvArgs,
+    },
+    /// Check if the source and target PolicySets are equivalent
+    CheckEquivalent {
+        #[clap(flatten)]
+        args: ComparePolicySetAnalysisArgs,
+        #[clap(flatten)]
+        mode: Mode,
+        #[clap(flatten)]
+        req_env: RequestEnvArgs,
+    },
+    /// Check if the target PolicySet authorizes all requests that the source PolicySet authorizes
+    CheckImplies {
+        #[clap(flatten)]
+        args: ComparePolicySetAnalysisArgs,
+        #[clap(flatten)]
+        mode: Mode,
+        #[clap(flatten)]
+        req_env: RequestEnvArgs,
+    },
+    /// Check if the source and target PolicySets are disjoint (there is no authorization request that both PolicySets allow)
+    CheckDisjoint {
+        #[clap(flatten)]
+        args: ComparePolicySetAnalysisArgs,
+        #[clap(flatten)]
+        mode: Mode,
+        #[clap(flatten)]
+        req_env: RequestEnvArgs,
+    },
+}
+
+#[derive(Clone, Debug, Serialize, Subcommand)]
+#[serde(rename_all = "kebab-case")]
+pub(crate) enum AnalysisCommands {
+    /// Analyze a PolicySet
+    Policies {
+        #[clap(flatten)]
+        args: PolicySetAnalysisArgs,
+    },
+    /// Compare the source PolicySet against the target PolicySet
+    Compare {
+        #[clap(flatten)]
+        args: ComparePolicySetAnalysisArgs,
+    },
+}
+
+#[derive(Clone, Debug, Serialize, Subcommand)]
+#[serde(rename_all = "kebab-case")]
+pub(crate) enum Command {
+    /// Run the Cedar Analyzer
+    Analyze {
+        #[clap(subcommand)]
+        command: AnalysisCommands,
+    },
+    /// Evaluate a Cedar PolicySet or Expression
+    Evaluate {
+        #[clap(subcommand)]
+        command: EvaluationCommands,
+    },
+    /// Validate PolicySets, Entities, or Requests against a Schema
+    Validate {
+        #[clap(subcommand)]
+        command: ValidationCommands,
+    },
+    /// Run the Cedar Symbolic Compiler
+    Symcc {
+        #[clap(subcommand)]
+        command: SymCCCommands,
+    },
+}
+
+/// Command Line Interface for Cedar Lean
+#[derive(Parser, Debug)]
+#[clap(name = "cedar-cli", version)]
+pub struct CliArgs {
+    #[clap(subcommand)]
+    pub(crate) command: Command,
+}

--- a/cedar-cli/src/cli_exec.rs
+++ b/cedar-cli/src/cli_exec.rs
@@ -1,0 +1,250 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+use crate::analysis;
+use crate::cli_enums::{
+    AnalysisCommands, CliArgs, Command, EvaluationCommands, ModeEnum, RequestArgsEnum,
+    SymCCCommands, ValidationCommands,
+};
+use crate::err::ExecError;
+use crate::evaluation;
+use crate::symcc;
+use crate::util;
+use crate::util::OpenRequestEnv;
+use crate::validation;
+
+impl EvaluationCommands {
+    /// Execute the task described by the evaluation command
+    fn exec(self) -> Result<(), ExecError> {
+        match self {
+            Self::Authorize {
+                policyset_file,
+                entities_file,
+                req_args,
+            } => {
+                let policyset = util::parse_policyset(&policyset_file)?;
+                let request = RequestArgsEnum::from(req_args).parse()?;
+                let entities = util::parse_entities(&entities_file)?;
+                evaluation::check_is_authorized(&policyset, &entities, &request)
+            }
+            Self::Evaluate {
+                input_expr_file,
+                entities_file,
+                req_args,
+                expected_expr_file,
+            } => {
+                let input_expr = util::parse_expression(&input_expr_file)?;
+                let entities = util::parse_entities(&entities_file)?;
+                let request = RequestArgsEnum::from(req_args).parse()?;
+                let output_expr = expected_expr_file
+                    .map(|fname| util::parse_expression(&fname))
+                    .transpose()?;
+                evaluation::evaluate(&input_expr, &entities, &request, output_expr.as_ref())
+            }
+        }
+    }
+}
+
+impl ValidationCommands {
+    /// Execute the task described by the validation request
+    fn exec(self) -> Result<(), ExecError> {
+        match self {
+            Self::PolicySet {
+                policyset_file,
+                schema_file,
+                validation_mode,
+            } => {
+                let policyset = util::parse_policyset(&policyset_file)?;
+                let schema = util::parse_schema(&schema_file)?;
+                let validation_mode = validation_mode.to_cedar();
+                validation::validate(&policyset, &schema, &validation_mode)
+            }
+            Self::Level {
+                policyset_file,
+                schema_file,
+                level,
+            } => {
+                let policyset = util::parse_policyset(&policyset_file)?;
+                let schema = util::parse_schema(&schema_file)?;
+                validation::level_validate(&policyset, &schema, level)
+            }
+            Self::Request {
+                schema_file,
+                req_args,
+            } => {
+                let schema = util::parse_schema(&schema_file)?;
+                let request = RequestArgsEnum::from(req_args).parse()?;
+                validation::validate_request(&schema, &request)
+            }
+            Self::Entities {
+                schema_file,
+                entities_file,
+            } => {
+                let schema = util::parse_schema(&schema_file)?;
+                let entities = util::parse_entities(&entities_file)?;
+                validation::validate_entities(&schema, &entities)
+            }
+        }
+    }
+}
+
+impl AnalysisCommands {
+    /// Execute the task described by the analysis command
+    fn exec(self) -> Result<(), ExecError> {
+        match self {
+            Self::Policies { args } => {
+                let policyset = util::parse_policyset(&args.policyset_file)?;
+                let schema = util::parse_schema(&args.schema_file)?;
+                let json_output = args.json_output;
+                analysis::analyze_policyset(policyset, schema, json_output)
+            }
+            Self::Compare { args } => {
+                let src_policyset = util::parse_policyset(&args.source_policyset_file)?;
+                let tgt_policyset = util::parse_policyset(&args.target_policyset_file)?;
+                let schema = util::parse_schema(&args.schema_file)?;
+                let json_output = args.json_output;
+                analysis::compare_policysets(src_policyset, tgt_policyset, schema, json_output)
+            }
+        }
+    }
+}
+
+impl SymCCCommands {
+    /// Execute the task described by the sym-eval command
+    fn exec(self) -> Result<(), ExecError> {
+        match self {
+            Self::CheckNeverErrors {
+                args,
+                mode,
+                req_env,
+            } => {
+                let policy = util::parse_policy(&args.policy_file)?;
+                let schema = util::parse_schema(&args.schema_file)?;
+                let req_env = OpenRequestEnv::from_request_args(req_env)?;
+                match ModeEnum::from(mode) {
+                    ModeEnum::RunAnalysis => {
+                        symcc::run_check_never_errors(policy, schema, &req_env)
+                    }
+                    ModeEnum::PrintSMTLib => {
+                        symcc::print_check_never_errors(policy, schema, &req_env)
+                    }
+                }
+            }
+            Self::CheckAlwaysAllows {
+                args,
+                mode,
+                req_env,
+            } => {
+                let policyset = util::parse_policyset(&args.policyset_file)?;
+                let schema = util::parse_schema(&args.schema_file)?;
+                let req_env = OpenRequestEnv::from_request_args(req_env)?;
+                match ModeEnum::from(mode) {
+                    ModeEnum::RunAnalysis => {
+                        symcc::run_check_always_allows(policyset, schema, &req_env)
+                    }
+                    ModeEnum::PrintSMTLib => {
+                        symcc::print_check_always_allows(policyset, schema, &req_env)
+                    }
+                }
+            }
+            Self::CheckAlwaysDenies {
+                args,
+                mode,
+                req_env,
+            } => {
+                let policyset = util::parse_policyset(&args.policyset_file)?;
+                let schema = util::parse_schema(&args.schema_file)?;
+                let req_env = OpenRequestEnv::from_request_args(req_env)?;
+                match ModeEnum::from(mode) {
+                    ModeEnum::RunAnalysis => {
+                        symcc::run_check_always_denies(policyset, schema, &req_env)
+                    }
+                    ModeEnum::PrintSMTLib => {
+                        symcc::print_check_always_denies(policyset, schema, &req_env)
+                    }
+                }
+            }
+            Self::CheckEquivalent {
+                args,
+                mode,
+                req_env,
+            } => {
+                let src_policyset = util::parse_policyset(&args.source_policyset_file)?;
+                let tgt_policyset = util::parse_policyset(&args.target_policyset_file)?;
+                let schema = util::parse_schema(&args.schema_file)?;
+                let req_env = OpenRequestEnv::from_request_args(req_env)?;
+                match ModeEnum::from(mode) {
+                    ModeEnum::RunAnalysis => {
+                        symcc::run_check_equivalent(src_policyset, tgt_policyset, schema, &req_env)
+                    }
+                    ModeEnum::PrintSMTLib => symcc::print_check_equivalent(
+                        src_policyset,
+                        tgt_policyset,
+                        schema,
+                        &req_env,
+                    ),
+                }
+            }
+            Self::CheckImplies {
+                args,
+                mode,
+                req_env,
+            } => {
+                let src_policyset = util::parse_policyset(&args.source_policyset_file)?;
+                let tgt_policyset = util::parse_policyset(&args.target_policyset_file)?;
+                let schema = util::parse_schema(&args.schema_file)?;
+                let req_env = OpenRequestEnv::from_request_args(req_env)?;
+                match ModeEnum::from(mode) {
+                    ModeEnum::RunAnalysis => {
+                        symcc::run_check_implies(src_policyset, tgt_policyset, schema, &req_env)
+                    }
+                    ModeEnum::PrintSMTLib => {
+                        symcc::print_check_implies(src_policyset, tgt_policyset, schema, &req_env)
+                    }
+                }
+            }
+            Self::CheckDisjoint {
+                args,
+                mode,
+                req_env,
+            } => {
+                let src_policyset = util::parse_policyset(&args.source_policyset_file)?;
+                let tgt_policyset = util::parse_policyset(&args.target_policyset_file)?;
+                let schema = util::parse_schema(&args.schema_file)?;
+                let req_env = OpenRequestEnv::from_request_args(req_env)?;
+                match ModeEnum::from(mode) {
+                    ModeEnum::RunAnalysis => {
+                        symcc::run_check_disjoint(src_policyset, tgt_policyset, schema, &req_env)
+                    }
+                    ModeEnum::PrintSMTLib => {
+                        symcc::print_check_disjoint(src_policyset, tgt_policyset, schema, &req_env)
+                    }
+                }
+            }
+        }
+    }
+}
+
+impl CliArgs {
+    /// Execute the task described by the command-line arguments
+    pub fn exec(self) -> Result<(), ExecError> {
+        match self.command {
+            Command::Analyze { command } => command.exec(),
+            Command::Evaluate { command } => command.exec(),
+            Command::Validate { command } => command.exec(),
+            Command::Symcc { command } => command.exec(),
+        }
+    }
+}

--- a/cedar-cli/src/err.rs
+++ b/cedar-cli/src/err.rs
@@ -1,0 +1,104 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+use cedar_policy::entities_errors::EntitiesError;
+use std::path::PathBuf;
+use thiserror::Error;
+
+/// The type of struct was expected to be contained within the file
+#[derive(Clone, Debug)]
+pub enum ContentType {
+    Context,
+    Entities,
+    Expression,
+    Policy,
+    PolicySet,
+    Request,
+    Schema,
+}
+
+/// The element of a RequestEnvironment that was involved in the error
+#[derive(Clone, Debug)]
+pub enum EntityType {
+    PrincipalTypeName,
+    ActionName,
+    ResourceTypeName,
+}
+
+/// The element of a Request that was involved in the error
+#[derive(Clone, Debug)]
+pub enum RequestElement {
+    Principal,
+    Action,
+    Resource,
+    Context,
+}
+
+#[derive(Error, Debug)]
+pub enum ExecError {
+    #[error("Error reading {content_type:?} from {file_name} : {error}")]
+    FileReadError {
+        content_type: ContentType,
+        file_name: PathBuf,
+        error: Box<dyn std::error::Error>,
+    },
+    #[error("Error parsing {content_type:?} from {file_name} : {error}")]
+    ParseError {
+        content_type: ContentType,
+        file_name: PathBuf,
+        error: Box<dyn std::error::Error>,
+    },
+    #[error("Error while attempting to use id annotations as policy ids in while parsing {content_type:?} from {file_name}: {error}")]
+    RenameIdError {
+        content_type: ContentType,
+        file_name: PathBuf,
+        error: miette::ErrReport,
+    },
+    #[error("Error parsing {content_type:?} from {file_name} : invalid JSON format")]
+    ParseJsonError {
+        content_type: ContentType,
+        file_name: PathBuf,
+    },
+    #[error("Error creating {entity_type:?} from {input_str} : {error}")]
+    EntityTypeError {
+        entity_type: EntityType,
+        input_str: String,
+        error: Box<dyn std::error::Error>,
+    },
+    #[error("Error Creating {element:?} from {input_str} : {error}")]
+    RequestError {
+        element: RequestElement,
+        input_str: String,
+        error: Box<dyn std::error::Error>,
+    },
+    #[error("Error converting Policy to a PolicySet : {error}")]
+    PolicyIntoPolicySetError { error: Box<dyn std::error::Error> },
+    #[error("Error during analysis : {error}")]
+    InternalAnalysisError { error: Box<dyn std::error::Error> },
+    #[error("Error Creating Request : {error}")]
+    RequestValidationError { error: Box<dyn std::error::Error> },
+    #[error("Could not fetch actions from Schema")]
+    ActionsFromSchemaError(#[from] EntitiesError),
+    #[error("{principal_type} cannot {action_name} on {resource_type} in the provided Schema")]
+    RequestEnvArgsIncompatible {
+        principal_type: String,
+        action_name: String,
+        resource_type: String,
+    },
+    #[error("Error deserializing Lean backend output")]
+    LeanDeserializationError,
+    #[error("Error occured in Lean backend : {0}")]
+    LeanBackendError(String),
+}

--- a/cedar-cli/src/evaluation.rs
+++ b/cedar-cli/src/evaluation.rs
@@ -1,0 +1,78 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+use crate::err::ExecError;
+use crate::lean_ffi::LeanDefinitionalEngine;
+use cedar_policy::{Entities, Expression, PolicySet, Request};
+
+/// Use the lean_ffi to check if the `policyset` allows the given `request`.
+pub fn check_is_authorized(
+    policyset: &PolicySet,
+    entities: &Entities,
+    request: &Request,
+) -> Result<(), ExecError> {
+    let lean_context = LeanDefinitionalEngine::new();
+    let auth_response = lean_context.is_authorized(policyset, entities, request)?;
+    let decision = match auth_response.decision.as_str() {
+        "allow" => "allowed",
+        "deny" => "denied",
+        _ => return Err(ExecError::LeanDeserializationError),
+    };
+    println!("Authorization request was {decision}.\n");
+    if decision == "denied" && auth_response.determining_policies.mk.l.len() == 0 {
+        print!("This request was implicitly denied as this request matched no policies")
+    } else {
+        print!("This was {decision} due to the following policies:");
+    }
+    for policy in auth_response.determining_policies.mk.l {
+        print!(" {policy}");
+    }
+    println!();
+    print!("The following policies did not contribute to the decision as they errored during evaluation:");
+    for policy in auth_response.erroring_policies.mk.l {
+        print!(" {policy}");
+    }
+    println!();
+    Ok(())
+}
+
+/// Use the lean_ffi to evaluate the input Cedar `Expression` and determine if it equivalent to
+/// the provided output Cedar `Expression` (if one was provided); otherwise, print the evaluation of the input.
+pub fn evaluate(
+    input_expr: &Expression,
+    entities: &Entities,
+    request: &Request,
+    expected_output: Option<&Expression>,
+) -> Result<(), ExecError> {
+    let lean_context = LeanDefinitionalEngine::new();
+    match expected_output {
+        Some(output_expr) => {
+            match lean_context.check_evaluate(input_expr, entities, request, output_expr) {
+                Ok(res) => {
+                    if res {
+                        println!("Input expression evaluated to the expected output expression.")
+                    } else {
+                        println!(
+                            "Input expression did not evaluate to the expected output expression."
+                        )
+                    }
+                    Ok(())
+                }
+                Err(e) => Err(e),
+            }
+        }
+        None => lean_context.print_evaluation(input_expr, entities, request),
+    }
+}

--- a/cedar-cli/src/lean_ffi.rs
+++ b/cedar-cli/src/lean_ffi.rs
@@ -1,0 +1,423 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+use crate::err::ExecError;
+use crate::messages::*;
+
+use cedar_policy::{
+    Entities, Expression, Policy, PolicySet, Request, RequestEnv, Schema, ValidationMode,
+};
+
+use lean_sys::lean_object;
+use lean_sys::{
+    lean_alloc_sarray, lean_dec, lean_dec_ref, lean_finalize_thread,
+    lean_initialize_runtime_module_locked, lean_initialize_thread, lean_io_mark_end_initialization,
+    lean_io_mk_world, lean_io_result_is_ok, lean_io_result_show_error, lean_sarray_object,
+    lean_set_exit_on_panic, lean_string_cstr,
+};
+
+use prost::Message;
+
+use serde::Deserialize;
+
+use std::ffi::{c_char, CStr};
+use std::sync::Once;
+
+// Import and signal RUST to link the exported Lean FFI code (which are C functions at this point)
+#[link(name = "Cedar", kind = "static")]
+#[link(name = "Cedar_SymCC", kind = "static")]
+#[link(name = "Protobuf", kind = "static")]
+#[link(name = "CedarProto", kind = "static")]
+#[link(name = "Batteries", kind = "static")]
+#[link(name = "CedarFFI", kind = "static")]
+#[link(name = "SymFFI", kind = "static")]
+extern "C" {
+    fn runCheckNeverErrors(req: *mut lean_object) -> *mut lean_object;
+    fn runCheckAlwaysAllows(req: *mut lean_object) -> *mut lean_object;
+    fn runCheckAlwaysDenies(req: *mut lean_object) -> *mut lean_object;
+    fn runCheckEquivalent(req: *mut lean_object) -> *mut lean_object;
+    fn runCheckImplies(req: *mut lean_object) -> *mut lean_object;
+    fn runCheckDisjoint(req: *mut lean_object) -> *mut lean_object;
+    fn printCheckNeverErrors(req: *mut lean_object) -> *mut lean_object;
+    fn printCheckAlwaysAllows(req: *mut lean_object) -> *mut lean_object;
+    fn printCheckAlwaysDenies(req: *mut lean_object) -> *mut lean_object;
+    fn printCheckEquivalent(req: *mut lean_object) -> *mut lean_object;
+    fn printCheckImplies(req: *mut lean_object) -> *mut lean_object;
+    fn printCheckDisjoint(req: *mut lean_object) -> *mut lean_object;
+
+    fn isAuthorized(req: *mut lean_object) -> *mut lean_object;
+    fn validate(req: *mut lean_object) -> *mut lean_object;
+    fn levelValidate(req: *mut lean_object) -> *mut lean_object;
+    fn printEvaluation(req: *mut lean_object) -> *mut lean_object;
+    fn checkEvaluate(req: *mut lean_object) -> *mut lean_object;
+    fn validateEntities(req: *mut lean_object) -> *mut lean_object;
+    fn validateRequest(req: *mut lean_object) -> *mut lean_object;
+
+    fn initialize_CedarFFI(builtin: u8, ob: *mut lean_object) -> *mut lean_object;
+    fn initialize_SymFFI(builtin: u8, ob: *mut lean_object) -> *mut lean_object;
+}
+
+/// Lean can only be initialized once, use a static variable to know if lean backend needs
+/// to be initialized
+static START: Once = Once::new();
+
+#[derive(Default)]
+/// A struct which will initialize the lean backend (and initialize a thread running the lean runtime)
+pub struct LeanDefinitionalEngine {}
+
+/// Lean return types
+
+/// List type
+#[derive(Debug, Deserialize)]
+pub(crate) struct ListDef<T> {
+    pub(crate) l: Vec<T>,
+}
+
+/// Set Type
+#[derive(Debug, Deserialize)]
+pub(crate) struct SetDef<T> {
+    pub(crate) mk: ListDef<T>,
+}
+
+/// Lean type: Except String T
+#[derive(Debug, Deserialize)]
+enum ResultDef<T> {
+    /// Successful execution
+    #[serde(rename = "ok")]
+    Ok(T),
+    /// Failure case
+    #[serde(rename = "error")]
+    Error(String),
+}
+
+/// Authorization Response
+#[derive(Debug, Deserialize)]
+pub(crate) struct AuthorizationResponse {
+    pub(crate) decision: String,
+    #[serde(rename = "determiningPolicies")]
+    pub(crate) determining_policies: SetDef<String>,
+    #[serde(rename = "erroringPolicies")]
+    pub(crate) erroring_policies: SetDef<String>,
+}
+
+/// Validation Response
+#[derive(Debug, Deserialize)]
+pub(crate) enum ValidationResponse {
+    /// Successful validation
+    #[serde(rename = "ok")]
+    Ok(()),
+    /// Validation error case
+    #[serde(rename = "error")]
+    Error(String),
+}
+
+/// Takes ownership of its argument -- do not access `lean_str_obj` after
+/// calling this function
+fn lean_obj_p_to_rust_string(lean_str_obj: *mut lean_object) -> String {
+    let lean_obj_p = unsafe { lean_string_cstr(lean_str_obj) };
+    let lean_obj_cstr = unsafe { CStr::from_ptr(lean_obj_p as *const c_char) };
+    let rust_string = lean_obj_cstr
+        .to_str()
+        .expect("failed to convert Lean object to string")
+        .to_owned();
+    unsafe {
+        lean_dec(lean_str_obj);
+    };
+    rust_string
+}
+
+fn buf_to_lean_obj(buf: &[u8]) -> *mut lean_object {
+    unsafe {
+        let x: *mut lean_sarray_object = lean_alloc_sarray(1, buf.len(), buf.len()).cast();
+        let y = (*x).m_data.as_mut_ptr();
+        for i in 0..buf.len() {
+            y.add(i).write(buf[i])
+        }
+        x.cast()
+    }
+}
+
+/// A macro which converts symcc-request to protobuf, calls the lean code, then deserializes the output
+macro_rules! checkPolicy_func {
+    ($func_name:ident, $lean_func_name:ident, $ret_ty:ty) => {
+        pub fn $func_name(
+            &self,
+            policy: &Policy,
+            schema: &Schema,
+            request_env: &RequestEnv,
+        ) -> Result<$ret_ty, ExecError> {
+            let lean_check_request =
+                proto::CheckPolicyRequest::new(policy, schema, request_env).encode_to_vec();
+            let lean_check_request = buf_to_lean_obj(&lean_check_request);
+            let response = unsafe { $lean_func_name(lean_check_request) };
+            let response = lean_obj_p_to_rust_string(response);
+            match serde_json::from_str(&response) {
+                Ok(ResultDef::Ok(t)) => Ok(t),
+                Ok(ResultDef::Error(s)) => Err(ExecError::LeanBackendError(s)),
+                Err(_) => Err(ExecError::LeanDeserializationError),
+            }
+        }
+    };
+}
+
+/// A macro which converts symcc-request to protobuf, calls the lean code, then deserializes the output
+macro_rules! checkPolicySet_func {
+    ($func_name:ident, $lean_func_name:ident, $ret_ty:ty) => {
+        pub fn $func_name(
+            &self,
+            policyset: &PolicySet,
+            schema: &Schema,
+            request_env: &RequestEnv,
+        ) -> Result<$ret_ty, ExecError> {
+            let lean_check_request =
+                proto::CheckPolicySetRequest::new(policyset, schema, request_env).encode_to_vec();
+            let lean_check_request = buf_to_lean_obj(&lean_check_request);
+            let response = unsafe { $lean_func_name(lean_check_request) };
+            let response = lean_obj_p_to_rust_string(response);
+            match serde_json::from_str(&response) {
+                Ok(ResultDef::Ok(t)) => Ok(t),
+                Ok(ResultDef::Error(s)) => Err(ExecError::LeanBackendError(s)),
+                Err(_) => Err(ExecError::LeanDeserializationError),
+            }
+        }
+    };
+}
+
+/// A macro which converts symcc-request to protobuf, calls the lean code, then deserializes the output
+macro_rules! comparePolicySet_func {
+    ($func_name:ident, $lean_func_name:ident, $ret_ty:ty) => {
+        pub fn $func_name(
+            &self,
+            src_policyset: &PolicySet,
+            tgt_policyset: &PolicySet,
+            schema: &Schema,
+            request_env: &RequestEnv,
+        ) -> Result<$ret_ty, ExecError> {
+            let lean_check_request = proto::ComparePolicySetsRequest::new(
+                src_policyset,
+                tgt_policyset,
+                schema,
+                request_env,
+            )
+            .encode_to_vec();
+            let lean_check_request = buf_to_lean_obj(&lean_check_request);
+            let response = unsafe { $lean_func_name(lean_check_request) };
+            let response = lean_obj_p_to_rust_string(response);
+            match serde_json::from_str(&response) {
+                Ok(ResultDef::Ok(t)) => Ok(t),
+                Ok(ResultDef::Error(s)) => Err(ExecError::LeanBackendError(s)),
+                Err(_) => Err(ExecError::LeanDeserializationError),
+            }
+        }
+    };
+}
+
+impl LeanDefinitionalEngine {
+    /// WARNING: we can only have one Lean thread
+    pub fn new() -> Self {
+        START.call_once(|| {
+            unsafe {
+                // following: https://lean-lang.org/lean4/doc/dev/ffi.html
+                lean_initialize_runtime_module_locked();
+                let builtin: u8 = 1;
+                let res = initialize_SymFFI(builtin, lean_io_mk_world());
+                if lean_io_result_is_ok(res) {
+                    lean_dec_ref(res);
+                } else {
+                    lean_io_result_show_error(res);
+                    lean_dec(res);
+                    panic!("Failed to initialize Lean");
+                }
+                let res = initialize_CedarFFI(builtin, lean_io_mk_world());
+                if lean_io_result_is_ok(res) {
+                    lean_dec_ref(res);
+                } else {
+                    lean_io_result_show_error(res);
+                    lean_dec(res);
+                    panic!("Failed to initialize Lean");
+                }
+                lean_io_mark_end_initialization();
+                // If we don't explicitly set this, Lean does not abort after hitting a panic
+                lean_set_exit_on_panic(true);
+            };
+        });
+        unsafe { lean_initialize_thread() };
+        Self {}
+    }
+
+    // Adds each of the run_(symcc-command) to call the corresponding lean function
+    // returns true if the check definitely holds and false if it definitely doesn't
+    // returns an error if the lean could not successfully run the solver or if the solver returned unknown
+    checkPolicy_func!(run_check_never_errors, runCheckNeverErrors, bool);
+    checkPolicySet_func!(run_check_always_allows, runCheckAlwaysAllows, bool);
+    checkPolicySet_func!(run_check_always_denies, runCheckAlwaysDenies, bool);
+    comparePolicySet_func!(run_check_equivalent, runCheckEquivalent, bool);
+    comparePolicySet_func!(run_check_implies, runCheckImplies, bool);
+    comparePolicySet_func!(run_check_disjoint, runCheckDisjoint, bool);
+
+    // Adds each of the print_(symcc-command) to call the corresponding lean function
+    checkPolicy_func!(print_check_never_errors, printCheckNeverErrors, ());
+    checkPolicySet_func!(print_check_always_allows, printCheckAlwaysAllows, ());
+    checkPolicySet_func!(print_check_always_denies, printCheckAlwaysDenies, ());
+    comparePolicySet_func!(print_check_equivalent, printCheckEquivalent, ());
+    comparePolicySet_func!(print_check_implies, printCheckImplies, ());
+    comparePolicySet_func!(print_check_disjoint, printCheckDisjoint, ());
+
+    /// Calls the lean backend to determine if the `Request` is allowed
+    /// by the `PolicySet` given the provided set of `Entities`
+    pub fn is_authorized(
+        &self,
+        policyset: &PolicySet,
+        entities: &Entities,
+        request: &Request,
+    ) -> Result<AuthorizationResponse, ExecError> {
+        let lean_auth_request =
+            proto::AuthorizationRequest::new(policyset, entities, request).encode_to_vec();
+        let lean_auth_request = buf_to_lean_obj(&lean_auth_request);
+        let response = unsafe { isAuthorized(lean_auth_request) };
+        let response = lean_obj_p_to_rust_string(response);
+        match serde_json::from_str(&response) {
+            Ok(ResultDef::Ok(resp)) => Ok(resp),
+            Ok(ResultDef::Error(s)) => Err(ExecError::LeanBackendError(s)),
+            Err(_) => Err(ExecError::LeanDeserializationError),
+        }
+    }
+
+    /// Calls the lean backend to print the evaluation of the input Cedar `Expression`
+    pub fn print_evaluation(
+        &self,
+        input_expr: &Expression,
+        entities: &Entities,
+        request: &Request,
+    ) -> Result<(), ExecError> {
+        let lean_eval_request =
+            proto::EvaluationRequestChecked::new(input_expr, entities, request).encode_to_vec();
+        let lean_eval_request = buf_to_lean_obj(&lean_eval_request);
+        let ret = unsafe { printEvaluation(lean_eval_request) };
+        let ret = lean_obj_p_to_rust_string(ret);
+        match serde_json::from_str(&ret) {
+            Ok(ResultDef::Ok(())) => Ok(()),
+            Ok(ResultDef::Error(s)) => Err(ExecError::LeanBackendError(s)),
+            Err(_) => Err(ExecError::LeanDeserializationError),
+        }
+    }
+
+    /// Calls the lean backend and returns `true` if the input Cedar `Expression`
+    /// evaluates to the output cedar `Expression`
+    pub fn check_evaluate(
+        &self,
+        input_expr: &Expression,
+        entities: &Entities,
+        request: &Request,
+        output_expr: &Expression,
+    ) -> Result<bool, ExecError> {
+        let lean_eval_request = proto::EvaluationRequestChecked::new_checked(
+            input_expr,
+            entities,
+            request,
+            output_expr,
+        )
+        .encode_to_vec();
+        let lean_eval_request = buf_to_lean_obj(&lean_eval_request);
+        let ret = unsafe { checkEvaluate(lean_eval_request) };
+        let ret = lean_obj_p_to_rust_string(ret);
+        match serde_json::from_str(&ret) {
+            Ok(ResultDef::Ok(are_eq)) => Ok(are_eq),
+            Ok(ResultDef::Error(s)) => Err(ExecError::LeanBackendError(s)),
+            Err(_) => Err(ExecError::LeanDeserializationError),
+        }
+    }
+
+    /// Calls the lean backend to validate the `PolicySet` against the provided `Schema`
+    pub fn validate(
+        &self,
+        policyset: &PolicySet,
+        schema: &Schema,
+        mode: &ValidationMode,
+    ) -> Result<ValidationResponse, ExecError> {
+        let lean_validation_request =
+            proto::ValidationRequest::new(policyset, schema, mode).encode_to_vec();
+        let lean_validation_request = buf_to_lean_obj(&lean_validation_request);
+        let ret = unsafe { validate(lean_validation_request) };
+        let ret = lean_obj_p_to_rust_string(ret);
+        match serde_json::from_str(&ret) {
+            Ok(ResultDef::Ok(res)) => Ok(res),
+            Ok(ResultDef::Error(s)) => Err(ExecError::LeanBackendError(s)),
+            Err(_) => Err(ExecError::LeanDeserializationError),
+        }
+    }
+
+    /// Calls the lean backend to validate the `PolicySet` against the provided `Schema` at level `level`
+    pub fn level_validate(
+        &self,
+        policyset: &PolicySet,
+        schema: &Schema,
+        level: i32,
+    ) -> Result<ValidationResponse, ExecError> {
+        let lean_validation_request =
+            proto::LevelValidationRequest::new(policyset, schema, level).encode_to_vec();
+        let lean_validation_request = buf_to_lean_obj(&lean_validation_request);
+        let ret = unsafe { levelValidate(lean_validation_request) };
+        let ret = lean_obj_p_to_rust_string(ret);
+        match serde_json::from_str(&ret) {
+            Ok(ResultDef::Ok(res)) => Ok(res),
+            Ok(ResultDef::Error(s)) => Err(ExecError::LeanBackendError(s)),
+            Err(_) => Err(ExecError::LeanDeserializationError),
+        }
+    }
+
+    /// Calls the lean backend to validate the `Entities` against the provided `Schema`
+    pub fn validate_entities(
+        &self,
+        schema: &Schema,
+        entities: &Entities,
+    ) -> Result<ValidationResponse, ExecError> {
+        let lean_validation_request =
+            proto::EntityValidationRequest::new(schema, entities).encode_to_vec();
+        let lean_validation_request = buf_to_lean_obj(&lean_validation_request);
+        let ret = unsafe { validateEntities(lean_validation_request) };
+        let ret = lean_obj_p_to_rust_string(ret);
+        match serde_json::from_str(&ret) {
+            Ok(ResultDef::Ok(res)) => Ok(res),
+            Ok(ResultDef::Error(s)) => Err(ExecError::LeanBackendError(s)),
+            Err(_) => Err(ExecError::LeanDeserializationError),
+        }
+    }
+
+    /// Calls the lean backend to validate the `Request` against the provided `Schema`
+    pub fn validate_request(
+        &self,
+        schema: &Schema,
+        request: &Request,
+    ) -> Result<ValidationResponse, ExecError> {
+        let lean_validation_request =
+            proto::RequestValidationRequest::new(schema, request).encode_to_vec();
+        let lean_validation_request = buf_to_lean_obj(&lean_validation_request);
+        let ret = unsafe { validateRequest(lean_validation_request) };
+        let ret = lean_obj_p_to_rust_string(ret);
+        match serde_json::from_str(&ret) {
+            Ok(ResultDef::Ok(res)) => Ok(res),
+            Ok(ResultDef::Error(s)) => Err(ExecError::LeanBackendError(s)),
+            Err(_) => Err(ExecError::LeanDeserializationError),
+        }
+    }
+}
+
+/// uninitialize lean thread when done
+impl Drop for LeanDefinitionalEngine {
+    fn drop(&mut self) {
+        unsafe { lean_finalize_thread() }
+    }
+}

--- a/cedar-cli/src/lib.rs
+++ b/cedar-cli/src/lib.rs
@@ -1,0 +1,30 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+mod analysis;
+mod cli_enums;
+mod cli_exec;
+mod err;
+mod evaluation;
+mod lean_ffi;
+mod messages;
+mod symcc;
+mod util;
+mod validation;
+
+/// Make only CLIArgs and ExecError public
+pub use cli_enums::CliArgs;
+pub use err::ExecError;

--- a/cedar-cli/src/main.rs
+++ b/cedar-cli/src/main.rs
@@ -1,0 +1,28 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+use cedar_cli::CliArgs;
+use clap::Parser;
+use std::process::ExitCode;
+
+fn main() -> ExitCode {
+    match CliArgs::parse().exec() {
+        Ok(_) => return ExitCode::SUCCESS,
+        Err(err) => {
+            eprintln!("{err}");
+            return ExitCode::from(2);
+        }
+    }
+}

--- a/cedar-cli/src/messages.rs
+++ b/cedar-cli/src/messages.rs
@@ -1,0 +1,211 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+pub use cedar_policy::{
+    Entities, Expression, Policy, PolicySet, Request, RequestEnv, Schema, ValidationMode,
+};
+
+pub mod proto {
+    #![allow(missing_docs)]
+    include!(concat!(env!("OUT_DIR"), "/cedar_symcc.rs"));
+}
+
+/// Serialize a Cedar Policy to a Protobuf message (note this is a custom Policy format that differs from cedar_policy::proto::Policy)
+impl From<&Policy> for proto::Policy {
+    fn from(policy: &Policy) -> Self {
+        Self {
+            template: Some(cedar_policy::proto::models::TemplateBody::from(
+                policy.as_ref().template(),
+            )),
+            policy: Some(cedar_policy::proto::models::Policy::from(policy)),
+        }
+    }
+}
+
+/// Serialize a RequestEnv to a Protobuf message
+impl From<&RequestEnv> for proto::RequestEnv {
+    fn from(req_env: &RequestEnv) -> Self {
+        Self {
+            principal: Some(cedar_policy::proto::models::Name::from(req_env.principal())),
+            action: Some(cedar_policy::proto::models::EntityUid::from(
+                req_env.action(),
+            )),
+            resource: Some(cedar_policy::proto::models::Name::from(req_env.resource())),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct CheckPolicyRequest {
+    pub policy: Policy,
+    pub schema: Schema,
+    pub request: RequestEnv,
+}
+
+impl proto::CheckPolicyRequest {
+    pub fn new(policy: &Policy, schema: &Schema, request: &RequestEnv) -> Self {
+        Self {
+            policy: Some(proto::Policy::from(policy)),
+            schema: Some(cedar_policy::proto::models::Schema::from(schema)),
+            request: Some(proto::RequestEnv::from(request)),
+        }
+    }
+}
+
+/// Serialize the symcc request arguments to a ProtoBuf message
+impl From<&CheckPolicyRequest> for proto::CheckPolicyRequest {
+    fn from(req: &CheckPolicyRequest) -> Self {
+        Self::new(&req.policy, &req.schema, &req.request)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct CheckPolicySetRequest {
+    pub policyset: PolicySet,
+    pub schema: Schema,
+    pub request: RequestEnv,
+}
+
+impl proto::CheckPolicySetRequest {
+    pub fn new(policyset: &PolicySet, schema: &Schema, request: &RequestEnv) -> Self {
+        Self {
+            policy_set: Some(cedar_policy::proto::models::PolicySet::from(policyset)),
+            schema: Some(cedar_policy::proto::models::Schema::from(schema)),
+            request: Some(proto::RequestEnv::from(request)),
+        }
+    }
+}
+
+/// Serialize the symcc request arguments to a ProtoBuf message
+impl From<&CheckPolicySetRequest> for proto::CheckPolicySetRequest {
+    fn from(req: &CheckPolicySetRequest) -> Self {
+        Self::new(&req.policyset, &req.schema, &req.request)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct ComparePolicySetsRequest {
+    pub src_policyset: PolicySet,
+    pub tgt_policyset: PolicySet,
+    pub schema: Schema,
+    pub request: RequestEnv,
+}
+
+impl proto::ComparePolicySetsRequest {
+    pub fn new(
+        src_policyset: &PolicySet,
+        tgt_policyset: &PolicySet,
+        schema: &Schema,
+        request: &RequestEnv,
+    ) -> Self {
+        Self {
+            src_policy_set: Some(cedar_policy::proto::models::PolicySet::from(src_policyset)),
+            tgt_policy_set: Some(cedar_policy::proto::models::PolicySet::from(tgt_policyset)),
+            schema: Some(cedar_policy::proto::models::Schema::from(schema)),
+            request: Some(proto::RequestEnv::from(request)),
+        }
+    }
+}
+
+/// Serialize the symcc request arguments to a ProtoBuf message
+impl From<&ComparePolicySetsRequest> for proto::ComparePolicySetsRequest {
+    fn from(req: &ComparePolicySetsRequest) -> Self {
+        Self::new(
+            &req.src_policyset,
+            &req.tgt_policyset,
+            &req.schema,
+            &req.request,
+        )
+    }
+}
+
+/// Serialize an authorization request
+impl proto::AuthorizationRequest {
+    pub fn new(policyset: &PolicySet, entities: &Entities, request: &Request) -> Self {
+        Self {
+            request: Some(cedar_policy::proto::models::Request::from(request)),
+            policies: Some(cedar_policy::proto::models::PolicySet::from(policyset)),
+            entities: Some(cedar_policy::proto::models::Entities::from(entities)),
+        }
+    }
+}
+
+/// Serialize an Expression evaluation request (checked or unchecked)
+impl proto::EvaluationRequestChecked {
+    pub fn new(expr: &Expression, entities: &Entities, request: &Request) -> Self {
+        Self {
+            expr: Some(cedar_policy::proto::models::Expr::from(expr)),
+            request: Some(cedar_policy::proto::models::Request::from(request)),
+            entities: Some(cedar_policy::proto::models::Entities::from(entities)),
+            expected: None,
+        }
+    }
+
+    pub fn new_checked(
+        expr: &Expression,
+        entities: &Entities,
+        request: &Request,
+        expected: &Expression,
+    ) -> Self {
+        Self {
+            expr: Some(cedar_policy::proto::models::Expr::from(expr)),
+            request: Some(cedar_policy::proto::models::Request::from(request)),
+            entities: Some(cedar_policy::proto::models::Entities::from(entities)),
+            expected: Some(cedar_policy::proto::models::Expr::from(expected)),
+        }
+    }
+}
+
+/// Serialize a PolicySet validation request
+impl proto::ValidationRequest {
+    pub fn new(policyset: &PolicySet, schema: &Schema, mode: &ValidationMode) -> Self {
+        Self {
+            schema: Some(cedar_policy::proto::models::Schema::from(schema)),
+            policies: Some(cedar_policy::proto::models::PolicySet::from(policyset)),
+            mode: cedar_policy::proto::models::ValidationMode::from(&mode.clone().into()).into(),
+        }
+    }
+}
+
+/// Serialize a PolicySet level-validation request
+impl proto::LevelValidationRequest {
+    pub fn new(policyset: &PolicySet, schema: &Schema, level: i32) -> Self {
+        Self {
+            schema: Some(cedar_policy::proto::models::Schema::from(schema)),
+            policies: Some(cedar_policy::proto::models::PolicySet::from(policyset)),
+            level: level,
+        }
+    }
+}
+
+/// Serialize an entities validation request
+impl proto::EntityValidationRequest {
+    pub fn new(schema: &Schema, entities: &Entities) -> Self {
+        Self {
+            schema: Some(cedar_policy::proto::models::Schema::from(schema)),
+            entities: Some(cedar_policy::proto::models::Entities::from(entities)),
+        }
+    }
+}
+
+/// Serialize a request validation request
+impl proto::RequestValidationRequest {
+    pub fn new(schema: &Schema, request: &Request) -> Self {
+        Self {
+            schema: Some(cedar_policy::proto::models::Schema::from(schema)),
+            request: Some(cedar_policy::proto::models::Request::from(request)),
+        }
+    }
+}

--- a/cedar-cli/src/symcc.rs
+++ b/cedar-cli/src/symcc.rs
@@ -1,0 +1,615 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+use crate::err::ExecError;
+use crate::lean_ffi::LeanDefinitionalEngine;
+use crate::util::{OpenRequestEnv, ReqEnv};
+use cedar_policy::{Policy, PolicySet, RequestEnv, Schema};
+use std::iter::zip;
+
+/// Run lean backend for analysis `check-never-errors`
+pub fn run_check_never_errors(
+    policy: Policy,
+    schema: Schema,
+    request_env: &OpenRequestEnv,
+) -> Result<(), ExecError> {
+    let lean_context = LeanDefinitionalEngine::new();
+    let req_envs = request_env.to_request_envs(&schema)?;
+    let mut results = Vec::new();
+    for req_env in req_envs.iter() {
+        results.push(lean_context.run_check_never_errors(&policy, &schema, req_env)?);
+    }
+    print_check_never_errors_results(&results, &req_envs, request_env);
+    Ok(())
+}
+
+/// Run lean backend for analysis `check-always-allows`
+pub fn run_check_always_allows(
+    policyset: PolicySet,
+    schema: Schema,
+    request_env: &OpenRequestEnv,
+) -> Result<(), ExecError> {
+    let lean_context = LeanDefinitionalEngine::new();
+    let req_envs = request_env.to_request_envs(&schema)?;
+    let mut results = Vec::new();
+    for req_env in req_envs.iter() {
+        results.push(lean_context.run_check_always_allows(&policyset, &schema, req_env)?);
+    }
+    print_check_always_allows_results(&results, &req_envs, request_env);
+    Ok(())
+}
+
+/// Run lean backend for analysis `check-always-denies`
+pub fn run_check_always_denies(
+    policyset: PolicySet,
+    schema: Schema,
+    request_env: &OpenRequestEnv,
+) -> Result<(), ExecError> {
+    let lean_context = LeanDefinitionalEngine::new();
+    let req_envs = request_env.to_request_envs(&schema)?;
+    let mut results = Vec::new();
+    for req_env in req_envs.iter() {
+        results.push(lean_context.run_check_always_denies(&policyset, &schema, &req_env)?);
+    }
+    print_check_always_denies_results(&results, &req_envs, request_env);
+    Ok(())
+}
+
+/// Run lean backend for analysis `check-equivalent`
+pub fn run_check_equivalent(
+    src_policyset: PolicySet,
+    tgt_policyset: PolicySet,
+    schema: Schema,
+    request_env: &OpenRequestEnv,
+) -> Result<(), ExecError> {
+    let lean_context = LeanDefinitionalEngine::new();
+    let req_envs = request_env.to_request_envs(&schema)?;
+    let mut results = Vec::new();
+    for req_env in req_envs.iter() {
+        results.push(lean_context.run_check_equivalent(
+            &src_policyset,
+            &tgt_policyset,
+            &schema,
+            &req_env,
+        )?);
+    }
+    print_check_equivalent_results(&results, &req_envs, request_env);
+    Ok(())
+}
+
+/// Run lean backend for analysis `check-implies`
+/// Checks if Src => Tgt---i.e., If every request allowed by src is also allowed by tgt
+pub fn run_check_implies(
+    src_policyset: PolicySet,
+    tgt_policyset: PolicySet,
+    schema: Schema,
+    request_env: &OpenRequestEnv,
+) -> Result<(), ExecError> {
+    let lean_context = LeanDefinitionalEngine::new();
+    let req_envs = request_env.to_request_envs(&schema)?;
+    let mut results = Vec::new();
+    for req_env in req_envs.iter() {
+        results.push(lean_context.run_check_implies(
+            &src_policyset,
+            &tgt_policyset,
+            &schema,
+            &req_env,
+        )?);
+    }
+    print_check_implies_results(&results, &req_envs, request_env);
+    Ok(())
+}
+/// Run lean backend for analysis `check-denies`
+pub fn run_check_disjoint(
+    src_policyset: PolicySet,
+    tgt_policyset: PolicySet,
+    schema: Schema,
+    request_env: &OpenRequestEnv,
+) -> Result<(), ExecError> {
+    let lean_context = LeanDefinitionalEngine::new();
+    let req_envs = request_env.to_request_envs(&schema)?;
+    let mut results = Vec::new();
+    for req_env in req_envs.iter() {
+        results.push(lean_context.run_check_disjoint(
+            &src_policyset,
+            &tgt_policyset,
+            &schema,
+            &req_env,
+        )?);
+    }
+    print_check_disjoint_results(&results, &req_envs, request_env);
+    Ok(())
+}
+
+/// Prints to stdout the SMTLib script produced by the lean backend for analysis `check-never-errors`
+pub fn print_check_never_errors(
+    policy: Policy,
+    schema: Schema,
+    request_env: &OpenRequestEnv,
+) -> Result<(), ExecError> {
+    let lean_context = LeanDefinitionalEngine::new();
+    let req_envs = request_env.to_request_envs(&schema)?;
+    for req_env in req_envs {
+        println!(";;");
+        println!(
+            ";; SMTLib encoding for RequestEnv {}",
+            ReqEnv::Env(req_env.clone())
+        );
+        println!(";;");
+        lean_context.print_check_never_errors(&policy, &schema, &req_env)?;
+        println!("");
+    }
+    Ok(())
+}
+
+/// Prints to stdout the SMTLib script produced by the lean backend for analysis `check-always-allows`
+pub fn print_check_always_allows(
+    policyset: PolicySet,
+    schema: Schema,
+    request_env: &OpenRequestEnv,
+) -> Result<(), ExecError> {
+    let lean_context = LeanDefinitionalEngine::new();
+    let req_envs = request_env.to_request_envs(&schema)?;
+    for req_env in req_envs {
+        println!(";;");
+        println!(
+            ";; SMTLib encoding for RequestEnv {}",
+            ReqEnv::Env(req_env.clone())
+        );
+        println!(";;");
+        lean_context.print_check_always_allows(&policyset, &schema, &req_env)?;
+        println!("");
+    }
+    Ok(())
+}
+
+/// Prints to stdout the SMTLib script produced by the lean backend for analysis `check-always-denies`
+pub fn print_check_always_denies(
+    policyset: PolicySet,
+    schema: Schema,
+    request_env: &OpenRequestEnv,
+) -> Result<(), ExecError> {
+    let lean_context = LeanDefinitionalEngine::new();
+    let req_envs = request_env.to_request_envs(&schema)?;
+    for req_env in req_envs {
+        println!(";;");
+        println!(
+            ";; SMTLib encoding for RequestEnv {}",
+            ReqEnv::Env(req_env.clone())
+        );
+        println!(";;");
+        lean_context.print_check_always_denies(&policyset, &schema, &req_env)?;
+        println!("");
+    }
+    Ok(())
+}
+
+/// Prints to stdout the SMTLib script produced by the lean backend for analysis `check-equivalent`
+pub fn print_check_equivalent(
+    src_policyset: PolicySet,
+    tgt_policyset: PolicySet,
+    schema: Schema,
+    request_env: &OpenRequestEnv,
+) -> Result<(), ExecError> {
+    let lean_context = LeanDefinitionalEngine::new();
+    let req_envs = request_env.to_request_envs(&schema)?;
+    for req_env in req_envs {
+        println!(";;");
+        println!(
+            ";; SMTLib encoding for RequestEnv {}",
+            ReqEnv::Env(req_env.clone())
+        );
+        println!(";;");
+        lean_context.print_check_equivalent(&src_policyset, &tgt_policyset, &schema, &req_env)?;
+        println!("");
+    }
+    Ok(())
+}
+
+/// Prints to stdout the SMTLib script produced by the lean backend for analysis `check-implies`
+pub fn print_check_implies(
+    src_policyset: PolicySet,
+    tgt_policyset: PolicySet,
+    schema: Schema,
+    request_env: &OpenRequestEnv,
+) -> Result<(), ExecError> {
+    let lean_context = LeanDefinitionalEngine::new();
+    let req_envs = request_env.to_request_envs(&schema)?;
+    for req_env in req_envs {
+        println!(";;");
+        println!(
+            ";; SMTLib encoding for RequestEnv {}",
+            ReqEnv::Env(req_env.clone())
+        );
+        println!(";;");
+        lean_context.print_check_implies(&src_policyset, &tgt_policyset, &schema, &req_env)?;
+        println!("");
+    }
+    Ok(())
+}
+
+/// Prints to stdout the SMTLib script produced by the lean backend for analysis `check-disjoint`
+pub fn print_check_disjoint(
+    src_policyset: PolicySet,
+    tgt_policyset: PolicySet,
+    schema: Schema,
+    request_env: &OpenRequestEnv,
+) -> Result<(), ExecError> {
+    let lean_context = LeanDefinitionalEngine::new();
+    let req_envs = request_env.to_request_envs(&schema)?;
+    for req_env in req_envs {
+        println!(";;");
+        println!(
+            ";; SMTLib encoding for RequestEnv {}",
+            ReqEnv::Env(req_env.clone())
+        );
+        println!(";;");
+        lean_context.print_check_disjoint(&src_policyset, &tgt_policyset, &schema, &req_env)?;
+        println!("");
+    }
+    Ok(())
+}
+
+/***************************************************************************************************
+ * Functions to pretty print results
+ ***************************************************************************************************/
+
+struct SigWidths {
+    principal_width: usize,
+    action_width: usize,
+    resource_width: usize,
+}
+
+impl SigWidths {
+    pub fn from_req_envs(req_envs: &Vec<RequestEnv>) -> Self {
+        let mut principal_width = 13; // PrincipalType
+        let mut action_width = 10; // ActionName
+        let mut resource_width = 12; // ResourceType
+
+        for req_env in req_envs.iter() {
+            principal_width = std::cmp::max(principal_width, req_env.principal().basename().len());
+            action_width = std::cmp::max(action_width, req_env.action().id().escaped().len());
+            resource_width = std::cmp::max(resource_width, req_env.resource().basename().len());
+        }
+
+        Self {
+            principal_width,
+            action_width,
+            resource_width,
+        }
+    }
+
+    pub fn principal(&self) -> usize {
+        self.principal_width
+    }
+
+    pub fn action(&self) -> usize {
+        self.action_width
+    }
+
+    pub fn resource(&self) -> usize {
+        self.resource_width
+    }
+
+    pub fn print_header(&self, result_width: usize, result_name: &str) {
+        let table_width = 13 + self.principal() + self.action() + self.resource() + result_width; // | {principal} | {action} | {resource} | {result} |
+        println!("{:=^1$}", "", table_width);
+        print!("| {: ^1$} | ", "PrincipalType", self.principal());
+        print!("{: ^1$} | ", "ActionName", self.action());
+        print!("{: ^1$} | ", "ResourceType", self.resource());
+        println!("{: ^1$} |", result_name, result_width);
+        println!("{:-^1$}", "", table_width);
+    }
+
+    pub fn print_row(&self, req_env: &RequestEnv, result_width: usize, result: &str) {
+        print!(
+            "| {: ^1$} | ",
+            req_env.principal().basename(),
+            self.principal()
+        );
+        print!("{: ^1$} | ", req_env.action().id().escaped(), self.action());
+        print!("{: ^1$} | ", req_env.resource().basename(), self.resource());
+        println!("{: ^1$} |", result, result_width);
+    }
+
+    pub fn print_footer(&self, result_width: usize) {
+        let table_width = 13 + self.principal() + self.action() + self.resource() + result_width; // | {principal} | {action} | {resource} | {result} |
+        println!("{:=^1$}", "", table_width);
+    }
+}
+
+fn print_check_never_errors_results(
+    results: &Vec<bool>,
+    req_envs: &Vec<RequestEnv>,
+    open_req_env: &OpenRequestEnv,
+) {
+    if results.iter().all(|r| *r) {
+        if open_req_env.is_any() {
+            println!("Policy never errors")
+        } else {
+            println!("Policy never errors when {}", open_req_env)
+        }
+    } else if results.iter().all(|r| !*r) {
+        if open_req_env.is_any() {
+            println!("Policy can error for all request signatures")
+        } else {
+            println!(
+                "Policy can error for all request signatures where {}",
+                open_req_env
+            )
+        }
+    } else {
+        if open_req_env.is_any() {
+            println!("Policy can error for some request signatures")
+        } else {
+            println!(
+                "Policy can error for some request signatures where {}",
+                open_req_env
+            )
+        }
+    }
+
+    println!();
+    println!("Per request signature results:");
+
+    let sig_widths = SigWidths::from_req_envs(req_envs);
+    let res_width = 12; // Never Errors
+
+    sig_widths.print_header(res_width, "Result");
+    for (req_env, result) in zip(req_envs.iter(), results.iter()) {
+        let result = if *result { "Never Errors" } else { "Errors" };
+        sig_widths.print_row(req_env, res_width, result);
+    }
+    sig_widths.print_footer(res_width);
+}
+
+fn print_check_always_allows_results(
+    results: &Vec<bool>,
+    req_envs: &Vec<RequestEnv>,
+    open_req_env: &OpenRequestEnv,
+) {
+    if results.iter().all(|r| *r) {
+        if open_req_env.is_any() {
+            println!("PolicySet allows all requests")
+        } else {
+            println!("PolicySet allows all requests when {}", open_req_env)
+        }
+    } else if results.iter().all(|r| !*r) {
+        if open_req_env.is_any() {
+            println!("PolicySet does not allow all requests for all request signatures")
+        } else {
+            println!(
+                "PolicySet does not allow all requests when {}",
+                open_req_env
+            )
+        }
+    } else {
+        if open_req_env.is_any() {
+            println!("PolicySet allows all requests for some request signatures")
+        } else {
+            println!(
+                "PolicySet allows all requests for some request signatures where {}",
+                open_req_env
+            )
+        }
+    }
+
+    println!();
+    println!("Per request signature results:");
+
+    let sig_widths = SigWidths::from_req_envs(req_envs);
+    let res_width = 18; // Does not Allow All
+
+    sig_widths.print_header(res_width, "Result");
+    for (req_env, result) in zip(req_envs.iter(), results.iter()) {
+        let result = if *result {
+            "Allows All"
+        } else {
+            "Does not Allow All"
+        };
+        sig_widths.print_row(req_env, res_width, result);
+    }
+    sig_widths.print_footer(res_width);
+}
+
+fn print_check_always_denies_results(
+    results: &Vec<bool>,
+    req_envs: &Vec<RequestEnv>,
+    open_req_env: &OpenRequestEnv,
+) {
+    if results.iter().all(|r| *r) {
+        if open_req_env.is_any() {
+            println!("PolicySet denies all requests")
+        } else {
+            println!("PolicySet denies all requests when {}", open_req_env)
+        }
+    } else if results.iter().all(|r| !*r) {
+        if open_req_env.is_any() {
+            println!("PolicySet does not deny all requests for all request signatures")
+        } else {
+            println!("PolicySet does not deny all requests when {}", open_req_env)
+        }
+    } else {
+        if open_req_env.is_any() {
+            println!("PolicySet denies all requests for some request signatures")
+        } else {
+            println!(
+                "PolicySet denies all requests for some request signatures where {}",
+                open_req_env
+            )
+        }
+    }
+
+    println!();
+    println!("Per request signature results:");
+
+    let sig_widths = SigWidths::from_req_envs(req_envs);
+    let res_width = 17; // Does not Deny All
+
+    sig_widths.print_header(res_width, "Result");
+    for (req_env, result) in zip(req_envs.iter(), results.iter()) {
+        let result = if *result {
+            "Denies All"
+        } else {
+            "Does not Deny All"
+        };
+        sig_widths.print_row(req_env, res_width, result);
+    }
+    sig_widths.print_footer(res_width);
+}
+
+fn print_check_equivalent_results(
+    results: &Vec<bool>,
+    req_envs: &Vec<RequestEnv>,
+    open_req_env: &OpenRequestEnv,
+) {
+    if results.iter().all(|r| *r) {
+        if open_req_env.is_any() {
+            println!("Source and Target PolicySets are equivalent")
+        } else {
+            println!(
+                "Source and Target PolicySets are equivalent when {}",
+                open_req_env
+            )
+        }
+    } else if results.iter().all(|r| !*r) {
+        if open_req_env.is_any() {
+            println!("Source and Target PolicySets are not equivalent")
+        } else {
+            println!(
+                "Source and Target PolicySets are not equivalent for all requests when {}",
+                open_req_env
+            )
+        }
+    } else {
+        if open_req_env.is_any() {
+            println!("Source and Target PolicySets are not equivalent for some signatures")
+        } else {
+            println!("Source and Target PolicySets are not equivalent for some request signatures where {}", open_req_env)
+        }
+    }
+
+    println!();
+    println!("Per request signature results:");
+
+    let sig_widths = SigWidths::from_req_envs(req_envs);
+    let res_width = 14; // Not Equivalent
+
+    sig_widths.print_header(res_width, "Result");
+    for (req_env, result) in zip(req_envs.iter(), results.iter()) {
+        let result = if *result {
+            "Equivalent"
+        } else {
+            "Not Equivalent"
+        };
+        sig_widths.print_row(req_env, res_width, result);
+    }
+    sig_widths.print_footer(res_width);
+}
+
+fn print_check_implies_results(
+    results: &Vec<bool>,
+    req_envs: &Vec<RequestEnv>,
+    open_req_env: &OpenRequestEnv,
+) {
+    if results.iter().all(|r| *r) {
+        if open_req_env.is_any() {
+            println!("Source PolicySet implies Target PolicySet")
+        } else {
+            println!(
+                "Source PolicySet implies Target PolicySet when {}",
+                open_req_env
+            )
+        }
+    } else if results.iter().all(|r| !*r) {
+        if open_req_env.is_any() {
+            println!("Source PolicySet does not imply Target PolicySet")
+        } else {
+            println!(
+                "Source PolicySet does not imply Target PolicySet for all requests where {}",
+                open_req_env
+            )
+        }
+    } else {
+        if open_req_env.is_any() {
+            println!("Source PolicySet implies Target PolicySet for some request signatures")
+        } else {
+            println!(
+                "Source PolicySet implies Target PolicySet for some request signatures where {}",
+                open_req_env
+            )
+        }
+    }
+
+    println!();
+    println!("Per request signature results:");
+
+    let sig_widths = SigWidths::from_req_envs(req_envs);
+    let res_width = 14; // Does Not Imply
+
+    sig_widths.print_header(res_width, "Result");
+    for (req_env, result) in zip(req_envs.iter(), results.iter()) {
+        let result = if *result { "Implies" } else { "Does Not Imply" };
+        sig_widths.print_row(req_env, res_width, result);
+    }
+    sig_widths.print_footer(res_width);
+}
+
+fn print_check_disjoint_results(
+    results: &Vec<bool>,
+    req_envs: &Vec<RequestEnv>,
+    open_req_env: &OpenRequestEnv,
+) {
+    if results.iter().all(|r| *r) {
+        if open_req_env.is_any() {
+            println!("Source PolicySet is disjoint with Target PolicySet")
+        } else {
+            println!(
+                "Source PolicySet is disjoint with Target PolicySet when {}",
+                open_req_env
+            )
+        }
+    } else if results.iter().all(|r| !*r) {
+        if open_req_env.is_any() {
+            println!("Source PolicySet is not disjoint with Target PolicySet")
+        } else {
+            println!(
+                "Source PolicySet is not disjoint with Target PolicySet for all requests where {}",
+                open_req_env
+            )
+        }
+    } else {
+        if open_req_env.is_any() {
+            println!(
+                "Source PolicySet is disjoint with Target PolicySet for some request signatures"
+            )
+        } else {
+            println!("Source PolicySet is disjoint with Target PolicySet for some request signatures where {}", open_req_env)
+        }
+    }
+
+    println!();
+    println!("Per request signature results:");
+
+    let sig_widths = SigWidths::from_req_envs(req_envs);
+    let res_width = 12; // Not Disjoint
+
+    sig_widths.print_header(res_width, "Result");
+    for (req_env, result) in zip(req_envs.iter(), results.iter()) {
+        let result = if *result { "Disjoint" } else { "Not Disjoint" };
+        sig_widths.print_row(req_env, res_width, result);
+    }
+    sig_widths.print_footer(res_width);
+}

--- a/cedar-cli/src/util.rs
+++ b/cedar-cli/src/util.rs
@@ -1,0 +1,715 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+use crate::analysis::{AnalyzePolicyFindings, PerSigFindings, VacuityResult};
+use crate::cli_enums::{ContextArg, RequestArgsEnum, ValidationMode};
+use crate::err::{ContentType, EntityType, ExecError, RequestElement};
+use cedar_policy::{
+    Context, Entities, EntityId, EntityTypeName, EntityUid, Expression, Policy, PolicyId,
+    PolicySet, Request, RequestEnv, Schema,
+};
+use itertools::Itertools;
+use miette::WrapErr;
+use serde::Serialize;
+use serde_json::{from_str, Value};
+use std::collections::HashSet;
+use std::{fs::read_to_string, path::PathBuf, str::FromStr};
+
+/// A struct reprensting which request environments to restrict the analysis to
+/// we will check against all (well-formed) request environments restricted to
+/// the `OpenRequestEnv`
+pub struct OpenRequestEnv {
+    principal_type: Option<EntityTypeName>,
+    action_id: Option<EntityUid>,
+    resource_type: Option<EntityTypeName>,
+}
+
+impl OpenRequestEnv {
+    pub fn any() -> Self {
+        Self {
+            principal_type: None,
+            action_id: None,
+            resource_type: None,
+        }
+    }
+
+    pub fn is_any(&self) -> bool {
+        match (&self.principal_type, &self.action_id, &self.resource_type) {
+            (None, None, None) => true,
+            _ => false,
+        }
+    }
+
+    fn principal_type_fmt(
+        ptype: &EntityTypeName,
+        f: &mut std::fmt::Formatter<'_>,
+    ) -> std::fmt::Result {
+        write!(f, "principal ∈ {}", ptype)
+    }
+
+    fn action_id_fmt(aid: &EntityUid, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "action == {}", aid)
+    }
+
+    fn resource_type_fmt(
+        rtype: &EntityTypeName,
+        f: &mut std::fmt::Formatter<'_>,
+    ) -> std::fmt::Result {
+        write!(f, "resource ∈ {}", rtype)
+    }
+}
+
+/// Add a pretty-print for OpenRequestEnv, if an element is not provided then it may be `any` such EntityType
+impl std::fmt::Display for OpenRequestEnv {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match (&self.principal_type, &self.action_id, &self.resource_type) {
+            (None, None, None) => Ok(()),
+            (Some(ptype), None, None) => Self::principal_type_fmt(ptype, f),
+            (None, Some(aid), None) => Self::action_id_fmt(aid, f),
+            (None, None, Some(rtype)) => Self::resource_type_fmt(rtype, f),
+            (Some(ptype), Some(aid), None) => {
+                Self::principal_type_fmt(ptype, f)?;
+                write!(f, " and ")?;
+                Self::action_id_fmt(aid, f)
+            }
+            (Some(ptype), None, Some(rtype)) => {
+                Self::principal_type_fmt(ptype, f)?;
+                write!(f, " and ")?;
+                Self::resource_type_fmt(rtype, f)
+            }
+            (None, Some(aid), Some(rtype)) => {
+                Self::action_id_fmt(aid, f)?;
+                write!(f, " and ")?;
+                Self::resource_type_fmt(rtype, f)
+            }
+            (Some(ptype), Some(aid), Some(rtype)) => {
+                Self::principal_type_fmt(ptype, f)?;
+                write!(f, ", ")?;
+                Self::action_id_fmt(aid, f)?;
+                write!(f, ", and ")?;
+                Self::resource_type_fmt(rtype, f)
+            }
+        }
+    }
+}
+
+/// A simple wrapper around Cedar's RequestEnv type to allow for pretty-printing
+#[derive(Debug)]
+pub enum ReqEnv {
+    Env(RequestEnv),
+}
+
+impl std::fmt::Display for ReqEnv {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let req_env = match self {
+            ReqEnv::Env(req_env) => req_env.clone(),
+        };
+        write!(
+            f,
+            "(PrincipalType: {0}, ActionName: {1}, ResourceType: {2})",
+            req_env.principal().basename(),
+            req_env.action().id().escaped(),
+            req_env.resource().basename()
+        )
+    }
+}
+
+/// Convert from strings to Cedar Types.
+impl OpenRequestEnv {
+    fn entity_type_from_str(
+        type_str: Option<String>,
+        err_type: EntityType,
+    ) -> Result<Option<EntityTypeName>, ExecError> {
+        let type_str = match type_str {
+            Option::None => return Ok(None),
+            Some(type_str) => type_str,
+        };
+        match EntityTypeName::from_str(&type_str) {
+            Ok(type_name) => Ok(Some(type_name)),
+            Err(parse_err) => Err(ExecError::EntityTypeError {
+                entity_type: err_type,
+                input_str: type_str,
+                error: Box::new(parse_err),
+            }),
+        }
+    }
+
+    fn action_id_from_str(action_name: Option<String>) -> Option<EntityUid> {
+        let action_name = match action_name {
+            Option::None => return None,
+            Some(action_name) => action_name,
+        };
+        let action_type = EntityTypeName::from_str("Action").unwrap();
+        let action_id = EntityId::from_str(&action_name).unwrap();
+        Some(EntityUid::from_type_name_and_id(action_type, action_id))
+    }
+
+    pub fn new(
+        principal_type: Option<String>,
+        action_name: Option<String>,
+        resource_type: Option<String>,
+    ) -> Result<OpenRequestEnv, ExecError> {
+        let principal_type =
+            Self::entity_type_from_str(principal_type, EntityType::PrincipalTypeName)?;
+        let action_id = Self::action_id_from_str(action_name);
+        let resource_type =
+            Self::entity_type_from_str(resource_type, EntityType::ResourceTypeName)?;
+
+        return Ok(OpenRequestEnv {
+            principal_type,
+            action_id,
+            resource_type,
+        });
+    }
+
+    /// Convert a OpenRequestEnv to a vector of RequestEnv that are
+    /// 1) consistent with OpenRequestEnv, and
+    /// 2) consistent with the provided `schema`
+    /// if `self` specifies any component and there are no (principal, action, resource)
+    /// consistent with both `self` and `schema`, then an error will be thrown. Otherwise,
+    /// if the schema has no such request environments, then an empty vector is returned.
+    pub fn to_request_envs(&self, schema: &Schema) -> Result<Vec<RequestEnv>, ExecError> {
+        let action_ids = schema
+            .action_entities()?
+            .into_iter()
+            .map(|action| action.uid());
+        let mut req_envs: Vec<RequestEnv> = Vec::new();
+        for action_id in action_ids {
+            match &self.action_id {
+                // only compare ids rather than full uids because JSON schemas append additional
+                // namespaces before action.
+                Some(req_act_id) if (*req_act_id).id() != action_id.id() => continue,
+                _ => (),
+            };
+            match schema.principals_for_action(&action_id) {
+                Some(principal_types) => {
+                    for principal_type in principal_types {
+                        match &self.principal_type {
+                            Some(req_principal_type) if req_principal_type != principal_type => {
+                                continue
+                            }
+                            _ => (),
+                        };
+                        match schema.resources_for_action(&action_id) {
+                            Some(resource_types) => {
+                                for resource_type in resource_types {
+                                    match &self.resource_type {
+                                        Some(req_resource_type)
+                                            if req_resource_type != resource_type =>
+                                        {
+                                            continue
+                                        }
+                                        _ => (),
+                                    };
+                                    let req_env = RequestEnv::new(
+                                        principal_type.clone(),
+                                        action_id.clone(),
+                                        resource_type.clone(),
+                                    );
+                                    req_envs.push(req_env)
+                                }
+                            }
+                            _ => (),
+                        }
+                    }
+                }
+                _ => (),
+            }
+        }
+        if req_envs.is_empty()
+            && (self.action_id.is_some()
+                || self.principal_type.is_some()
+                || self.resource_type.is_some())
+        {
+            return Err(ExecError::RequestEnvArgsIncompatible {
+                principal_type: match &self.principal_type {
+                    Some(principal_type) => principal_type.basename().into(),
+                    _ => "Every principal".into(),
+                },
+                action_name: match &self.action_id {
+                    Some(action_id) => action_id.id().escaped().into(),
+                    _ => "perform any action".into(),
+                },
+                resource_type: match &self.resource_type {
+                    Some(resource_type) => resource_type.basename().into(),
+                    _ => "any resource".into(),
+                },
+            });
+        }
+        // Make determinstic order to make CLI more usable for error detection
+        req_envs.sort();
+        Ok(req_envs)
+    }
+}
+
+/// Auxilary function that parses a Policy, simple wrapper around cedar::Policy::from_str
+pub fn parse_policy(fname: &PathBuf) -> Result<Policy, ExecError> {
+    match read_to_string(fname) {
+        Ok(policy_text) => match Policy::from_str(policy_text.as_str()) {
+            Ok(policy) => Ok(rename_from_id_annotation_policy(policy)),
+            Err(parse_err) => Err(ExecError::ParseError {
+                content_type: ContentType::Policy,
+                file_name: fname.to_path_buf(),
+                error: Box::new(parse_err),
+            }),
+        },
+        Err(read_error) => Err(ExecError::FileReadError {
+            content_type: ContentType::Policy,
+            file_name: fname.to_path_buf(),
+            error: Box::new(read_error),
+        }),
+    }
+}
+
+fn rename_from_id_annotation_policy(policy: Policy) -> Policy {
+    match policy.annotation("id") {
+        None => policy,
+        Some(anno) => anno
+            .parse()
+            .map(|id| policy.new_id(id))
+            .unwrap_or_else(|never| match never {}),
+    }
+}
+
+/// Auxilary function that parses a PolicySet, simple wrapper around cedar::PolicySet::from_str
+pub fn parse_policyset(fname: &PathBuf) -> Result<PolicySet, ExecError> {
+    match read_to_string(fname) {
+        Ok(policyset_text) => match PolicySet::from_str(policyset_text.as_str()) {
+            Ok(policyset) => match rename_from_id_annotation_policyset(policyset) {
+                Ok(pset) => Ok(pset),
+                Err(err) => Err(ExecError::RenameIdError {
+                    content_type: ContentType::PolicySet,
+                    file_name: fname.to_path_buf(),
+                    error: err,
+                }),
+            },
+            Err(parse_err) => Err(ExecError::ParseError {
+                content_type: ContentType::PolicySet,
+                file_name: fname.to_path_buf(),
+                error: Box::new(parse_err),
+            }),
+        },
+        Err(read_error) => Err(ExecError::FileReadError {
+            content_type: ContentType::PolicySet,
+            file_name: fname.to_path_buf(),
+            error: Box::new(read_error),
+        }),
+    }
+}
+
+fn rename_from_id_annotation_policyset(ps: PolicySet) -> miette::Result<PolicySet> {
+    let mut new_ps = PolicySet::new();
+    let t_iter = ps.templates().map(|t| match t.annotation("id") {
+        None => Ok(t.clone()),
+        Some(anno) => anno.parse().map(|a| t.new_id(a)),
+    });
+    for t in t_iter {
+        let template = t.unwrap_or_else(|never| match never {});
+        new_ps
+            .add_template(template)
+            .wrap_err("failed to add template to policy set")?;
+    }
+    let p_iter = ps.policies().map(|p| match p.annotation("id") {
+        None => Ok(p.clone()),
+        Some(anno) => anno.parse().map(|a| p.new_id(a)),
+    });
+    for p in p_iter {
+        let policy = p.unwrap_or_else(|never| match never {});
+        new_ps
+            .add(policy)
+            .wrap_err("failed to add template to policy set")?;
+    }
+    Ok(new_ps)
+}
+
+/// Auxilary function that parses a Schema
+/// if the schema-file name ends in .json use JSON format, otherwise
+/// use the cedar-schema format.
+pub fn parse_schema(fname: &PathBuf) -> Result<Schema, ExecError> {
+    match read_to_string(fname) {
+        Ok(schema_text) => {
+            if fname.ends_with(".json") {
+                match Schema::from_json_str(schema_text.as_str()) {
+                    Ok(schema) => Ok(schema),
+                    Err(schema_err) => Err(ExecError::ParseError {
+                        content_type: ContentType::Schema,
+                        file_name: fname.to_path_buf(),
+                        error: Box::new(schema_err),
+                    }),
+                }
+            } else {
+                match Schema::from_str(schema_text.as_str()) {
+                    Ok(schema) => Ok(schema),
+                    Err(schema_err) => Err(ExecError::ParseError {
+                        content_type: ContentType::Schema,
+                        file_name: fname.to_path_buf(),
+                        error: Box::new(schema_err),
+                    }),
+                }
+            }
+        }
+        Err(read_error) => Err(ExecError::FileReadError {
+            content_type: ContentType::Schema,
+            file_name: fname.to_path_buf(),
+            error: Box::new(read_error),
+        }),
+    }
+}
+
+/// Auxillary function used to parse a file containing Cedar Entities
+pub fn parse_entities(fname: &PathBuf) -> Result<Entities, ExecError> {
+    match read_to_string(fname) {
+        Ok(entities_json_str) => match Entities::from_json_str(&entities_json_str, None) {
+            Ok(entities) => Ok(entities),
+            Err(e) => Err(ExecError::ParseError {
+                content_type: ContentType::Entities,
+                file_name: fname.to_path_buf(),
+                error: Box::new(e),
+            }),
+        },
+        Err(read_error) => Err(ExecError::FileReadError {
+            content_type: ContentType::Entities,
+            file_name: fname.to_path_buf(),
+            error: Box::new(read_error),
+        }),
+    }
+}
+
+/// Auxillary function used to parse a file containing a Cedar Expression
+pub fn parse_expression(fname: &PathBuf) -> Result<Expression, ExecError> {
+    match read_to_string(fname) {
+        Ok(expr_str) => match Expression::from_str(&expr_str) {
+            Ok(expr) => Ok(expr),
+            Err(e) => Err(ExecError::ParseError {
+                content_type: ContentType::Expression,
+                file_name: fname.to_path_buf(),
+                error: Box::new(e),
+            }),
+        },
+        Err(read_error) => Err(ExecError::FileReadError {
+            content_type: ContentType::Expression,
+            file_name: fname.to_path_buf(),
+            error: Box::new(read_error),
+        }),
+    }
+}
+
+impl ContextArg {
+    /// Parses a ContextArg into a Cedar Context struct
+    pub fn parse(self) -> Result<Context, ExecError> {
+        match self {
+            Self::Default => Ok(Context::empty()),
+            Self::FromString { json_str } => match Context::from_json_str(&json_str, None) {
+                Ok(c) => Ok(c),
+                Err(e) => Err(ExecError::RequestError {
+                    element: RequestElement::Context,
+                    input_str: json_str,
+                    error: Box::new(e),
+                }),
+            },
+            Self::FromFile { file_name } => match read_to_string(&file_name) {
+                Ok(json_str) => match Context::from_json_str(&json_str, None) {
+                    Ok(c) => Ok(c),
+                    Err(e) => Err(ExecError::ParseError {
+                        content_type: ContentType::Context,
+                        file_name: file_name.to_path_buf(),
+                        error: Box::new(e),
+                    }),
+                },
+                Err(e) => Err(ExecError::FileReadError {
+                    content_type: ContentType::Context,
+                    file_name: file_name.to_path_buf(),
+                    error: Box::new(e),
+                }),
+            },
+        }
+    }
+}
+
+/// Auxillary function that converts a string to an Cedar EntityUid
+fn parse_entity_uid(input_str: String, element: RequestElement) -> Result<EntityUid, ExecError> {
+    match EntityUid::from_str(&input_str) {
+        Ok(euid) => Ok(euid),
+        Err(e) => Err(ExecError::RequestError {
+            element,
+            input_str,
+            error: Box::new(e),
+        }),
+    }
+}
+
+/// Auxillary function used to convert CLI arguments into a Cedar Request struct
+fn request_from_args(
+    principal: String,
+    action: String,
+    resource: String,
+    context: ContextArg,
+) -> Result<Request, ExecError> {
+    let principal = parse_entity_uid(principal, RequestElement::Principal)?;
+    let action = parse_entity_uid(action, RequestElement::Action)?;
+    let resource = parse_entity_uid(resource, RequestElement::Resource)?;
+    let context = context.parse()?;
+    match Request::new(principal, action, resource, context, None) {
+        Ok(r) => Ok(r),
+        Err(e) => Err(ExecError::RequestValidationError { error: Box::new(e) }),
+    }
+}
+
+/// Auxillary function used to help parse JSON values
+fn string_from_value(v: Option<&Value>) -> Option<String> {
+    match v {
+        Some(Value::String(s)) => Some(s.clone()),
+        _ => None,
+    }
+}
+
+/// Auxillary function used to convert a JSON representation of a request into a Cedar Request struct
+fn request_from_json_value(v: Value, fname: PathBuf) -> Result<Request, ExecError> {
+    let principal = string_from_value(v.get("principal"));
+    let action = string_from_value(v.get("action"));
+    let resource = string_from_value(v.get("resource"));
+    let context = v.get("context");
+    match (principal, action, resource, context) {
+        (Some(p), Some(a), Some(r), Some(c)) => request_from_args(
+            p,
+            a,
+            r,
+            ContextArg::FromString {
+                json_str: c.to_string(),
+            },
+        ),
+        _ => Err(ExecError::ParseJsonError {
+            content_type: ContentType::Request,
+            file_name: fname,
+        }),
+    }
+}
+
+impl RequestArgsEnum {
+    /// A function that parses a RequestArgEnum into a Cedar Request struct
+    pub fn parse(self) -> Result<Request, ExecError> {
+        match self {
+            Self::FromArgs {
+                principal,
+                action,
+                resource,
+                context,
+            } => request_from_args(principal, action, resource, context),
+            Self::FromFile { file_name } => match read_to_string(&file_name) {
+                Ok(json_str) => match from_str::<Value>(&json_str) {
+                    Ok(v) => request_from_json_value(v, file_name),
+                    Err(e) => Err(ExecError::ParseError {
+                        content_type: ContentType::Request,
+                        file_name: file_name,
+                        error: Box::new(e),
+                    }),
+                },
+                Err(e) => Err(ExecError::FileReadError {
+                    content_type: ContentType::Request,
+                    file_name: file_name,
+                    error: Box::new(e),
+                }),
+            },
+        }
+    }
+}
+
+/// Convert from our ValidationMode enum to Cedar ValidationMode enum
+impl ValidationMode {
+    pub fn to_cedar(self) -> cedar_policy::ValidationMode {
+        match self {
+            Self::Strict => cedar_policy::ValidationMode::Strict,
+            Self::Permissive => cedar_policy::ValidationMode::Permissive,
+        }
+    }
+}
+
+/// Helper classes for printing findings to json
+#[derive(Serialize, Debug, Clone)]
+pub struct RequestEnvSer {
+    pub principal_type: String,
+    pub action_uid: String,
+    pub resource_type: String,
+}
+
+impl RequestEnvSer {
+    pub fn new(req_env: &RequestEnv) -> Self {
+        RequestEnvSer {
+            principal_type: req_env.principal().basename().to_string(),
+            action_uid: req_env.action().id().escaped().to_string(),
+            resource_type: req_env.resource().basename().to_string(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct PolicySer {
+    policy_id: PolicyId,
+    policy_str: String,
+}
+
+impl PolicySer {
+    fn new(policy_id: &PolicyId, policy_set: &PolicySet) -> Self {
+        let policy_str = policy_set.policy(policy_id).unwrap().to_cedar().unwrap();
+        PolicySer {
+            policy_id: policy_id.clone(),
+            policy_str,
+        }
+    }
+
+    fn from_set(pid_set: &HashSet<PolicyId>, policy_set: &PolicySet) -> Vec<PolicySer> {
+        pid_set
+            .iter()
+            .map(|pid| PolicySer::new(pid, policy_set))
+            .collect_vec()
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct PermitShadowedByPermit {
+    permit: PolicySer,
+    shadowing_permits: Vec<PolicySer>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct ForbidShadowedByForbids {
+    forbid: PolicySer,
+    shadowing_forbids: Vec<PolicySer>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct PermitOverridenByForbids {
+    permit: PolicySer,
+    overriding_forbids: Vec<PolicySer>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct EquivalentPolicies {
+    equivalent_policies: Vec<PolicySer>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct VacuityFinding {
+    policy: PolicySer,
+    status: VacuityResult,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct PerSigFindingsSer {
+    req_env: RequestEnvSer,
+    equiv_classes: Vec<EquivalentPolicies>,
+    permit_shadowed_by_permits: Vec<PermitShadowedByPermit>,
+    forbid_shadowed_by_forbids: Vec<ForbidShadowedByForbids>,
+    permit_overriden_by_forbids: Vec<PermitOverridenByForbids>,
+}
+
+impl PerSigFindingsSer {
+    fn new(per_sig_findings: &PerSigFindings, policy_set: &PolicySet) -> Self {
+        let equiv_classes = per_sig_findings
+            .equiv_classes
+            .iter()
+            .filter_map(|pid_set| {
+                if pid_set.is_empty() {
+                    None
+                } else {
+                    Some(EquivalentPolicies {
+                        equivalent_policies: PolicySer::from_set(pid_set, policy_set),
+                    })
+                }
+            })
+            .collect_vec();
+
+        let permit_shadowed_by_permits = per_sig_findings
+            .permit_shadowed_by_permits
+            .iter()
+            .filter_map(|(pid, pid_set)| {
+                if pid_set.is_empty() {
+                    None
+                } else {
+                    Some(PermitShadowedByPermit {
+                        permit: PolicySer::new(pid, policy_set),
+                        shadowing_permits: PolicySer::from_set(pid_set, policy_set),
+                    })
+                }
+            })
+            .collect_vec();
+        let forbid_shadowed_by_forbids = per_sig_findings
+            .forbid_shadowed_by_forbids
+            .iter()
+            .filter_map(|(pid, pid_set)| {
+                if pid_set.is_empty() {
+                    None
+                } else {
+                    Some(ForbidShadowedByForbids {
+                        forbid: PolicySer::new(pid, policy_set),
+                        shadowing_forbids: PolicySer::from_set(pid_set, policy_set),
+                    })
+                }
+            })
+            .collect_vec();
+
+        let permit_overriden_by_forbids = per_sig_findings
+            .permit_overriden_by_forbids
+            .iter()
+            .filter_map(|(pid, pid_set)| {
+                if pid_set.is_empty() {
+                    None
+                } else {
+                    Some(PermitOverridenByForbids {
+                        permit: PolicySer::new(pid, policy_set),
+                        overriding_forbids: PolicySer::from_set(pid_set, policy_set),
+                    })
+                }
+            })
+            .collect_vec();
+        PerSigFindingsSer {
+            req_env: per_sig_findings.req_env.clone(),
+            equiv_classes,
+            permit_shadowed_by_permits,
+            forbid_shadowed_by_forbids,
+            permit_overriden_by_forbids,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct AnalyzePolicyFindingsSer {
+    vacuous_result: VacuityResult,
+    vacuous_policies: Vec<VacuityFinding>,
+    per_sig_findings: Vec<PerSigFindingsSer>,
+}
+
+impl AnalyzePolicyFindingsSer {
+    pub(crate) fn new(analyze_findings: &AnalyzePolicyFindings, policy_set: &PolicySet) -> Self {
+        let vacuous_policies = analyze_findings
+            .vacuous_policies
+            .iter()
+            .map(|(pid, res)| VacuityFinding {
+                policy: PolicySer::new(pid, policy_set),
+                status: *res,
+            })
+            .collect_vec();
+        let per_sig_findings = analyze_findings
+            .per_sig_findings
+            .iter()
+            .map(|findings| PerSigFindingsSer::new(findings, policy_set))
+            .collect_vec();
+        AnalyzePolicyFindingsSer {
+            vacuous_result: analyze_findings.vacuous_result,
+            vacuous_policies,
+            per_sig_findings,
+        }
+    }
+}

--- a/cedar-cli/src/validation.rs
+++ b/cedar-cli/src/validation.rs
@@ -1,0 +1,89 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+use crate::err::ExecError;
+use crate::lean_ffi::{LeanDefinitionalEngine, ValidationResponse};
+use cedar_policy::{Entities, PolicySet, Request, Schema, ValidationMode};
+
+/// Validate (using the lean_ffi backend) that the input `PolicySet` matches the provided
+/// `Schema` for the given `ValidationMode` (Strict or Permissive)
+pub fn validate(
+    policyset: &PolicySet,
+    schema: &Schema,
+    mode: &ValidationMode,
+) -> Result<(), ExecError> {
+    let lean_context = LeanDefinitionalEngine::new();
+    match lean_context.validate(policyset, schema, mode) {
+        Ok(ValidationResponse::Ok(())) => {
+            println!("Policyset successfully validated");
+            Ok(())
+        }
+        Ok(ValidationResponse::Error(s)) => {
+            println!("Policyset failed to validate: {s}");
+            Ok(())
+        }
+        Err(e) => Err(e),
+    }
+}
+
+/// Validates (using the lean_ffi backend) that the input `PolicySet` matches the provided
+/// `Schema` at level `level`. Level 0 means no entity or context record fields are accessed.
+/// Level `i` means that record fields are accessed upto depth `i`.
+pub fn level_validate(policyset: &PolicySet, schema: &Schema, level: i32) -> Result<(), ExecError> {
+    let lean_context = LeanDefinitionalEngine::new();
+    match lean_context.level_validate(policyset, schema, level) {
+        Ok(ValidationResponse::Ok(())) => {
+            println!("Policyset successfully validated at level {level}");
+            Ok(())
+        }
+        Ok(ValidationResponse::Error(s)) => {
+            println!("Policyset failed to validate at level {level}: {s}");
+            Ok(())
+        }
+        Err(e) => Err(e),
+    }
+}
+
+/// Validates (using the lean_ffi backend) that the input `Entities` matches the provided `Schema`
+pub fn validate_entities(schema: &Schema, entities: &Entities) -> Result<(), ExecError> {
+    let lean_context = LeanDefinitionalEngine::new();
+    match lean_context.validate_entities(schema, entities) {
+        Ok(ValidationResponse::Ok(())) => {
+            println!("Entities successfully validated");
+            Ok(())
+        }
+        Ok(ValidationResponse::Error(s)) => {
+            println!("Entities failed to validate: {s}");
+            Ok(())
+        }
+        Err(e) => Err(e),
+    }
+}
+
+/// Validates (using the lean_ffi backend) that the input `Request` matches the provided `Schema`
+pub fn validate_request(schema: &Schema, request: &Request) -> Result<(), ExecError> {
+    let lean_context = LeanDefinitionalEngine::new();
+    match lean_context.validate_request(schema, request) {
+        Ok(ValidationResponse::Ok(())) => {
+            println!("Request successfully validated");
+            Ok(())
+        }
+        Ok(ValidationResponse::Error(s)) => {
+            println!("Request failed to validate: {s}");
+            Ok(())
+        }
+        Err(e) => Err(e),
+    }
+}

--- a/cedar-lean/CedarFFI.lean
+++ b/cedar-lean/CedarFFI.lean
@@ -1,0 +1,17 @@
+/-
+ Copyright Cedar Contributors
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-/
+
+import CedarFFI.Main

--- a/cedar-lean/CedarFFI/Main.lean
+++ b/cedar-lean/CedarFFI/Main.lean
@@ -1,0 +1,146 @@
+/-
+ Copyright Cedar Contributors
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-/
+
+import Lean.Data.Json.FromToJson
+
+import Cedar.Spec
+import Cedar.Validation
+import CedarProto
+import Protobuf
+
+/-! This file defines the public interfaces for the Lean implementation.
+    The input and output are stringified JSON objects. -/
+
+namespace DiffTest
+
+open Cedar.Spec
+open Cedar.Validation
+open Proto
+
+/--
+  `req`: binary protobuf for an `AuthorizationRequest`
+
+  returns a string containing JSON
+-/
+@[export isAuthorized] unsafe def isAuthorizedFFI (req: ByteArray) : String :=
+    let result: Except String Response :=
+      match (@Message.interpret? AuthorizationRequest) req with
+      | .error e =>
+        .error s!"isAuthorizedDRT: failed to parse input: {e}"
+      | .ok p =>
+        let result := isAuthorized p.request p.entities p.policies
+        .ok result
+    toString (Lean.toJson result)
+
+/--
+  `req`: binary protobuf for a `ValidationRequest`
+
+  returns a string containing JSON
+-/
+@[export validate] unsafe def validateReqFFI (req : ByteArray) : String :=
+    let result: Except String ValidationResult :=
+      match (@Message.interpret? ValidationRequest) req with
+      | .error e =>
+        .error s!"validateDRT: failed to parse input: {e}"
+      | .ok v =>
+        let result := validate v.policies v.schema
+        .ok result
+    toString (Lean.toJson result)
+
+/--
+  `req`: binary protobuf for a `LevelValidationRequest`
+
+  returns a string containing JSON
+-/
+@[export levelValidate] unsafe def levelValidateFFI (req : ByteArray) : String :=
+    let result: Except String ValidationResult :=
+      match (@Message.interpret? LevelValidationRequest) req with
+      | .error e =>
+        .error s!"levelValidateDRT: failed to parse input: {e}"
+      | .ok v =>
+        let result := validateWithLevel v.policies v.schema v.level.level
+        .ok result
+    toString (Lean.toJson result)
+
+/--
+  `req`: binary protobuf for an `EvaluationRequest`
+
+  Parses req, evalutes expression, and prints it.
+  returns a string encoding either .error err_msg if an error occurs or .ok () upon success
+-/
+@[export printEvaluation] unsafe def printEvaluationFFI (req: ByteArray) : String :=
+  let result : Except String Unit :=
+    match (@Message.interpret? EvaluationRequest) req with
+    | .error e => .error s!"evaluate: failed to parse input: {e}"
+    | .ok v =>
+      match evaluate v.expr v.request v.entities with
+      | .error e => .error s!"evaluate: error during evaluation: {reprStr e}"
+      | .ok v =>
+        match unsafeIO (println! "{reprStr v}") with
+        | .error _ => .error s!"evaluate: error printing value"
+        | .ok _ => .ok ()
+  toString (Lean.toJson result)
+
+/--
+  `req`: binary protobuf for an `EvaluationRequest`
+
+  returns a string containing JSON, indicating whether the Lean evaluation
+  result matches the `expected` in the request (where `expected = none`
+  indicates the evaluation is expected to produce an error)
+-/
+@[export checkEvaluate] unsafe def checkEvaluateFFI (req : ByteArray) : String :=
+  let result : Except String Bool := do
+    match (@Message.interpret? EvaluationRequest) req with
+    | .error e => .error s!"evaluate: failed to parse input: {e}"
+    | .ok v =>
+      match (evaluate v.expr v.request v.entities), v.expected with
+      | .error _, .none => .ok true
+      | .ok v₁, .some v₂ => .ok (v₁ == v₂)
+      | _, _ => .ok false
+  toString (Lean.toJson result)
+
+/--
+  `req`: binary protobuf for an `EntityValidationRequest`
+
+  returns a string containing JSON
+-/
+@[export validateEntities] unsafe def validateEntitiesFFI (req : ByteArray) : String :=
+  let result : Except String EntityValidationResult :=
+    match (@Message.interpret? EntityValidationRequest) req with
+    | .error e => .error s!"validateEntitiesDRT: failed to parse input: {e}"
+    | .ok v => do
+        let actionEntities := (v.schema.acts.mapOnValues actionSchemaEntryToEntityData)
+        let entities := Cedar.Data.Map.make (v.entities.kvs ++ actionEntities.kvs)
+        let schema := updateSchema v.schema actionEntities
+        let result := Cedar.Validation.validateEntities schema entities
+        .ok result
+  toString (Lean.toJson result)
+
+/--
+  `req`: binary protobuf for a `RequestValidationRequest`
+
+  returns a string containing JSON
+-/
+@[export validateRequest] unsafe def validateRequestFFI (req : ByteArray) : String :=
+  let result : Except String RequestValidationResult :=
+    match (@Message.interpret? RequestValidationRequest) req with
+    | .error e => .error s!"validateRequestDRT: failed to parse input: {e}"
+    | .ok v => do
+        let result := Cedar.Validation.validateRequest v.schema v.request
+        .ok result
+  toString (Lean.toJson result)
+
+end DiffTest

--- a/cedar-lean/CedarProto.lean
+++ b/cedar-lean/CedarProto.lean
@@ -32,6 +32,7 @@ import CedarProto.PrincipalOrResourceConstraint
 import CedarProto.Request
 import CedarProto.RequestValidationRequest
 import CedarProto.Schema
+import CedarProto.SymCCRequest
 import CedarProto.TemplateBody
 import CedarProto.Type
 import CedarProto.ValidationRequest

--- a/cedar-lean/CedarProto/RequestEnv.lean
+++ b/cedar-lean/CedarProto/RequestEnv.lean
@@ -1,0 +1,54 @@
+/-
+ Copyright Cedar Contributors
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-/
+import Cedar.Spec
+import Cedar.Validation
+import Protobuf.Message
+import Protobuf.Structure
+
+-- Message Dependencies
+import CedarProto.Expr
+import CedarProto.EntityUID
+import CedarProto.Type
+
+open Proto
+
+namespace Cedar.Validation.Proto
+
+structure RequestEnv where
+  principal : Spec.EntityType
+  action : Spec.EntityUID
+  resource : Spec.EntityType
+deriving Inhabited
+
+namespace RequestEnv
+
+instance : Message RequestEnv where
+  parseField (t : Proto.Tag) := do
+    match t.fieldNum with
+    | 1 => parseFieldElement t principal (update principal)
+    | 2 => parseFieldElement t action (update action)
+    | 3 => parseFieldElement t resource (update resource)
+    | _ => let _ ← t.wireType.skip ; pure ignore
+
+  merge x y := {
+    principal := Field.merge x.principal y.principal
+    action := Field.merge x.action y.action
+    resource := Field.merge x.resource y.resource
+  }
+
+end RequestEnv
+
+end Cedar.Validation.Proto

--- a/cedar-lean/CedarProto/SymCCRequest.lean
+++ b/cedar-lean/CedarProto/SymCCRequest.lean
@@ -1,0 +1,173 @@
+/-
+ Copyright Cedar Contributors
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-/
+
+import Cedar.Spec
+import Protobuf.Message
+import Protobuf.Structure
+
+-- Message Dependencies
+import CedarProto.Policy
+import CedarProto.PolicySet
+import CedarProto.RequestEnv
+import CedarProto.Schema
+
+open Proto
+
+
+namespace Cedar.SymCC.Proto
+
+structure Policy where
+  template : Spec.Proto.Template
+  policy : Spec.TemplateLinkedPolicy
+deriving Inhabited
+
+namespace Policy
+
+instance : Message Policy where
+  parseField (t : Proto.Tag) := do
+    match t.fieldNum with
+    | 1 => parseFieldElement t template (update template)
+    | 2 => parseFieldElement t policy (update policy)
+    | _ => let _ ← t.wireType.skip ; pure ignore
+
+  merge x y := {
+    template := Field.merge x.template y.template
+    policy := Field.merge x.policy y.policy
+  }
+
+def toPolicy : Policy -> Except String Spec.Policy
+  | { template, policy } =>
+    let template := template.toIdAndTemplate.snd
+    match template.link? policy.id policy.slotEnv with
+    | .ok policy => .ok policy
+    | .error s => .error s
+
+end Policy
+end Cedar.SymCC.Proto
+
+namespace Cedar.Spec
+
+def Scope.merge (x y : Spec.Scope) : Spec.Scope :=
+  match x, y with
+  | .any, .any => .any
+  | .eq e₁, .eq e₂ => .eq (Field.merge e₁ e₂)
+  | .mem e₁, .mem e₂ => .mem (Field.merge e₁ e₂)
+  | .is n₁, .is n₂ => .is (Field.merge n₁ n₂)
+  | .isMem n₁ e₁, .isMem n₂ e₂ => .isMem (Field.merge n₁ n₂) (Field.merge e₁ e₂)
+  | _, _ => y
+
+def PrincipalScope.merge (x y : PrincipalScope) : PrincipalScope :=
+  let ⟨ sc₁ ⟩ := x
+  let ⟨ sc₂ ⟩ := y
+  .principalScope (Scope.merge sc₁ sc₂)
+
+def ResourceScope.merge (x y : ResourceScope) : ResourceScope :=
+  let ⟨ sc₁ ⟩ := x
+  let ⟨ sc₂ ⟩ := y
+  .resourceScope (Scope.merge sc₁ sc₂)
+
+def Policy.merge (x y : Spec.Policy) : Spec.Policy := {
+  id             := Field.merge x.id y.id
+  effect         := Field.merge x.effect y.effect
+  principalScope := x.principalScope.merge y.principalScope
+  actionScope    := Field.merge x.actionScope y.actionScope
+  resourceScope  := x.resourceScope.merge y.resourceScope
+  condition      := Field.merge x.condition y.condition
+}
+
+instance : Field Policy :=
+  Field.fromInterFieldFallible SymCC.Proto.Policy.toPolicy Policy.merge
+
+end Cedar.Spec
+
+namespace Cedar.SymCC.Proto
+
+structure CheckPolicyRequest where
+  policy  : Spec.Policy
+  schema  : Validation.Schema
+  request : Validation.Proto.RequestEnv
+deriving Inhabited
+
+namespace CheckPolicyRequest
+
+instance : Message CheckPolicyRequest where
+  parseField (t : Proto.Tag) := do
+    match t.fieldNum with
+    | 1 => parseFieldElement t policy (update policy)
+    | 2 => parseFieldElement t schema (update schema)
+    | 3 => parseFieldElement t request (update request)
+    | _ => let _ ← t.wireType.skip ; pure ignore
+
+  merge x y := {
+    policy  := Field.merge x.policy y.policy
+    schema  := Field.merge x.schema y.schema
+    request := Field.merge x.request y.request
+  }
+
+end CheckPolicyRequest
+
+structure CheckPolicySetRequest where
+  policySet : Spec.Policies
+  schema : Validation.Schema
+  request : Validation.Proto.RequestEnv
+deriving Inhabited
+
+namespace CheckPolicySetRequest
+
+instance : Message CheckPolicySetRequest where
+  parseField (t : Proto.Tag) := do
+    match t.fieldNum with
+    | 1 => parseFieldElement t policySet (update policySet)
+    | 2 => parseFieldElement t schema (update schema)
+    | 3 => parseFieldElement t request (update request)
+    | _ => let _ ← t.wireType.skip ; pure ignore
+
+  merge x y := {
+    policySet := Field.merge x.policySet y.policySet
+    schema := Field.merge x.schema y.schema
+    request := Field.merge x.request y.request
+  }
+
+end CheckPolicySetRequest
+
+structure ComparePolicySetsRequest where
+  srcPolicySet : Spec.Policies
+  tgtPolicySet : Spec.Policies
+  schema : Validation.Schema
+  request : Validation.Proto.RequestEnv
+deriving Inhabited
+
+namespace ComparePolicySetsRequest
+
+instance : Message ComparePolicySetsRequest where
+  parseField (t : Proto.Tag) := do
+    match t.fieldNum with
+    | 1 => parseFieldElement t srcPolicySet (update srcPolicySet)
+    | 2 => parseFieldElement t tgtPolicySet (update tgtPolicySet)
+    | 3 => parseFieldElement t schema (update schema)
+    | 4 => parseFieldElement t request (update request)
+    | _ => let _ ← t.wireType.skip ; pure ignore
+
+  merge x y := {
+    srcPolicySet := Field.merge x.srcPolicySet y.srcPolicySet
+    tgtPolicySet := Field.merge x.tgtPolicySet y.tgtPolicySet
+    schema := Field.merge x.schema y.schema
+    request := Field.merge x.request y.request
+  }
+
+end ComparePolicySetsRequest
+
+end Cedar.SymCC.Proto

--- a/cedar-lean/SymFFI.lean
+++ b/cedar-lean/SymFFI.lean
@@ -1,0 +1,17 @@
+/-
+ Copyright Cedar Contributors
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-/
+
+import SymFFI.Main

--- a/cedar-lean/SymFFI/Main.lean
+++ b/cedar-lean/SymFFI/Main.lean
@@ -1,0 +1,502 @@
+/-
+ Copyright Cedar Contributors
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-/
+
+import Lean.Data.Json.FromToJson
+
+import Cedar.Spec
+import Cedar.Validation
+import Cedar.SymCC
+import CedarProto
+import Protobuf
+
+namespace Cedar.SymCC.Proto
+
+open Cedar.Spec
+open Cedar.SymCC
+open Cedar.Validation
+open Proto
+
+/--
+  `req`: binary protobuf for an `CheckPolicyRequest`
+
+  Upon success returns a well-typed policy and symbolic environment corresponding to the request `req`
+  Returns a failure if
+  1.) Protobuf message could not be parsed
+  2.) The requestEnv of `req` is not consistent with the schema of `req`
+  3.) The policy of `req` is not well-typed for the requestEnv of `req`
+-/
+def parseCheckPolicyReq (req : ByteArray) : Except String (Spec.Policy × SymEnv) :=
+  match (@Proto.Message.interpret? CheckPolicyRequest) req with
+  | .error e => .error s!"failed to parse input: {e}"
+  | .ok req =>
+    let policy := req.policy
+    let schema := req.schema
+    let request := req.request
+    match schema.environment? request.principal request.resource request.action with
+    | none => .error s!"failed to get environment from requestEnv (PrincipalType: {request.principal}, ActionName: {request.action}, ResourceType: {request.resource})"
+    | some env =>
+      match wellTypedPolicy policy env with
+      | none => .error s!"failed to validate policy for requestEnv (PrincipalType: {request.principal}, ActionName: {request.action}, ResourceType: {request.resource})"
+      | some policy => .ok (policy, SymEnv.ofTypeEnv env)
+
+/--
+  `req`: binary protobuf for an `CheckPolicySetRequest`
+
+  Upon success returns a list of well-typed policies and symbolic environment corresponding to the request `req`
+  Returns a failure if
+  1.) Protobuf message could not be parsed
+  2.) The requestEnv of `req` is not consistent with the schema of `req`
+  3.) Any policy of the policySet of `req` is not well-typed for the requestEnv of `req`
+-/
+def parseCheckPoliciesReq (req : ByteArray) : Except String (Spec.Policies × SymEnv) :=
+  match (@Proto.Message.interpret? CheckPolicySetRequest) req with
+  | .error e => .error s!"failed to parse input: {e}"
+  | .ok req =>
+    let policySet := req.policySet
+    let schema := req.schema
+    let request := req.request
+    match schema.environment? request.principal request.resource request.action with
+    | none => .error s!"failed to get environment from requestEnv (PrincipalType: {request.principal}, ActionName: {request.action}, ResourceType: {request.resource})"
+    | some env =>
+      match wellTypedPolicies policySet env with
+      | none => .error s!"failed to validate policy for requestEnv (PrincipalType: {request.principal}, ActionName: {request.action}, ResourceType: {request.resource})"
+      | some policies => .ok (policies, SymEnv.ofTypeEnv env)
+
+/--
+  `req`: binary protobuf for an `CheckPolicySetRequest`
+
+  Upon success returns a list of well-typed policies and symbolic environment corresponding to the request `req`
+  Returns a failure if
+  1.) Protobuf message could not be parsed
+  2.) The requestEnv of `req` is not consistent with the schema of `req`
+  3.) Any policy of the source or target PolicySets of `req` is not well-typed for the requestEnv of `req`
+-/
+def parseComparePolicySetsReq (req : ByteArray) : Except String (Spec.Policies × Spec.Policies × SymEnv) :=
+  match (@Proto.Message.interpret? ComparePolicySetsRequest) req with
+  | .error e => .error s!"failed to parse input: {e}"
+  | .ok req =>
+    let srcPolicySet := req.srcPolicySet
+    let tgtPolicySet := req.tgtPolicySet
+    let schema := req.schema
+    let request := req.request
+    match schema.environment? request.principal request.resource request.action with
+    | none => .error s!"failed to get environment from requestEnv (PrincipalType: {request.principal}, ActionName: {request.action}, ResourceType: {request.resource})"
+    | some env =>
+      match wellTypedPolicies srcPolicySet env, wellTypedPolicies tgtPolicySet env with
+      | none, _
+      | _, none => .error s!"failed to validate policy for requestEnv (PrincipalType: {request.principal}, ActionName: {request.action}, ResourceType: {request.resource})"
+      | some srcPolicies, some tgtPolicies => .ok (srcPolicies, tgtPolicies, SymEnv.ofTypeEnv env)
+
+
+/--
+  Run `solver` on `vcs` without exposing the IO monad to the calling code
+-/
+private unsafe def unsafeSolve {α} (solver : IO Solver) (vcs : SolverM α) : Except String α := do
+  match unsafeIO solver with
+  | .error _ => .error "error creating solver"
+  | .ok solver =>
+    match unsafeIO (vcs |>.run solver) with
+    | .error _ => .error "error encoding verification conditions or running solver"
+    | .ok b => .ok b
+
+@[implemented_by unsafeSolve]
+opaque solve {α} (solver : IO Solver) (vcs : SolverM α) : Except String α
+
+/--
+  `req`: binary protobuf for an `CheckPolicyRequest`
+
+  returns JSON encoded string that encodes
+  1.) .error err_message if there was in error in parsing or running the solver
+  2.) .ok true if the solver could prove `req` holds
+  3.) .ok false if the solver could prove `req` does not hold
+-/
+@[export runCheckNeverErrors] unsafe def runCheckNeverErrors (req : ByteArray) : String :=
+  let result : Except String Bool :=
+    match parseCheckPolicyReq req with
+    | .error s => .error s!"checkNeverErrors: {s}"
+    | .ok (policy, εnv) =>
+      match solve Solver.cvc5 (Cedar.SymCC.checkNeverErrors policy εnv) with
+      | .error s => .error s!"checkNeverErrors: {s}"
+      | .ok b => .ok b
+  toString (Lean.toJson result)
+
+/--
+  `req`: binary protobuf for an `CheckPolicySetRequest`
+
+  returns JSON encoded string that encodes
+  1.) .error err_message if there was in error in parsing or running the solver
+  2.) .ok true if the solver could prove `req` holds
+  3.) .ok false if the solver could prove `req` does not hold
+-/
+@[export runCheckAlwaysAllows] unsafe def runCheckAlwaysAllows (req : ByteArray) : String :=
+  let result : Except String Bool :=
+    match parseCheckPoliciesReq req with
+    | .error s => .error s!"checkAlwaysAllows: {s}"
+    | .ok (policies, εnv) =>
+      match solve Solver.cvc5 (Cedar.SymCC.checkAlwaysAllows policies εnv) with
+      | .error s => .error s!"checkAlwaysAllows: {s}"
+      | .ok b => .ok b
+  toString (Lean.toJson result)
+
+/--
+  `req`: binary protobuf for an `CheckPolicySetRequest`
+
+  returns JSON encoded string that encodes
+  1.) .error err_message if there was in error in parsing or running the solver
+  2.) .ok true if the solver could prove `req` holds
+  3.) .ok false if the solver could prove `req` does not hold
+-/
+@[export runCheckAlwaysDenies] unsafe def runCheckAlwaysDenies (req : ByteArray) : String :=
+  let result : Except String Bool :=
+    match parseCheckPoliciesReq req with
+    | .error s => .error s!"checkAlwaysDenies: {s}"
+    | .ok (policies, εnv) =>
+      match solve Solver.cvc5 (Cedar.SymCC.checkAlwaysDenies policies εnv) with
+      | .error s => .error s!"checkAlwaysDenies: {s}"
+      | .ok b => .ok b
+  toString (Lean.toJson result)
+
+/--
+  `req`: binary protobuf for an `ComparePolicySetsRequest`
+
+  returns JSON encoded string that encodes
+  1.) .error err_message if there was in error in parsing or running the solver
+  2.) .ok true if the solver could prove `req` holds
+  3.) .ok false if the solver could prove `req` does not hold
+-/
+@[export runCheckEquivalent] unsafe def runCheckEquivalent (req : ByteArray) : String :=
+  let result : Except String Bool :=
+    match parseComparePolicySetsReq req with
+    | .error s => .error s!"checkEquivalent: {s}"
+    | .ok (srcPolicies, tgtPolicies, εnv) =>
+      match solve Solver.cvc5 (Cedar.SymCC.checkEquivalent srcPolicies tgtPolicies εnv) with
+      | .error s => .error s!"checkEquivalent: {s}"
+      | .ok b => .ok b
+  toString (Lean.toJson result)
+/--
+  `req`: binary protobuf for an `ComparePolicySetsRequest`
+
+  returns JSON encoded string that encodes
+  1.) .error err_message if there was in error in parsing or running the solver
+  2.) .ok true if the solver could prove `req` holds
+  3.) .ok false if the solver could prove `req` does not hold
+-/
+@[export runCheckImplies] unsafe def runCheckImplies (req : ByteArray) : String :=
+  let result : Except String Bool :=
+    match parseComparePolicySetsReq req with
+    | .error s => .error s!"checkImplies: {s}"
+    | .ok (srcPolicies, tgtPolicies, εnv) =>
+      match solve Solver.cvc5 (Cedar.SymCC.checkImplies srcPolicies tgtPolicies εnv) with
+      | .error s => .error s!"checkImplies: {s}"
+      | .ok b => .ok b
+  toString (Lean.toJson result)
+
+/--
+  `req`: binary protobuf for an `ComparePolicySetsRequest`
+
+  returns JSON encoded string that encodes
+  1.) .error err_message if there was in error in parsing or running the solver
+  2.) .ok true if the solver could prove `req` holds
+  3.) .ok false if the solver could prove `req` does not hold
+-/
+@[export runCheckDisjoint] unsafe def runCheckDisjoint (req : ByteArray) : String :=
+  let result : Except String Bool :=
+    match parseComparePolicySetsReq req with
+    | .error s => .error s!"checkDisjoint: {s}"
+    | .ok (srcPolicies, tgtPolicies, εnv) =>
+      match solve Solver.cvc5 (Cedar.SymCC.checkDisjoint srcPolicies tgtPolicies εnv) with
+      | .error s => .error s!"checkDisjoint: {s}"
+      | .ok b => .ok b
+  toString (Lean.toJson result)
+
+/--
+  Auxillary function that encodes and runs the solver on the generated VCs. Useful for
+  running the File or Buffer based solvers to print or stringify the SMTLib representation
+  of the VCs.
+-/
+private def ignoreOutput (vc : SymEnv → Result Asserts) (εnv : SymEnv) : SolverM Unit := do
+  match vc εnv with
+  | .ok asserts =>
+    if asserts.any (· == false) || asserts.all (· == true) then
+      Solver.reset
+    else
+      let _ ← Encoder.encode asserts εnv (produceModels := false)
+      match (← Solver.checkSat) with
+      | .unsat   => pure ()
+      | .sat     => pure ()
+      | .unknown => pure ()
+  | .error err =>
+    throw (IO.userError s!"SymCC failed: {reprStr err}.")
+
+/--
+  `req`: binary protobuf for an `CheckPolicyRequest`
+
+  returns JSON encoded string that encodes
+  1.) .error err_message if there was in error in parsing or encoding the vcs
+  2.) .ok () if the vcs were successfully printed to stdout in SMTLib format
+-/
+@[export printCheckNeverErrors] unsafe def printCheckNeverErrors (req : ByteArray) : String :=
+  let result : Except String Unit :=
+    match parseCheckPolicyReq req with
+    | .error s => .error s!"checkNeverErrors: {s}"
+    | .ok (policy, εnv) =>
+      let stdOut := unsafeBaseIO IO.getStdout
+      let solver := Solver.streamWriter stdOut
+      let vcs := ignoreOutput (verifyNeverErrors policy) εnv
+      match solve solver vcs with
+      | .error s => .error s!"checkNeverErrors: {s}"
+      | .ok _ => .ok ()
+  toString (Lean.toJson result)
+
+/--
+  `req`: binary protobuf for an `CheckPolicySetRequest`
+
+  returns JSON encoded string that encodes
+  1.) .error err_message if there was in error in parsing or encoding the vcs
+  2.) .ok () if the vcs were successfully printed to stdout in SMTLib format
+-/
+@[export printCheckAlwaysAllows] unsafe def printCheckAlwaysAllows (req : ByteArray) : String :=
+  let result : Except String Unit :=
+    match parseCheckPoliciesReq req with
+    | .error s => .error s!"checkAlwaysAllows: {s}"
+    | .ok (policies, εnv) =>
+      let stdOut := unsafeBaseIO IO.getStdout
+      let solver := Solver.streamWriter stdOut
+      let vcs := ignoreOutput (verifyAlwaysAllows policies) εnv
+      match solve solver vcs with
+      | .error s => .error s!"checkAlwaysAllows: {s}"
+      | .ok _ => .ok ()
+  toString (Lean.toJson result)
+
+/--
+  `req`: binary protobuf for an `CheckPolicySetRequest`
+
+  returns JSON encoded string that encodes
+  1.) .error err_message if there was in error in parsing or encoding the vcs
+  2.) .ok () if the vcs were successfully printed to stdout in SMTLib format
+-/
+@[export printCheckAlwaysDenies] unsafe def printCheckAlwaysDenies (req : ByteArray) : String :=
+  let result : Except String Unit :=
+    match parseCheckPoliciesReq req with
+    | .error s => .error s!"checkAlwaysDenies: {s}"
+    | .ok (policies, εnv) =>
+      let stdOut := unsafeBaseIO IO.getStdout
+      let solver := Solver.streamWriter stdOut
+      let vcs := ignoreOutput (verifyAlwaysDenies policies) εnv
+      match solve solver vcs with
+      | .error s => .error s!"checkAlwaysDenies: {s}"
+      | .ok _ => .ok ()
+  toString (Lean.toJson result)
+
+/--
+  `req`: binary protobuf for an `CheckPolicySetRequest`
+
+  returns JSON encoded string that encodes
+  1.) .error err_message if there was in error in parsing or encoding the vcs
+  2.) .ok () if the vcs were successfully printed to stdout in SMTLib format
+-/
+@[export printCheckEquivalent] unsafe def printCheckEquivalent (req : ByteArray) : String :=
+  let result : Except String Unit :=
+    match parseComparePolicySetsReq req with
+    | .error s => .error s!"checkEquivalent: {s}"
+    | .ok (srcPolicies, tgtPolicies, εnv) =>
+      let stdOut := unsafeBaseIO IO.getStdout
+      let solver := Solver.streamWriter stdOut
+      let vcs := ignoreOutput (verifyEquivalent srcPolicies tgtPolicies) εnv
+      match solve solver vcs with
+      | .error s => .error s!"checkEquivalent: {s}"
+      | .ok _ => .ok ()
+  toString (Lean.toJson result)
+
+/--
+  `req`: binary protobuf for an `CheckPolicySetRequest`
+
+  returns JSON encoded string that encodes
+  1.) .error err_message if there was in error in parsing or encoding the vcs
+  2.) .ok () if the vcs were successfully printed to stdout in SMTLib format
+-/
+@[export printCheckImplies] unsafe def printCheckImplies (req : ByteArray) : String :=
+  let result : Except String Unit :=
+    match parseComparePolicySetsReq req with
+    | .error s => .error s!"checkImplies: {s}"
+    | .ok (srcPolicies, tgtPolicies, εnv) =>
+      let stdOut := unsafeBaseIO IO.getStdout
+      let solver := Solver.streamWriter stdOut
+      let vcs := ignoreOutput (verifyImplies srcPolicies tgtPolicies) εnv
+      match solve solver vcs with
+      | .error s => .error s!"checkImplies: {s}"
+      | .ok _ => .ok ()
+  toString (Lean.toJson result)
+
+/--
+  `req`: binary protobuf for an `CheckPolicySetRequest`
+
+  returns JSON encoded string that encodes
+  1.) .error err_message if there was in error in parsing or encoding the vcs
+  2.) .ok () if the vcs were successfully printed to stdout in SMTLib format
+-/
+@[export printCheckDisjoint] unsafe def printCheckDisjoint (req : ByteArray) : String :=
+  let result : Except String Unit :=
+    match parseComparePolicySetsReq req with
+    | .error s => .error s!"checkDisjoint: {s}"
+    | .ok (srcPolicies, tgtPolicies, εnv) =>
+      let stdOut := unsafeBaseIO IO.getStdout
+      let solver := Solver.streamWriter stdOut
+      let vcs := ignoreOutput (verifyDisjoint srcPolicies tgtPolicies) εnv
+      match solve solver vcs with
+      | .error s => .error s!"checkDisjoint: {s}"
+      | .ok _ => .ok ()
+  toString (Lean.toJson result)
+
+/--
+  `req`: binary protobuf for an `CheckPolicyRequest`
+
+  returns JSON encoded string that encodes
+  1.) .error err_message if there was in error in parsing or encoding the vcs
+  2.) .ok SMTLib-Script where SMTLib-Script is a string containing the SMTLib script encoding the verification query
+-/
+@[export smtLibOfCheckNeverErrors] unsafe def smtLibOfCheckNeverErrors (req : ByteArray) : String :=
+  let result : Except String String :=
+    match parseCheckPolicyReq req with
+    | .error s => .error s!"checkNeverErrors: {s}"
+    | .ok (policy, εnv) =>
+      let buffer := unsafeBaseIO (IO.mkRef ⟨ByteArray.empty, 0⟩)
+      let solver := Solver.bufferWriter buffer
+      let vcs := ignoreOutput (verifyNeverErrors policy) εnv
+      match solve solver vcs with
+      | .error s => .error s!"checkNeverErrors: {s}"
+      | .ok _ =>
+        match unsafeIO (buffer.swap ⟨ByteArray.empty, 0⟩) with
+        | .error _ => .error s!"checkNeverErrors: error retrieving SMTLib script from buffer"
+        | .ok inner_buffer => .ok ((String.fromUTF8? inner_buffer.data).getD "")
+  toString (Lean.toJson result)
+
+/--
+  `req`: binary protobuf for an `CheckPolicySetRequest`
+
+  returns JSON encoded string that encodes
+  1.) .error err_message if there was in error in parsing or encoding the vcs
+  2.) .ok SMTLib-Script where SMTLib-Script is a string containing the SMTLib script encoding the verification query
+-/
+@[export smtLibOfCheckAlwaysAllows] unsafe def smtLibOfCheckAlwaysAllows (req : ByteArray) : String :=
+  let result : Except String String :=
+    match parseCheckPoliciesReq req with
+    | .error s => .error s!"checkAlwaysAllows: {s}"
+    | .ok (policies, εnv) =>
+      let buffer := unsafeBaseIO (IO.mkRef ⟨ByteArray.empty, 0⟩)
+      let solver := Solver.bufferWriter buffer
+      let vcs := ignoreOutput (verifyAlwaysAllows policies) εnv
+      match solve solver vcs with
+      | .error s => .error s!"checkAlwaysAllows: {s}"
+      | .ok _ =>
+        match unsafeIO (buffer.swap ⟨ByteArray.empty, 0⟩) with
+        | .error _ => .error s!"checkAlwaysAllows: error retrieving SMTLib script from buffer"
+        | .ok inner_buffer => .ok ((String.fromUTF8? inner_buffer.data).getD "")
+  toString (Lean.toJson result)
+
+/--
+  `req`: binary protobuf for an `CheckPolicySetRequest`
+
+  returns JSON encoded string that encodes
+  1.) .error err_message if there was in error in parsing or encoding the vcs
+  2.) .ok SMTLib-Script where SMTLib-Script is a string containing the SMTLib script encoding the verification query
+-/
+@[export smtLibOfCheckAlwaysDenies] unsafe def smtLibOfCheckAlwaysDenies (req : ByteArray) : String :=
+  let result : Except String String :=
+    match parseCheckPoliciesReq req with
+    | .error s => .error s!"checkAlwaysDenies: {s}"
+    | .ok (policies, εnv) =>
+      let buffer := unsafeBaseIO (IO.mkRef ⟨ByteArray.empty, 0⟩)
+      let solver := Solver.bufferWriter buffer
+      let vcs := ignoreOutput (verifyAlwaysDenies policies) εnv
+      match solve solver vcs with
+      | .error s => .error s!"checkAlwaysDenies: {s}"
+      | .ok _ =>
+        match unsafeIO (buffer.swap ⟨ByteArray.empty, 0⟩) with
+        | .error _ => .error s!"checkAlwaysDenies: error retrieving SMTLib script from buffer"
+        | .ok inner_buffer => .ok ((String.fromUTF8? inner_buffer.data).getD "")
+  toString (Lean.toJson result)
+
+/--
+  `req`: binary protobuf for an `CheckPolicySetRequest`
+
+  returns JSON encoded string that encodes
+  1.) .error err_message if there was in error in parsing or encoding the vcs
+  2.) .ok SMTLib-Script where SMTLib-Script is a string containing the SMTLib script encoding the verification query
+-/
+@[export smtLibOfCheckEquivalent] unsafe def smtLibOfCheckEquivalent (req : ByteArray) : String :=
+  let result : Except String String :=
+    match parseComparePolicySetsReq req with
+    | .error s => .error s!"checkEquivalent: {s}"
+    | .ok (srcPolicies, tgtPolicies, εnv) =>
+      let buffer := unsafeBaseIO (IO.mkRef ⟨ByteArray.empty, 0⟩)
+      let solver := Solver.bufferWriter buffer
+      let vcs := ignoreOutput (verifyEquivalent srcPolicies tgtPolicies) εnv
+      match solve solver vcs with
+      | .error s => .error s!"checkEquivalent: {s}"
+      | .ok _ =>
+        match unsafeIO (buffer.swap ⟨ByteArray.empty, 0⟩) with
+        | .error _ => .error s!"checkEquivalent: error retrieving SMTLib script from buffer"
+        | .ok inner_buffer => .ok ((String.fromUTF8? inner_buffer.data).getD "")
+  toString (Lean.toJson result)
+
+/--
+  `req`: binary protobuf for an `CheckPolicySetRequest`
+
+  returns JSON encoded string that encodes
+  1.) .error err_message if there was in error in parsing or encoding the vcs
+  2.) .ok SMTLib-Script where SMTLib-Script is a string containing the SMTLib script encoding the verification query
+-/
+@[export smtLibOfCheckImplies] unsafe def smtLibOfCheckImplies (req : ByteArray) : String :=
+  let result : Except String String :=
+    match parseComparePolicySetsReq req with
+    | .error s => .error s!"checkImplies: {s}"
+    | .ok (srcPolicies, tgtPolicies, εnv) =>
+      let buffer := unsafeBaseIO (IO.mkRef ⟨ByteArray.empty, 0⟩)
+      let solver := Solver.bufferWriter buffer
+      let vcs := ignoreOutput (verifyImplies srcPolicies tgtPolicies) εnv
+      match solve solver vcs with
+      | .error s => .error s!"checkImplies: {s}"
+      | .ok _ =>
+        match unsafeIO (buffer.swap ⟨ByteArray.empty, 0⟩) with
+        | .error _ => .error s!"checkImplies: error retrieving SMTLib script from buffer"
+        | .ok inner_buffer => .ok ((String.fromUTF8? inner_buffer.data).getD "")
+  toString (Lean.toJson result)
+
+/--
+  `req`: binary protobuf for an `CheckPolicySetRequest`
+
+  returns JSON encoded string that encodes
+  1.) .error err_message if there was in error in parsing or encoding the vcs
+  2.) .ok SMTLib-Script where SMTLib-Script is a string containing the SMTLib script encoding the verification query
+-/
+@[export smtLibOfCheckDisjoint] unsafe def smtLibOfCheckDisjoint (req : ByteArray) : String :=
+  let result : Except String String :=
+    match parseComparePolicySetsReq req with
+    | .error s => .error s!"checkDisjoint: {s}"
+    | .ok (srcPolicies, tgtPolicies, εnv) =>
+      let buffer := unsafeBaseIO (IO.mkRef ⟨ByteArray.empty, 0⟩)
+      let solver := Solver.bufferWriter buffer
+      let vcs := ignoreOutput (verifyDisjoint srcPolicies tgtPolicies) εnv
+      match solve solver vcs with
+      | .error s => .error s!"checkDisjoint: {s}"
+      | .ok _ =>
+        match unsafeIO (buffer.swap ⟨ByteArray.empty, 0⟩) with
+        | .error _ => .error s!"checkDisjoint: error retrieving SMTLib script from buffer"
+        | .ok inner_buffer => .ok ((String.fromUTF8? inner_buffer.data).getD "")
+  toString (Lean.toJson result)
+
+end Cedar.SymCC.Proto

--- a/cedar-lean/lakefile.lean
+++ b/cedar-lean/lakefile.lean
@@ -50,6 +50,12 @@ lean_lib Protobuf where
 lean_lib CedarProto where
   defaultFacets := #[LeanLib.staticFacet]
 
+lean_lib CedarFFI where
+  defaultFacets := #[LeanLib.staticFacet]
+
+lean_lib SymFFI where
+  defaultFacets := #[LeanLib.staticFacet]
+
 lean_exe CedarUnitTests where
   root := `UnitTest.Main
 


### PR DESCRIPTION
Adds a rust based CLI that uses [`cedar`](https://github.com/cedar-policy/cedar) to parse policies, schemas, entities, requests, contexts, etc. and then uses the lean formalization of cedar (`cedar-lean`) to evaluate a users request.
