### PR TITLE
A bunch more renames for consistency

### DIFF
--- a/cedar-lean/Cedar/SymCC/Compiler.lean
+++ b/cedar-lean/Cedar/SymCC/Compiler.lean
@@ -20,14 +20,14 @@ import Cedar.SymCC.Factory
 
 /-!
 
-This file defines the Cedar symbolic evaluator.
+This file defines the Cedar symbolic compiler.
 
-The symbolic evaluator takes as input a Cedar expression and a symbolic
+The symbolic compiler takes as input a Cedar expression and a symbolic
 environment. Given these inputs, it produces a Term encoding of the expression.
 
-If the evaluator returns a Term, this Term represents a sound and complete
+If the compiler returns a Term, this Term represents a sound and complete
 encoding of the input expression's semantics with respect to the given
-environment: using this reduction for verification will neither miss bugs
+environment: using this Term for verification will neither miss bugs
 (soundness) nor produce false positives (completeness).
 -/
 

--- a/cedar-lean/Cedar/SymCC/Env.lean
+++ b/cedar-lean/Cedar/SymCC/Env.lean
@@ -17,7 +17,7 @@
 import Cedar.SymCC.Tags
 
 /-!
-This file defines the ADTs that represent the symbolic evaluation environment.
+This file defines the ADTs that represent the symbolic environment.
 The environment consists of a symbolic request, entity store, and action store.
 A symbolic environment is _literal_ when it consists of literal terms and
 interpreted functions (UDFs).

--- a/cedar-lean/Cedar/SymCC/ExtFun.lean
+++ b/cedar-lean/Cedar/SymCC/ExtFun.lean
@@ -27,10 +27,10 @@ arguments, an extension function will return a well-formed and type-correct
 output. Otherwise, the output is an arbitrary term.
 
 This design lets us minimize the number of error paths in the overall
-specification of symbolic evaluation, which makes for nicer code and proofs, and
+specification of symbolic compilation, which makes for nicer code and proofs, and
 it more closely tracks the specification of the concrete evaluator.
 
-See `Evaluator.lean` to see how the symbolic evaluator uses this API. See also
+See `Compiler.lean` to see how the symbolic compiler uses this API. See also
 `Factory.lean`.
 
 -/

--- a/cedar-lean/Cedar/SymCC/Extractor.lean
+++ b/cedar-lean/Cedar/SymCC/Extractor.lean
@@ -35,7 +35,7 @@ If `I` is the result of solving a `verify*` query (see Cedar.SymCC.Verifier),
 then `εnv.extract? xs I` is a valid strongly well-formed counterexample
 to that query. More generally, `εnv.extract? xs I` extracts such a
 counterexample for any verification query that is expressed as a boolean
-combination of (boolean) terms obtained by reducing `xs` with respect to `εnv`.
+combination of (boolean) terms obtained by compiling `xs` with respect to `εnv`.
 
 See `Cedar.Thm.SymCC.Verification` for how this is used to prove that verification
 queries based on Cedar's compiler and hierarchy enforcer are correct.

--- a/cedar-lean/Cedar/SymCC/Factory.lean
+++ b/cedar-lean/Cedar/SymCC/Factory.lean
@@ -30,10 +30,10 @@ arguments, a factory function will return a well-formed and type-correct output.
 Otherwise, the output is an arbitrary term.
 
 This design lets us minimize the number of error paths in the overall
-specification of symbolic evaluation, which makes for nicer code and proofs, and
+specification of symbolic compilation, which makes for nicer code and proofs, and
 it more closely tracks the specification of the concrete evaluator.
 
-See `Evaluator.lean` to see how the symbolic evaluator uses this API.
+See `Compiler.lean` to see how the symbolic compiler uses this API.
 -/
 
 namespace Cedar.SymCC
@@ -147,7 +147,7 @@ def app : UnaryFunction → Term → Term
 -- We are doing very weak partial evaluation for bitvectors: just constant
 -- propagation. If more rewrites are needed, we can add them later.  This simple
 -- approach is sufficient for the strong PE property we care about:  if given a
--- fully concrete input, the symbolic evaluator returns a fully concrete output.
+-- fully concrete input, the symbolic compiler returns a fully concrete output.
 
 def bvneg : Term → Term
   | .prim (.bitvec b)  => b.neg

--- a/cedar-lean/Cedar/SymCC/Result.lean
+++ b/cedar-lean/Cedar/SymCC/Result.lean
@@ -15,7 +15,7 @@
 -/
 
 /-!
-This file defines the Result type for symbolic evaluation.
+This file defines the Result type for symbolic compilation.
 -/
 
 namespace Cedar.SymCC

--- a/cedar-lean/Cedar/SymCC/Term.lean
+++ b/cedar-lean/Cedar/SymCC/Term.lean
@@ -21,10 +21,10 @@ import Init.Data.BitVec.Basic
 
 /-!
 This file defines the Cedar Term language, a strongly and simply typed IR to
-which we compile Cedar expression during symbolic evalution. The Term language
-has a straightforward translation to SMTLib. It is designed to compile the
-semantic gap between Cedar and SMTLib, and to faciliate proofs of soundness and
-completeness of the Cedar symbolic evaluator.
+which we compile Cedar expressions. The Term language has a straightforward
+translation to SMTLib. It is designed to reduce the semantic gap between Cedar
+and SMTLib, and to faciliate proofs of soundness and completeness of the Cedar
+symbolic compiler.
 
 Terms should _not_ be created directly using `Term` constructors. Instead, they
 should be created using the factory functions defined in `Factory.lean`.

--- a/cedar-lean/Cedar/SymCC/Verifier.lean
+++ b/cedar-lean/Cedar/SymCC/Verifier.lean
@@ -19,7 +19,7 @@ import Cedar.SymCC.Authorizer
 import Cedar.SymCC.Compiler
 
 /-!
-This file contains `verify*` functions that use the Cedar symbolic evaluator,
+This file contains `verify*` functions that use the Cedar symbolic compiler,
 authorizer, and hierarchy enforcer to generate a list of `Asserts`. These are
 boolean terms whose conjunction is unsatisfiable if and only if the verified
 property holds.

--- a/cedar-lean/Cedar/Thm/SymCC/Authorizer.lean
+++ b/cedar-lean/Cedar/Thm/SymCC/Authorizer.lean
@@ -106,7 +106,7 @@ private theorem compile_and_wf_option_bool {x₁ x₂ : Expr} {εnv : SymEnv} {t
   simp only [compile_wf hwε hok, true_and]
   replace ⟨t₁, hok₁, hok⟩ := compile_and_ok_implies hok
   split at hok <;> try simp only [hok, typeOf_term_some, typeOf_bool]
-  simp only [ReduceAndSym] at hok
+  simp only [CompileAndSym] at hok
   replace ⟨hty₁, t₂, hok₂, hty₂, hok⟩ := hok
   subst hok
   have ⟨hw₁, hw₂⟩ := wf_εnv_for_and_implies hwε

--- a/cedar-lean/Cedar/Thm/SymCC/Compiler.lean
+++ b/cedar-lean/Cedar/Thm/SymCC/Compiler.lean
@@ -27,7 +27,7 @@ import Cedar.Thm.SymCC.Compiler.Unary
 
 /-!
 This file proves two key auxiliary lemmas used to show the soundness
-and completeness of Cedar's symbolic evaluator.
+and completeness of Cedar's symbolic compiler.
 --/
 
 namespace Cedar.Thm
@@ -35,12 +35,12 @@ namespace Cedar.Thm
 open Spec SymCC Factory
 
 /--
-The lemma shows that the symbolic evaluator (`compile`) behaves like the
+The lemma shows that the symbolic compiler (`compile`) behaves like the
 concrete evaluator (`evaluate`) on literal inputs.
 
 In particular, let `x` be an expression, `εnv` a well-formed symbolic
 environment for `x`, and `env` a well-formed concrete environment for `x` that
-is equivalent to `εnv`. Then, the result produced by the symbolic evaluator on
+is equivalent to `εnv`. Then, the result produced by the symbolic compiler on
 `x` and `εnv` is equivalent to the result produced by the concrete evaluator `x`
 and `env`.
 -/
@@ -82,18 +82,18 @@ theorem compile_evaluate {x : Expr} {env : Env} {εnv : SymEnv} {t : Term} :
     have ih₁ := @compile_evaluate x₁
     exact compile_evaluate_hasAttr h₁ h₂ h₃ h₄ ih₁
   | .set xs           =>
-    have ih : ∀ xᵢ ∈ xs, ReduceEvaluate xᵢ := by
+    have ih : ∀ xᵢ ∈ xs, CompileEvaluate xᵢ := by
       intro xᵢ _
       exact @compile_evaluate xᵢ
     exact compile_evaluate_set h₁ h₂ h₃ h₄ ih
   | .record axs      =>
-    have ih : ∀ aᵢ xᵢ, (aᵢ, xᵢ) ∈ axs → ReduceEvaluate xᵢ := by
+    have ih : ∀ aᵢ xᵢ, (aᵢ, xᵢ) ∈ axs → CompileEvaluate xᵢ := by
       intro aᵢ xᵢ h
       have _ : sizeOf xᵢ < 1 + sizeOf axs := List.sizeOf_snd_lt_sizeOf_list h
       exact @compile_evaluate xᵢ
     exact compile_evaluate_record h₁ h₂ h₃ h₄ ih
   | .call _ xs       =>
-    have ih : ∀ xᵢ ∈ xs, ReduceEvaluate xᵢ := by
+    have ih : ∀ xᵢ ∈ xs, CompileEvaluate xᵢ := by
       intro xᵢ _
       exact @compile_evaluate xᵢ
     exact compile_evaluate_call h₁ h₂ h₃ h₄ ih
@@ -102,8 +102,8 @@ theorem compile_evaluate {x : Expr} {env : Env} {εnv : SymEnv} {t : Term} :
 The lemma shows that `interpret` and `compile` can be applied in any order to get
 the same result. In particular, let `x` be an expression, `εnv` a well-formed
 symbolic environment for `x`, and `I` a well-formed interpretion for `εnv`.
-Then, reducing `x` with respect to `(εnv.interpret I)` gives the same result as
-interpreting the output of reducing `x` with respect to `εnv`.
+Then, compiling `x` with respect to `(εnv.interpret I)` gives the same result as
+interpreting the output of compiling `x` with respect to `εnv`.
 -/
 theorem compile_interpret {x : Expr} {εnv : SymEnv} {I : Interpretation} {t : Term} :
   I.WellFormed εnv.entities →
@@ -142,18 +142,18 @@ theorem compile_interpret {x : Expr} {εnv : SymEnv} {I : Interpretation} {t : T
     have ih₁ := @compile_interpret x₁
     exact compile_interpret_hasAttr h₁ h₂ h₃ ih₁
   | .set xs            =>
-    have ih : ∀ xᵢ ∈ xs, ReduceInterpret xᵢ := by
+    have ih : ∀ xᵢ ∈ xs, CompileInterpret xᵢ := by
       intro xᵢ _
       exact @compile_interpret xᵢ
     exact compile_interpret_set h₁ h₂ h₃ ih
   | .record axs      =>
-    have ih : ∀ aᵢ xᵢ, (aᵢ, xᵢ) ∈ axs → ReduceInterpret xᵢ := by
+    have ih : ∀ aᵢ xᵢ, (aᵢ, xᵢ) ∈ axs → CompileInterpret xᵢ := by
       intro aᵢ xᵢ h
       have _ : sizeOf xᵢ < 1 + sizeOf axs := List.sizeOf_snd_lt_sizeOf_list h
       exact @compile_interpret xᵢ
     exact compile_interpret_record h₁ h₂ h₃ ih
   | .call _ xs       =>
-    have ih : ∀ xᵢ ∈ xs, ReduceInterpret xᵢ := by
+    have ih : ∀ xᵢ ∈ xs, CompileInterpret xᵢ := by
       intro xᵢ _
       exact @compile_interpret xᵢ
     exact compile_interpret_call h₁ h₂ h₃ ih

--- a/cedar-lean/Cedar/Thm/SymCC/Compiler/Args.lean
+++ b/cedar-lean/Cedar/Thm/SymCC/Compiler/Args.lean
@@ -18,7 +18,7 @@ import Cedar.Thm.SymCC.Compiler.Invert
 import Cedar.Thm.SymCC.Compiler.WF
 
 /-!
-This file contains utility lemmas for proving reduction theorems
+This file contains utility lemmas for proving compilation theorems
 about lists of argument terms.
 --/
 
@@ -38,7 +38,7 @@ theorem compile_wfs {xs : List Expr} {εnv : SymEnv} {ts : List Term}
 theorem compile_interpret_ihs {xs : List Expr} {εnv : SymEnv} {I : Interpretation} {ts : List Term}
   (hI  : Interpretation.WellFormed I εnv.entities)
   (hwε : ∀ (x : Expr), x ∈ xs → SymEnv.WellFormedFor εnv x)
-  (ih  : ∀ (x : Expr), x ∈ xs → ReduceInterpret x)
+  (ih  : ∀ (x : Expr), x ∈ xs → CompileInterpret x)
   (hok : List.Forall₂ (fun x t => compile x εnv = Except.ok t) xs ts) :
   List.Forall₂ (fun x t => compile x (SymEnv.interpret I εnv) = Except.ok (Term.interpret I t)) xs ts
 := by
@@ -80,7 +80,7 @@ theorem compile_evaluate_ihs {xs : List Expr} {env : Env} {εnv : SymEnv}
   (heq : env ∼ εnv)
   (hwe : ∀ (x : Expr), x ∈ xs → env.WellFormedFor x)
   (hwε : ∀ (x : Expr), x ∈ xs → εnv.WellFormedFor x)
-  (ih  : ∀ (x : Expr), x ∈ xs → ReduceEvaluate x)
+  (ih  : ∀ (x : Expr), x ∈ xs → CompileEvaluate x)
   (hok : List.Forall₂ (fun x t => compile x εnv = Except.ok t) xs ts) :
   List.Forall₂ (fun x t => evaluate x env.request env.entities ∼ t) xs ts
 := by

--- a/cedar-lean/Cedar/Thm/SymCC/Compiler/Attr.lean
+++ b/cedar-lean/Cedar/Thm/SymCC/Compiler/Attr.lean
@@ -18,7 +18,7 @@ import Cedar.Thm.SymCC.Compiler.Invert
 import Cedar.Thm.SymCC.Compiler.WF
 
 /-!
-This file proves the reduction lemmas for `.hasAttr` and `.getAttr` expressions.
+This file proves the compilation lemmas for `.hasAttr` and `.getAttr` expressions.
 --/
 
 namespace Cedar.Thm
@@ -185,7 +185,7 @@ theorem compile_evaluate_hasAttr {x₁ : Expr} {a : Attr} {env : Env} {εnv : Sy
   (hwe : env.WellFormedFor (.hasAttr x₁ a))
   (hwε : εnv.WellFormedFor (.hasAttr x₁ a))
   (hok : compile (.hasAttr x₁ a) εnv = .ok t)
-  (ih  : ReduceEvaluate x₁) :
+  (ih  : CompileEvaluate x₁) :
   evaluate (.hasAttr x₁ a) env.request env.entities ∼ t
 := by
   replace ⟨t₁, t₂, hok, hr, ht⟩ := compile_hasAttr_ok_implies hok
@@ -348,7 +348,7 @@ theorem compile_interpret_hasAttr {x₁ : Expr} {a : Attr} {εnv : SymEnv} {I : 
   (hI  : I.WellFormed εnv.entities)
   (hwε : εnv.WellFormedFor (.hasAttr x₁ a))
   (hok : compile (.hasAttr x₁ a) εnv = .ok t)
-  (ih  : ReduceInterpret x₁) :
+  (ih  : CompileInterpret x₁) :
   compile (.hasAttr x₁ a) (εnv.interpret I) = .ok (t.interpret I)
 := by
   have hwε' := interpret_εntities_wf hwε.left.right hI
@@ -505,7 +505,7 @@ theorem compile_evaluate_getAttr {x₁ : Expr} {a : Attr} {env : Env} {εnv : Sy
   (hwe : env.WellFormedFor (.getAttr x₁ a))
   (hwε : εnv.WellFormedFor (.getAttr x₁ a))
   (hok : compile (.getAttr x₁ a) εnv = .ok t)
-  (ih  : ReduceEvaluate x₁) :
+  (ih  : CompileEvaluate x₁) :
   evaluate (.getAttr x₁ a) env.request env.entities ∼ t
 := by
   replace ⟨t₁, t₂, hok, hr, ht⟩ := compile_getAttr_ok_implies hok
@@ -667,7 +667,7 @@ theorem compile_interpret_getAttr {x₁ : Expr} {a : Attr} {εnv : SymEnv} {I : 
   (hI  : I.WellFormed εnv.entities)
   (hwε : εnv.WellFormedFor (.getAttr x₁ a))
   (hok : compile (.getAttr x₁ a) εnv = .ok t)
-  (ih  : ReduceInterpret x₁) :
+  (ih  : CompileInterpret x₁) :
   compile (.getAttr x₁ a) (εnv.interpret I) = .ok (t.interpret I)
 := by
   have hwε' := interpret_εntities_wf hwε.left.right hI

--- a/cedar-lean/Cedar/Thm/SymCC/Compiler/Basic.lean
+++ b/cedar-lean/Cedar/Thm/SymCC/Compiler/Basic.lean
@@ -34,7 +34,7 @@ namespace Cedar.Thm
 
 open Spec SymCC Factory
 
-def ReduceEvaluate (x : Expr) : Prop :=
+def CompileEvaluate (x : Expr) : Prop :=
   ∀ {env : Env} {εnv : SymEnv} {t : Term},
     env ∼ εnv →
     env.WellFormedFor x →
@@ -42,7 +42,7 @@ def ReduceEvaluate (x : Expr) : Prop :=
     compile x εnv = .ok t →
     evaluate x env.request env.entities ∼ t
 
-def ReduceInterpret (x : Expr) : Prop :=
+def CompileInterpret (x : Expr) : Prop :=
   ∀ {εnv : SymEnv} {I : Interpretation} {t : Term},
     I.WellFormed εnv.entities →
     εnv.WellFormedFor x →

--- a/cedar-lean/Cedar/Thm/SymCC/Compiler/Binary.lean
+++ b/cedar-lean/Cedar/Thm/SymCC/Compiler/Binary.lean
@@ -18,7 +18,7 @@ import Cedar.Thm.SymCC.Compiler.Invert
 import Cedar.Thm.SymCC.Compiler.WF
 
 /-!
-This file proves the reduction lemmas for `.binaryApp` expressions.
+This file proves the compilation lemmas for `.binaryApp` expressions.
 --/
 
 namespace Cedar.Thm
@@ -331,8 +331,8 @@ theorem compile_interpret_binaryApp {op₂ : BinaryOp} {x₁ x₂ : Expr} {εnv 
   (hI  : I.WellFormed εnv.entities)
   (hwε : εnv.WellFormedFor (.binaryApp op₂ x₁ x₂))
   (hok : compile (.binaryApp op₂ x₁ x₂) εnv = .ok t)
-  (ih₁ : ReduceInterpret x₁)
-  (ih₂ : ReduceInterpret x₂) :
+  (ih₁ : CompileInterpret x₁)
+  (ih₂ : CompileInterpret x₂) :
   compile (.binaryApp op₂ x₁ x₂) (εnv.interpret I) = .ok (t.interpret I)
 := by
   replace ⟨t₁, t₂, t₃, hok₁, hok₂, hok, ht⟩ := compile_binaryApp_ok_implies hok
@@ -1258,8 +1258,8 @@ theorem compile_evaluate_binaryApp {op₂ : BinaryOp} {x₁ x₂ : Expr} {env : 
   (hwe : env.WellFormedFor (.binaryApp op₂ x₁ x₂))
   (hwε : εnv.WellFormedFor (.binaryApp op₂ x₁ x₂))
   (hok : compile (.binaryApp op₂ x₁ x₂) εnv = .ok t)
-  (ih₁ : ReduceEvaluate x₁)
-  (ih₂ : ReduceEvaluate x₂) :
+  (ih₁ : CompileEvaluate x₁)
+  (ih₂ : CompileEvaluate x₂) :
   evaluate (.binaryApp op₂ x₁ x₂) env.request env.entities ∼ t
 := by
   replace ⟨t₁, t₂, t₃, hok₁, hok₂, hok, ht⟩ := compile_binaryApp_ok_implies hok

--- a/cedar-lean/Cedar/Thm/SymCC/Compiler/Call.lean
+++ b/cedar-lean/Cedar/Thm/SymCC/Compiler/Call.lean
@@ -19,7 +19,7 @@ import Cedar.Thm.SymCC.Compiler.Invert
 import Cedar.Thm.SymCC.Compiler.WF
 
 /-!
-This file proves the reduction lemmas for `.call` expressions.
+This file proves the compilation lemmas for `.call` expressions.
 --/
 
 namespace Cedar.Thm
@@ -1049,7 +1049,7 @@ theorem compile_interpret_call {f : ExtFun} {xs : List Expr} {εnv : SymEnv} {I 
   (hI  : I.WellFormed εnv.entities)
   (hwε : εnv.WellFormedFor (.call f xs))
   (hok : compile (.call f xs) εnv = .ok t)
-  (ih  : ∀ x ∈ xs, ReduceInterpret x) :
+  (ih  : ∀ x ∈ xs, CompileInterpret x) :
   compile (.call f xs) (εnv.interpret I) = .ok (t.interpret I)
 := by
   replace ⟨ts, hok₂, hok⟩ := compile_call_ok_implies hok
@@ -1432,7 +1432,7 @@ theorem compile_evaluate_call {f : ExtFun} {xs : List Expr} {env : Env} {εnv : 
   (hwe : env.WellFormedFor (.call f xs))
   (hwε : εnv.WellFormedFor (.call f xs))
   (hok : compile (.call f xs) εnv = .ok t)
-  (ih  : ∀ x ∈ xs, ReduceEvaluate x) :
+  (ih  : ∀ x ∈ xs, CompileEvaluate x) :
   evaluate (.call f xs) env.request env.entities ∼ t
 := by
   replace ⟨ts, hok₂, hok⟩ := compile_call_ok_implies hok

--- a/cedar-lean/Cedar/Thm/SymCC/Compiler/Control.lean
+++ b/cedar-lean/Cedar/Thm/SymCC/Compiler/Control.lean
@@ -18,7 +18,7 @@ import Cedar.Thm.SymCC.Compiler.Invert
 import Cedar.Thm.SymCC.Compiler.WF
 
 /-!
-This file proves the reduction lemmas for `.ite`, `.and`, and `.or` expressions.
+This file proves the compilation lemmas for `.ite`, `.and`, and `.or` expressions.
 --/
 
 namespace Cedar.Thm
@@ -28,11 +28,11 @@ open Batteries Data Spec SymCC Factory
 private theorem compile_evaluate_ite_none {x₂ x₃ : Expr} {εnv : SymEnv} {t : Term} {e : Spec.Error} {ty : TermType}
   (hwφ₂ : SymEnv.WellFormedFor εnv x₂)
   (hwφ₃ : SymEnv.WellFormedFor εnv x₃)
-  (h₁   : ReduceIfSym t (Term.none ty) (compile x₂ εnv) (compile x₃ εnv))
+  (h₁   : CompileIfSym t (Term.none ty) (compile x₂ εnv) (compile x₃ εnv))
   (h₂   : ¬e = Error.entityDoesNotExist) :
   (Except.error e : Spec.Result Value) ∼ t
 := by
-  simp only [ReduceIfSym, Term.typeOf, TermType.option.injEq] at h₁
+  simp only [CompileIfSym, Term.typeOf, TermType.option.injEq] at h₁
   replace ⟨h₁, t₂, t₃, h₃, h₄, h₅, h₆⟩ := h₁
   subst h₁
   replace ⟨hwφ₂, ty, hty⟩ := compile_wf hwφ₂ h₃
@@ -52,9 +52,9 @@ theorem compile_evaluate_ite {x₁ x₂ x₃ : Expr} {env : Env} {εnv : SymEnv}
   (h₂  : env.WellFormedFor (.ite x₁ x₂ x₃))
   (h₃  : εnv.WellFormedFor (.ite x₁ x₂ x₃))
   (h₄  : compile (.ite x₁ x₂ x₃) εnv = .ok t)
-  (ih₁ : ReduceEvaluate x₁)
-  (ih₂ : ReduceEvaluate x₂)
-  (ih₃ : ReduceEvaluate x₃) :
+  (ih₁ : CompileEvaluate x₁)
+  (ih₂ : CompileEvaluate x₂)
+  (ih₃ : CompileEvaluate x₃) :
   evaluate (.ite x₁ x₂ x₃) env.request env.entities ∼ t
 := by
   replace ⟨t₁, hr₁, h₄⟩ := compile_ite_ok_implies h₄
@@ -76,7 +76,7 @@ theorem compile_evaluate_ite {x₁ x₂ x₃ : Expr} {env : Env} {εnv : SymEnv}
       replace ih₁ := same_ok_bool_implies ih₁
       subst ih₁
       cases b <;>
-      simp only [ReduceIfSym] at h₄ <;>
+      simp only [CompileIfSym] at h₄ <;>
       rw [eq_comm] at h₄
       case false => simp only [ite_false, ih₃ h₁ hwf₃ hwφ₃ h₄, reduceCtorEq]
       case true  => simp only [ite_true, ih₂ h₁ hwf₂ hwφ₂ h₄]
@@ -100,7 +100,7 @@ theorem compile_evaluate_ite {x₁ x₂ x₃ : Expr} {env : Env} {εnv : SymEnv}
           exact compile_evaluate_ite_none hwφ₂ hwφ₃ h₄ (by simp only [not_false_eq_true, reduceCtorEq])
         case inr h₅ h₆ =>
           replace ⟨t', hr₁, hr₁'⟩ := hr₁ ; subst hr₁ hr₁'
-          simp only [ReduceIfSym, Term.typeOf, TermType.option.injEq] at h₄
+          simp only [CompileIfSym, Term.typeOf, TermType.option.injEq] at h₄
           replace hwφ₁ := wf_term_some_implies hwφ₁
           replace ih₁ := lit_term_some_implies_lit ih₁
           replace ih₁ := wfl_of_type_bool_is_true_or_false (And.intro hwφ₁ ih₁) h₄.left
@@ -111,9 +111,9 @@ theorem compile_interpret_ite {x₁ x₂ x₃ : Expr} {εnv : SymEnv} {I : Inter
   (h₁  : I.WellFormed εnv.entities)
   (h₂  : εnv.WellFormedFor (.ite x₁ x₂ x₃))
   (h₃  : compile (.ite x₁ x₂ x₃) εnv = .ok t)
-  (ih₁ : ReduceInterpret x₁)
-  (ih₂ : ReduceInterpret x₂)
-  (ih₃ : ReduceInterpret x₃) :
+  (ih₁ : CompileInterpret x₁)
+  (ih₂ : CompileInterpret x₂)
+  (ih₃ : CompileInterpret x₃) :
   compile (.ite x₁ x₂ x₃) (εnv.interpret I) = .ok (t.interpret I)
 := by
   replace ⟨_, hr₁, h₃⟩ := compile_ite_ok_implies h₃
@@ -190,11 +190,11 @@ theorem compile_interpret_ite {x₁ x₂ x₃ : Expr} {εnv : SymEnv} {I : Inter
 
 private theorem compile_evaluate_and_none {x₂ : Expr} {εnv : SymEnv} {t : Term} {e : Spec.Error} {ty : TermType}
   (hwφ₂ : SymEnv.WellFormedFor εnv x₂)
-  (h₁   : ReduceAndSym t (Term.none ty) (compile x₂ εnv))
+  (h₁   : CompileAndSym t (Term.none ty) (compile x₂ εnv))
   (h₂   : ¬e = Error.entityDoesNotExist) :
   (Except.error e : Spec.Result Value) ∼ t
 := by
-  simp only [ReduceAndSym, Term.typeOf, TermType.option.injEq] at h₁
+  simp only [CompileAndSym, Term.typeOf, TermType.option.injEq] at h₁
   replace ⟨h₁, t₂, h₃, h₄, h₅⟩ := h₁
   subst h₁
   replace ⟨hwφ₂, _, _⟩ := compile_wf hwφ₂ h₃
@@ -233,8 +233,8 @@ theorem compile_evaluate_and {x₁ x₂ : Expr} {env : Env} {εnv : SymEnv} {t :
   (h₂  : env.WellFormedFor (.and x₁ x₂))
   (h₃  : εnv.WellFormedFor (.and x₁ x₂))
   (h₄  : compile (.and x₁ x₂) εnv = .ok t)
-  (ih₁ : ReduceEvaluate x₁)
-  (ih₂ : ReduceEvaluate x₂) :
+  (ih₁ : CompileEvaluate x₁)
+  (ih₂ : CompileEvaluate x₂) :
   evaluate (.and x₁ x₂) env.request env.entities ∼ t
 := by
   replace ⟨_, hr₁, h₄⟩ := compile_and_ok_implies h₄
@@ -289,8 +289,8 @@ theorem compile_interpret_and {x₁ x₂ : Expr} {εnv : SymEnv} {I : Interpreta
   (h₁  : I.WellFormed εnv.entities)
   (h₂  : εnv.WellFormedFor (.and x₁ x₂))
   (h₃  : compile (.and x₁ x₂) εnv = .ok t)
-  (ih₁ : ReduceInterpret x₁)
-  (ih₂ : ReduceInterpret x₂) :
+  (ih₁ : CompileInterpret x₁)
+  (ih₂ : CompileInterpret x₂) :
   compile (.and x₁ x₂) (εnv.interpret I) = .ok (t.interpret I)
 := by
   replace ⟨_, hr₁, h₃⟩ := compile_and_ok_implies h₃
@@ -365,11 +365,11 @@ theorem compile_interpret_and {x₁ x₂ : Expr} {εnv : SymEnv} {I : Interpreta
 
 private theorem compile_evaluate_or_none {x₂ : Expr} {εnv : SymEnv} {t : Term} {e : Spec.Error} {ty : TermType}
   (hwφ₂ : SymEnv.WellFormedFor εnv x₂)
-  (h₁   : ReduceOrSym t (Term.none ty) (compile x₂ εnv))
+  (h₁   : CompileOrSym t (Term.none ty) (compile x₂ εnv))
   (h₂   : ¬e = Error.entityDoesNotExist) :
   (Except.error e : Spec.Result Value) ∼ t
 := by
-  simp only [ReduceOrSym, Term.typeOf, TermType.option.injEq] at h₁
+  simp only [CompileOrSym, Term.typeOf, TermType.option.injEq] at h₁
   replace ⟨h₁, t₂, h₃, h₄, h₅⟩ := h₁
   subst h₁
   replace ⟨hwφ₂, _, _⟩ := compile_wf hwφ₂ h₃
@@ -389,8 +389,8 @@ theorem compile_evaluate_or {x₁ x₂ : Expr} {env : Env} {εnv : SymEnv} {t : 
   (h₂  : env.WellFormedFor (.or x₁ x₂))
   (h₃  : εnv.WellFormedFor (.or x₁ x₂))
   (h₄  : compile (.or x₁ x₂) εnv = .ok t)
-  (ih₁ : ReduceEvaluate x₁)
-  (ih₂ : ReduceEvaluate x₂) :
+  (ih₁ : CompileEvaluate x₁)
+  (ih₂ : CompileEvaluate x₂) :
   evaluate (.or x₁ x₂) env.request env.entities ∼ t
 := by
   replace ⟨_, hr₁, h₄⟩ := compile_or_ok_implies h₄
@@ -445,8 +445,8 @@ theorem compile_interpret_or {x₁ x₂ : Expr} {εnv : SymEnv} {I : Interpretat
   (h₁  : I.WellFormed εnv.entities)
   (h₂  : εnv.WellFormedFor (.or x₁ x₂))
   (h₃  : compile (.or x₁ x₂) εnv = .ok t)
-  (ih₁ : ReduceInterpret x₁)
-  (ih₂ : ReduceInterpret x₂) :
+  (ih₁ : CompileInterpret x₁)
+  (ih₂ : CompileInterpret x₂) :
   compile (.or x₁ x₂) (εnv.interpret I) = .ok (t.interpret I)
 := by
   replace ⟨_, hr₁, h₃⟩ := compile_or_ok_implies h₃

--- a/cedar-lean/Cedar/Thm/SymCC/Compiler/Invert.lean
+++ b/cedar-lean/Cedar/Thm/SymCC/Compiler/Invert.lean
@@ -24,7 +24,7 @@ namespace Cedar.Thm
 
 open Batteries Data Spec SymCC Factory
 
-def ReduceIfSym (t t₁ : Term) (r₂ r₃ : SymCC.Result Term) : Prop :=
+def CompileIfSym (t t₁ : Term) (r₂ r₃ : SymCC.Result Term) : Prop :=
   t₁.typeOf = (.option .bool) ∧
   ∃ t₂ t₃,
     r₂ = .ok t₂ ∧
@@ -39,9 +39,9 @@ theorem compile_ite_ok_implies {x₁ x₂ x₃ : Expr} {εnv : SymEnv} {t : Term
     match t₁ with
      | .some (.prim (.bool true))  => t = compile x₂ εnv
      | .some (.prim (.bool false)) => t = compile x₃ εnv
-     | t₁ => ReduceIfSym t t₁ (compile x₂ εnv) (compile x₃ εnv)
+     | t₁ => CompileIfSym t t₁ (compile x₂ εnv) (compile x₃ εnv)
 := by
-  simp only [ReduceIfSym]
+  simp only [CompileIfSym]
   simp only [compile, compileIf] at h₁
   simp_do_let (compile x₁ εnv) at h₁
   split at h₁
@@ -62,7 +62,7 @@ theorem compile_ite_ok_implies {x₁ x₂ x₃ : Expr} {εnv : SymEnv} {t : Term
       compile_ite_ok_implies]
   case h_4 => simp only [reduceCtorEq] at h₁
 
-def ReduceAndSym (t t₁ : Term) (r₂ : SymCC.Result Term): Prop :=
+def CompileAndSym (t t₁ : Term) (r₂ : SymCC.Result Term): Prop :=
   t₁.typeOf = .option .bool ∧
   ∃ t₂,
     r₂ = .ok t₂ ∧
@@ -75,12 +75,12 @@ theorem compile_and_ok_implies {x₁ x₂ : Expr} {εnv : SymEnv} {t : Term}
     (compile x₁ εnv) = .ok t₁ ∧
     match t₁ with
      | .some (.prim (.bool false)) => t = t₁
-     | _ => ReduceAndSym t t₁ (compile x₂ εnv)
+     | _ => CompileAndSym t t₁ (compile x₂ εnv)
 := by
   simp only [compile] at h₁
   simp_do_let (compile x₁ εnv) at h₁ ; rename_i t₁ h₂
   exists t₁
-  simp only [true_and, ReduceAndSym]
+  simp only [true_and, CompileAndSym]
   simp only [compileAnd] at h₁
   split at h₁
   case h_1 =>
@@ -98,7 +98,7 @@ theorem compile_and_ok_implies {x₁ x₂ : Expr} {εnv : SymEnv} {t : Term}
       simp only [h₆, h₁, and_self]
   case h_3 => simp only [reduceCtorEq] at h₁
 
-def ReduceOrSym (t t₁ : Term) (r₂ : SymCC.Result Term): Prop :=
+def CompileOrSym (t t₁ : Term) (r₂ : SymCC.Result Term): Prop :=
   t₁.typeOf = .option .bool ∧
   ∃ t₂,
     r₂ = .ok t₂ ∧
@@ -111,12 +111,12 @@ theorem compile_or_ok_implies {x₁ x₂ : Expr} {εnv : SymEnv} {t : Term}
     (compile x₁ εnv) = .ok t₁ ∧
     match t₁ with
     | .some (.prim (.bool true)) => t = t₁
-    | _ => ReduceOrSym t t₁ (compile x₂ εnv)
+    | _ => CompileOrSym t t₁ (compile x₂ εnv)
 := by
   simp only [compile] at h₁
   simp_do_let (compile x₁ εnv) at h₁ ; rename_i t₁ h₂
   exists t₁
-  simp only [true_and, ReduceOrSym]
+  simp only [true_and, CompileOrSym]
   simp only [compileOr] at h₁
   split at h₁
   case h_1 =>

--- a/cedar-lean/Cedar/Thm/SymCC/Compiler/LitVar.lean
+++ b/cedar-lean/Cedar/Thm/SymCC/Compiler/LitVar.lean
@@ -17,7 +17,7 @@
 import Cedar.Thm.SymCC.Compiler.Basic
 
 /-!
-This file proves the reduction lemmas for `.lit` and `.var` expressions.
+This file proves the compilation lemmas for `.lit` and `.var` expressions.
 --/
 
 namespace Cedar.Thm

--- a/cedar-lean/Cedar/Thm/SymCC/Compiler/Record.lean
+++ b/cedar-lean/Cedar/Thm/SymCC/Compiler/Record.lean
@@ -18,7 +18,7 @@ import Cedar.Thm.SymCC.Compiler.Invert
 import Cedar.Thm.SymCC.Compiler.WF
 
 /-!
-This file proves the reduction lemmas for `.record` expressions.
+This file proves the compilation lemmas for `.record` expressions.
 --/
 
 namespace Cedar.Thm
@@ -40,7 +40,7 @@ theorem compile_attr_expr_wfs {εnv : SymEnv} {axs : List (Attr × Expr)} {ats :
 private theorem compile_interpret_ihs {axs : List (Attr × Expr)} {ats : List (Attr × Term)} {εnv : SymEnv} {I : Interpretation}
   (hI : Interpretation.WellFormed I εnv.entities)
   (hwε : ∀ (ax : Attr × Expr), ax ∈ axs → SymEnv.WellFormedFor εnv ax.snd)
-  (ih : ∀ (a : Attr) (x : Expr), (a, x) ∈ axs → ReduceInterpret x)
+  (ih : ∀ (a : Attr) (x : Expr), (a, x) ∈ axs → CompileInterpret x)
   (hok : List.Forall₂ (λ px pt => px.fst = pt.fst ∧ compile px.snd εnv = Except.ok pt.snd) axs ats) :
   List.Forall₂ (λ (a, x) (a', t) => a = a' ∧ compile x (εnv.interpret I) = .ok (t.interpret I)) axs ats
 := by
@@ -170,7 +170,7 @@ theorem compile_interpret_record {axs : List (Attr × Expr)} {εnv : SymEnv} {I 
   (hI  : I.WellFormed εnv.entities)
   (hwε : εnv.WellFormedFor (.record axs))
   (hok : compile (.record axs) εnv = .ok t)
-  (ih  : ∀ a x, (a, x) ∈ axs → ReduceInterpret x) :
+  (ih  : ∀ a x, (a, x) ∈ axs → CompileInterpret x) :
   compile (.record axs) (εnv.interpret I) = .ok (t.interpret I)
 := by
   replace ⟨ats, hok, ht⟩ := compile_record_ok_implies hok
@@ -200,7 +200,7 @@ private theorem compile_evaluate_ihs {axs : List (Attr × Expr)} {ats : List (At
   (heq : env ∼ εnv)
   (hwe : ∀ (ax : Attr × Expr), ax ∈ axs → env.WellFormedFor ax.snd)
   (hwε : ∀ (ax : Attr × Expr), ax ∈ axs → εnv.WellFormedFor ax.snd)
-  (ih  : ∀ a x, (a, x) ∈ axs → ReduceEvaluate x)
+  (ih  : ∀ a x, (a, x) ∈ axs → CompileEvaluate x)
   (hok : List.Forall₂ (fun px pt => px.fst = pt.fst ∧ compile px.snd εnv = Except.ok pt.snd) axs ats) :
   List.Forall₂ (fun px pt => px.fst = pt.fst ∧ evaluate px.snd env.request env.entities ∼ pt.snd) axs ats
 := by
@@ -289,7 +289,7 @@ theorem compile_evaluate_record {axs : List (Attr × Expr)} {env : Env} {εnv : 
   (hwe : env.WellFormedFor (.record axs))
   (hwε : εnv.WellFormedFor (.record axs))
   (hok : compile (.record axs) εnv = .ok t)
-  (ih  : ∀ a x, (a, x) ∈ axs → ReduceEvaluate x) :
+  (ih  : ∀ a x, (a, x) ∈ axs → CompileEvaluate x) :
   evaluate (.record axs) env.request env.entities ∼ t
 := by
   replace ⟨ats, hok, ht⟩ := compile_record_ok_implies hok

--- a/cedar-lean/Cedar/Thm/SymCC/Compiler/Set.lean
+++ b/cedar-lean/Cedar/Thm/SymCC/Compiler/Set.lean
@@ -19,7 +19,7 @@ import Cedar.Thm.SymCC.Compiler.Invert
 import Cedar.Thm.SymCC.Compiler.WF
 
 /-!
-This file proves the reduction lemmas for `.set` expressions.
+This file proves the compilation lemmas for `.set` expressions.
 --/
 
 namespace Cedar.Thm
@@ -100,7 +100,7 @@ theorem compile_interpret_set {xs : List Expr} {εnv : SymEnv} {I : Interpretati
   (hI  : I.WellFormed εnv.entities)
   (hwε : εnv.WellFormedFor (.set xs))
   (hok : compile (.set xs) εnv = .ok t)
-  (ih  : ∀ x ∈ xs, ReduceInterpret x) :
+  (ih  : ∀ x ∈ xs, CompileInterpret x) :
   compile (.set xs) (εnv.interpret I) = .ok (t.interpret I)
 := by
   replace ⟨ts, hok, ht⟩ := compile_set_ok_implies hok
@@ -203,7 +203,7 @@ theorem compile_evaluate_set {xs : List Expr} {env : Env} {εnv : SymEnv} {t : T
   (hwe : env.WellFormedFor (.set xs))
   (hwε : εnv.WellFormedFor (.set xs))
   (hok : compile (.set xs) εnv = .ok t)
-  (ih  : ∀ x ∈ xs, ReduceEvaluate x) :
+  (ih  : ∀ x ∈ xs, CompileEvaluate x) :
   evaluate (.set xs) env.request env.entities ∼ t
 := by
   replace ⟨ts, hok, ht⟩ := compile_set_ok_implies hok

--- a/cedar-lean/Cedar/Thm/SymCC/Compiler/Unary.lean
+++ b/cedar-lean/Cedar/Thm/SymCC/Compiler/Unary.lean
@@ -18,7 +18,7 @@ import Cedar.Thm.SymCC.Compiler.Invert
 import Cedar.Thm.SymCC.Compiler.WF
 
 /-!
-This file proves the reduction lemmas for `.unaryApp` expressions.
+This file proves the compilation lemmas for `.unaryApp` expressions.
 --/
 
 namespace Cedar.Thm
@@ -99,7 +99,7 @@ theorem compile_evaluate_unaryApp {op₁ : UnaryOp} {x₁ : Expr} {env : Env} {�
   (hwe : env.WellFormedFor (.unaryApp op₁ x₁))
   (hwε : εnv.WellFormedFor (.unaryApp op₁ x₁))
   (hok : compile (.unaryApp op₁ x₁) εnv = .ok t)
-  (ih  : ReduceEvaluate x₁) :
+  (ih  : CompileEvaluate x₁) :
   evaluate (.unaryApp op₁ x₁) env.request env.entities ∼ t
 := by
   replace ⟨t₁, t₂, hok, hr, ht⟩ := compile_unaryApp_ok_implies hok
@@ -186,7 +186,7 @@ theorem compile_interpret_unaryApp {op₁ : UnaryOp} {x₁ : Expr} {εnv : SymEn
   (hI  : I.WellFormed εnv.entities)
   (hwε : εnv.WellFormedFor (.unaryApp op₁ x₁))
   (hok : compile (.unaryApp op₁ x₁) εnv = .ok t)
-  (ih  : ReduceInterpret x₁) :
+  (ih  : CompileInterpret x₁) :
   compile (.unaryApp op₁ x₁) (εnv.interpret I) = .ok (t.interpret I)
 := by
   replace ⟨t₁, t₂, hok, ha, ht⟩ := compile_unaryApp_ok_implies hok

--- a/cedar-lean/Cedar/Thm/SymCC/Compiler/WF.lean
+++ b/cedar-lean/Cedar/Thm/SymCC/Compiler/WF.lean
@@ -31,9 +31,9 @@ namespace Cedar.Thm
 
 open Batteries Data Spec SymCC Factory
 
----------- Reduce is well-formed ----------
+---------- Compile is well-formed ----------
 
-private def ReduceWF (x : Expr)  : Prop :=
+private def CompileWF (x : Expr)  : Prop :=
   ∀ {εnv : SymEnv} {t : Term},
     εnv.WellFormedFor x →
     compile x εnv = .ok t →
@@ -87,9 +87,9 @@ private theorem compile_var_wf {v : Var} {εnv : SymEnv} {t : Term}
 private theorem compile_ite_wf {x₁ x₂ x₃: Expr} {εnv : SymEnv} {t : Term}
   (hwf : SymEnv.WellFormedFor εnv (Expr.ite x₁ x₂ x₃))
   (hok : compile (Expr.ite x₁ x₂ x₃) εnv = Except.ok t)
-  (ih₁ : ReduceWF x₁)
-  (ih₂ : ReduceWF x₂)
-  (ih₃ : ReduceWF x₃) :
+  (ih₁ : CompileWF x₁)
+  (ih₂ : CompileWF x₂)
+  (ih₃ : CompileWF x₃) :
   t.WellFormed εnv.entities ∧ ∃ ty, t.typeOf = .option ty
 := by
   have ⟨hwφ₁, hwφ₂, hwφ₃⟩ := wf_εnv_for_ite_implies hwf
@@ -123,8 +123,8 @@ private theorem compile_ite_wf {x₁ x₂ x₃: Expr} {εnv : SymEnv} {t : Term}
 private theorem compile_and_wf {x₁ x₂: Expr} {εnv : SymEnv} {t : Term}
   (hwf : SymEnv.WellFormedFor εnv (Expr.and x₁ x₂))
   (hok : compile (Expr.and x₁ x₂) εnv = Except.ok t)
-  (ih₁ : ReduceWF x₁)
-  (ih₂ : ReduceWF x₂) :
+  (ih₁ : CompileWF x₁)
+  (ih₂ : CompileWF x₂) :
   t.WellFormed εnv.entities ∧ ∃ ty, t.typeOf = .option ty
 := by
   have ⟨hwφ₁, hwφ₂⟩ := wf_εnv_for_and_implies hwf
@@ -154,8 +154,8 @@ private theorem compile_and_wf {x₁ x₂: Expr} {εnv : SymEnv} {t : Term}
 private theorem compile_or_wf {x₁ x₂: Expr} {εnv : SymEnv} {t : Term}
   (hwf : SymEnv.WellFormedFor εnv (Expr.or x₁ x₂))
   (hok : compile (Expr.or x₁ x₂) εnv = Except.ok t)
-  (ih₁ : ReduceWF x₁)
-  (ih₂ : ReduceWF x₂) :
+  (ih₁ : CompileWF x₁)
+  (ih₂ : CompileWF x₂) :
   t.WellFormed εnv.entities ∧ ∃ ty, t.typeOf = .option ty
 := by
   have ⟨hwφ₁, hwφ₂⟩ := wf_εnv_for_or_implies hwf
@@ -235,7 +235,7 @@ theorem compileHasAttr_wf {t t₁: Term} {a : Attr} {εs : SymEntities}
 private theorem compile_hasAttr_wf {x₁ : Expr} {a : Attr} {εnv : SymEnv} {t : Term}
   (hwf : SymEnv.WellFormedFor εnv (Expr.hasAttr x₁ a))
   (hok : compile (Expr.hasAttr x₁ a) εnv = Except.ok t)
-  (ih₁ : ReduceWF x₁) :
+  (ih₁ : CompileWF x₁) :
   t.WellFormed εnv.entities ∧ ∃ ty, t.typeOf = .option ty
 := by
   have hwφ₁ := wf_εnv_for_hasAttr_implies hwf
@@ -271,7 +271,7 @@ theorem compileGetAttr_wf {t t₁: Term} {a : Attr} {εs : SymEntities}
 private theorem compile_getAttr_wf {x₁ : Expr} {a : Attr} {εnv : SymEnv} {t : Term}
   (hwf : SymEnv.WellFormedFor εnv (Expr.getAttr x₁ a))
   (hok : compile (Expr.getAttr x₁ a) εnv = Except.ok t)
-  (ih₁ : ReduceWF x₁) :
+  (ih₁ : CompileWF x₁) :
   t.WellFormed εnv.entities ∧ ∃ ty, t.typeOf = .option ty
 := by
   have hwφ₁ := wf_εnv_for_getAttr_implies hwf
@@ -332,7 +332,7 @@ theorem compileApp₁_wf {op₁ : UnaryOp} {t t₁: Term} {εs : SymEntities}
 private theorem compile_unaryApp_wf {op₁ : UnaryOp} {x₁ : Expr} {εnv : SymEnv} {t : Term}
   (hwf : SymEnv.WellFormedFor εnv (Expr.unaryApp op₁ x₁))
   (hok : compile (Expr.unaryApp op₁ x₁) εnv = Except.ok t)
-  (ih₁ : ReduceWF x₁) :
+  (ih₁ : CompileWF x₁) :
   t.WellFormed εnv.entities ∧ ∃ ty, t.typeOf = .option ty
 := by
   have hwφ₁ := wf_εnv_for_unaryApp_implies hwf
@@ -552,8 +552,8 @@ theorem compileApp₂_wf {op₂ : BinaryOp} {t t₁ t₂: Term} {εs : SymEntiti
 private theorem compile_binaryApp_wf {op₂ : BinaryOp} {x₁ x₂ : Expr} {εnv : SymEnv} {t : Term}
   (hwf : SymEnv.WellFormedFor εnv (Expr.binaryApp op₂ x₁ x₂))
   (hok : compile (Expr.binaryApp op₂ x₁ x₂) εnv = Except.ok t)
-  (ih₁ : ReduceWF x₁)
-  (ih₂ : ReduceWF x₂) :
+  (ih₁ : CompileWF x₁)
+  (ih₂ : CompileWF x₂) :
   t.WellFormed εnv.entities ∧ ∃ ty, t.typeOf = .option ty
 := by
   have ⟨hwφ₁, hwφ₂⟩ := wf_εnv_for_binaryApp_implies hwf
@@ -571,7 +571,7 @@ private theorem compile_binaryApp_wf {op₂ : BinaryOp} {x₁ x₂ : Expr} {εnv
 private theorem compile_set_wf {xs : List Expr} {εnv : SymEnv} {t : Term}
   (hwf : SymEnv.WellFormedFor εnv (Expr.set xs))
   (hok : compile (Expr.set xs) εnv = Except.ok t)
-  (ih  : ∀ x ∈ xs, ReduceWF x) :
+  (ih  : ∀ x ∈ xs, CompileWF x) :
   t.WellFormed εnv.entities ∧ ∃ ty, t.typeOf = .option ty
 := by
   replace hwf := wf_εnv_for_set_implies hwf
@@ -592,7 +592,7 @@ private theorem compile_set_wf {xs : List Expr} {εnv : SymEnv} {t : Term}
 private theorem compile_record_wf {axs : List (Attr × Expr)} {εnv : SymEnv} {t : Term}
   (hwf : SymEnv.WellFormedFor εnv (Expr.record axs))
   (hok : compile (Expr.record axs) εnv = Except.ok t)
-  (ih  : ∀ (aᵢ : Attr) (xᵢ : Expr), (aᵢ, xᵢ) ∈ axs → Cedar.Thm.ReduceWF xᵢ) :
+  (ih  : ∀ (aᵢ : Attr) (xᵢ : Expr), (aᵢ, xᵢ) ∈ axs → CompileWF xᵢ) :
   t.WellFormed εnv.entities ∧ ∃ ty, t.typeOf = .option ty
 := by
   replace hwf := wf_εnv_for_record_implies hwf
@@ -744,7 +744,7 @@ theorem compileCall_wf {f : ExtFun} {ts : List Term} {εs : SymEntities} {t : Te
 private theorem compile_call_wf {f : ExtFun} {xs : List Expr} {εnv : SymEnv} {t : Term}
   (hwf : SymEnv.WellFormedFor εnv (Expr.call f xs))
   (hok : compile (Expr.call f xs) εnv = Except.ok t)
-  (ih  : ∀ x ∈ xs, ReduceWF x) :
+  (ih  : ∀ x ∈ xs, CompileWF x) :
   t.WellFormed εnv.entities ∧ ∃ ty, t.typeOf = .option ty
 := by
   replace hwf := wf_εnv_for_call_implies hwf
@@ -790,18 +790,18 @@ theorem compile_wf {x : Expr} {εnv : SymEnv} {t : Term} :
     have ih₁ := @compile_wf x₁
     exact compile_hasAttr_wf hwf hok ih₁
   | .set xs          =>
-    have ih : ∀ xᵢ ∈ xs, ReduceWF xᵢ := by
+    have ih : ∀ xᵢ ∈ xs, CompileWF xᵢ := by
       intro xᵢ _
       exact @compile_wf xᵢ
     exact compile_set_wf hwf hok ih
   | .record axs      =>
-    have ih : ∀ aᵢ xᵢ, (aᵢ, xᵢ) ∈ axs → ReduceWF xᵢ := by
+    have ih : ∀ aᵢ xᵢ, (aᵢ, xᵢ) ∈ axs → CompileWF xᵢ := by
       intro aᵢ xᵢ h
       have _ : sizeOf xᵢ < 1 + sizeOf axs := List.sizeOf_snd_lt_sizeOf_list h
       exact @compile_wf xᵢ
     exact compile_record_wf hwf hok ih
   | .call _ xs       =>
-    have ih : ∀ xᵢ ∈ xs, ReduceWF xᵢ := by
+    have ih : ∀ xᵢ ∈ xs, CompileWF xᵢ := by
       intro xᵢ _
       exact @compile_wf xᵢ
     exact compile_call_wf hwf hok ih

--- a/cedar-lean/Cedar/Thm/SymCC/Data/Basic.lean
+++ b/cedar-lean/Cedar/Thm/SymCC/Data/Basic.lean
@@ -27,7 +27,7 @@ import Cedar.Thm.SymCC.Data.BitVec
 # Well-formedness and interpretations
 
 This file defines well-formedness constraints and relations on concrete and
-symbolic structures. We prove correctness properties of the symbolic evaluator
+symbolic structures. We prove correctness properties of the symbolic compiler
 with respect to these defintions.
 
 Well-formedness of a concrete structure is defined with respect to a set of
@@ -71,10 +71,10 @@ A literal term or symbolic request represent a single corresponding Cedar
 structure (i.e., a `Value`, `Outcome Value`, or `Request`). A well-formed
 literal symbolic environment `εnv : SymEnv` represents a set of well-formed
 concrete environments that lead to equivalent evaluation outcomes. In
-particular, if `εnv` is a literal symbolic environmnent that is well-formed for
+particular, if `εnv` is a literal symbolic environment that is well-formed for
 an expression `x`, then `x` produces the same outcome when evaluated against any
 concrete environment `env ∈ εnv` that is well-formed for `x`. We write `env ∈ εnv`
-to denote that exists a well-fromed interpretation `I` such that
+to denote that exists a well-formed interpretation `I` such that
 `εnv.interpret I` is a literal that represents `env`.
 -/
 

--- a/cedar-lean/Cedar/Thm/SymCC/Enforcer/Compile.lean
+++ b/cedar-lean/Cedar/Thm/SymCC/Enforcer/Compile.lean
@@ -306,7 +306,7 @@ theorem compile_interpret_in_footprint {x : Expr} {εnv : SymEnv} {I : Interpret
 
 -------------------
 
-private def ReduceInterpretOnFootprint (x : Expr) (ft : Set Term) (εnv : SymEnv) (I₁ I₂ : Interpretation) : Prop :=
+private def CompileInterpretOnFootprint (x : Expr) (ft : Set Term) (εnv : SymEnv) (I₁ I₂ : Interpretation) : Prop :=
   ∀ {t : Term},
     εnv.WellFormedFor x →
     I₁.WellFormed εnv.entities →
@@ -402,9 +402,9 @@ private theorem compile_interpret_ite_on_footprint {x₁ x₂ x₃ : Expr} {ft :
   (hsm : εnv.SameOn ft I₁ I₂)
   (hft : footprint (.ite x₁ x₂ x₃) εnv ⊆ ft)
   (hok : compile (.ite x₁ x₂ x₃) εnv = .ok t)
-  (ih₁ : ReduceInterpretOnFootprint x₁ ft εnv I₁ I₂)
-  (ih₂ : ReduceInterpretOnFootprint x₂ ft εnv I₁ I₂)
-  (ih₃ : ReduceInterpretOnFootprint x₃ ft εnv I₁ I₂) :
+  (ih₁ : CompileInterpretOnFootprint x₁ ft εnv I₁ I₂)
+  (ih₂ : CompileInterpretOnFootprint x₂ ft εnv I₁ I₂)
+  (ih₃ : CompileInterpretOnFootprint x₃ ft εnv I₁ I₂) :
   t.interpret I₁ = t.interpret I₂
 := by
   replace hwε := wf_εnv_for_ite_implies hwε
@@ -435,8 +435,8 @@ private theorem compile_interpret_and_on_footprint {x₁ x₂ : Expr} {ft : Set 
   (hsm : εnv.SameOn ft I₁ I₂)
   (hft : footprint (.and x₁ x₂) εnv ⊆ ft)
   (hok : compile (.and x₁ x₂) εnv = .ok t)
-  (ih₁ : ReduceInterpretOnFootprint x₁ ft εnv I₁ I₂)
-  (ih₂ : ReduceInterpretOnFootprint x₂ ft εnv I₁ I₂) :
+  (ih₁ : CompileInterpretOnFootprint x₁ ft εnv I₁ I₂)
+  (ih₂ : CompileInterpretOnFootprint x₂ ft εnv I₁ I₂) :
   t.interpret I₁ = t.interpret I₂
 := by
   replace ⟨t₁, hok₁, hok⟩ := compile_and_ok_implies hok
@@ -470,8 +470,8 @@ private theorem compile_interpret_or_on_footprint {x₁ x₂ : Expr} {ft : Set T
   (hsm : εnv.SameOn ft I₁ I₂)
   (hft : footprint (.or x₁ x₂) εnv ⊆ ft)
   (hok : compile (.or x₁ x₂) εnv = .ok t)
-  (ih₁ : ReduceInterpretOnFootprint x₁ ft εnv I₁ I₂)
-  (ih₂ : ReduceInterpretOnFootprint x₂ ft εnv I₁ I₂) :
+  (ih₁ : CompileInterpretOnFootprint x₁ ft εnv I₁ I₂)
+  (ih₂ : CompileInterpretOnFootprint x₂ ft εnv I₁ I₂) :
   t.interpret I₁ = t.interpret I₂
 := by
   replace ⟨t₁, hok₁, hok⟩ := compile_or_ok_implies hok
@@ -541,7 +541,7 @@ private theorem compile_interpret_unaryApp_on_footprint {op₁ : UnaryOp} {x₁ 
   (hsm : εnv.SameOn ft I₁ I₂)
   (hft : footprint (.unaryApp op₁ x₁) εnv ⊆ ft)
   (hok : compile (.unaryApp op₁ x₁) εnv = .ok t)
-  (ih₁ : ReduceInterpretOnFootprint x₁ ft εnv I₁ I₂) :
+  (ih₁ : CompileInterpretOnFootprint x₁ ft εnv I₁ I₂) :
   t.interpret I₁ = t.interpret I₂
 := by
   simp only [footprint] at hft
@@ -569,8 +569,8 @@ private theorem compile_interpret_binaryApp_on_footprint {op₂ : BinaryOp} {x�
   (hsm : εnv.SameOn ft I₁ I₂)
   (hft : footprint (.binaryApp op₂ x₁ x₂) εnv ⊆ ft)
   (hok : compile (.binaryApp op₂ x₁ x₂) εnv = .ok t)
-  (ih₁ : ReduceInterpretOnFootprint x₁ ft εnv I₁ I₂)
-  (ih₂ : ReduceInterpretOnFootprint x₂ ft εnv I₁ I₂) :
+  (ih₁ : CompileInterpretOnFootprint x₁ ft εnv I₁ I₂)
+  (ih₂ : CompileInterpretOnFootprint x₂ ft εnv I₁ I₂) :
   t.interpret I₁ = t.interpret I₂
 := by
   replace ⟨t₁, t₂, t₃, hok₁, hok₂, hok, ht⟩ := compile_binaryApp_ok_implies hok
@@ -736,7 +736,7 @@ private theorem compile_interpret_hasAttr_on_footprint {x₁ : Expr}  {a₁ : At
   (hsm : εnv.SameOn ft I₁ I₂)
   (hft : footprint (.hasAttr x₁ a₁) εnv ⊆ ft)
   (hok : compile (.hasAttr x₁ a₁) εnv = .ok t)
-  (ih₁ : ReduceInterpretOnFootprint x₁ ft εnv I₁ I₂) :
+  (ih₁ : CompileInterpretOnFootprint x₁ ft εnv I₁ I₂) :
   t.interpret I₁ = t.interpret I₂
 := by
   replace hwε := wf_εnv_for_hasAttr_implies hwε
@@ -772,7 +772,7 @@ private theorem compile_interpret_getAttr_on_footprint {x₁ : Expr}  {a₁ : At
   (hsm : εnv.SameOn ft I₁ I₂)
   (hft : footprint (.getAttr x₁ a₁) εnv ⊆ ft)
   (hok : compile (.getAttr x₁ a₁) εnv = .ok t)
-  (ih₁ : ReduceInterpretOnFootprint x₁ ft εnv I₁ I₂) :
+  (ih₁ : CompileInterpretOnFootprint x₁ ft εnv I₁ I₂) :
   t.interpret I₁ = t.interpret I₂
 := by
   simp only [footprint, footprint.ofEntity, hok, Set.union_subset] at hft
@@ -822,7 +822,7 @@ private theorem compile_interpret_on_footprint_ihs {xs : List Expr} {ts : List T
   (hsm : εnv.SameOn ft I₁ I₂)
   (hft : List.mapUnion (fun x => footprint x εnv) xs ⊆ ft)
   (hok : ∀ t ∈ ts, ∃ x ∈ xs, compile x εnv = .ok t)
-  (ih  : ∀ x ∈ xs, ReduceInterpretOnFootprint x ft εnv I₁ I₂) :
+  (ih  : ∀ x ∈ xs, CompileInterpretOnFootprint x ft εnv I₁ I₂) :
   ∀ t ∈ ts, t.interpret I₁ = t.interpret I₂
 := by
   intro t ht
@@ -837,7 +837,7 @@ private theorem compile_interpret_set_on_footprint {xs : List Expr} {ft : Set Te
   (hsm : εnv.SameOn ft I₁ I₂)
   (hft : footprint (.set xs) εnv ⊆ ft)
   (hok : compile (.set xs) εnv = .ok t)
-  (ih  : ∀ x ∈ xs, ReduceInterpretOnFootprint x ft εnv I₁ I₂) :
+  (ih  : ∀ x ∈ xs, CompileInterpretOnFootprint x ft εnv I₁ I₂) :
   t.interpret I₁ = t.interpret I₂
 := by
   replace hwε := wf_εnv_for_set_implies hwε
@@ -893,7 +893,7 @@ private theorem compile_interpret_record_on_footprint {axs : List (Attr × Expr)
   (hft : footprint (.record axs) εnv ⊆ ft)
   (hok : compile (.record axs) εnv = .ok t)
   (ih  : ∀ (a₁ : Attr) (x₁ : Expr), sizeOf (a₁, x₁).snd < 1 + sizeOf axs →
-    ReduceInterpretOnFootprint x₁ ft εnv I₁ I₂) :
+    CompileInterpretOnFootprint x₁ ft εnv I₁ I₂) :
   t.interpret I₁ = t.interpret I₂
 := by
   simp only [footprint, List.attach₂, List.mapUnion_pmap_subtype (λ x : Attr × Expr => footprint x.snd εnv)] at hft
@@ -934,7 +934,7 @@ private theorem compile_interpret_call_on_footprint {xfn : ExtFun} {xs : List Ex
   (hsm : εnv.SameOn ft I₁ I₂)
   (hft : footprint (.call xfn xs) εnv ⊆ ft)
   (hok : compile (.call xfn xs) εnv = .ok t)
-  (ih  : ∀ x ∈ xs, ReduceInterpretOnFootprint x ft εnv I₁ I₂) :
+  (ih  : ∀ x ∈ xs, CompileInterpretOnFootprint x ft εnv I₁ I₂) :
   t.interpret I₁ = t.interpret I₂
 := by
   simp only [footprint, List.attach_def, List.mapUnion_pmap_subtype (footprint · εnv) ] at hft

--- a/cedar-lean/Cedar/Thm/SymbolicCompilation.lean
+++ b/cedar-lean/Cedar/Thm/SymbolicCompilation.lean
@@ -20,7 +20,7 @@ import Cedar.Thm.SymCC.Compiler
 
 /-!
 This file defines the top-level correctness properties for the symbolic
-evaluator. We show the encoding is sound and complete with respect to the
+compiler. We show the encoding is sound and complete with respect to the
 concrete semantics of Cedar. That is, the symbolic semantics both
 overapproximates (soundness) and underapproximates (completeness) the concrete
 semantics.
@@ -32,15 +32,15 @@ open Spec SymCC
 
 /--
 Let `x` be a Cedar expression, `env` a concrete evaluation environment (request
-and entities), `εnv` a symbolic evaluation environment, and `t` the outcome of
-reducing `x` to a Term with respect to `εnv`.
+and entities), `εnv` a symbolic environment, and `t` the outcome of
+compiling `x` to a Term with respect to `εnv`.
 
 Let `x` and `env` be a well-formed input to the concrete evaluator, i.e.,
 `env.WellFormedFor x`.  This means that the entity store `env.entities` has
 no dangling entity references, and all entity references that occur in `x` and
 `env.request` are included in `env.entities`.
 
-Let `x` and `εnv` be a well-formed input to the symbolic evaluator, i.e.,
+Let `x` and `εnv` be a well-formed input to the symbolic compiler, i.e.,
 `εnv.WellFormedFor x`.  This means that the symbolic entity store `εnv.entities`
 has no dangling (undefined) entity types or references; all term types contained
 in `εnv.entities` represent valid Cedar types; and all entity references that
@@ -59,9 +59,9 @@ corresponding concrete structure using a suitable sameness relation.
 
 Given the above, the soundness theorem says that the output of the concrete
 evaluator on `x` and `env` is contained in the set of concrete outcomes
-represented by the output of the symbolic evaluator on `x` and `εnv`. We state
+represented by the output of the symbolic compiler on `x` and `εnv`. We state
 soundness in terms of `Outcome`s rather than `Result`s because the symbolic
-evaluator does not distinguish between different kinds of errors---only between
+compiler does not distinguish between different kinds of errors---only between
 normal and erroring executions.
 -/
 theorem compile_is_sound {x : Expr} {env : Env} {εnv : SymEnv} {t : Term.Outcome εnv} :
@@ -81,11 +81,11 @@ theorem compile_is_sound {x : Expr} {env : Env} {εnv : SymEnv} {t : Term.Outcom
   exists I
 
 /--
-Let `x` be a Cedar expression and `εnv` a symbolic evaluation environment, where
-`x` and `εnv` are a well-formed input to the symbolic evaluator, i.e.,
+Let `x` be a Cedar expression and `εnv` a symbolic environment, where
+`x` and `εnv` are a well-formed input to the symbolic compiler, i.e.,
 `εnv.WellFormedFor x`.
 
-Let `t` the outcome of reducing `x` to a Term with respect to `εnv`, and `o` a
+Let `t` the outcome of compiling `x` to a Term with respect to `εnv`, and `o` a
 concrete outcome represented by `t`.
 
 Then, the completeness theorem says that there exists a concrete environment
@@ -115,7 +115,7 @@ theorem compile_is_complete {x : Expr} {εnv : SymEnv} {t : Term.Outcome εnv} {
 
 /--
 Let `ps` be Cedar policies, `env` a concrete evaluation environment (request and
-entities), `εnv` a symbolic evaluation environment, and `t` the term resulting
+entities), `εnv` a symbolic environment, and `t` the term resulting
 from symbolically authorizing `ps` with respect to `εnv`, i.e.,
 `SymCC.isAuthorized ps εnv = .ok t`.
 
@@ -165,7 +165,7 @@ theorem isAuthorized_is_sound  {ps : Policies} {env : Env} {εnv : SymEnv} {t : 
   exists I
 
 /--
-Let `ps` be Cedar policies and `εnv` a symbolic evaluation environment, where
+Let `ps` be Cedar policies and `εnv` a symbolic environment, where
 `ps` and `εnv` are a well-formed input to the symbolic authorizer, i.e.,
 `εnv.WellFormedForPolicies ps`.
 

--- a/cedar-lean/SymTest/Arith.lean
+++ b/cedar-lean/SymTest/Arith.lean
@@ -16,7 +16,7 @@
 
 import SymTest.Util
 
-/-! This file unit tests symbolic evaluation of arithmetic operators. -/
+/-! This file unit tests symbolic compilation of arithmetic operators. -/
 
 namespace SymTest.Arith
 

--- a/cedar-lean/SymTest/Datetime.lean
+++ b/cedar-lean/SymTest/Datetime.lean
@@ -16,7 +16,7 @@
 
 import SymTest.Util
 
-/-! This file unit tests symbolic evaluation of Decimal operators. -/
+/-! This file unit tests symbolic compilation of Decimal operators. -/
 
 namespace SymTest.Datetime
 
@@ -45,13 +45,13 @@ def durLit (str : String) : Expr :=
   .call .duration [.lit (.string str)]
 
 private def testValidConstructor (str : String) (rep : Int) : TestCase SolverM :=
-  testReduce str
+  testCompile str
     (durLit str)
     durationSymEnv
     (.ok (.some (.prim (.ext (.duration (Ext.Datetime.duration? rep).get!)))))
 
 private def testInvalidConstructor (str : String) (msg : String) : TestCase SolverM :=
-  testReduce s!"{str} [{msg}]"
+  testCompile s!"{str} [{msg}]"
     (durLit str)
     durationSymEnv
     (.error .typeError)
@@ -391,13 +391,13 @@ def dtLit (str : String) : Expr :=
   .call .datetime [.lit (.string str)]
 
 private def testValidConstructor (str : String) (rep : Int) : TestCase SolverM :=
-  testReduce str
+  testCompile str
     (dtLit str)
     datetimeSymEnv
     (.ok (.some (.prim (.ext (.datetime (Ext.Datetime.datetime? rep).get!)))))
 
 private def testInvalidConstructor (str : String) (msg : String) : TestCase SolverM :=
-  testReduce s!"{str} [{msg}]"
+  testCompile s!"{str} [{msg}]"
     (dtLit str)
     datetimeSymEnv
     (.error .typeError)

--- a/cedar-lean/SymTest/Decimal.lean
+++ b/cedar-lean/SymTest/Decimal.lean
@@ -16,7 +16,7 @@
 
 import SymTest.Util
 
-/-! This file unit tests symbolic evaluation of Decimal operators. -/
+/-! This file unit tests symbolic compilation of Decimal operators. -/
 
 namespace SymTest.Decimal
 
@@ -43,13 +43,13 @@ def decLit (str : String) : Expr :=
   .call .decimal [.lit (.string str)]
 
 private def testValid (str : String) (rep : Int) : TestCase SolverM :=
-  testReduce str
+  testCompile str
     (decLit str)
     decimalSymEnv
     (.ok (.some (.prim (.ext (.decimal (Ext.Decimal.decimal? rep).get!)))))
 
 private def testInvalid (str : String) (msg : String) : TestCase SolverM :=
-  testReduce s!"{str} [{msg}]"
+  testCompile s!"{str} [{msg}]"
     (decLit str)
     decimalSymEnv
     (.error .typeError)
@@ -75,7 +75,7 @@ def testsForDecimalConstructor :=
     testInvalid "1.23456" "too many fractional digits",
     testInvalid "922337203685477.5808" "overflow",
     testInvalid "-922337203685477.5809" "overflow",
-    testReduce s!"Error: applying decimal constructor to a non-literal"
+    testCompile s!"Error: applying decimal constructor to a non-literal"
       (.call .decimal [s])
       decimalSymEnv
       (.error .typeError)

--- a/cedar-lean/SymTest/Has.lean
+++ b/cedar-lean/SymTest/Has.lean
@@ -16,7 +16,7 @@
 
 import SymTest.Util
 
-/-! This file unit tests symbolic evaluation of the `has` operator. -/
+/-! This file unit tests symbolic compilation of the `has` operator. -/
 
 namespace SymTest.Has
 

--- a/cedar-lean/SymTest/IPAddr.lean
+++ b/cedar-lean/SymTest/IPAddr.lean
@@ -16,7 +16,7 @@
 
 import SymTest.Util
 
-/-! This file unit tests symbolic evaluation of IPAddr operators. -/
+/-! This file unit tests symbolic compilation of IPAddr operators. -/
 
 namespace SymTest.IPAddr
 
@@ -43,13 +43,13 @@ def ipLit (str : String) : Expr :=
   .call .ip [.lit (.string str)]
 
 private def testValid (str : String) : TestCase SolverM :=
-  testReduce str
+  testCompile str
     (ipLit str)
     ipSymEnv
     (.ok (.some (IPAddr.ipTerm (Ext.IPAddr.ip str).get!)))
 
 private def testInvalid (str : String) (msg : String) : TestCase SolverM :=
-  testReduce s!"{str} [{msg}]"
+  testCompile s!"{str} [{msg}]"
     (ipLit str)
     ipSymEnv
     (.error .typeError)
@@ -80,14 +80,14 @@ def testsForIpConstructor :=
     testInvalid "::/001" "no leading zeros",
     testInvalid "127.0.0.1/01" "no leading zeros",
     testInvalid "F:AE::F:5:F:F:0/01" "no leading zeros",
-    testReduce s!"Error: applying ip constructor to a non-literal"
+    testCompile s!"Error: applying ip constructor to a non-literal"
       (.call .ip [s])
       ipSymEnv
       (.error .typeError)
   ]
 
 private def testIs (msg : String) (isFun : ExtFun) (x : Expr) (expected : Bool) : TestCase SolverM :=
-  testReduce s!"Expected {expected}: {reprStr isFun} {msg}]"
+  testCompile s!"Expected {expected}: {reprStr isFun} {msg}]"
     (.call isFun [x])
     ipSymEnv
     (.ok (.some expected))
@@ -99,7 +99,7 @@ private def testIsMulticast (msg : String) (x : Expr) (expected : Bool) : TestCa
   testIs msg .isMulticast x expected
 
 private def testInRange (str₁ str₂ : String) (expected : Bool) : TestCase SolverM :=
-  testReduce s!"Expected {expected}: inRange {str₁} {str₂}]"
+  testCompile s!"Expected {expected}: inRange {str₁} {str₂}]"
     (.call .isInRange [(ipLit str₁), (ipLit str₂)])
     ipSymEnv
     (.ok (.some expected))

--- a/cedar-lean/SymTest/In.lean
+++ b/cedar-lean/SymTest/In.lean
@@ -16,7 +16,7 @@
 
 import SymTest.Util
 
-/-! This file unit tests symbolic evaluation of membership operators on entities
+/-! This file unit tests symbolic compilation of membership operators on entities
 and sets of entities: `in`, `contains`, `containsAny`, and `containsAll`. -/
 
 namespace SymTest.In

--- a/cedar-lean/SymTest/Like.lean
+++ b/cedar-lean/SymTest/Like.lean
@@ -16,7 +16,7 @@
 
 import SymTest.Util
 
-/-! This file unit tests symbolic evaluation of the `like` operator on strings. -/
+/-! This file unit tests symbolic compilation of the `like` operator on strings. -/
 
 namespace SymTest.Like
 

--- a/cedar-lean/SymTest/Tags.lean
+++ b/cedar-lean/SymTest/Tags.lean
@@ -16,7 +16,7 @@
 
 import SymTest.Util
 
-/-! This file unit tests symbolic evaluation of the `hasTag` and `getTag` operators. -/
+/-! This file unit tests symbolic compilation of the `hasTag` and `getTag` operators. -/
 
 namespace SymTest.Tags
 
@@ -40,7 +40,7 @@ private def getₖ : Expr := .binaryApp .getTag (.var .principal) (.getAttr (.va
 def testsForTagOps :=
   suite "Tags.basic"
   [
-    testReduce "False: principal.hasTag(\"a\")"
+    testCompile "False: principal.hasTag(\"a\")"
       hasₐ
       noTagsEnv
       (.ok (.some false)),

--- a/cedar-lean/SymTest/Util.lean
+++ b/cedar-lean/SymTest/Util.lean
@@ -19,7 +19,7 @@ import Cedar.SymCC.Encoder
 import Cedar.SymCC.Verifier
 import UnitTest.Run
 
-/-! This file defines simple utilities for unit testing symbolic evaluation. -/
+/-! This file defines simple utilities for unit testing symbolic compilation. -/
 
 namespace SymTest
 
@@ -63,7 +63,7 @@ def testVerifyImplies (desc : String) (x₁ x₂ : Expr) (εnv : SymEnv) (expect
 def testVerifyEquivalent (desc : String) (x₁ x₂ : Expr) (εnv : SymEnv) (expected : Outcome) : TestCase SolverM :=
   test desc ⟨λ _ => expected.check (verifyEquivalent [(permit x₁)] [(permit x₂)]) εnv⟩
 
-def testReduce (desc : String) (x : Expr) (εnv : SymEnv) (expected : SymCC.Result Term) : TestCase SolverM :=
+def testCompile (desc : String) (x : Expr) (εnv : SymEnv) (expected : SymCC.Result Term) : TestCase SolverM :=
   test desc ⟨λ _ => checkEq (compile x εnv) expected⟩
 
 namespace BasicTypes

--- a/cedar-lean/SymTest/Verifier.lean
+++ b/cedar-lean/SymTest/Verifier.lean
@@ -176,8 +176,8 @@ private def testVerifyDisjoint? (expected : Finding) (ps₁ ps₂ : Policies) : 
 
 def testTrivialPolicies :=
   suite "Reduction of trivial policies" [
-    testReduce policyAllowAll.id policyAllowAll.toExpr εnvRead (.ok (.some true)),
-    testReduce policyAllowNone.id policyAllowNone.toExpr εnvRead (.ok (.some false)),
+    testCompile policyAllowAll.id policyAllowAll.toExpr εnvRead (.ok (.some true)),
+    testCompile policyAllowNone.id policyAllowNone.toExpr εnvRead (.ok (.some false)),
   ]
 
 def testsForNeverErrors? :=

--- a/cedar-lean/SymTest/WellTyped.lean
+++ b/cedar-lean/SymTest/WellTyped.lean
@@ -107,7 +107,7 @@ propagating contextual information---specifically, the path condition---from the
 top down, just like the validator. It is possible to do this and to prove it
 correct (see https://dl.acm.org/doi/10.1145/3498709), but it would require
 invasive changes to both the compiler and all the accompanying proofs.  We can
-do this if we find that calling the typechecker prior to symbolic evaluation
+do this if we find that calling the typechecker prior to symbolic compilation
 introduces too much of a burden in practice (e.g., by making debugging difficult
 due to the deepening of the analysis pipeline).
 -/


### PR DESCRIPTION
Conducts a bunch more renames in SymCC, mostly in comments and in lemma/theorem names.  Making everything more consistent with the terminology used in the main SymCC code.


