### PR TITLE
Constrained schema generation to prevent slow units

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,10 @@ jobs:
           wget -q --show-progress https://github.com/Z3Prover/z3/releases/download/z3-4.12.1/z3-4.12.1-x64-glibc-2.35.zip
           unzip z3-4.12.1-x64-glibc-2.35.zip
           echo "$(pwd)/z3-4.12.1-x64-glibc-2.35/bin" >> $GITHUB_PATH
+      - name: Set up dotnet
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ env.dotnet-version }}
       - name: Audit Dafny files
         shell: bash
         working-directory: ./cedar-dafny
@@ -63,6 +67,10 @@ jobs:
           distribution: 'corretto'
           java-version: '17'
           cache: 'gradle'
+      - name: Set up dotnet
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ env.dotnet-version }}
       - name: Build Dafny def engine
         working-directory: ./cedar-dafny
         shell: bash


### PR DESCRIPTION
Improved the throughput of fuzzing targets that use the schema generator by imposing size constraints.

*Issue #, if available:*
N/A

*Description of changes:*

* Added an upper bound on the number of components in a namespace's path for schema generation
* Refactored pick_entity_types closure into function
* Added constraint on the number of request environments per action for schema generation
