### PR TITLE
Fix SMT encoding of string literals

### DIFF
--- a/cedar-lean/Cedar/SymCC/Encoder.lean
+++ b/cedar-lean/Cedar/SymCC/Encoder.lean
@@ -147,7 +147,7 @@ https://smtlib.cs.uiowa.edu/theories-UnicodeStrings.shtml. Here,
 we're assuming ASCII strings for simplicity.
 -/
 def encodeString (s : String) : String :=
-  s!"\"{s}\""
+  s!"\"{s.replace "\"" "\"\""}\""
 
 def encodeBitVec {n : Nat} (bv : _root_.BitVec n) : String :=
   s!"(_ bv{bv.toNat} {n})"

--- a/cedar-lean/Cedar/SymCC/Encoder.lean
+++ b/cedar-lean/Cedar/SymCC/Encoder.lean
@@ -145,6 +145,9 @@ String printing has to be done carefully in the presence of
 non-ASCII characters.  See the SMTLib standard for the details:
 https://smtlib.cs.uiowa.edu/theories-UnicodeStrings.shtml. Here,
 we're assuming ASCII strings for simplicity.
+
+According to the standard, `""` is the only escape sequence
+in strings, which is interpreted as a single `"` character.
 -/
 def encodeString (s : String) : String :=
   s!"\"{s.replace "\"" "\"\""}\""

--- a/cedar-lean/SymTest/Verifier.lean
+++ b/cedar-lean/SymTest/Verifier.lean
@@ -241,6 +241,13 @@ def testsForDisjoint? :=
     testVerifyDisjoint? .cex [policyOverflowError 3] [policyNoOverflowError 3 (by decide)],
   ]
 
+def testsForEncoder? :=
+  suite "SymCC.Encoder" [
+    testVerifyAlwaysAllows? .cex [
+      policy "AllowAll" .permit (.binaryApp .eq (.var .principal) (.lit (.entityUID ⟨Photoflash.userType, "\""⟩) ))
+    ]
+  ]
+
 def tests := [
   testTrivialPolicies,
   testsForNeverErrors?,
@@ -249,6 +256,7 @@ def tests := [
   testsForAlwaysDenies?,
   testsForEquivalent?,
   testsForDisjoint?,
+  testsForEncoder?,
 ]
 
 -- Uncomment for interactive debugging


### PR DESCRIPTION
*Issue #636*

*Description of changes:*

Escape character `"` correctly in `encodeString` (which is the only type of escape sequence per SMT-LIB [standard](https://smt-lib.org/papers/smt-lib-reference-v2.7-r2025-04-09.pdf)).

The added test would get stuck without this fix (not entirely sure why, but presumably due to CVC5 waiting more string contents since an invalid string literal `"""` is fed into it).

