### PR TITLE
Downgrade `prost` and `prost-build` versions

### DIFF
--- a/cedar-drt/Cargo.toml
+++ b/cedar-drt/Cargo.toml
@@ -17,10 +17,10 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 lazy_static = "1.4"
 smol_str = { version = "0.3", features = ["serde"] }
-prost = "0.14"
+prost = "0.13"
 
 [build-dependencies]
-prost-build = "0.14"
+prost-build = "0.13"
 
 [features]
 integration-testing = []

--- a/cedar-drt/fuzz/Cargo.toml
+++ b/cedar-drt/fuzz/Cargo.toml
@@ -29,7 +29,7 @@ rand_chacha = { version = "0.9", optional = true }
 similar-asserts = "1.5.0"
 thiserror = "2.0"
 logos = "0.15.0"
-prost = "0.14"
+prost = "0.13"
 itertools = "0.14.0"
 
 [dependencies.uuid]

--- a/cedar-lean-ffi/Cargo.toml
+++ b/cedar-lean-ffi/Cargo.toml
@@ -10,12 +10,12 @@ lean-sys = { version = "0.0.8", default-features = false }
 serde = "1"
 serde_json = "1.0"
 thiserror = "2.0"
-prost = "0.14"
+prost = "0.13"
 itertools = "0.14.0"
 miette = "7.6.0"
 
 [build-dependencies]
-prost-build = "0.14"
+prost-build = "0.13"
 cargo_metadata = "0.20.0"
 
 [profile.release]


### PR DESCRIPTION
Version `prost` and `prost-build` 0.14 have been [yanked](https://github.com/tokio-rs/prost/issues/1296) from crates.io. This PR downgrades to 0.13 which works fine.

(Reverts #639 - note that no changes were made `Cargo.lock`s)



