### PR TITLE
Fixes lean deserialization error occurring in cedar_lean_ffi::CedarLeanFFI::print_evaluation

### DIFF
--- a/cedar-lean-ffi/src/lean_ffi.rs
+++ b/cedar-lean-ffi/src/lean_ffi.rs
@@ -1078,6 +1078,27 @@ mod test {
     }
 
     #[test]
+    fn test_print_evaluate() {
+        let input_expr = Expression::from_str("1 + 2").expect("Failed to parse expression");
+        let err_expr = Expression::from_str("1 + true").expect("Failed to parse expression");
+        let entities = Entities::empty();
+        let req = request(
+            "Identity::\"Alice\"",
+            "Action::\"view\"",
+            "Thing::\"Thing1\"",
+        );
+
+        let ffi = CedarLeanFfi::new();
+
+        ffi.print_evaluation(&input_expr, &entities, &req)
+            .expect("Lean call unexpectedly failed for check_evaluate");
+
+        // Erroring expressions should print the evaluation error, not result in an FFI error.
+        ffi.print_evaluation(&err_expr, &entities, &req)
+            .expect("Lean call unexpectedly failed for check_evaluate");
+    }
+
+    #[test]
     fn test_check_evaluate() {
         let input_expr = Expression::from_str("1 + 2").expect("Failed to parse expression");
         let eval_expr = Expression::from_str("3").expect("Failed to parse expression");


### PR DESCRIPTION
Addresses the lean-deserialization error encountered in Issue #633  (This PR does not address the primary issue which relates to entity references.)

Fixes a bug in `cedar_lean_ffi::CedarLeanFFI::print_evaluation` where the type returned by Lean code was not the type expected by rust bindings. Also adds a test to catch future similar errors.