### PR TITLE
Adds a dockerfile to build and run cedar-lean-cli.

### DIFF
--- a/cedar-lean-cli/Dockerfile
+++ b/cedar-lean-cli/Dockerfile
@@ -3,7 +3,7 @@ FROM amazonlinux:2023 AS prepare
 RUN yum update -y \
   && yum install -y \
   curl-minimal clang tar zip unzip python3 git xz \
-  make wget gcc gcc-c++ \
+  make wget gcc gcc-c++ protobuf-compiler \
   && yum clean all
 
 # Setup Rust toolchain
@@ -14,9 +14,6 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > /tmp/rustup.sh \
 
 # Install Lean
 RUN wget https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh && sh elan-init.sh -y --default-toolchain none
-
-# Install protoc
-RUN wget https://github.com/protocolbuffers/protobuf/releases/download/v29.0/protoc-29.0-linux-x86_64.zip && unzip protoc-29.0-linux-x86_64.zip && rm protoc-29.0-linux-x86_64.zip
 
 # Install CVC5
 RUN ARCH=$(uname -m) && \

--- a/cedar-lean-cli/Dockerfile
+++ b/cedar-lean-cli/Dockerfile
@@ -1,0 +1,55 @@
+FROM amazonlinux:2023 AS prepare
+
+RUN yum update -y \
+  && yum install -y \
+  curl-minimal clang tar zip unzip python3 git xz \
+  make wget gcc gcc-c++ \
+  && yum clean all
+
+# Setup Rust toolchain
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > /tmp/rustup.sh \
+  && chmod +x /tmp/rustup.sh \
+  && /tmp/rustup.sh -y \
+  && . ~/.profile; rustup component add llvm-tools-preview rust-src
+
+# Install Lean
+RUN wget https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh && sh elan-init.sh -y --default-toolchain none
+
+# Install protoc
+RUN wget https://github.com/protocolbuffers/protobuf/releases/download/v29.0/protoc-29.0-linux-x86_64.zip && unzip protoc-29.0-linux-x86_64.zip && rm protoc-29.0-linux-x86_64.zip
+
+# Install CVC5
+RUN ARCH=$(uname -m) && \
+    if [ "$ARCH" = "x86_64" ]; then \
+        ARCH_NAME="x86_64"; \
+    elif [ "$ARCH" = "aarch64" ] || [ "$ARCH" = "arm64" ]; then \
+        ARCH_NAME="arm64"; \
+    else \
+        echo "Unsupported architecture: $ARCH" && \
+        exit 1; \
+    fi && \
+    wget https://github.com/cvc5/cvc5/releases/download/cvc5-1.2.1/cvc5-Linux-${ARCH_NAME}-static.zip && \
+    unzip cvc5-Linux-${ARCH_NAME}-static.zip && \
+    chmod +x cvc5-Linux-${ARCH_NAME}-static/bin/cvc5 && \
+    mv cvc5-Linux-${ARCH_NAME}-static/bin/cvc5 /usr/local/bin/
+
+ENV CVC5=cvc5
+
+FROM prepare AS build
+
+ENV CEDAR_SPEC_ROOT=/opt/src/cedar-spec
+COPY . $CEDAR_SPEC_ROOT
+
+# Build the Lean formalization and extract to static C libraries
+WORKDIR $CEDAR_SPEC_ROOT/cedar-lean-ffi
+RUN source /root/.profile \
+  && elan default "$(cat ../lean-toolchain)" \
+  && ./build_lean_lib.sh
+
+# Build CLI
+WORKDIR $CEDAR_SPEC_ROOT/cedar-lean-cli
+RUN source /root/.profile \
+  && source ../cedar-lean-ffi/set_env_vars.sh \
+  && cargo install --path .
+
+ENTRYPOINT ["/usr/bin/bash", "--rcfile", "../rcfile"]

--- a/cedar-lean-cli/README.md
+++ b/cedar-lean-cli/README.md
@@ -4,6 +4,21 @@ This directory contains a command line interface (CLI) for interacting with the 
 
 ## Build
 
+The simplest way to build the CLI is to use the provided Dockerfile to build and run the cli within a docker container.
+
+```
+# Create a docker image that is identified with the tag "cedar-lean-cli"
+docker build -t cedar-lean-cli -f ./Dockerfile ..
+
+# Create and enter a container using the newly created cedar-lean-cli docker image
+docker run -it cedar-lean-cli
+
+# You can now run the cedar-lean-cli within the container
+bash-5.2# cedar-lean-cli help
+```
+
+If you prefer to install directly on your machine, you may follow the below detailed instructions for installing `cedar-lean-cli` from source.
+
 ### Prerequisites:
 
 #### Install Lean

--- a/cedar-lean-cli/README.md
+++ b/cedar-lean-cli/README.md
@@ -8,6 +8,7 @@ The simplest way to build the CLI is to use the provided Dockerfile to build and
 
 ```
 # Create a docker image that is identified with the tag "cedar-lean-cli"
+cd cedar-lean-cli                                   # Enter the cedar-lean-cli directory
 docker build -t cedar-lean-cli -f ./Dockerfile ..
 
 # Create and enter a container using the newly created cedar-lean-cli docker image

--- a/rcfile
+++ b/rcfile
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 source /root/.profile
-source ./set_env_vars.sh
+source ../cedar-lean-ffi/set_env_vars.sh


### PR DESCRIPTION
This PR addresses issue #635  by adding a new Dockerfile that creates a docker image that pre-installs cedar-lean-cli and all of its dependencies.

To build:
```
cd cedar-lean-cli
docker build -t cedar-lean-cli -f ./Dockerfile ..
```

Create and enter a container running the newly created docker image:
```
docker run -it cedar-lean-cli
```
