### PR TITLE
Adds ability to parse entities using a provided schema during evaluation.

### DIFF
--- a/cedar-lean-cli/src/cli_enums.rs
+++ b/cedar-lean-cli/src/cli_enums.rs
@@ -217,6 +217,8 @@ pub(crate) enum EvaluationCommands {
         /// A file containing the entities relevant for authorization
         #[clap(required = true)]
         entities_file: PathBuf,
+        /// A file containing a Schema to parse entities with
+        schema_file: Option<PathBuf>,
         #[clap(flatten)]
         req_args: RequestArgs,
     },
@@ -228,7 +230,10 @@ pub(crate) enum EvaluationCommands {
         /// A file containing the Entities needed for evaluation
         #[clap(required = true)]
         entities_file: PathBuf,
+        /// A file containing a Schema to parse entities with
+        schema_file: Option<PathBuf>,
         /// A file containing the expected output of the evaluation
+        #[arg(long = "output")]
         expected_expr_file: Option<PathBuf>,
         #[clap(flatten)]
         req_args: RequestArgs,

--- a/cedar-lean-cli/src/cli_exec.rs
+++ b/cedar-lean-cli/src/cli_exec.rs
@@ -32,21 +32,29 @@ impl EvaluationCommands {
             Self::Authorize {
                 policyset_file,
                 entities_file,
+                schema_file,
                 req_args,
             } => {
                 let policyset = util::parse_policyset(&policyset_file)?;
+                let schema = schema_file
+                    .map(|schema_file| util::parse_schema(&schema_file))
+                    .transpose()?;
                 let request = RequestArgsEnum::from(req_args).parse()?;
-                let entities = util::parse_entities(&entities_file)?;
+                let entities = util::parse_entities(&entities_file, schema.as_ref())?;
                 evaluation::check_is_authorized(&policyset, &entities, &request)
             }
             Self::Evaluate {
                 input_expr_file,
                 entities_file,
+                schema_file,
                 req_args,
                 expected_expr_file,
             } => {
                 let input_expr = util::parse_expression(&input_expr_file)?;
-                let entities = util::parse_entities(&entities_file)?;
+                let schema = schema_file
+                    .map(|schema_file| util::parse_schema(&schema_file))
+                    .transpose()?;
+                let entities = util::parse_entities(&entities_file, schema.as_ref())?;
                 let request = RequestArgsEnum::from(req_args).parse()?;
                 let output_expr = expected_expr_file
                     .map(|fname| util::parse_expression(&fname))
@@ -93,7 +101,7 @@ impl ValidationCommands {
                 entities_file,
             } => {
                 let schema = util::parse_schema(&schema_file)?;
-                let entities = util::parse_entities(&entities_file)?;
+                let entities = util::parse_entities(&entities_file, Some(&schema))?;
                 validation::validate_entities(&schema, &entities)
             }
         }

--- a/cedar-lean-cli/src/evaluation.rs
+++ b/cedar-lean-cli/src/evaluation.rs
@@ -40,11 +40,14 @@ pub fn check_is_authorized(
         print!(" {policy}");
     }
     println!();
-    print!("The following policies did not contribute to the decision as they errored during evaluation:");
-    for policy in auth_response.erroring_policies() {
-        print!(" {policy}");
+    if !auth_response.erroring_policies().is_empty() {
+        println!();
+        print!("The following policies did not contribute to the decision as they errored during evaluation:");
+        for policy in auth_response.erroring_policies() {
+            print!(" {policy}");
+        }
+        println!();
     }
-    println!();
     Ok(())
 }
 

--- a/cedar-lean-cli/src/util.rs
+++ b/cedar-lean-cli/src/util.rs
@@ -360,9 +360,9 @@ pub fn parse_schema(fname: &PathBuf) -> Result<Schema, ExecError> {
 }
 
 /// Auxillary function used to parse a file containing Cedar Entities
-pub fn parse_entities(fname: &PathBuf) -> Result<Entities, ExecError> {
+pub fn parse_entities(fname: &PathBuf, schema: Option<&Schema>) -> Result<Entities, ExecError> {
     match read_to_string(fname) {
-        Ok(entities_json_str) => match Entities::from_json_str(&entities_json_str, None) {
+        Ok(entities_json_str) => match Entities::from_json_str(&entities_json_str, schema) {
             Ok(entities) => Ok(entities),
             Err(e) => Err(ExecError::ParseError {
                 content_type: ContentType::Entities,


### PR DESCRIPTION
Addresses issue #633 which noticed the difference between entity parsing with and without schemas. This PR updates the cedar-lean-cli to allow a user to provide a schema while parsing entities.
