### PR TITLE
[cedar-policy-generators] Add support for generating cedar-policy types

### DIFF
--- a/cedar-policy-generators/Cargo.toml
+++ b/cedar-policy-generators/Cargo.toml
@@ -7,6 +7,7 @@ publish = false
 [dependencies]
 arbitrary = "1.4"
 cedar-policy-core = { path = "../cedar/cedar-policy-core", version = "4.*", features = ["arbitrary"] }
+cedar-policy = { path = "../cedar/cedar-policy", version = "4.*", optional = true }
 clap = { version = "4.3.16", features = ["derive"] }
 highway = "1.3.0"
 serde = { version = "1.0", features = ["derive"] }
@@ -17,6 +18,9 @@ anyhow = "1.0.72"
 serde_with = "3.4.0"
 thiserror = "2.0"
 nonempty = { version = "0.10", features = ["arbitrary"] }
+
+[features]
+cedar-policy = ["dep:cedar-policy"]
 
 [dev.dependencies]
 rand = "0.8.5"

--- a/cedar-policy-generators/src/abac.rs
+++ b/cedar-policy-generators/src/abac.rs
@@ -910,6 +910,13 @@ impl From<ABACPolicy> for StaticPolicy {
     }
 }
 
+#[cfg(feature = "cedar-policy")]
+impl From<ABACPolicy> for cedar_policy::Policy {
+    fn from(abac: ABACPolicy) -> cedar_policy::Policy {
+        StaticPolicy::from(abac).into()
+    }
+}
+
 /// Represents an ABAC request, i.e., fully general
 #[derive(Debug, Clone)]
 pub struct ABACRequest(pub Request);
@@ -936,6 +943,13 @@ impl DerefMut for ABACRequest {
 impl From<ABACRequest> for ast::Request {
     fn from(abac: ABACRequest) -> ast::Request {
         abac.0.into()
+    }
+}
+
+#[cfg(feature = "cedar-policy")]
+impl From<ABACRequest> for cedar_policy::Request {
+    fn from(abac: ABACRequest) -> cedar_policy::Request {
+        ast::Request::from(abac).into()
     }
 }
 

--- a/cedar-policy-generators/src/hierarchy.rs
+++ b/cedar-policy-generators/src/hierarchy.rs
@@ -294,6 +294,14 @@ impl TryFrom<Hierarchy> for Entities {
     }
 }
 
+#[cfg(feature = "cedar-policy")]
+impl TryFrom<Hierarchy> for cedar_policy::Entities {
+    type Error = String;
+    fn try_from(h: Hierarchy) -> std::result::Result<Self, Self::Error> {
+        Entities::try_from(h).map(Into::into)
+    }
+}
+
 impl From<Entities> for Hierarchy {
     fn from(entities: Entities) -> Hierarchy {
         let mut uids = Vec::new();
@@ -313,6 +321,13 @@ impl From<Entities> for Hierarchy {
             entities: entities.into_iter().map(|e| (e.uid().clone(), e)).collect(),
             entity_types,
         }
+    }
+}
+
+#[cfg(feature = "cedar-policy")]
+impl From<cedar_policy::Entities> for Hierarchy {
+    fn from(entities: cedar_policy::Entities) -> Self {
+        entities.as_ref().clone().into()
     }
 }
 

--- a/cedar-policy-generators/src/policy.rs
+++ b/cedar-policy-generators/src/policy.rs
@@ -46,14 +46,6 @@ pub struct GeneratedPolicy {
     abac_constraints: Expr,
 }
 
-impl From<GeneratedPolicy> for est::Policy {
-    fn from(gp: GeneratedPolicy) -> est::Policy {
-        let sp: StaticPolicy = gp.into();
-        let p: Policy = sp.into();
-        p.into()
-    }
-}
-
 impl GeneratedPolicy {
     /// Create a new `GeneratedPolicy` with these fields
     pub fn new(
@@ -178,6 +170,21 @@ impl From<GeneratedPolicy> for Template {
             gen.resource_constraint.into(),
             gen.abac_constraints,
         )
+    }
+}
+
+impl From<GeneratedPolicy> for est::Policy {
+    fn from(gp: GeneratedPolicy) -> est::Policy {
+        let sp: StaticPolicy = gp.into();
+        let p: Policy = sp.into();
+        p.into()
+    }
+}
+
+#[cfg(feature = "cedar-policy")]
+impl From<GeneratedPolicy> for cedar_policy::Policy {
+    fn from(gp: GeneratedPolicy) -> Self {
+        StaticPolicy::from(gp).into()
     }
 }
 

--- a/cedar-policy-generators/src/policy_set.rs
+++ b/cedar-policy-generators/src/policy_set.rs
@@ -77,6 +77,14 @@ impl From<GeneratedPolicySet> for ast::PolicySet {
     }
 }
 
+#[cfg(feature = "cedar-policy")]
+impl TryFrom<GeneratedPolicySet> for cedar_policy::PolicySet {
+    type Error = cedar_policy::PolicySetError;
+    fn try_from(generated: GeneratedPolicySet) -> Result<Self, Self::Error> {
+        ast::PolicySet::from(generated).try_into()
+    }
+}
+
 impl Display for GeneratedPolicySet {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut iter = self.0.iter();

--- a/cedar-policy-generators/src/rbac.rs
+++ b/cedar-policy-generators/src/rbac.rs
@@ -86,6 +86,14 @@ impl TryFrom<RBACHierarchy> for Entities {
     }
 }
 
+#[cfg(feature = "cedar-policy")]
+impl TryFrom<RBACHierarchy> for cedar_policy::Entities {
+    type Error = String;
+    fn try_from(rbac: RBACHierarchy) -> Result<cedar_policy::Entities, String> {
+        Entities::try_from(rbac).map(Into::into)
+    }
+}
+
 /// Represents an RBAC entity, ie, without attributes
 #[derive(Debug, Clone)]
 pub struct RBACEntity(pub Entity);
@@ -140,6 +148,13 @@ impl From<RBACEntity> for Entity {
     }
 }
 
+#[cfg(feature = "cedar-policy")]
+impl From<RBACEntity> for cedar_policy::Entity {
+    fn from(rbac: RBACEntity) -> cedar_policy::Entity {
+        Entity::from(rbac).into()
+    }
+}
+
 /// Represents an RBAC policy, ie, with no `when` or `unless` clauses
 #[derive(Debug, Clone, Serialize)]
 #[serde(transparent)]
@@ -161,6 +176,13 @@ impl DerefMut for RBACPolicy {
 impl From<RBACPolicy> for StaticPolicy {
     fn from(rbac: RBACPolicy) -> StaticPolicy {
         rbac.0.into()
+    }
+}
+
+#[cfg(feature = "cedar-policy")]
+impl From<RBACPolicy> for cedar_policy::Policy {
+    fn from(rbac: RBACPolicy) -> cedar_policy::Policy {
+        StaticPolicy::from(rbac).into()
     }
 }
 
@@ -218,6 +240,13 @@ impl DerefMut for RBACRequest {
 impl From<RBACRequest> for ast::Request {
     fn from(rbac: RBACRequest) -> ast::Request {
         rbac.0.into()
+    }
+}
+
+#[cfg(feature = "cedar-policy")]
+impl From<RBACRequest> for cedar_policy::Request {
+    fn from(rbac: RBACRequest) -> cedar_policy::Request {
+        ast::Request::from(rbac).into()
     }
 }
 

--- a/cedar-policy-generators/src/request.rs
+++ b/cedar-policy-generators/src/request.rs
@@ -67,6 +67,13 @@ impl From<Request> for ast::Request {
     }
 }
 
+#[cfg(feature = "cedar-policy")]
+impl From<Request> for cedar_policy::Request {
+    fn from(req: Request) -> Self {
+        ast::Request::from(req).into()
+    }
+}
+
 impl std::fmt::Display for Request {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(

--- a/cedar-policy-generators/src/schema.rs
+++ b/cedar-policy-generators/src/schema.rs
@@ -1964,6 +1964,14 @@ impl TryFrom<Schema> for ValidatorSchema {
     }
 }
 
+#[cfg(feature = "cedar-policy")]
+impl TryFrom<Schema> for cedar_policy::Schema {
+    type Error = SchemaError;
+    fn try_from(schema: Schema) -> std::result::Result<cedar_policy::Schema, Self::Error> {
+        ValidatorSchema::try_from(schema).map(Into::into)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::Schema;


### PR DESCRIPTION
Via optional Cargo feature `cedar-policy`, so that folks who don't need this functionality don't need to bring in the `cedar-policy` dependency.  (No strong reason to do this behind a feature, but it's very easy to do in the implementation so why not.)


