### PR TITLE
Fix validator soundness when `updateSchema` is not used

### DIFF
--- a/cedar-lean/Cedar/Thm/Validation/RequestEntityValidation.lean
+++ b/cedar-lean/Cedar/Thm/Validation/RequestEntityValidation.lean
@@ -217,7 +217,7 @@ theorem instance_of_entity_schema_refl {entities : Entities} {ets : EntitySchema
     split at h₀
     any_goals contradiction
     case _ h₃ h₄ h₅ =>
-    simp [ValidActionEntityEntry]
+    simp [WellFormedActionData]
     and_intros
     · simp [h₃]
     · simp [h₂]

--- a/cedar-lean/Cedar/Thm/Validation/RequestEntityValidation.lean
+++ b/cedar-lean/Cedar/Thm/Validation/RequestEntityValidation.lean
@@ -159,10 +159,10 @@ theorem instance_of_request_type_refl {request : Request} {reqty : RequestType} 
   · exact instance_of_entity_type_refl h₃
   · exact instance_of_type_refl h₄
 
-theorem instance_of_schema_refl {entities : Entities} {ets : EntitySchema} {acts : ActionSchema} :
-  instanceOfSchema entities ets acts = .ok () →
-    InstanceOfEntitySchema entities ets acts ∧
-    InstanceOfActionSchema entities acts
+theorem instance_of_schema_refl {entities : Entities} {env : Environment} :
+  instanceOfSchema entities env = .ok () →
+    InstanceOfEntitySchema entities env ∧
+    InstanceOfActionSchema entities env.acts
 := by
   intro h₀
   simp only [InstanceOfEntitySchema]
@@ -170,7 +170,7 @@ theorem instance_of_schema_refl {entities : Entities} {ets : EntitySchema} {acts
   split at h₀
   case h_1 => contradiction
   case h_2 h₀₁ =>
-  generalize h₁ : (λ x : EntityUID × EntityData => instanceOfSchema.instanceOfEntityData ets acts x.fst x.snd) = f
+  generalize h₁ : (λ x : EntityUID × EntityData => instanceOfSchema.instanceOfEntityData env x.fst x.snd) = f
   rw [h₁] at h₀₁
   constructor
   · intro uid data h₂
@@ -178,7 +178,7 @@ theorem instance_of_schema_refl {entities : Entities} {ets : EntitySchema} {acts
     replace h₀ := h₀ (Map.find?_mem_toList h₂)
     rw [← h₁] at h₀
     simp only [instanceOfSchema.instanceOfEntityData] at h₀
-    cases h₂ : Map.find? ets uid.ty <;> simp [h₂] at h₀
+    cases h₂ : Map.find? env.ets uid.ty <;> simp [h₂] at h₀
     case some entry =>
       apply Or.inl
       exists entry
@@ -225,14 +225,14 @@ theorem instance_of_schema_refl {entities : Entities} {ets : EntitySchema} {acts
       case _ h₃ h₄ h₅ =>
       simp [WellFormedActionData]
       and_intros
-      · simp [h₃]
       · simp [h₂]
       · simp [h₄]
       · simp [h₅]
+      · simp [h₃]
   · generalize h₁ : (fun x : EntityUID × ActionSchemaEntry => instanceOfSchema.instanceOfActionSchemaData entities x.fst x.snd) = f
     rw [h₁] at h₀
     intro uid entry h₂
-    replace h₀ := List.forM_ok_implies_all_ok (Map.toList acts) f h₀ (uid, entry)
+    replace h₀ := List.forM_ok_implies_all_ok (Map.toList env.acts) f h₀ (uid, entry)
     replace h₀ := h₀ (Map.find?_mem_toList h₂)
     rw [← h₁] at h₀
     simp only [instanceOfSchema.instanceOfActionSchemaData, beq_iff_eq] at h₀
@@ -253,7 +253,7 @@ theorem request_and_entities_match_env {env : Environment} {request : Request} {
   simp only [entitiesMatchEnvironment] at h₁
   constructor
   exact instance_of_request_type_refl h₀
-  cases h₂ : instanceOfSchema entities env.ets env.acts <;> simp only [h₂, Except.bind_err, Except.bind_ok, reduceCtorEq] at h₁
+  cases h₂ : instanceOfSchema entities env <;> simp only [h₂, Except.bind_err, Except.bind_ok, reduceCtorEq] at h₁
   exact instance_of_schema_refl h₂
 
 theorem request_and_entities_validate_implies_match_schema (schema : Schema) (request : Request) (entities : Entities) :

--- a/cedar-lean/Cedar/Thm/Validation/RequestEntityValidation.lean
+++ b/cedar-lean/Cedar/Thm/Validation/RequestEntityValidation.lean
@@ -159,90 +159,88 @@ theorem instance_of_request_type_refl {request : Request} {reqty : RequestType} 
   · exact instance_of_entity_type_refl h₃
   · exact instance_of_type_refl h₄
 
-theorem instance_of_entity_schema_refl {entities : Entities} {ets : EntitySchema} {acts : ActionSchema} :
-  instanceOfEntitySchema entities ets acts = .ok () → InstanceOfEntitySchema entities ets acts
+theorem instance_of_schema_refl {entities : Entities} {ets : EntitySchema} {acts : ActionSchema} :
+  instanceOfSchema entities ets acts = .ok () →
+    InstanceOfEntitySchema entities ets acts ∧
+    InstanceOfActionSchema entities acts
 := by
   intro h₀
   simp only [InstanceOfEntitySchema]
-  simp only [instanceOfEntitySchema] at h₀
-  generalize h₁ : (λ x : EntityUID × EntityData => instanceOfEntitySchema.instanceOfEntityData ets acts x.fst x.snd) = f
-  rw [h₁] at h₀
-  intro uid data h₂
-  have h₀ := List.forM_ok_implies_all_ok (Map.toList entities) f h₀ (uid, data)
-  replace h₀ := h₀ (Map.find?_mem_toList h₂)
-  rw [← h₁] at h₀
-  simp only [instanceOfEntitySchema.instanceOfEntityData] at h₀
-  cases h₂ : Map.find? ets uid.ty <;> simp [h₂] at h₀
-  case some entry =>
-    apply Or.inl
-    exists entry
-    simp only [h₂, true_and]
-    split at h₀ <;> try simp only [reduceCtorEq] at h₀
-    rename_i hv
-    constructor
-    simp only [EntitySchemaEntry.isValidEntityEID] at hv
-    simp only [IsValidEntityEID]
-    split at hv
-    · simp
-    · simp
-      rw [Set.contains_prop_bool_equiv] at hv
-      exact hv
-    split at h₀ <;> try simp only [reduceCtorEq] at h₀
-    constructor <;> rename_i h₃
-    · exact instance_of_type_refl h₃
-    · split at h₀ <;> try simp only [reduceCtorEq] at h₀
-      rename_i h₄
-      simp only [Set.all, List.all_eq_true] at h₄
+  simp only [instanceOfSchema, bind, Except.bind] at h₀
+  split at h₀
+  case h_1 => contradiction
+  case h_2 h₀₁ =>
+  generalize h₁ : (λ x : EntityUID × EntityData => instanceOfSchema.instanceOfEntityData ets acts x.fst x.snd) = f
+  rw [h₁] at h₀₁
+  constructor
+  · intro uid data h₂
+    have h₀ := List.forM_ok_implies_all_ok (Map.toList entities) f h₀₁ (uid, data)
+    replace h₀ := h₀ (Map.find?_mem_toList h₂)
+    rw [← h₁] at h₀
+    simp only [instanceOfSchema.instanceOfEntityData] at h₀
+    cases h₂ : Map.find? ets uid.ty <;> simp [h₂] at h₀
+    case some entry =>
+      apply Or.inl
+      exists entry
+      simp only [h₂, true_and]
+      split at h₀ <;> try simp only [reduceCtorEq] at h₀
+      rename_i hv
       constructor
-      · intro anc ancin
-        simp only [Set.contains, List.elem_eq_mem, decide_eq_true_eq] at h₄
-        rw [← Set.in_list_iff_in_set] at ancin
-        replace h₄ := h₄ anc ancin
-        simp at h₄
-        exact h₄.left
+      simp only [EntitySchemaEntry.isValidEntityEID] at hv
+      simp only [IsValidEntityEID]
+      split at hv
+      · simp
+      · simp
+        rw [Set.contains_prop_bool_equiv] at hv
+        exact hv
+      split at h₀ <;> try simp only [reduceCtorEq] at h₀
+      constructor <;> rename_i h₃
+      · exact instance_of_type_refl h₃
       · split at h₀ <;> try simp only [reduceCtorEq] at h₀
-        unfold InstanceOfEntityTags
-        rename_i h₅
-        simp only [instanceOfEntitySchema.instanceOfEntityTags] at h₅
-        split at h₅ <;> rename_i heq <;> simp only [heq]
-        · intro v hv
-          simp only [List.all_eq_true] at h₅
-          exact instance_of_type_refl (h₅ v hv)
-        · simp only [beq_iff_eq] at h₅
-          exact h₅
-  case none =>
-    apply Or.inr
-    split at h₀
-    split at h₀
-    split at h₀
-    any_goals contradiction
-    case _ h₃ h₄ h₅ =>
-    simp [WellFormedActionData]
-    and_intros
-    · simp [h₃]
-    · simp [h₂]
-    · simp [h₄]
-    · simp [h₅]
-
-theorem instance_of_action_schema_refl {entities : Entities} {acts : ActionSchema} :
-  instanceOfActionSchema entities acts = .ok () → InstanceOfActionSchema entities acts
-:= by
-  intro h₀
-  simp only [InstanceOfActionSchema]
-  simp only [instanceOfActionSchema] at h₀
-  generalize h₁ : (fun x : EntityUID × ActionSchemaEntry => instanceOfActionSchema.instanceOfActionSchemaData entities x.fst x.snd) = f
-  rw [h₁] at h₀
-  intro uid entry h₂
-  replace h₀ := List.forM_ok_implies_all_ok (Map.toList acts) f h₀ (uid, entry)
-  replace h₀ := h₀ (Map.find?_mem_toList h₂)
-  rw [← h₁] at h₀
-  simp only [instanceOfActionSchema.instanceOfActionSchemaData, beq_iff_eq] at h₀
-  cases h₂ : Map.find? entities uid <;> simp [h₂] at h₀
-  case some data =>
-    exists data
-    apply And.intro rfl
-    simp only [h₀]
-
+        rename_i h₄
+        simp only [Set.all, List.all_eq_true] at h₄
+        constructor
+        · intro anc ancin
+          simp only [Set.contains, List.elem_eq_mem, decide_eq_true_eq] at h₄
+          rw [← Set.in_list_iff_in_set] at ancin
+          replace h₄ := h₄ anc ancin
+          simp at h₄
+          exact h₄.left
+        · split at h₀ <;> try simp only [reduceCtorEq] at h₀
+          unfold InstanceOfEntityTags
+          rename_i h₅
+          simp only [instanceOfSchema.instanceOfEntityTags] at h₅
+          split at h₅ <;> rename_i heq <;> simp only [heq]
+          · intro v hv
+            simp only [List.all_eq_true] at h₅
+            exact instance_of_type_refl (h₅ v hv)
+          · simp only [beq_iff_eq] at h₅
+            exact h₅
+    case none =>
+      apply Or.inr
+      split at h₀
+      split at h₀
+      split at h₀
+      any_goals contradiction
+      case _ h₃ h₄ h₅ =>
+      simp [WellFormedActionData]
+      and_intros
+      · simp [h₃]
+      · simp [h₂]
+      · simp [h₄]
+      · simp [h₅]
+  · generalize h₁ : (fun x : EntityUID × ActionSchemaEntry => instanceOfSchema.instanceOfActionSchemaData entities x.fst x.snd) = f
+    rw [h₁] at h₀
+    intro uid entry h₂
+    replace h₀ := List.forM_ok_implies_all_ok (Map.toList acts) f h₀ (uid, entry)
+    replace h₀ := h₀ (Map.find?_mem_toList h₂)
+    rw [← h₁] at h₀
+    simp only [instanceOfSchema.instanceOfActionSchemaData, beq_iff_eq] at h₀
+    cases h₂ : Map.find? entities uid <;> simp [h₂] at h₀
+    case some data =>
+      exists data
+      apply And.intro rfl
+      simp only [h₀]
 
 theorem request_and_entities_match_env {env : Environment} {request : Request} {entities : Entities} :
   requestMatchesEnvironment env request →
@@ -255,8 +253,8 @@ theorem request_and_entities_match_env {env : Environment} {request : Request} {
   simp only [entitiesMatchEnvironment] at h₁
   constructor
   exact instance_of_request_type_refl h₀
-  cases h₂ : instanceOfEntitySchema entities env.ets env.acts <;> simp only [h₂, Except.bind_err, Except.bind_ok, reduceCtorEq] at h₁
-  exact And.intro (instance_of_entity_schema_refl h₂) (instance_of_action_schema_refl h₁)
+  cases h₂ : instanceOfSchema entities env.ets env.acts <;> simp only [h₂, Except.bind_err, Except.bind_ok, reduceCtorEq] at h₁
+  exact instance_of_schema_refl h₂
 
 theorem request_and_entities_validate_implies_match_schema (schema : Schema) (request : Request) (entities : Entities) :
   validateRequest schema request = .ok () →

--- a/cedar-lean/Cedar/Thm/Validation/Typechecker/BinaryApp/GetTag.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Typechecker/BinaryApp/GetTag.lean
@@ -120,7 +120,7 @@ theorem type_of_getTag_is_sound {x₁ x₂ : Expr} {c₁ c₂ : Capabilities} {e
       simp only [Map.findOrErr_err_iff_find?_none, h₁, reduceCtorEq] at hf₃
     · cases ht₂
   | inr h =>
-    replace ⟨_, _, h₂, _, _⟩ := h
+    replace ⟨h₂, _, _⟩ := h
     simp only [EntitySchema.tags?, h₂, Option.map] at ht
     contradiction
 

--- a/cedar-lean/Cedar/Thm/Validation/Typechecker/BinaryApp/GetTag.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Typechecker/BinaryApp/GetTag.lean
@@ -94,28 +94,34 @@ theorem type_of_getTag_is_sound {x₁ x₂ : Expr} {c₁ c₂ : Capabilities} {e
   simp only [hf₁, Except.bind_ok, Except.bind_err, false_implies, Except.error.injEq, or_self, or_false, true_and,
     type_is_inhabited, and_self, reduceCtorEq]
   rw [Map.findOrErr_ok_iff_find?_some] at hf₁
-  replace ⟨entry, hf₂, _, _, _, h₂⟩  := h₂.right.left uid d hf₁
-  simp only [InstanceOfEntityTags] at h₂
-  simp [EntitySchema.tags?, Option.map_eq_some_iff] at ht
-  replace ⟨_, ht₁, ht₂⟩ := ht
-  simp only [hf₂, Option.some.injEq] at ht₁
-  subst ht₁
-  simp only [EntitySchemaEntry.tags?] at h₂ ht₂
-  split at ht₂
-  simp only [ht₂] at h₂
-  have hf₃ := Map.findOrErr_returns d.tags s Error.tagDoesNotExist
-  rcases hf₃ with ⟨v, hf₃⟩ | hf₃ <;>
-  simp only [hf₃, false_implies, Except.error.injEq, or_self, false_and, exists_const, and_false,
-    Except.ok.injEq, false_or, exists_eq_left', reduceCtorEq]
-  · simp only [htx, TypedExpr.typeOf, ← List.empty_eq, empty_capabilities_invariant request entities, implies_true, true_and, reduceCtorEq]
-    apply h₂
-    exact Map.findOrErr_ok_implies_in_values hf₃
-  · replace h₁ := h₁.right x₁ x₂ hc₁
-    simp only [EvaluatesTo, evaluate, ih₁, ih₂, apply₂, hasTag, Except.bind_ok, Except.ok.injEq,
-      Value.prim.injEq, Prim.bool.injEq, false_or, reduceCtorEq] at h₁
-    simp only [Entities.tagsOrEmpty, hf₁, Map.contains_iff_some_find?] at h₁
-    replace ⟨_, h₁⟩ := h₁
-    simp only [Map.findOrErr_err_iff_find?_none, h₁, reduceCtorEq] at hf₃
-  · cases ht₂
+  cases h₂.right.left uid d hf₁ with
+  | inl h =>
+    replace ⟨entry, hf₂, _, _, _, h₂⟩ := h
+    simp only [InstanceOfEntityTags] at h₂
+    simp [EntitySchema.tags?, Option.map_eq_some_iff] at ht
+    replace ⟨_, ht₁, ht₂⟩ := ht
+    simp only [hf₂, Option.some.injEq] at ht₁
+    subst ht₁
+    simp only [EntitySchemaEntry.tags?] at h₂ ht₂
+    split at ht₂
+    simp only [ht₂] at h₂
+    have hf₃ := Map.findOrErr_returns d.tags s Error.tagDoesNotExist
+    rcases hf₃ with ⟨v, hf₃⟩ | hf₃ <;>
+    simp only [hf₃, false_implies, Except.error.injEq, or_self, false_and, exists_const, and_false,
+      Except.ok.injEq, false_or, exists_eq_left', reduceCtorEq]
+    · simp only [htx, TypedExpr.typeOf, ← List.empty_eq, empty_capabilities_invariant request entities, implies_true, true_and, reduceCtorEq]
+      apply h₂
+      exact Map.findOrErr_ok_implies_in_values hf₃
+    · replace h₁ := h₁.right x₁ x₂ hc₁
+      simp only [EvaluatesTo, evaluate, ih₁, ih₂, apply₂, hasTag, Except.bind_ok, Except.ok.injEq,
+        Value.prim.injEq, Prim.bool.injEq, false_or, reduceCtorEq] at h₁
+      simp only [Entities.tagsOrEmpty, hf₁, Map.contains_iff_some_find?] at h₁
+      replace ⟨_, h₁⟩ := h₁
+      simp only [Map.findOrErr_err_iff_find?_none, h₁, reduceCtorEq] at hf₃
+    · cases ht₂
+  | inr h =>
+    replace ⟨_, _, h₂, _, _⟩ := h
+    simp only [EntitySchema.tags?, h₂, Option.map] at ht
+    contradiction
 
 end Cedar.Thm

--- a/cedar-lean/Cedar/Thm/Validation/Typechecker/BinaryApp/HasTag.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Typechecker/BinaryApp/HasTag.lean
@@ -56,7 +56,7 @@ private theorem map_empty_contains_instance_of_ff [DecidableEq α] [DecidableEq 
   simp only [Map.not_contains_of_empty, false_is_instance_of_ff]
 
 private theorem no_tags_type_implies_no_tags {uid : EntityUID} {env : Environment} {entities : Entities}
-  (h₁ : InstanceOfEntitySchema entities env.ets env.acts)
+  (h₁ : InstanceOfEntitySchema entities env)
   (h₂ : env.ets.tags? uid.ty = .some .none) :
   InstanceOfType (Value.prim (Prim.bool ((entities.tagsOrEmpty uid).contains s))) (CedarType.bool BoolType.ff)
 := by
@@ -77,14 +77,14 @@ private theorem no_tags_type_implies_no_tags {uid : EntityUID} {env : Environmen
         simp only [h₁, map_empty_contains_instance_of_ff]
       · simp only [h₁, map_empty_contains_instance_of_ff]
     | inr h₁ =>
-      replace ⟨e, _, _, _, h₁⟩ := h₁
+      replace ⟨_, _, h₁, ⟨e, _⟩⟩ := h₁
       simp only [h₁, Map.empty, Map.contains, Map.find?, Map.kvs, List.find?, Option.isSome]
       constructor
       constructor
   · exact map_empty_contains_instance_of_ff
 
 private theorem no_type_implies_no_tags {uid : EntityUID} {env : Environment} {entities : Entities}
-  (h₁ : InstanceOfEntitySchema entities env.ets env.acts)
+  (h₁ : InstanceOfEntitySchema entities env)
   (h₂ : env.ets.tags? uid.ty = .none) :
   InstanceOfType (Value.prim (Prim.bool ((entities.tagsOrEmpty uid).contains s))) (CedarType.bool BoolType.ff)
 := by
@@ -97,7 +97,7 @@ private theorem no_type_implies_no_tags {uid : EntityUID} {env : Environment} {e
       simp only [EntitySchema.tags?, Option.map_eq_none_iff] at h₂
       simp only [h₁, reduceCtorEq] at h₂
     | inr h₁ =>
-      replace ⟨e, _, _, _, h₁⟩ := h₁
+      replace ⟨_, _, h₁, ⟨e, _⟩⟩ := h₁
       simp only [h₁, Map.empty, Map.contains, Map.find?, Map.kvs, List.find?, Option.isSome]
       constructor
       constructor

--- a/cedar-lean/Cedar/Thm/Validation/Typechecker/BinaryApp/HasTag.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Typechecker/BinaryApp/HasTag.lean
@@ -56,37 +56,51 @@ private theorem map_empty_contains_instance_of_ff [DecidableEq α] [DecidableEq 
   simp only [Map.not_contains_of_empty, false_is_instance_of_ff]
 
 private theorem no_tags_type_implies_no_tags {uid : EntityUID} {env : Environment} {entities : Entities}
-  (h₁ : InstanceOfEntitySchema entities env.ets)
+  (h₁ : InstanceOfEntitySchema entities env.ets env.acts)
   (h₂ : env.ets.tags? uid.ty = .some .none) :
   InstanceOfType (Value.prim (Prim.bool ((entities.tagsOrEmpty uid).contains s))) (CedarType.bool BoolType.ff)
 := by
   simp only [Entities.tagsOrEmpty]
   split
   · rename_i d hf
-    replace ⟨e, hf', _, _, h₁⟩ := h₁ uid d hf
-    simp only [InstanceOfEntityTags] at h₁
-    simp only [EntitySchema.tags?, Option.map_eq_some_iff] at h₂
-    replace ⟨e', h₂, h₃⟩ := h₂
-    simp only [hf', Option.some.injEq] at h₂
-    subst h₂
-    simp only [EntitySchemaEntry.tags?] at h₁ h₃
-    split at h₃
-    · simp only [h₃] at h₁
-      simp only [h₁, map_empty_contains_instance_of_ff]
-    · simp only [h₁, map_empty_contains_instance_of_ff]
+    cases h₁ uid d hf with
+    | inl h₁ =>
+      replace ⟨e, hf', _, _, h₁⟩ := h₁
+      simp only [InstanceOfEntityTags] at h₁
+      simp only [EntitySchema.tags?, Option.map_eq_some_iff] at h₂
+      replace ⟨e', h₂, h₃⟩ := h₂
+      simp only [hf', Option.some.injEq] at h₂
+      subst h₂
+      simp only [EntitySchemaEntry.tags?] at h₁ h₃
+      split at h₃
+      · simp only [h₃] at h₁
+        simp only [h₁, map_empty_contains_instance_of_ff]
+      · simp only [h₁, map_empty_contains_instance_of_ff]
+    | inr h₁ =>
+      replace ⟨e, _, _, _, h₁⟩ := h₁
+      simp only [h₁, Map.empty, Map.contains, Map.find?, Map.kvs, List.find?, Option.isSome]
+      constructor
+      constructor
   · exact map_empty_contains_instance_of_ff
 
 private theorem no_type_implies_no_tags {uid : EntityUID} {env : Environment} {entities : Entities}
-  (h₁ : InstanceOfEntitySchema entities env.ets)
+  (h₁ : InstanceOfEntitySchema entities env.ets env.acts)
   (h₂ : env.ets.tags? uid.ty = .none) :
   InstanceOfType (Value.prim (Prim.bool ((entities.tagsOrEmpty uid).contains s))) (CedarType.bool BoolType.ff)
 := by
   simp only [Entities.tagsOrEmpty]
   split
   · rename_i d hf
-    replace ⟨e, h₁, _, _, _⟩ := h₁ uid d hf
-    simp only [EntitySchema.tags?, Option.map_eq_none_iff] at h₂
-    simp only [h₁, reduceCtorEq] at h₂
+    cases h₁ uid d hf with
+    | inl h₁ =>
+      replace ⟨e, h₁, _, _, _⟩ := h₁
+      simp only [EntitySchema.tags?, Option.map_eq_none_iff] at h₂
+      simp only [h₁, reduceCtorEq] at h₂
+    | inr h₁ =>
+      replace ⟨e, _, _, _, h₁⟩ := h₁
+      simp only [h₁, Map.empty, Map.contains, Map.find?, Map.kvs, List.find?, Option.isSome]
+      constructor
+      constructor
   · exact map_empty_contains_instance_of_ff
 
 private theorem mem_capabilities_implies_mem_tags {x₁ x₂ : Expr} {c₁ : Capabilities} {request : Request} {entities : Entities} {uid : EntityUID} {s : String}

--- a/cedar-lean/Cedar/Thm/Validation/Typechecker/BinaryApp/Mem.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Typechecker/BinaryApp/Mem.lean
@@ -128,7 +128,7 @@ theorem acts_maybeDescendentOf_false_implies_not_ancestor_type
   contradiction
 
 theorem entity_type_in_false_implies_inₑ_false {euid₁ euid₂ : EntityUID} {env : Environment} {entities : Entities}
-  (h₁ : InstanceOfEntitySchema entities env.ets env.acts)
+  (h₁ : InstanceOfEntitySchema entities env)
   (hₐ : InstanceOfActionSchema entities env.acts)
   (h₂ : env.descendentOf euid₁.ty euid₂.ty = false) :
   inₑ euid₁ euid₂ entities = false
@@ -153,7 +153,7 @@ theorem entity_type_in_false_implies_inₑ_false {euid₁ euid₂ : EntityUID} {
       rw [←Set.contains_prop_bool_equiv] at h₂₂
       simp [h₂₁, h₂₂] at h₂
     | inr h₁ =>
-      have ⟨entry, h₅, h₁, _, _⟩ := h₁
+      have ⟨h₁, _, _, ⟨entry, h₅⟩⟩ := h₁
       have h₂ := h₂.2
       simp only [h₁, Bool.decide_eq_true, Bool.or_false, ActionSchema.actionType?] at h₂
       have h₆ := acts_maybeDescendentOf_false_implies_not_ancestor_type hₐ h₂ h₄ h₅ euid₂ h₃
@@ -263,7 +263,7 @@ theorem entity_set_type_implies_set_of_entities {vs : List Value} {ety : EntityT
     apply h₅ euid heuid
 
 theorem entity_type_in_false_implies_inₛ_false {euid : EntityUID} {euids : List EntityUID} {ety : EntityType} {env : Environment} {entities : Entities}
-  (h₁ : InstanceOfEntitySchema entities env.ets env.acts)
+  (h₁ : InstanceOfEntitySchema entities env)
   (hₐ : InstanceOfActionSchema entities env.acts)
   (h₂ : env.descendentOf euid.ty ety = false)
   (h₃ : ∀ euid, euid ∈ euids → euid.ty = ety) :
@@ -302,7 +302,7 @@ theorem entity_type_in_false_implies_inₛ_false {euid : EntityUID} {euids : Lis
       rw [h₂] at h₇
       contradiction
     | inr h₁ =>
-      have ⟨entry, h₉, h₁, _, _⟩ := h₁
+      have ⟨h₁, _, _, ⟨entry, h₉⟩⟩ := h₁
       simp only [
         Bool.if_false_right,
         Bool.decide_eq_true,

--- a/cedar-lean/Cedar/Thm/Validation/Typechecker/HasAttr.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Typechecker/HasAttr.lean
@@ -184,7 +184,7 @@ theorem type_of_hasAttr_is_sound_for_entities {x₁ : Expr} {a : Attr} {c₁ c�
       contradiction
     | inr h₂ =>
       -- Action entity always have empty attributes
-      have ⟨_, _, _, h₉, _⟩ := h₂
+      have ⟨_, h₉, _⟩ := h₂
       simp only [h₉, Map.contains, Map.find?, Map.empty, Map.kvs]
       constructor
 

--- a/cedar-lean/Cedar/Thm/Validation/Typechecker/HasAttr.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Typechecker/HasAttr.lean
@@ -177,10 +177,16 @@ theorem type_of_hasAttr_is_sound_for_entities {x₁ : Expr} {a : Attr} {c₁ c�
     replace ⟨_, h₂, _⟩ := h₂
     cases h₈ : Map.find? entities uid <;> simp
     simp [Map.not_contains_of_empty, InstanceOfBoolType]
-    replace ⟨_, h₈, _⟩ := h₂ uid _ h₈
-    rw [h₇] at h₈
-    contradiction
-
+    cases h₂ uid _ h₈ with
+    | inl h₂ =>
+      replace ⟨_, h₈, _⟩ := h₂
+      rw [h₇] at h₈
+      contradiction
+    | inr h₂ =>
+      -- Action entity always have empty attributes
+      have ⟨_, _, _, h₉, _⟩ := h₂
+      simp only [h₉, Map.contains, Map.find?, Map.empty, Map.kvs]
+      constructor
 
 theorem type_of_hasAttr_is_sound {x₁ : Expr} {a : Attr} {c₁ c₂ : Capabilities} {env : Environment} {ty : TypedExpr} {request : Request} {entities : Entities}
   (h₁ : CapabilitiesInvariant c₁ request entities)

--- a/cedar-lean/Cedar/Thm/Validation/Typechecker/Types.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Typechecker/Types.lean
@@ -337,7 +337,7 @@ theorem well_typed_entity_attributes {env : Environment} {request : Request} {en
   InstanceOfType d.attrs (.record rty)
 := by
   have ⟨_, h₁, _⟩ := h₁
-  simp [InstanceOfEntitySchema, Environment.schema] at h₁
+  simp [InstanceOfEntitySchema] at h₁
   specialize h₁ uid d h₂
   cases h₁ with
   | inl h₁ =>

--- a/cedar-lean/Cedar/Thm/Validation/Typechecker/Types.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Typechecker/Types.lean
@@ -99,7 +99,7 @@ For every entity `(uid, data)` in the store,
    in the type store.
 4. The entity's tags' types are consistent with the tags information in the type store.
 -/
-def ValidEntityEntry (uid : EntityUID) (data : EntityData) (ets : EntitySchema) : Prop :=
+def WellFormedEntityData (uid : EntityUID) (data : EntityData) (ets : EntitySchema) : Prop :=
   ∃ entry, ets.find? uid.ty = some entry ∧
     IsValidEntityEID entry uid.eid ∧
     InstanceOfType data.attrs (.record entry.attrs) ∧
@@ -107,10 +107,10 @@ def ValidEntityEntry (uid : EntityUID) (data : EntityData) (ets : EntitySchema) 
     InstanceOfEntityTags data entry
 
 /--
-Similar to `ValidEntityEntry`, but a special case for action entities
+Similar to `WellFormedEntityData`, but a special case for action entities
 since they are stored disjoint from `ets`
 -/
-def ValidActionEntityEntry (uid : EntityUID) (data : EntityData) (ets : EntitySchema) (as : ActionSchema) : Prop :=
+def WellFormedActionData (uid : EntityUID) (data : EntityData) (ets : EntitySchema) (as : ActionSchema) : Prop :=
   ∃ entry, as.find? uid = some entry ∧
     -- Action entiies types should be disjoint from `ets`
     ets.find? uid.ty = none ∧
@@ -125,8 +125,8 @@ Each entry in the store is valid
 -/
 def InstanceOfEntitySchema (entities : Entities) (ets : EntitySchema) (as : ActionSchema) : Prop :=
   ∀ uid data, entities.find? uid = some data →
-    ValidEntityEntry uid data ets ∨
-    ValidActionEntityEntry uid data ets as
+    WellFormedEntityData uid data ets ∨
+    WellFormedActionData uid data ets as
 
 /--
 For every action in the entity store, the action's ancestors are consistent

--- a/cedar-lean/Cedar/Thm/Validation/Typechecker/Types.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Typechecker/Types.lean
@@ -124,7 +124,8 @@ def WellFormedActionData (uid : EntityUID) (data : EntityData) (ets : EntitySche
 Each entry in the store is valid
 -/
 def InstanceOfEntitySchema (entities : Entities) (ets : EntitySchema) (as : ActionSchema) : Prop :=
-  ∀ uid data, entities.find? uid = some data →
+  ∀ (uid : EntityUID) (data : EntityData),
+    entities.find? uid = some data →
     WellFormedEntityData uid data ets ∨
     WellFormedActionData uid data ets as
 

--- a/cedar-lean/Cedar/Thm/Validation/WellTyped/Soundness.lean
+++ b/cedar-lean/Cedar/Thm/Validation/WellTyped/Soundness.lean
@@ -330,7 +330,7 @@ theorem well_typed_is_sound_binary_app
             specialize h₆ v₁ (Data.Map.in_list_in_values (Data.Map.find?_mem_toList heq))
             exact type_lifting_preserves_instance_of_type h₆
           | inr h₁ =>
-            replace ⟨entry₁, ⟨_, _, _, h₆⟩⟩ := h₁
+            replace ⟨_, _, h₆, entry₁, _⟩ := h₁
             simp only [← hᵢ, h₆, Data.Map.empty, Data.Map.find?, List.find?] at heq
             contradiction
         · simp only [reduceCtorEq, false_and, exists_const] at hᵢ
@@ -417,7 +417,7 @@ InstanceOfType v (x₁.getAttr attr ty).typeOf
         }
       · cases h₇
     | inr h₁ =>
-      have ⟨entry, _, _, h₁, _⟩ := h₁
+      have ⟨_, h₁, _, ⟨entry, _⟩⟩ := h₁
       simp only [h₁, Data.Map.empty, Data.Map.find?, List.find?] at h₇
       contradiction
   · simp only [Except.bind_err, reduceCtorEq] at h₇

--- a/cedar-lean/Cedar/Thm/Validation/WellTyped/Soundness.lean
+++ b/cedar-lean/Cedar/Thm/Validation/WellTyped/Soundness.lean
@@ -317,16 +317,22 @@ theorem well_typed_is_sound_binary_app
         · simp only [Except.ok.injEq, exists_eq_left'] at hᵢ
           rename_i entry heq₁
           specialize h₁ uid₁ entry heq₁
-          replace ⟨entry₁, ⟨h₅, _, _, _, h₆⟩⟩ := h₁
-          simp [InstanceOfEntityTags] at h₆
-          simp [EntitySchema.tags?] at h₄
-          rcases h₄ with ⟨_, h₃₁, h₃₂⟩
-          simp only [h₅, Option.some.injEq] at h₃₁
-          simp only [← h₃₁] at h₃₂
-          simp only [h₃₂] at h₆
-          simp only [←hᵢ] at heq
-          specialize h₆ v₁ (Data.Map.in_list_in_values (Data.Map.find?_mem_toList heq))
-          exact type_lifting_preserves_instance_of_type h₆
+          cases h₁ with
+          | inl h₁ =>
+            replace ⟨entry₁, ⟨h₅, _, _, _, h₆⟩⟩ := h₁
+            simp [InstanceOfEntityTags] at h₆
+            simp [EntitySchema.tags?] at h₄
+            rcases h₄ with ⟨_, h₃₁, h₃₂⟩
+            simp only [h₅, Option.some.injEq] at h₃₁
+            simp only [← h₃₁] at h₃₂
+            simp only [h₃₂] at h₆
+            simp only [←hᵢ] at heq
+            specialize h₆ v₁ (Data.Map.in_list_in_values (Data.Map.find?_mem_toList heq))
+            exact type_lifting_preserves_instance_of_type h₆
+          | inr h₁ =>
+            replace ⟨entry₁, ⟨_, _, _, h₆⟩⟩ := h₁
+            simp only [← hᵢ, h₆, Data.Map.empty, Data.Map.find?, List.find?] at heq
+            contradiction
         · simp only [reduceCtorEq, false_and, exists_const] at hᵢ
       · cases h₃
 
@@ -378,36 +384,42 @@ InstanceOfType v (x₁.getAttr attr ty).typeOf
   split at h₇
   · simp only [Except.bind_ok] at h₇
     rename_i data heq
-    rcases h₁ uid data heq with ⟨entry, h₁₁, _, h₁₂, _⟩
-    split at h₇
-    · rename_i v₁ heq₁
-      simp only [Except.ok.injEq] at h₇
-      cases h₁₂
-      rename_i h₈ _
-      simp only [EntitySchema.attrs?, Option.map_eq_some_iff] at h₅
-      rcases h₅ with ⟨a, ⟨a₁, h₅₁, h₅₃⟩, h₅₂⟩
-      simp [←het] at h₁₁
-      simp only [h₁₁, Option.some.injEq] at h₅₁
-      simp only [← h₅₁] at h₅₃
-      have h₈ := λ qty => h₈ attr v₁ qty heq₁
-      simp only [h₅₂] at h₈
-      simp only [Option.map_eq_some_iff] at h₆
-      rcases h₆ with ⟨qty, h₆₁, h₆₂⟩
-      simp [←h₅₂, RecordType.liftBoolTypes, lift_bool_types_record_eq_map_on_values] at h₆₁
-      replace ⟨qty', h₆₁, h₆₃⟩ := Data.Map.find?_mapOnValues_some' QualifiedType.liftBoolTypes h₆₁
-      simp [←h₅₃] at h₆₁
-      specialize h₈ qty' h₆₁
-      simp [TypedExpr.typeOf]
-      subst h₆₂
-      subst h₆₃
-      cases qty'
-      all_goals {
-        simp [QualifiedType.liftBoolTypes, Qualified.getType]
-        simp [Qualified.getType] at h₈
-        subst h₇
-        exact type_lifting_preserves_instance_of_type h₈
-      }
-    · cases h₇
+    cases h₁ uid data heq with
+    | inl h₁ =>
+      have ⟨entry, h₁₁, _, h₁₂, _⟩ := h₁
+      split at h₇
+      · rename_i v₁ heq₁
+        simp only [Except.ok.injEq] at h₇
+        cases h₁₂
+        rename_i h₈ _
+        simp only [EntitySchema.attrs?, Option.map_eq_some_iff] at h₅
+        rcases h₅ with ⟨a, ⟨a₁, h₅₁, h₅₃⟩, h₅₂⟩
+        simp [←het] at h₁₁
+        simp only [h₁₁, Option.some.injEq] at h₅₁
+        simp only [← h₅₁] at h₅₃
+        have h₈ := λ qty => h₈ attr v₁ qty heq₁
+        simp only [h₅₂] at h₈
+        simp only [Option.map_eq_some_iff] at h₆
+        rcases h₆ with ⟨qty, h₆₁, h₆₂⟩
+        simp [←h₅₂, RecordType.liftBoolTypes, lift_bool_types_record_eq_map_on_values] at h₆₁
+        replace ⟨qty', h₆₁, h₆₃⟩ := Data.Map.find?_mapOnValues_some' QualifiedType.liftBoolTypes h₆₁
+        simp [←h₅₃] at h₆₁
+        specialize h₈ qty' h₆₁
+        simp [TypedExpr.typeOf]
+        subst h₆₂
+        subst h₆₃
+        cases qty'
+        all_goals {
+          simp [QualifiedType.liftBoolTypes, Qualified.getType]
+          simp [Qualified.getType] at h₈
+          subst h₇
+          exact type_lifting_preserves_instance_of_type h₈
+        }
+      · cases h₇
+    | inr h₁ =>
+      have ⟨entry, _, _, h₁, _⟩ := h₁
+      simp only [h₁, Data.Map.empty, Data.Map.find?, List.find?] at h₇
+      contradiction
   · simp only [Except.bind_err, reduceCtorEq] at h₇
 
 theorem well_typed_is_sound_get_attr_record

--- a/cedar-lean/Cedar/Validation/Typechecker.lean
+++ b/cedar-lean/Cedar/Validation/Typechecker.lean
@@ -156,9 +156,6 @@ def actionUID? (x : Expr) (acts: ActionSchema) : Option EntityUID := do
   let uid ← entityUID? x
   if acts.contains uid then .some uid else .none
 
-def actionType? (ety : EntityType) (acts: ActionSchema) : Bool :=
-  acts.keys.any (EntityUID.ty · == ety)
-
 -- x₁ in x₂ where x₁ has type ety₁ and x₂ has type ety₂
 def typeOfInₑ (ety₁ ety₂ : EntityType) (x₁ x₂ : Expr) (env : Environment) : BoolType :=
   match actionUID? x₁ env.acts, entityUID? x₂ with
@@ -167,7 +164,7 @@ def typeOfInₑ (ety₁ ety₂ : EntityType) (x₁ x₂ : Expr) (env : Environme
     then .tt
     else .ff
   | _, _ =>
-    if env.ets.descendentOf ety₁ ety₂
+    if env.descendentOf ety₁ ety₂
     then .anyBool
     else .ff
 
@@ -179,7 +176,7 @@ def typeOfInₛ (ety₁ ety₂ : EntityType) (x₁ x₂ : Expr) (env : Environme
     then .tt
     else .ff
   | _, _ =>
-    if env.ets.descendentOf ety₁ ety₂
+    if env.descendentOf ety₁ ety₂
     then .anyBool
     else .ff
 
@@ -191,7 +188,7 @@ def typeOfHasTag (ety : EntityType) (x : Expr) (t : Expr) (c : Capabilities) (en
     then ok (.bool .tt)
     else ok (.bool .anyBool) (Capabilities.singleton x (.tag t))
   | .none           =>
-    if actionType? ety env.acts
+    if env.acts.actionType? ety
     then ok (.bool .ff) -- action tags not allowed
     else err (.unknownEntity ety)
 
@@ -258,7 +255,7 @@ def typeOfHasAttr (ty : TypedExpr) (x : Expr) (a : Attr) (c : Capabilities) (env
       let (ty', c) ← hasAttrInRecord rty x a c false
       ok ty' c
     | .none     =>
-      if actionType? ety env.acts
+      if env.acts.actionType? ety
       then ok (.bool .ff) -- action attributes not allowed
       else err (.unknownEntity ety)
   | _           => err (.unexpectedType ty.typeOf)

--- a/cedar-lean/Cedar/Validation/Types.lean
+++ b/cedar-lean/Cedar/Validation/Types.lean
@@ -205,9 +205,6 @@ def Environment.descendentOf (env : Environment) (ety₁ ety₂ : EntityType) : 
     | .some entry => entry.ancestors.contains ety₂
     | .none       => env.acts.maybeDescendentOf ety₁ ety₂
 
-def Environment.schema (env : Environment) : Schema :=
-  { ets := env.ets, acts := env.acts }
-
 ----- Derivations -----
 
 deriving instance Repr, DecidableEq for BoolType

--- a/cedar-lean/Cedar/Validation/Types.lean
+++ b/cedar-lean/Cedar/Validation/Types.lean
@@ -195,15 +195,15 @@ structure Environment where
   acts : ActionSchema
   reqty : RequestType
 
+def ActionSchema.maybeDescendentOf (as : ActionSchema) (ety₁ ety₂ : EntityType) : Bool :=
+  as.kvs.any λ (act, entry) => act.ty = ety₁ && entry.ancestors.any (EntityUID.ty · == ety₂)
+
 def Environment.descendentOf (env : Environment) (ety₁ ety₂ : EntityType) : Bool :=
   if ety₁ = ety₂
   then true
   else match env.ets.find? ety₁ with
     | .some entry => entry.ancestors.contains ety₂
-    | .none =>
-      -- For actions, this is sound but may not be precise
-      if env.acts.actionType? ety₁ then true
-      else false
+    | .none       => env.acts.maybeDescendentOf ety₁ ety₂
 
 ----- Derivations -----
 

--- a/cedar-lean/Cedar/Validation/Types.lean
+++ b/cedar-lean/Cedar/Validation/Types.lean
@@ -205,6 +205,9 @@ def Environment.descendentOf (env : Environment) (ety₁ ety₂ : EntityType) : 
     | .some entry => entry.ancestors.contains ety₂
     | .none       => env.acts.maybeDescendentOf ety₁ ety₂
 
+def Environment.schema (env : Environment) : Schema :=
+  { ets := env.ets, acts := env.acts }
+
 ----- Derivations -----
 
 deriving instance Repr, DecidableEq for BoolType

--- a/cedar-lean/Cedar/Validation/Types.lean
+++ b/cedar-lean/Cedar/Validation/Types.lean
@@ -120,6 +120,8 @@ inductive EntitySchemaEntry where
   | standard (ty: StandardSchemaEntry)
   | enum (eids: Set String)
 
+abbrev EntitySchema := Map EntityType EntitySchemaEntry
+
 def EntitySchemaEntry.isValidEntityEID (entry: EntitySchemaEntry) (eid: String): Bool :=
   match entry with
   | .standard _ => true
@@ -136,8 +138,6 @@ def EntitySchemaEntry.attrs : EntitySchemaEntry → RecordType
 def EntitySchemaEntry.ancestors : EntitySchemaEntry → Set EntityType
   | .standard ty => ty.ancestors
   | .enum _ => Set.empty
-
-abbrev EntitySchema := Map EntityType EntitySchemaEntry
 
 def EntitySchema.entityTypeMembers? (ets: EntitySchema) (et: EntityType) : Option (Set String) :=
   match ets.find? et with
@@ -158,13 +158,6 @@ def EntitySchema.attrs? (ets : EntitySchema) (ety : EntityType) : Option RecordT
 def EntitySchema.tags? (ets : EntitySchema) (ety : EntityType) : Option (Option CedarType) :=
   (ets.find? ety).map EntitySchemaEntry.tags?
 
-def EntitySchema.descendentOf (ets : EntitySchema) (ety₁ ety₂ : EntityType) : Bool :=
-  if ety₁ = ety₂
-  then true
-  else match ets.find? ety₁ with
-    | .some entry => entry.ancestors.contains ety₂
-    | .none => false
-
 structure ActionSchemaEntry where
   appliesToPrincipal : Set EntityType
   appliesToResource : Set EntityType
@@ -173,6 +166,9 @@ structure ActionSchemaEntry where
 deriving Repr, Inhabited
 
 abbrev ActionSchema := Map EntityUID ActionSchemaEntry
+
+def ActionSchema.actionType? (acts: ActionSchema) (ety : EntityType) : Bool :=
+  acts.keys.any (EntityUID.ty · == ety)
 
 def ActionSchema.contains (as : ActionSchema) (uid : EntityUID) : Bool :=
   (as.find? uid).isSome
@@ -198,6 +194,16 @@ structure Environment where
   ets : EntitySchema
   acts : ActionSchema
   reqty : RequestType
+
+def Environment.descendentOf (env : Environment) (ety₁ ety₂ : EntityType) : Bool :=
+  if ety₁ = ety₂
+  then true
+  else match env.ets.find? ety₁ with
+    | .some entry => entry.ancestors.contains ety₂
+    | .none =>
+      -- For actions, this is sound but may not be precise
+      if env.acts.actionType? ety₁ then true
+      else false
 
 ----- Derivations -----
 

--- a/cedar-lean/CedarFFI/Main.lean
+++ b/cedar-lean/CedarFFI/Main.lean
@@ -164,8 +164,7 @@ def runAndTimeIO (f : IO α) : IO (Timed α) := do
     | .ok v => do
         let actionEntities := (v.schema.acts.mapOnValues actionSchemaEntryToEntityData)
         let entities := Cedar.Data.Map.make (v.entities.kvs ++ actionEntities.kvs)
-        let schema := updateSchema v.schema actionEntities
-        let result := runAndTime (λ () => Cedar.Validation.validateEntities schema entities )
+        let result := runAndTime (λ () => Cedar.Validation.validateEntities v.schema entities )
         .ok (unsafeBaseIO result)
   toString (Lean.toJson result)
 

--- a/cedar-lean/DiffTest/Main.lean
+++ b/cedar-lean/DiffTest/Main.lean
@@ -143,8 +143,7 @@ def runAndTimeIO (f : IO α) : IO (Timed α) := do
     | .ok v => do
         let actionEntities := (v.schema.acts.mapOnValues actionSchemaEntryToEntityData)
         let entities := Cedar.Data.Map.make (v.entities.kvs ++ actionEntities.kvs)
-        let schema := updateSchema v.schema actionEntities
-        let result := runAndTime (λ () => Cedar.Validation.validateEntities schema entities )
+        let result := runAndTime (λ () => Cedar.Validation.validateEntities v.schema entities )
         .ok (unsafeBaseIO result)
   toString (Lean.toJson result)
 


### PR DESCRIPTION
**Current status**
The soundness of validator/type checking depends on [this precondition](https://github.com/cedar-policy/cedar-spec/blob/f39f21acdddff3b7bed6f507b2812f638b886f93/cedar-lean/Cedar/Thm/Validation/Typechecker/Types.lean#L102-L108) on the schema:
```
def InstanceOfEntitySchema (entities : Entities) (ets: EntitySchema) : Prop :=
  ∀ uid data, entities.find? uid = some data →
    ∃ entry, ets.find? uid.ty = some entry ∧
      IsValidEntityEID entry uid.eid ∧
      InstanceOfType data.attrs (.record entry.attrs) ∧
      (∀ ancestor, ancestor ∈ data.ancestors → ancestor.ty ∈ entry.ancestors) ∧
      InstanceOfEntityTags data entry
```
In particular, for actions, this requires that all action entity types to be in `EntitySchema`

However, this condition is not satisfied by the Rust version: [`ValidationSchema`](https://github.com/cedar-policy/cedar/blob/b18b7b0a092a7e264548ffcb789e46cfa891371a/cedar-policy-core/src/validator/schema.rs#L231-L249)
```
pub struct ValidatorSchema {
    entity_types: HashMap<EntityType, ValidatorEntityType>,
    actions: HashMap<EntityUID, Arc<Entity>>,
    ...
}
```
where entity types in `actions` and `entity_types` are *disjoint*.

This leads to a precondition violation when Rust `ValidatorSchema` are passed to the Lean version for validation

The current fix for this in DRT is to have a function called [`updateSchema`](https://github.com/cedar-policy/cedar-spec/blob/f39f21acdddff3b7bed6f507b2812f638b886f93/cedar-lean/Cedar/Validation/RequestEntityValidator.lean#L159), which is called [here](https://github.com/cedar-policy/cedar-spec/blob/f39f21acdddff3b7bed6f507b2812f638b886f93/cedar-lean/DiffTest/Main.lean#L146), that adds action entity types to `ets` in the schema (which corresponds to `entity_types`, I think?)
```
structure Schema where
  ets : EntitySchema
  acts : ActionSchema
```

**However, this leads to two issues:**
- In some cases such as `cedar-lean-cli`, `updateSchema` is not called on schema parsed in Rust, leading to a *soundness issue*; for example, when validating [this example Cedar policy by @emina and @chaluli](https://gist.github.com/zhengyao-lin/33666aee8e9694ebed7c9ed7c800e7d6):
```
Rust version:
  × policy set validation failed
  ╰─▶ the types Long and String are not compatible
   ╭─[4:8]
 3 │   if principal.a in N::Action::"bad"
 4 │   then 1 == "2"
   ·        ────────
 5 │   else true
   ╰────

Lean version (via cedar-lean-cli validate policy-set)
Policyset successfully validated
^ this is unsound!
```
Note that you'd have to update `cedar-lean-ffi/Cargo.toml` and `cedar-lean-cli/Cargo.toml` to the latest `cedar-policy` Rust crate, otherwise `cedar-lean-cli` fails due to another front-end issue in Rust that was [fixed](https://github.com/cedar-policy/cedar/pull/1652) recently.

- To make things a bit more tricky, `updateSchema` conflicts with the definition of [`SymEntities.ofSchema`](https://github.com/cedar-policy/cedar-spec/blob/f39f21acdddff3b7bed6f507b2812f638b886f93/cedar-lean/Cedar/SymCC/Env.lean#L199) in SymCC:
```
def SymEntities.ofSchema (ets : EntitySchema) (acts : ActionSchema) : SymEntities :=
  let eData := ets.toList.map λ (ety, sch) => (ety, SymEntityData.ofEntityType ety sch)
  let actTys := (acts.toList.map λ (act, _) => act.ty).eraseDups
  let aData := actTys.map λ actTy => (actTy, SymEntityData.ofActionType actTy actTys acts)
  Map.make (eData ++ aData)
```
Because `updateSchema` already puts all action entity types to `eData`, incorrect symbolic representations of action entity types are used, overriding the correct ones in `aData`.

**This PR**

This PR fixes the validator and its soundness proof even in the absence of `updateSchema`.
This way, we also avoid changing SymCC's `SymEntities.ofSchema` and any related proofs.

This primarily includes these precondition and executable code changes:
- `InstanceOfEntitySchema` is updated to allow action entity types to not occur in `EntitySchema` but only in `ActionSchema`. This is still compatible with `updateSchema`, so it should not break DRT.
- `EntitySchema.descendentOf` is modified to `Environment.descendentOf` to also consider action entities when the entity type is not in `ets`
- `instanceOfEntitySchema` is updated to check the new precondition
- Soundness proofs are fixed

