### PR TITLE
[4.5.x] use the 4.5.x branch of Cedar

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ COPY . $CEDAR_SPEC_ROOT
 
 # Clone `cedar` repository
 WORKDIR $CEDAR_SPEC_ROOT
-RUN git clone --depth 1 https://github.com/cedar-policy/cedar
+RUN git clone --depth 1 -b release/4.5.x https://github.com/cedar-policy/cedar
 
 # Build the Lean formalization and extract to static C libraries
 WORKDIR $CEDAR_SPEC_ROOT/cedar-lean


### PR DESCRIPTION
Ensures that the Dockerfile pulls from the 4.5.x branch of Cedar, not the `main` branch, here on the 4.5.x branch of `cedar-spec`


