### PR TITLE
Revert "[4.5.x] use the 4.5.x branch of Cedar (#649)"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ COPY . $CEDAR_SPEC_ROOT
 
 # Clone `cedar` repository
 WORKDIR $CEDAR_SPEC_ROOT
-RUN git clone --depth 1 -b release/4.5.x https://github.com/cedar-policy/cedar
+RUN git clone --depth 1 https://github.com/cedar-policy/cedar
 
 # Build the Lean formalization and extract to static C libraries
 WORKDIR $CEDAR_SPEC_ROOT/cedar-lean


### PR DESCRIPTION
This reverts commit #649, which was accidentally merged to `main`.  It should have been merged to `release/4.5.x` (and will be in #650).


