### PR TITLE
update to Lean 4.21

### DIFF
--- a/cedar-lean/Cedar/Spec/Ext/IPAddr.lean
+++ b/cedar-lean/Cedar/Spec/Ext/IPAddr.lean
@@ -137,7 +137,7 @@ private def parsePrefixNat (str : String) (digits : Nat) (size : Nat) : Option (
   if 0 < len && len ≤ digits && (str.startsWith "0" → str = "0")
   then do
     let n ← str.toNat?
-    if n ≤ size then .some (Fin.ofNat' (size+1) n) else .none
+    if n ≤ size then .some (Fin.ofNat (size+1) n) else .none
   else .none
 
 private def parseNumV4 (str : String) : Option (BitVec 8) :=

--- a/cedar-lean/Cedar/Thm/Authorization/Authorizer.lean
+++ b/cedar-lean/Cedar/Thm/Authorization/Authorizer.lean
@@ -304,8 +304,8 @@ theorem mapM_asEntityUID_on_set_uids_produces_ok (uids : List EntityUID) :
 := by
   apply if_mapM_doesn't_fail_on_list_then_doesn't_fail_on_set
   unfold Except.isOk Except.toBool
-  split <;> simp
-  case a.h_2 e h => simp [mapM_asEntityUID_of_uid] at h
+  split <;> simp only [Bool.false_eq_true]
+  case h_2 e h => simp only [mapM_asEntityUID_of_uid, reduceCtorEq] at h
 
 theorem mapOrErr_value_asEntityUID_on_uids_produces_set (list : List EntityUID) (err : Error) :
   Set.mapOrErr Value.asEntityUID (Set.make (list.map (Value.prim ∘ Prim.entityUID))) err =
@@ -346,9 +346,9 @@ theorem action_in_set_of_euids_produces_boolean (list : List EntityUID) (request
   unfold producesBool
   split <;> simp
   case h_2 _ h =>
-    simp [evaluate, apply₂, inₛ] at h
+    simp only [evaluate, apply₂, inₛ, bind_assoc, Except.bind_ok, imp_false, Bool.forall_bool] at h
     rw [List.mapM₁_eq_mapM (evaluate · request entities)] at h
-    simp [mapM_evaluate_uids_produces_uids] at h
+    simp only [mapM_evaluate_uids_produces_uids] at h
     simp [mapOrErr_value_asEntityUID_on_uids_produces_set] at h
 
 /--

--- a/cedar-lean/Cedar/Thm/Data/List/Basic.lean
+++ b/cedar-lean/Cedar/Thm/Data/List/Basic.lean
@@ -441,15 +441,15 @@ theorem mapM_key_id_sortedBy_key {α β : Type} [LT α] {ks : List α} {kvs : Li
   case cons_nil head =>
     have ⟨_, _⟩ : ∃ kv, kvs = [kv] := by
       cases hm₁ : fn head <;>
-      simp only [hm₁, List.mapM_cons, List.mapM_nil, Option.pure_def, Option.bind_none_fun, Option.bind_some_fun, Option.none_bind, Option.some_bind, Option.some.injEq, reduceCtorEq] at hm
+      simp only [hm₁, List.mapM_cons, List.mapM_nil, Option.pure_def, Option.bind_none_fun, Option.bind_some_fun, Option.bind_none, Option.bind_some, Option.some.injEq, reduceCtorEq] at hm
       simp [←hm]
     subst kvs
     exact SortedBy.cons_nil
   case cons_cons head₀ head₁ tail hlt hs =>
     simp only [List.mapM_cons, Option.pure_def, Option.bind_eq_bind] at hm
-    cases hm₁ : (fn head₀) <;> simp only [hm₁, Option.none_bind, Option.some_bind, Option.some.injEq, reduceCtorEq] at hm
-    cases hm₂ : (fn head₁) <;> simp only [hm₂, Option.none_bind, Option.some_bind, Option.some.injEq, reduceCtorEq] at hm
-    cases hm₃ : (tail.mapM (λ k => (fn k).bind λ v => some (k, v))) <;> simp only [hm₃, Option.none_bind, Option.some_bind, Option.some.injEq, reduceCtorEq] at hm
+    cases hm₁ : (fn head₀) <;> simp only [hm₁, Option.bind_none, Option.bind_some, Option.some.injEq, reduceCtorEq] at hm
+    cases hm₂ : (fn head₁) <;> simp only [hm₂, Option.bind_none, Option.bind_some, Option.some.injEq, reduceCtorEq] at hm
+    cases hm₃ : (tail.mapM (λ k => (fn k).bind λ v => some (k, v))) <;> simp only [hm₃, Option.bind_none, Option.bind_some, Option.some.injEq, reduceCtorEq] at hm
     rename_i v₀ v₁ kvs'
     subst kvs
 

--- a/cedar-lean/Cedar/Thm/Data/List/Lemmas.lean
+++ b/cedar-lean/Cedar/Thm/Data/List/Lemmas.lean
@@ -355,13 +355,6 @@ theorem mapM_some {xs : List α} :
   case nil => simp only [mapM_nil, Option.pure_def]
   case cons hd tl ih => simp [ih]
 
-theorem mapM_map {α β γ} [Monad m] [LawfulMonad m] {f : α → β} {g : β → m γ} {xs : List α} :
-  List.mapM g (xs.map f) = xs.mapM λ x => g (f x)
-:= by
-  induction xs
-  case nil => simp only [map_nil, mapM_nil]
-  case cons hd tl ih => simp [ih]
-
 theorem mapM_pmap_subtype [Monad m] [LawfulMonad m]
   {p : α → Prop}
   (f : α → m β)
@@ -426,8 +419,8 @@ theorem not_mem_implies_not_mem_mapM_key_id {α β : Type} {ks : List α} {kvs :
     cases hl'
   case cons head tail =>
     simp only [List.mapM_cons, Option.pure_def, Option.bind_eq_bind] at hm
-    cases hm₁ : fn head <;> simp only [hm₁, Option.none_bind, Option.some_bind, reduceCtorEq] at hm
-    cases hm₂ : (tail.mapM (λ k => (fn k).bind λ v => some (k, v))) <;> simp only [hm₂, Option.none_bind, Option.some_bind, Option.some.injEq, reduceCtorEq] at hm
+    cases hm₁ : fn head <;> simp only [hm₁, Option.bind_none, Option.bind_some, reduceCtorEq] at hm
+    cases hm₂ : (tail.mapM (λ k => (fn k).bind λ v => some (k, v))) <;> simp only [hm₂, Option.bind_none, Option.bind_some, Option.some.injEq, reduceCtorEq] at hm
     subst kvs
     cases hl'
     case head =>
@@ -990,8 +983,8 @@ theorem foldlM_of_assoc_some (f : α → α → Option α) (x₀ x₁ x₂ x₃ 
     cases h₄ : f x₂ hd <;> simp only [h₄, false_and, exists_false, Option.some.injEq, exists_eq_left', reduceCtorEq] at h₃
     case some x₄ =>
     have h₅ := h₁ x₀ x₁ hd
-    simp only [h₂, h₄, Option.some_bind] at h₅
-    cases h₆ : f x₁ hd <;> simp only [h₆, Option.some_bind, Option.none_bind, reduceCtorEq] at h₅
+    simp only [h₂, h₄, Option.bind_some] at h₅
+    cases h₆ : f x₁ hd <;> simp only [h₆, Option.bind_some, Option.bind_none, reduceCtorEq] at h₅
     case some x₅ =>
     have h₇ := List.foldlM_of_assoc_some f x₂ hd x₄ x₃ tl h₁ h₄ h₃
     cases h₈ : List.foldlM f hd tl <;> simp only [h₈, Option.bind_some_fun, Option.bind_none_fun, reduceCtorEq] at h₇
@@ -1005,7 +998,7 @@ theorem foldlM_of_assoc_some (f : α → α → Option α) (x₀ x₁ x₂ x₃ 
       have h₁₀ := List.foldlM_of_assoc_some f x₁ hd x₅ x₇ tl h₁ h₆ h₉
       simp only [h₈, Option.bind_some_fun] at h₁₀
       specialize h₁ x₀ x₁ x₆
-      simp only [h₂, h₁₀, Option.some_bind] at h₁
+      simp only [h₂, h₁₀, Option.bind_some] at h₁
       simp [←h₁, h₇]
 
 theorem foldlM_of_assoc_none' (f : α → α → Option α) (x₀ x₁ x₂ : α) (xs : List α)
@@ -1072,13 +1065,13 @@ theorem foldlM_of_assoc (f : α → α → Option α) (x₀ x₁ : α) (xs : Lis
   (do let y ← List.foldlM f x₁ xs ; f x₀ y)
 := by
   simp only [List.foldlM, Option.bind_eq_bind]
-  cases h₂ : f x₀ x₁ <;> simp only [Option.some_bind, Option.none_bind]
+  cases h₂ : f x₀ x₁ <;> simp only [Option.bind_some, Option.bind_none]
   case none =>
     induction xs generalizing x₁
     case nil => simp [h₂]
     case cons hd tl ih =>
       simp only [List.foldlM, Option.bind_eq_bind]
-      cases h₃ : f x₁ hd <;> simp only [Option.some_bind, Option.none_bind]
+      cases h₃ : f x₁ hd <;> simp only [Option.bind_some, Option.bind_none]
       case some x₂ =>
       apply ih x₂
       specialize h₁ x₀ x₁ hd

--- a/cedar-lean/Cedar/Thm/Data/Map.lean
+++ b/cedar-lean/Cedar/Thm/Data/Map.lean
@@ -442,14 +442,14 @@ theorem find?_mapM_key_id {α β : Type} [BEq α] [LawfulBEq α] {ks : List α} 
   cases h₂
   case head l =>
     simp only [List.mapM_cons, Option.pure_def, Option.bind_eq_bind] at h₁
-    cases hf : fn k <;> simp only [hf, Option.none_bind, Option.some_bind, reduceCtorEq] at h₁
-    cases ht₁ : (l.mapM (λ k => (fn k).bind λ v => some (k, v))) <;> simp [ht₁ , Option.none_bind, Option.some_bind, reduceCtorEq, Option.some.injEq] at h₁
+    cases hf : fn k <;> simp only [hf, Option.bind_none, Option.bind_some, reduceCtorEq] at h₁
+    cases ht₁ : (l.mapM (λ k => (fn k).bind λ v => some (k, v))) <;> simp [ht₁ , Option.bind_none, Option.bind_some, reduceCtorEq, Option.some.injEq] at h₁
     subst h₁
     simp
   case tail h t h₂  =>
     simp only [List.mapM_cons, Option.pure_def, Option.bind_eq_bind] at h₁
-    cases hf : fn h <;> simp only [hf, Option.none_bind, Option.some_bind, reduceCtorEq] at h₁
-    cases ht₁ : (t.mapM (λ k => (fn k).bind λ v => some (k, v))) <;> simp only [ht₁, Option.none_bind, Option.some_bind, reduceCtorEq, Option.some.injEq] at h₁
+    cases hf : fn h <;> simp only [hf, Option.bind_none, Option.bind_some, reduceCtorEq] at h₁
+    cases ht₁ : (t.mapM (λ k => (fn k).bind λ v => some (k, v))) <;> simp only [ht₁, Option.bind_none, Option.bind_some, reduceCtorEq, Option.some.injEq] at h₁
     subst h₁
     simp only [List.find?]
     cases h₃ : (h == k)
@@ -855,7 +855,7 @@ theorem mapMOnValues_cons {α : Type 0} [LT α] [DecidableLT α] {f : β → Opt
   case none => simp [h₁, h₂, mapMOnValues]
   case some v' =>
     cases h₃ : (mk tl).mapMOnValues f
-    <;> simp only [Option.none_bind, Option.some_bind]
+    <;> simp only [Option.bind_none, Option.bind_some]
     <;> unfold mapMOnValues at *
     <;> simp only [h₁, Option.pure_def, Option.bind_eq_bind, Option.bind_eq_none_iff,
           Option.bind_eq_some_iff, Option.some.injEq, reduceCtorEq, List.mapM_cons]

--- a/cedar-lean/Cedar/Thm/SymCC/Compiler/Record.lean
+++ b/cedar-lean/Cedar/Thm/SymCC/Compiler/Record.lean
@@ -282,7 +282,7 @@ private theorem same_forall₂_implies_same_record {ats : List (Attr × Term)} {
     simp only at h₁
     have hhd : Term.value?.attrValue? thd.fst thd.snd = some (vhd.fst, some vhd.snd) := by
       rw [← h₁.left, value?_some_implies_attrValue?_some h₁.right]
-    simp only [List.filterMap_cons, hhd, Option.some_bind, Option.map_some, ih]
+    simp only [List.filterMap_cons, hhd, Option.bind_some, Option.map_some, ih]
 
 theorem compile_evaluate_record {axs : List (Attr × Expr)} {env : Env} {εnv : SymEnv} {t : Term}
   (heq : env ∼ εnv)

--- a/cedar-lean/Cedar/Thm/SymCC/Compiler/WellTyped.lean
+++ b/cedar-lean/Cedar/Thm/SymCC/Compiler/WellTyped.lean
@@ -1003,7 +1003,7 @@ theorem compile_well_typed_hasAttr
       CompileWellTyped, TypedExpr.toExpr, compile, compileHasAttr,
       compileAttrsOf, SymEntities.attrs,
       Option.bind_eq_bind, bind_assoc, Except.bind_ok,
-      TermType.ofType, Option.some_bind,
+      TermType.ofType, Option.bind_some,
     ]
     have hattrs_exists :
       εnv.entities.attrs ety = .some sym_ety_data.attrs
@@ -1241,7 +1241,7 @@ theorem compile_well_typed_record
     (fun x => do Except.ok (x.fst, ← compile x.snd εnv))
     (List.map (fun x => (x.1.fst, x.1.snd.toExpr)) xs.attach₂)]
   -- Strip off the second later of mapM₂
-  simp only [List.mapM_map]
+  simp only [List.mapM_map, Function.comp_def]
   have e := List.mapM₂_eq_mapM
     (fun x => do Except.ok (x.fst, ← compile x.snd.toExpr εnv))
     xs

--- a/cedar-lean/Cedar/Thm/SymCC/Concretizer/Lit.lean
+++ b/cedar-lean/Cedar/Thm/SymCC/Concretizer/Lit.lean
@@ -110,7 +110,7 @@ private theorem wfl_term_isStringSetType_implies_setOfTags?_some {t : Term} {εs
     replace hty := wf_term_set_implies_typeOf_elt hwl.left hin
     exact wfl_term_ofStringType_implies_tag?_some (And.intro hwt hlit) hty
   replace ⟨tags, h⟩ := List.all_some_implies_mapM_some h
-  simp only [h, Option.some_bind, Option.some.injEq, exists_eq']
+  simp only [h, Option.bind_some, Option.some.injEq, exists_eq']
 
 private theorem concretize?_wfl_ρ_implies_some {ρ : SymRequest} {εs : SymEntities} :
   ρ.WellFormed εs → ρ.isLiteral →

--- a/cedar-lean/Cedar/Thm/SymCC/Concretizer/Same.lean
+++ b/cedar-lean/Cedar/Thm/SymCC/Concretizer/Same.lean
@@ -310,7 +310,7 @@ private theorem concretize?_some_same_tags {uid : EntityUID} {δ : SymEntityData
     simp only [ht]
   case some τs =>
     cases hkeys : (app τs.keys (Term.entity uid)).setOfTags? <;>
-    simp only [hkeys, Option.none_bind, Option.some_bind, reduceCtorEq] at ht
+    simp only [hkeys, Option.bind_none, Option.bind_some, reduceCtorEq] at ht
     rename_i ts
     simp only [Option.bind] at ht
     split at ht <;> simp only [Option.some.injEq, reduceCtorEq] at ht

--- a/cedar-lean/Cedar/Thm/SymCC/Concretizer/WFValue.lean
+++ b/cedar-lean/Cedar/Thm/SymCC/Concretizer/WFValue.lean
@@ -275,7 +275,7 @@ private theorem term_record_value?_some_implies_eq_entityUIDs {ats : List (Attr 
   simp only at hv
   have ha := value?_attrValue?_fst hv
   simp only at ha ; subst ha
-  simp only [hv, Option.map, Option.some_bind]
+  simp only [hv, Option.map, Option.bind_some]
   cases vopt
   case a.none =>
     simp only [Option.mapD_none]

--- a/cedar-lean/Cedar/Thm/SymCC/Data/BitVec.lean
+++ b/cedar-lean/Cedar/Thm/SymCC/Data/BitVec.lean
@@ -552,7 +552,7 @@ theorem sdiv_pos_bounded {bv₁ bv₂ : BitVec 64}
     simp only [Int.tdiv, Nat.succ_eq_add_one, Int.ofNat_eq_coe, Int.neg_natCast_le_natCast,
       Int.ofNat_le, true_and, ge_iff_le]
     simp only [Int.ofNat_le] at h₂
-    simp only [Int.ofNat_pos] at h₀
+    simp only [Int.natCast_pos] at h₀
     clear h₁ h₃ nlow
     simp only [Nat.le_div_iff_mul_le h₀]
     apply Nat.le_trans _ h₂

--- a/cedar-lean/Cedar/Thm/SymCC/Env/WF.lean
+++ b/cedar-lean/Cedar/Thm/SymCC/Env/WF.lean
@@ -662,7 +662,7 @@ theorem wf_εnv_implies_attrs_wf
   case none => contradiction
   case some d =>
     have ⟨h1, h2, h3, _⟩ := hwf_entities ety d hety_exists
-    simp only [Option.some_bind, Option.some.injEq] at hattrs_exists
+    simp only [Option.bind_some, Option.some.injEq] at hattrs_exists
     simp only [hattrs_exists] at h1 h2 h3
     simp [h1, h2, h3]
 

--- a/cedar-lean/Cedar/Thm/SymCC/Term/Interpret/Factory.lean
+++ b/cedar-lean/Cedar/Thm/SymCC/Term/Interpret/Factory.lean
@@ -105,9 +105,7 @@ theorem interpret_and {εs : SymEntities} {I : Interpretation} {t₁ t₂ : Term
           rcases hor with hor | hor <;> subst hor <;>
           simp [interpret_term_prim, Term.prim.injEq, TermPrim.bool.injEq, or_false, or_true,
             true_or, ↓reduceIte, ite_self, Bool.false_eq_true]
-          split <;> try rfl
-          rw [eq_comm]
-          assumption
+          exact eq_comm.mp
         case inr =>
           have hb₁ := interpret_term_wfl hI hw₁
           have hb₂ := interpret_term_wfl hI hw₂
@@ -260,7 +258,7 @@ theorem interpret_eq_simplify {I : Interpretation} {t₁ t₂ : Term} :
   I.WellFormed εs → t₁.WellFormed εs → t₂.WellFormed εs →
   (Factory.eq.simplify t₁ t₂).interpret I = Factory.eq.simplify (t₁.interpret I) (t₂.interpret I)
 := by
-  cases t₁, t₂ using Factory.eq.simplify.fun_cases
+  fun_cases Factory.eq.simplify t₁ t₂
   <;> simp_all only [Factory.eq.simplify, interpret_term_prim, reduceIte, forall_self_imp,
     Bool.false_eq_true, Bool.and_eq_true, decide_eq_true_eq, implies_true, true_and]
   case case2 =>
@@ -338,8 +336,8 @@ theorem interpret_eq {I : Interpretation} {t₁ t₂ : Term} :
   (Factory.eq t₁ t₂).interpret I = Factory.eq (t₁.interpret I) (t₂.interpret I)
 := by
   intro h₁ h₂ h₃
-  cases t₁, t₂ using Factory.eq.fun_cases
-  · simp only [Factory.eq, interpret_term_some]
+  fun_cases Factory.eq t₁ t₂
+  · simp only [interpret_term_some]
     exact interpret_eq_simplify h₁ (wf_term_some_implies h₂) (wf_term_some_implies h₃)
   · simp [pe_eq_some_none, interpret_term_prim, interpret_term_some, interpret_term_none]
   · simp [pe_eq_none_some, interpret_term_prim, interpret_term_some, interpret_term_none]

--- a/cedar-lean/Cedar/Thm/SymCC/Term/PE.lean
+++ b/cedar-lean/Cedar/Thm/SymCC/Term/PE.lean
@@ -237,17 +237,16 @@ theorem pe_eq_simplify_lit {t₁ t₂ : Term} :
   Term.isLiteral (Factory.eq.simplify t₁ t₂) ∧
   Factory.eq.simplify t₁ t₂ = (t₁ == t₂)
 := by
-  cases t₁, t₂ using Factory.eq.simplify.fun_cases
-  <;> simp_all [Factory.eq.simplify, Term.isLiteral, pe_eq_simplify_same]
+  fun_cases Factory.eq.simplify t₁ t₂
+  <;> simp_all [Term.isLiteral, pe_eq_simplify_same]
 
 theorem pe_eq_lit {t₁ t₂ : Term} :
   t₁.isLiteral → t₂.isLiteral →
   Term.isLiteral (Factory.eq t₁ t₂) ∧
   Factory.eq t₁ t₂ = (t₁ == t₂)
 := by
-  cases t₁, t₂ using Factory.eq.fun_cases
-  · simp only [Factory.eq]
-    intro h₁ h₂
+  fun_cases Factory.eq t₁ t₂
+  · intro h₁ h₂
     have h₃ := pe_eq_simplify_lit (lit_term_some_implies_lit h₁) (lit_term_some_implies_lit h₂)
     rw [h₃.left, h₃.right]
     simp only [Term.prim.injEq, TermPrim.bool.injEq]
@@ -255,8 +254,7 @@ theorem pe_eq_lit {t₁ t₂ : Term} :
     cases h : t₁ == t₂ <;> simp_all
   · simp [pe_eq_some_none, Term.isLiteral]
   · simp [pe_eq_none_some, Term.isLiteral]
-  · simp only [Factory.eq]
-    exact pe_eq_simplify_lit
+  · exact pe_eq_simplify_lit
 
 theorem pe_eq_prim {p₁ p₂ : TermPrim} :
   Factory.eq (.prim p₁) (.prim p₂) = (p₁ == p₂)

--- a/cedar-lean/Cedar/Thm/SymCC/Term/Same.lean
+++ b/cedar-lean/Cedar/Thm/SymCC/Term/Same.lean
@@ -252,7 +252,7 @@ local macro "simp_same_prim_implies" prim_injEq:ident : tactic => do
     all_goals {
       simp only [BitVec.int64?, Option.bind] at h₁
       split at h₁ <;>
-      simp only [Option.some_bind, Option.some.injEq, Value.prim.injEq, Option.none_bind, reduceCtorEq] at h₁
+      simp only [Option.bind_some, Option.some.injEq, Value.prim.injEq, Option.bind_none, reduceCtorEq] at h₁
     }
   ))
 

--- a/cedar-lean/Cedar/Thm/SymCC/Term/WF.lean
+++ b/cedar-lean/Cedar/Thm/SymCC/Term/WF.lean
@@ -668,7 +668,7 @@ theorem wf_eq_simplify {εs : SymEntities} {t₁ t₂ : Term}
   (h₃ : t₁.typeOf = t₂.typeOf) :
   (eq.simplify t₁ t₂).WellFormed εs ∧ (eq.simplify t₁ t₂).typeOf = .bool
 := by
-  cases t₁, t₂ using Factory.eq.simplify.fun_cases
+  fun_cases Factory.eq.simplify t₁ t₂
   <;> simp_all only [Factory.eq.simplify, Term.prim.injEq, TermPrim.bool.injEq,
     Bool.and_self, Bool.and_false, Bool.and_true, Bool.true_and, Bool.false_and,
     Bool.and_eq_true, Bool.not_eq_true, Bool.false_eq_true, Bool.true_eq_false,
@@ -686,16 +686,14 @@ theorem wf_eq {εs : SymEntities} {t₁ t₂ : Term}
   (h₃ : t₁.typeOf = t₂.typeOf) :
   (eq t₁ t₂).WellFormed εs ∧ (eq t₁ t₂).typeOf = .bool
 := by
-  cases t₁, t₂ using Factory.eq.fun_cases
+  fun_cases Factory.eq t₁ t₂
   · replace h₁ := wf_term_some_implies h₁
     replace h₂ := wf_term_some_implies h₂
     simp only [Term.typeOf, TermType.option.injEq] at h₃
-    simp only [Factory.eq]
     exact wf_eq_simplify h₁ h₂ h₃
   · simp [Factory.eq, wf_bool, typeOf_bool]
   · simp [Factory.eq, wf_bool, typeOf_bool]
-  · simp only [Factory.eq]
-    exact wf_eq_simplify h₁ h₂ h₃
+  · exact wf_eq_simplify h₁ h₂ h₃
 
 theorem wf_and {εs : SymEntities} {t₁ t₂ : Term}
   (h₁ : t₁.WellFormed εs)

--- a/cedar-lean/Cedar/Thm/Validation/Slice.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Slice.lean
@@ -45,7 +45,7 @@ theorem slice_at_level_inner_well_formed {entities : Entities} {work slice : Set
         simp only [hs₁, Option.map_eq_map, Option.bind_eq_bind, Option.bind_none_fun, Option.bind_some_fun, reduceCtorEq] at hs
       rename_i n eds
       cases hs₂ : eds.mapM (Entities.sliceAtLevel.sliceAtLevel entities ·.sliceEUIDs n) <;>
-        simp only [hs₂, Option.map_none, Option.map_some, Option.none_bind, Option.some_bind, reduceCtorEq, Option.some.injEq] at hs
+        simp only [hs₂, Option.map_none, Option.map_some, Option.bind_none, Option.bind_some, reduceCtorEq, Option.some.injEq] at hs
       rename_i slice'
       exists work, (slice'.mapUnion id)
     subst hs
@@ -66,7 +66,7 @@ theorem checked_eval_entity_in_slice  {n : Nat} {c c' : Capabilities} {tx : Type
     simp only [hs₁, Option.bind_none_fun, reduceCtorEq] at hs
   rename_i eids
   cases hs₂ : (eids.elts.mapM (λ e => (Map.find? entities e).bind λ ed => some (e, ed))) <;>
-    simp only [hs₂, Option.bind_eq_bind, Option.bind_some_fun, Option.none_bind, reduceCtorEq, Option.some_bind, Option.some.injEq] at hs
+    simp only [hs₂, Option.bind_eq_bind, Option.bind_some_fun, Option.bind_none, reduceCtorEq, Option.bind_some, Option.some.injEq] at hs
   subst hs
   have hf₁ : Map.contains entities euid := by simp [Map.contains, hf]
   have hw : ReachableIn entities request.sliceEUIDs euid (n + 1) :=
@@ -93,7 +93,7 @@ theorem not_entities_then_not_slice {n: Nat} {request : Request} {uid : EntityUI
     simp only [hs₁, Option.bind_none_fun, reduceCtorEq] at hs
   rename_i eids
   cases hs₂ : (eids.elts.mapM (λ e => (entities.find? e).bind λ ed => some (e, ed))) <;>
-    simp only [hs₂, Option.bind_eq_bind, Option.bind_some_fun, Option.none_bind, reduceCtorEq, Option.some_bind, Option.some.injEq] at hs
+    simp only [hs₂, Option.bind_eq_bind, Option.bind_some_fun, Option.bind_none, reduceCtorEq, Option.bind_some, Option.some.injEq] at hs
   subst hs
   exact Map.mapM_key_id_key_none_implies_find?_none hs₂ hse
 

--- a/cedar-lean/Cedar/Thm/Validation/Slice/Reachable.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Slice/Reachable.lean
@@ -231,7 +231,7 @@ theorem in_work_then_in_slice {entities : Entities} {work slice : Set EntityUID}
   rename_i eds
   cases hs₂ :
     List.mapM (λ x => Entities.sliceAtLevel.sliceAtLevel entities x.sliceEUIDs n) eds
-  <;> simp only [hs₂, Option.map_none, Option.map_some, Option.none_bind, Option.some_bind, reduceCtorEq,Option.some.injEq] at hs
+  <;> simp only [hs₂, Option.map_none, Option.map_some, Option.bind_none, Option.bind_some, reduceCtorEq,Option.some.injEq] at hs
   rename_i slice'
   subst hs
   have ⟨ _, hc ⟩ := Set.mem_union_iff_mem_or work (slice'.mapUnion id) euid
@@ -257,7 +257,7 @@ theorem slice_contains_reachable {n: Nat} {work : Set EntityUID} {euid : EntityU
       simp only [hs₁, Option.bind_none_fun, reduceCtorEq] at hs
     rename_i eds
     cases hs₂ : Option.map (List.mapUnion id) (List.mapM (λ x => Entities.sliceAtLevel.sliceAtLevel entities x.sliceEUIDs n) eds) <;>
-      simp only [hs₂, Option.map_eq_map, Option.bind_eq_bind, Option.bind_some_fun, Option.none_bind, reduceCtorEq, Option.some_bind, Option.some.injEq] at hs
+      simp only [hs₂, Option.map_eq_map, Option.bind_eq_bind, Option.bind_some_fun, Option.bind_none, reduceCtorEq, Option.bind_some, Option.some.injEq] at hs
     subst hs
     rename_i slice'
     cases hs₃ : List.mapM (λ x => Entities.sliceAtLevel.sliceAtLevel entities x.sliceEUIDs n) eds <;>

--- a/cedar-lean/Cedar/Thm/Validation/SubstituteAction.lean
+++ b/cedar-lean/Cedar/Thm/Validation/SubstituteAction.lean
@@ -126,12 +126,11 @@ theorem substitute_action_preserves_evaluation_set {xs : List Expr} {request : R
     simp only [mapOnVars, evaluate, List.mapM₁, List.attach_def, List.mapM_pmap_subtype (fun x => evaluate x request entities)]
     simp only [List.mapM_cons, bind_assoc, pure_bind]
     rw [h₁]
-    simp [List.mapM_map]
+    simp only [List.mapM_map, Function.comp_def]
     have h₂ : ∀ (x₁ : Expr), x₁ ∈ t → SubstituteActionPreservesEvaluation x₁ request entities :=
     by
-      simp [h₀] at ih₁
-      obtain ⟨_, h₂⟩ := ih₁
-      exact h₂
+      simp only [h₀, List.mem_cons, forall_eq_or_imp] at ih₁
+      exact ih₁.right
     simp [List.mapM_congr h₂]
 
 theorem substitute_action_nil_record : ∀ (uid : EntityUID),
@@ -164,7 +163,7 @@ theorem substitute_action_preserves_evaluation_record {axs : List (Attr × Expr)
     simp only [bindAttr]
     simp only [List.mapM_cons, bind_assoc, Except.bind_ok, pure_bind]
     rw [h₁]
-    simp only [List.mapM_map]
+    simp only [List.mapM_map, Function.comp_def]
     have h₂ : ∀ x ∈ tl,
     (do
       let v ← evaluate (substituteAction request.action x.snd) request entities
@@ -175,9 +174,8 @@ theorem substitute_action_preserves_evaluation_record {axs : List (Attr × Expr)
     := by
       intro x hx
       replace (a, x) := x
-      simp [h₀] at ih₁
-      obtain ⟨_, h₂⟩ := ih₁
-      simp [h₂ a x hx]
+      simp only [h₀, List.mem_cons, forall_eq_or_imp, Prod.forall] at ih₁
+      simp [ih₁.right a x hx]
     rw [List.mapM_congr h₂]
 
 theorem substitute_action_nil_call : ∀ (uid : EntityUID) (xfn : ExtFun),
@@ -213,12 +211,11 @@ theorem substitute_action_preserves_evaluation_call {xfn : ExtFun} {xs : List Ex
     simp only [mapOnVars, evaluate, List.mapM₁, List.attach_def, List.mapM_pmap_subtype (fun x => evaluate x request entities)]
     simp only [List.mapM_cons, bind_assoc, pure_bind]
     rw [h₁]
-    simp [List.mapM_map]
+    simp only [List.mapM_map, Function.comp_def]
     have h₂ : ∀ (x₁ : Expr), x₁ ∈ t → SubstituteActionPreservesEvaluation x₁ request entities :=
     by
-      simp [h₀] at ih₁
-      obtain ⟨_, h₂⟩ := ih₁
-      exact h₂
+      simp only [h₀, List.mem_cons, forall_eq_or_imp] at ih₁
+      exact ih₁.right
     rw [List.mapM_congr h₂]
 
 theorem substitute_action_preserves_evaluation (expr : Expr) (request : Request) (entities : Entities) :

--- a/cedar-lean/Cedar/Thm/Validation/Typechecker.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Typechecker.lean
@@ -406,31 +406,31 @@ theorem type_of_preserves_evaluation_results {e : Expr} {c₁ c₂ : Capabilitie
     simp only [err, reduceCtorEq] at h₃₂
   case _ c₁ xs hᵢ =>
     simp only [typeOf, do_eq_ok, Prod.exists, exists_and_right] at h₃
-    rcases h₃ with ⟨ty, h₃₁, h₃₂⟩
-    simp [List.mapM₁_eq_mapM (fun x => justType (typeOf x c₁ env)), List.mapM_ok_iff_forall₂] at h₃₁
-    simp [typeOfSet] at h₃₂
-    split at h₃₂ <;> simp [err] at h₃₂
-    split at h₃₂ <;> simp [ok] at h₃₂
-    rcases h₃₂ with ⟨h₃₂, _⟩
+    replace ⟨ty, h₃₁, h₃₂⟩ := h₃
+    simp only [List.mapM₁_eq_mapM (fun x => justType (typeOf x c₁ env)), List.mapM_ok_iff_forall₂] at h₃₁
+    simp only [typeOfSet, List.empty_eq] at h₃₂
+    split at h₃₂ <;> simp only [err, reduceCtorEq] at h₃₂
+    split at h₃₂ <;> simp only [ok, Except.ok.injEq, Prod.mk.injEq, List.nil_eq, reduceCtorEq] at h₃₂
+    replace ⟨h₃₂, _⟩ := h₃₂
     subst h₃₂
-    simp only [TypedExpr.toExpr, evaluate, List.map₁_eq_map, List.mapM₁_eq_mapM (fun x => evaluate x request entities), List.mapM_map]
+    simp only [TypedExpr.toExpr, evaluate, List.map₁_eq_map, List.mapM₁_eq_mapM (fun x => evaluate x request entities), List.mapM_map, Function.comp_def]
     have h₄ := type_of_ok_list h₃₁ (λ x₁ h => hᵢ x₁ h h₁)
     simp only [List.forall₂_implies_mapM_eq _ _ h₄, List.mapM_cons, bind_pure_comp, bind_assoc,
       bind_map_left]
   case _ c₁ axs hᵢ =>
-    simp [typeOf, do_eq_ok] at h₃
-    rcases h₃ with ⟨atys, h₃₁, h₃₂⟩
-    simp [ok] at h₃₂
-    rcases h₃₂ with ⟨h₃₂, _⟩
+    simp only [typeOf, List.empty_eq, do_eq_ok] at h₃
+    replace ⟨atys, h₃₁, h₃₂⟩ := h₃
+    simp only [ok, Except.ok.injEq, Prod.mk.injEq, List.nil_eq] at h₃₂
+    replace ⟨h₃₂, _⟩ := h₃₂
     subst h₃₂
-    simp [evaluate, List.mapM₂, List.attach₂]
+    simp only [evaluate, List.mapM₂, List.attach₂]
     rw [List.mapM_pmap_subtype (fun (x : Attr × Expr) => bindAttr x.fst (evaluate x.snd request entities))]
-    simp [TypedExpr.toExpr, List.attach₂]
+    simp only [TypedExpr.toExpr, List.attach₂]
     rw [List.map_pmap_subtype (fun (x : Attr × TypedExpr) => (x.fst, x.snd.toExpr))]
-    simp [evaluate, List.mapM₂, List.attach₂]
+    simp only [evaluate, List.mapM₂, List.attach₂]
     rw [List.mapM_pmap_subtype (fun (x : Attr × Expr) => bindAttr x.fst (evaluate x.snd request entities))]
-    simp [List.mapM_map]
-    simp [evaluate, List.mapM₂, List.attach₂] at h₃₁
+    simp only [List.mapM_map, Function.comp_def]
+    simp only [List.mapM₂, List.attach₂] at h₃₁
     rw [List.mapM_pmap_subtype (fun (x : Attr × Expr) => Except.map (fun x_1 => (x.fst, x_1.fst)) (typeOf x.snd c₁ env)), List.mapM_ok_iff_forall₂] at h₃₁
     have h₄ := type_of_ok_attr_list h₃₁ (λ a₁ x₁ h => hᵢ a₁ x₁ h h₁)
     simp only [List.forall₂_implies_mapM_eq _ _ h₄]

--- a/cedar-lean/Cedar/Thm/Validation/Typechecker/And.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Typechecker/And.lean
@@ -46,11 +46,11 @@ theorem type_of_and_inversion {x₁ x₂ : Expr} {c c' : Capabilities} {env : En
   rename_i res₁
   simp only [typeOfAnd, List.empty_eq] at h₁
   split at h₁ <;> simp [ok, err] at h₁
-  case ok.h_1 h₃ =>
+  case h_1 h₃ =>
     have ⟨ hl₁, hr₁ ⟩ := h₁
     subst hl₁ hr₁
     exists res₁.fst, BoolType.ff, res₁.snd
-  case ok.h_2 bty₁ h₃ h₄ =>
+  case h_2 bty₁ h₃ h₄ =>
     exists res₁.fst, bty₁, res₁.snd
     simp [h₄, ResultType.typeOf, Except.map]
     split ; contradiction
@@ -58,11 +58,11 @@ theorem type_of_and_inversion {x₁ x₂ : Expr} {c c' : Capabilities} {env : En
     rename_i res₂
     split at h₁ <;> simp at h₁ <;>
     have ⟨hty, hc⟩ := h₁ <;> subst hty hc
-    case isFalse.ok.h_1 hty₂ =>
+    case h_1 hty₂ =>
       exists .ff, res₂.fst
       apply And.intro (by simp)
       exists .ff, res₂.snd
-    case isFalse.ok.h_2 hty₂ =>
+    case h_2 hty₂ =>
       exists bty₁, res₂.fst
       apply And.intro (by simp)
       exists BoolType.tt, res₂.snd
@@ -70,7 +70,7 @@ theorem type_of_and_inversion {x₁ x₂ : Expr} {c c' : Capabilities} {env : En
       case ff => contradiction
       all_goals
         simp [hty₂, lubBool]
-    case isFalse.ok.h_3 bty₂ h₄ h₅ hty₂ =>
+    case h_3 bty₂ h₄ h₅ hty₂ =>
       exists .anyBool, res₂.fst
       apply And.intro (by simp)
       exists BoolType.anyBool, res₂.snd

--- a/cedar-lean/Cedar/Thm/Validation/Typechecker/BinaryApp/Cmp.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Typechecker/BinaryApp/Cmp.lean
@@ -101,15 +101,15 @@ theorem type_of_int_cmp_is_sound {op₂ : BinaryOp} {x₁ x₂ : Expr} {c₁ c�
     rw [htl₁] at ih₃
     rw [htl₂] at ih₄
   )
-  case' inl =>
-    have ⟨i₁, ih₁⟩ := instance_of_int_is_int ih₃
-    have ⟨i₂, ih₂⟩ := instance_of_int_is_int ih₄
-  case' inr.inl =>
-    have ⟨i₁, ih₁⟩ := instance_of_datetime_type_is_datetime ih₃
-    have ⟨i₂, ih₂⟩ := instance_of_datetime_type_is_datetime ih₄
-  case' inr.inr =>
-    have ⟨i₁, ih₁⟩ := instance_of_duration_type_is_duration ih₃
-    have ⟨i₂, ih₂⟩ := instance_of_duration_type_is_duration ih₄
+  have ⟨i₁, ih₁⟩ := instance_of_int_is_int ih₃
+  have ⟨i₂, ih₂⟩ := instance_of_int_is_int ih₄
+  rotate_left
+  have ⟨i₁, ih₁⟩ := instance_of_datetime_type_is_datetime ih₃
+  have ⟨i₂, ih₂⟩ := instance_of_datetime_type_is_datetime ih₄
+  rotate_left
+  have ⟨i₁, ih₁⟩ := instance_of_duration_type_is_duration ih₃
+  have ⟨i₂, ih₂⟩ := instance_of_duration_type_is_duration ih₄
+  rotate_left
   all_goals (
     subst ih₁ ih₂
     rcases h₀ with h₀ | h₀

--- a/cedar-lean/Cedar/Thm/Validation/Typechecker/Call.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Typechecker/Call.lean
@@ -935,15 +935,11 @@ theorem type_of_preserves_evaluation_results_call {xfn ty c₂ request entities}
   intro h₁ h₂
   simp [typeOfCall] at h₁
   split at h₁ <;>
-  simp [ok, err, do_ok_eq_ok] at h₁ <;>
-  try (
-    rcases h₁ with ⟨_, _, h₁⟩
-    subst h₁
-    simp [TypedExpr.toExpr, evaluate, List.mapM₁_eq_mapM fun x => evaluate x request entities, List.map₁_eq_map, List.mapM_map, h₂]
-  )
+  simp [ok, err, do_ok_eq_ok] at h₁
   all_goals
-    rcases h₁ with ⟨h₁, _⟩
+    try replace ⟨_, _, h₁⟩ := h₁
+    try replace ⟨h₁, _⟩ := h₁
     subst h₁
-    simp [TypedExpr.toExpr, evaluate, List.mapM₁_eq_mapM fun x => evaluate x request entities, List.map₁_eq_map, List.mapM_map, h₂]
+    simp [TypedExpr.toExpr, evaluate, List.mapM₁_eq_mapM (evaluate · request entities), List.map₁_eq_map, List.mapM_map, h₂, Function.comp_def]
 
 end Cedar.Thm

--- a/cedar-lean/Cedar/Thm/Validation/Typechecker/HasAttr.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Typechecker/HasAttr.lean
@@ -139,7 +139,7 @@ theorem type_of_hasAttr_is_sound_for_entities {x₁ : Expr} {a : Attr} {c₁ c�
   split at h₃ <;> try simp [err, hasAttrInRecord] at h₃
   rename_i _ rty h₇
   split at h₃
-  case h_1.h_1 =>
+  case h_1 =>
     split at h₃ <;> rcases h₃ with ⟨h₃, _⟩ <;>
     apply InstanceOfType.instance_of_bool <;>
     simp [InstanceOfBoolType]
@@ -148,7 +148,7 @@ theorem type_of_hasAttr_is_sound_for_entities {x₁ : Expr} {a : Attr} {c₁ c�
     simp [CapabilitiesInvariant] at h₁
     replace h₁ := h₁.left x₁ a h₉
     simp [EvaluatesTo, evaluate, h₅, hasAttr, attrsOf, h₈] at h₁
-  case h_1.h_2 =>
+  case h_2 =>
     simp [ok] at h₃
     have ⟨h₃, _⟩ := h₃
     simp [←h₃]
@@ -158,11 +158,11 @@ theorem type_of_hasAttr_is_sound_for_entities {x₁ : Expr} {a : Attr} {c₁ c�
     rename_i _ _ h₉ _ _
     simp [Entities.attrsOrEmpty] at h₈
     split at h₈
-    case h₁.true.h_1 _ _ _ _ _ h₁₀ =>
+    case h_1 _ _ _ _ _ h₁₀ =>
       have h₁₁ := well_typed_entity_attributes h₂ h₁₀ h₇
       have h₁₂ := absent_attribute_is_absent h₁₁ h₉
       simp [Map.contains_iff_some_find?, h₁₂] at h₈
-    case h₁.true.h_2 =>
+    case h_2 =>
       rcases (Map.not_contains_of_empty a) with _
       contradiction
   case h_2 =>

--- a/cedar-lean/Cedar/Thm/Validation/Typechecker/IfThenElse.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Typechecker/IfThenElse.lean
@@ -48,7 +48,7 @@ theorem type_of_ite_inversion {x₁ x₂ x₃ : Expr} {c c' : Capabilities} {env
   rename_i res₁
   split at h₁ <;> try { simp [ok, err] at h₁ } <;>
   rename_i c₁ hr₁
-  case ok.h_1 =>
+  case h_1 =>
     exists res₁.fst, BoolType.tt, res₁.snd
     simp [hr₁]
     cases h₃ : typeOf x₂ (c ∪ res₁.snd) env <;> simp [h₃] at h₁
@@ -57,7 +57,7 @@ theorem type_of_ite_inversion {x₁ x₂ x₃ : Expr} {c c' : Capabilities} {env
     subst ht₂ hc₂
     simp [h₃, ←hr₁, TypedExpr.typeOf]
     exists res₂.snd
-  case ok.h_2 =>
+  case h_2 =>
     exists res₁.fst, BoolType.ff, res₁.snd
     simp [hr₁]
     cases h₃ : typeOf x₃ c env <;> simp [h₃] at h₁
@@ -66,7 +66,7 @@ theorem type_of_ite_inversion {x₁ x₂ x₃ : Expr} {c c' : Capabilities} {env
     replace ⟨hl₁, hr₁⟩ := h₁
     subst hl₁ hr₁
     exists res₃.fst, res₃.fst
-  case ok.h_3 =>
+  case h_3 =>
     exists res₁.fst, BoolType.anyBool, res₁.snd
     simp [hr₁]
     cases h₃ : typeOf x₂ (c ∪ res₁.snd) env <;> simp [h₃] at h₁

--- a/cedar-lean/Cedar/Thm/Validation/Typechecker/LUB.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Typechecker/LUB.lean
@@ -196,7 +196,7 @@ theorem lub_comm {ty₁ ty₂ : CedarType} :
   case h_4 =>
     rename_i h₁ h₂ h₃
     split <;> split <;> rename_i h₄
-    case isTrue.h_4 | isFalse.h_4 =>
+    case h_4 | h_4 => -- we have two goals named h_4 and Lean is perfectly fine with that; this selects them both
       rename_i _ _ h₅ _ _ _ _
       rw [eq_comm] at h₅
       simp [h₅]

--- a/cedar-lean/Cedar/Thm/Validation/Typechecker/Or.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Typechecker/Or.lean
@@ -51,10 +51,10 @@ theorem type_of_or_inversion {x₁ x₂ : Expr} {c c' : Capabilities} {env : Env
   simp [typeOfOr] at h₁
   split at h₁ <;> simp [ok, err] at h₁ <;>
   rename_i hr₁
-  case ok.h_1 c₁  =>
+  case h_1 c₁  =>
     exists res₁.fst, BoolType.tt, res₁.snd
     simp [←h₁, hr₁]
-  case ok.h_2 c₁ =>
+  case h_2 c₁ =>
     cases h₃ : typeOf x₂ c env <;> simp [h₃] at h₁
     rename_i res₂
     split at h₁ <;> simp [ok, err] at h₁
@@ -66,7 +66,7 @@ theorem type_of_or_inversion {x₁ x₂ : Expr} {c c' : Capabilities} {env : Env
     exists bty₂, res₂.fst
     simp only [exists_eq_right_right', true_and]
     exists bty₂, res₂.snd
-  case ok.h_3 bty₁ hneq₁ hneq₂ =>
+  case h_3 bty₁ hneq₁ hneq₂ =>
     cases bty₁ <;> simp at hneq₁ hneq₂
     exists res₁.fst, BoolType.anyBool, res₁.snd
     simp [hr₁]
@@ -75,15 +75,15 @@ theorem type_of_or_inversion {x₁ x₂ : Expr} {c c' : Capabilities} {env : Env
     split at h₁ <;> simp [ok, err] at h₁ <;>
     rename_i hr₂ <;>
     have ⟨ht, hc⟩ := h₁ <;> subst ht hc <;> simp [hr₁, ResultType.typeOf, Except.map]
-    case anyBool.ok.h_1 =>
+    case h_1 =>
       exists BoolType.tt, res₂.fst
       simp only [hr₂, true_and]
       exists BoolType.tt, res₂.snd
-    case anyBool.ok.h_2 =>
+    case h_2 =>
       exists BoolType.anyBool, res₂.fst
       simp only [true_and]
       exists BoolType.ff, res₂.snd
-    case anyBool.ok.h_3 bty₂ hneq₁ hneq₂ =>
+    case h_3 bty₂ hneq₁ hneq₂ =>
       exists BoolType.anyBool, res₂.fst
       simp
       exists bty₂, res₂.snd

--- a/cedar-lean/lakefile.lean
+++ b/cedar-lean/lakefile.lean
@@ -18,9 +18,9 @@ import Lake
 open Lake DSL
 
 meta if get_config? env = some "dev" then -- dev is so not everyone has to build it
-require "leanprover" / "doc-gen4" @ git "v4.20.0"
+require "leanprover" / "doc-gen4" @ git "v4.21.0"
 
-require "leanprover-community" / "batteries" @ git "v4.20.0"
+require "leanprover-community" / "batteries" @ git "v4.21.0"
 
 package Cedar
 

--- a/cedar-lean/lean-toolchain
+++ b/cedar-lean/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:v4.20.1
+leanprover/lean4:v4.21.0


### PR DESCRIPTION
Also a few tiny drive-by improvements as I saw them.

Most important changes:
- `Option.some_bind` and `Option.none_bind` deprecated and replaced with `Option.bind_some` and `Option.bind_none`; this was an easy change (particularly since they did it by deprecation and not just removing the old lemmas)
- `List.mapM_map` was added to std library and also made a `simp` lemma I think.  This conflicts with our own lemma `List.mapM_map` which was almost identical, but the std one uses the `∘` operator in its statement whereas ours did not.  Necessitated adding `Function.comp_def` to many `simp`s that previously relied on `List.mapM_map` in order to bring the proof back to the previous, expected state.
- Lean has improved auto-naming of goals in many cases


