### PR TITLE
Restore validation mode conversion

### DIFF
--- a/cedar-lean-ffi/src/messages.rs
+++ b/cedar-lean-ffi/src/messages.rs
@@ -174,7 +174,7 @@ impl proto::ValidationRequest {
         Self {
             schema: Some(cedar_policy::proto::models::Schema::from(schema)),
             policies: Some(cedar_policy::proto::models::PolicySet::from(policyset)),
-            mode: cedar_policy::proto::models::ValidationMode::from(mode).into(),
+            mode: cedar_policy::proto::models::ValidationMode::from(&(*mode).into()).into(),
         }
     }
 }


### PR DESCRIPTION
*Issue #, if available:* https://github.com/cedar-policy/cedar-spec/issues/653

*Description of changes:* 

This fixes a failure when trying to build `cedar-lean-cli` with Docker. This PR restores the conversion to what it was before this change was introduced: https://github.com/cedar-policy/cedar-spec/pull/646/files#diff-69c38356fced3c28f4fc3bfb225b9f3f92a616d9c7c18477b80b2b1dc7f60e07L177

```
15.83    Compiling cedar-policy-formatter v4.5.0
26.88 error[E0277]: the trait bound `cedar_policy::proto::models::ValidationMode: From<&cedar_policy::ValidationMode>` is not satisfied
26.88    --> /opt/src/cedar-spec/cedar-lean-ffi/src/messages.rs:177:19
26.88     |
26.88 177 |             mode: cedar_policy::proto::models::ValidationMode::from(mode).into(),
26.88     |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `From<&cedar_policy::ValidationMode>` is not implemented for `cedar_policy::proto::models::ValidationMode`
26.88     |
26.88     = help: the trait `From<&cedar_policy::ValidationMode>` is not implemented for `cedar_policy::proto::models::ValidationMode`
26.88             but trait `From<&cedar_policy_core::validator::ValidationMode>` is implemented for it
26.88     = help: for that trait implementation, expected `cedar_policy_core::validator::ValidationMode`, found `cedar_policy::ValidationMode`
26.88
26.92 For more information about this error, try `rustc --explain E0277`.
26.92 error: could not compile `cedar-lean-ffi` (lib) due to 1 previous error
26.96 error: failed to compile `cedar-lean-cli v4.4.0 (/opt/src/cedar-spec/cedar-lean-cli)`, intermediate artifacts can be found at `/opt/src/cedar-spec/cedar-lean-cli/target`.
26.96 To reuse those artifacts with a future compilation, set the environment variable `CARGO_TARGET_DIR` to that path.
------
Dockerfile:48
--------------------
  47 |     WORKDIR $CEDAR_SPEC_ROOT/cedar-lean-cli
  48 | >>> RUN source /root/.profile \
  49 | >>>   && source ../cedar-lean-ffi/set_env_vars.sh \
  50 | >>>   && cargo install --path .
  51 |
--------------------
ERROR: failed to solve: process "/bin/sh -c source /root/.profile   && source ../cedar-lean-ffi/set_env_vars.sh   && cargo install --path ." did not complete successfully: exit code: 101
```