### PR TITLE
Update proto conversions to be compatiable with all versions of cedar-policy >= 4.4.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,8 +92,24 @@ jobs:
       cedar_spec_ref: ${{ github.ref }}
       cedar_policy_ref: ${{ needs.get-branch-name.outputs.branch_name }}
 
-  test_docker_build:
-    name: Test Docker build
+  test_cli_docker_build:
+    name: Test CLI Docker Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout cedar-spec
+        uses: actions/checkout@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./cedar-lean-cli/Dockerfile
+          push: false
+          tags: cedar-lean-cli:latest
+
+  test_drt_docker_build:
+    name: Test DRT Docker build
     runs-on: ubuntu-latest
     steps:
       - name: Set up Docker Buildx

--- a/cedar-lean-ffi/src/messages.rs
+++ b/cedar-lean-ffi/src/messages.rs
@@ -174,7 +174,7 @@ impl proto::ValidationRequest {
         // Use a custom code to do this so that this code will compile against any cedar-policy version >= 4.4.0
         let mode = match mode {
             ValidationMode::Strict => cedar_policy::proto::models::ValidationMode::Strict,
-            _ => panic!("Lean Validator only supports strict validation")
+            _ => panic!("Lean Validator only supports strict validation"),
         };
         Self {
             schema: Some(cedar_policy::proto::models::Schema::from(schema)),

--- a/cedar-lean-ffi/src/messages.rs
+++ b/cedar-lean-ffi/src/messages.rs
@@ -171,10 +171,15 @@ impl proto::EvaluationRequestChecked {
 /// Serialize a PolicySet validation request
 impl proto::ValidationRequest {
     pub(crate) fn new(policyset: &PolicySet, schema: &Schema, mode: &ValidationMode) -> Self {
+        // Use a custom code to do this so that this code will compile against any cedar-policy version >= 4.4.0
+        let mode = match mode {
+            ValidationMode::Strict => cedar_policy::proto::models::ValidationMode::Strict,
+            _ => panic!("Lean Validator only supports strict validation")
+        };
         Self {
             schema: Some(cedar_policy::proto::models::Schema::from(schema)),
             policies: Some(cedar_policy::proto::models::PolicySet::from(policyset)),
-            mode: cedar_policy::proto::models::ValidationMode::from(mode).into(),
+            mode: mode.into(),
         }
     }
 }


### PR DESCRIPTION
Addresses issue #653 

Updates protobuf conversion for Validation mode (makes compatible with both main and v4.5.0).

