### PR TITLE
Prove that well-formed `Environment` compiles to well-formed `SymEnv`

### DIFF
--- a/cedar-lean/Cedar/Thm/Data/List/Lemmas.lean
+++ b/cedar-lean/Cedar/Thm/Data/List/Lemmas.lean
@@ -1470,4 +1470,30 @@ decreasing_by
     _ < xs.length := by
       simp [*]
 
+theorem mem_eraseDups_implies_mem
+  [BEq α] [LawfulBEq α]
+  {xs : List α} {x : α}
+  (hmem : x ∈ xs.eraseDups) :
+  x ∈ xs
+:= by
+  cases xs with
+  | nil => contradiction
+  | cons hd tl =>
+    simp only [eraseDups_cons, mem_cons] at hmem
+    simp only [mem_cons]
+    cases hmem with
+    | inl h => exact Or.inl h
+    | inr h =>
+      apply Or.inr
+      have := mem_eraseDups_implies_mem h
+      have := List.mem_filter.mp this
+      exact this.1
+termination_by xs.length
+decreasing_by
+  calc
+    (List.filter (fun b => !b == hd) tl).length <= tl.length := by
+      apply List.length_filter_le
+    _ < xs.length := by
+      simp [*]
+
 end List

--- a/cedar-lean/Cedar/Thm/Data/List/Lemmas.lean
+++ b/cedar-lean/Cedar/Thm/Data/List/Lemmas.lean
@@ -383,6 +383,14 @@ theorem mapM₂_eq_mapM [Monad m] [LawfulMonad m] [SizeOf α] [SizeOf β]
 := by
   simp only [mapM₂, attach₂, mapM_pmap_subtype]
 
+theorem mapM₃_eq_mapM [Monad m] [LawfulMonad m] [SizeOf α] [SizeOf β]
+  (f : (α × β) → m γ)
+  (as : List (α × β)) :
+  List.mapM₃ as (λ x : { x // sizeOf x.snd < 1 + (1 + sizeOf as) } => f x.val) =
+  List.mapM f as
+:= by
+  simp only [mapM₃, attach₃, mapM_pmap_subtype]
+
 theorem mapM_implies_nil {f : α → Except β γ} {as : List α}
   (h₁ : List.mapM f as = Except.ok []) :
   as = []

--- a/cedar-lean/Cedar/Thm/Data/List/Lemmas.lean
+++ b/cedar-lean/Cedar/Thm/Data/List/Lemmas.lean
@@ -1438,4 +1438,36 @@ theorem find?_compose {α β} (f : α → β) (p₁ : β → Bool) (p₂ : α �
       specialize hₐ head
       simp only [Function.comp_apply, heq₁, heq₂, Bool.false_eq_true] at hₐ
     case _ => exact h hₐ
+
+theorem mem_implies_mem_eraseDups
+  [BEq α] [LawfulBEq α]
+  {xs : List α} {x : α}
+  (hmem : x ∈ xs) :
+  x ∈ xs.eraseDups
+:= by
+  cases xs with
+  | nil => contradiction
+  | cons hd tl =>
+    simp only [List.eraseDups_cons, List.mem_cons]
+    simp only [List.mem_cons] at hmem
+    cases hx : x == hd
+    · simp only [beq_eq_false_iff_ne, ne_eq] at hx
+      apply Or.inr
+      simp only [hx, false_or] at hmem
+      apply mem_implies_mem_eraseDups
+      apply List.mem_filter.mpr
+      simp only [hmem, true_and]
+      simp only [Bool.not_eq_eq_eq_not, Bool.not_true, beq_eq_false_iff_ne, ne_eq]
+      exact hx
+    · apply Or.inl
+      simp only [beq_iff_eq] at hx
+      exact hx
+termination_by xs.length
+decreasing_by
+  calc
+    (List.filter (fun b => !b == hd) tl).length <= tl.length := by
+      apply List.length_filter_le
+    _ < xs.length := by
+      simp [*]
+
 end List

--- a/cedar-lean/Cedar/Thm/Data/Map.lean
+++ b/cedar-lean/Cedar/Thm/Data/Map.lean
@@ -201,6 +201,13 @@ theorem contains_iff_some_find? {α β} [BEq α] {m : Map α β} {k : α} :
   m.contains k ↔ ∃ v, m.find? k = .some v
 := by simp [contains, Option.isSome_iff_exists]
 
+theorem find?_some_implies_contains {α β} [BEq α] {m : Map α β} {k : α} {v : β} :
+  m.find? k = .some v → m.contains k
+:= by
+  intros h
+  apply contains_iff_some_find?.mpr
+  simp [h]
+
 theorem not_contains_of_empty {α β} [BEq α] (k : α) :
   ¬ (Map.empty : Map α β).contains k
 := by simp [contains, empty, find?, List.find?]

--- a/cedar-lean/Cedar/Thm/Data/Map.lean
+++ b/cedar-lean/Cedar/Thm/Data/Map.lean
@@ -427,7 +427,7 @@ theorem find?_implies_make_find?
   {l : List (α × β)}
   {k : α} {v : β}
   (h : List.find? (λ x => x.fst == k) l = some (k, v)) :
-  (Data.Map.make l).find? k = some v
+  (make l).find? k = some v
 := by
   apply (in_list_iff_find?_some (Data.Map.make_wf l)).mp
   simp only [make, Data.Map.kvs]

--- a/cedar-lean/Cedar/Thm/SymCC/Compiler.lean
+++ b/cedar-lean/Cedar/Thm/SymCC/Compiler.lean
@@ -15,7 +15,6 @@
 -/
 
 import Cedar.Thm.SymCC.Env.Interpret
-import Cedar.Thm.SymCC.Env.ofEnv
 import Cedar.Thm.SymCC.Term.Same
 import Cedar.Thm.SymCC.Compiler.Attr
 import Cedar.Thm.SymCC.Compiler.Binary
@@ -25,9 +24,6 @@ import Cedar.Thm.SymCC.Compiler.LitVar
 import Cedar.Thm.SymCC.Compiler.Record
 import Cedar.Thm.SymCC.Compiler.Set
 import Cedar.Thm.SymCC.Compiler.Unary
-import Cedar.Thm.SymCC.Compiler.WellTyped
-import Cedar.Thm.Validation.WellTyped.Definition
-import Cedar.Thm.Validation.Typechecker.WF
 
 /-!
 This file proves two key auxiliary lemmas used to show the soundness
@@ -174,25 +170,5 @@ theorem compile_bisimulation {x : Expr} {env : Env} {εnv : SymEnv} {t : Term} {
   have h₆ := interpret_εnv_wf_for_expr h₁ h₃
   have h₇ := compile_interpret h₃ h₁ h₅
   exact compile_evaluate h₄ h₂ h₆ h₇
-
-/--
-Given a well-typed expression `tx` in a well-formed environment `Γ`,
-`compile` should succeed and produce a term with the corresponding
-type `TermType.ofType tx.typeOf`.
--/
-theorem compile_well_typed {tx : TypedExpr} {Γ : Environment} :
-  Γ.WellFormed →
-  TypedExpr.WellTyped Γ tx →
-  ∃ t : Term,
-    compile tx.toExpr (SymEnv.ofEnv Γ) = .ok t ∧
-    t.typeOf = .option (TermType.ofType tx.typeOf)
-:= by
-  intros hwf hwt
-  apply compile_well_typed_on_wf_expr
-  constructor
-  · rfl
-  constructor
-  · exact hwt
-  · apply ofEnv_wf_for_expr hwf hwt
 
 end Cedar.Thm

--- a/cedar-lean/Cedar/Thm/SymCC/Compiler.lean
+++ b/cedar-lean/Cedar/Thm/SymCC/Compiler.lean
@@ -32,7 +32,7 @@ and completeness of Cedar's symbolic compiler.
 
 namespace Cedar.Thm
 
-open Spec SymCC Factory Validation
+open Spec SymCC Factory
 
 /--
 The lemma shows that the symbolic compiler (`compile`) behaves like the

--- a/cedar-lean/Cedar/Thm/SymCC/Compiler.lean
+++ b/cedar-lean/Cedar/Thm/SymCC/Compiler.lean
@@ -15,6 +15,7 @@
 -/
 
 import Cedar.Thm.SymCC.Env.Interpret
+import Cedar.Thm.SymCC.Env.ofEnv
 import Cedar.Thm.SymCC.Term.Same
 import Cedar.Thm.SymCC.Compiler.Attr
 import Cedar.Thm.SymCC.Compiler.Binary
@@ -24,6 +25,9 @@ import Cedar.Thm.SymCC.Compiler.LitVar
 import Cedar.Thm.SymCC.Compiler.Record
 import Cedar.Thm.SymCC.Compiler.Set
 import Cedar.Thm.SymCC.Compiler.Unary
+import Cedar.Thm.SymCC.Compiler.WellTyped
+import Cedar.Thm.Validation.WellTyped.Definition
+import Cedar.Thm.Validation.Typechecker.WF
 
 /-!
 This file proves two key auxiliary lemmas used to show the soundness
@@ -32,7 +36,7 @@ and completeness of Cedar's symbolic compiler.
 
 namespace Cedar.Thm
 
-open Spec SymCC Factory
+open Spec SymCC Factory Validation
 
 /--
 The lemma shows that the symbolic compiler (`compile`) behaves like the
@@ -170,5 +174,25 @@ theorem compile_bisimulation {x : Expr} {env : Env} {εnv : SymEnv} {t : Term} {
   have h₆ := interpret_εnv_wf_for_expr h₁ h₃
   have h₇ := compile_interpret h₃ h₁ h₅
   exact compile_evaluate h₄ h₂ h₆ h₇
+
+/--
+Given a well-typed expression `tx` in a well-formed environment `Γ`,
+`compile` should succeed and produce a term with the corresponding
+type `TermType.ofType tx.typeOf`.
+-/
+theorem compile_well_typed {tx : TypedExpr} {Γ : Environment} :
+  Γ.WellFormed →
+  TypedExpr.WellTyped Γ tx →
+  ∃ t : Term,
+    compile tx.toExpr (SymEnv.ofEnv Γ) = .ok t ∧
+    t.typeOf = .option (TermType.ofType tx.typeOf)
+:= by
+  intros hwf hwt
+  apply compile_well_typed_on_wf_expr
+  constructor
+  · rfl
+  constructor
+  · exact hwt
+  · apply ofEnv_wf_for_expr hwf hwt
 
 end Cedar.Thm

--- a/cedar-lean/Cedar/Thm/SymCC/Compiler/WellTyped.lean
+++ b/cedar-lean/Cedar/Thm/SymCC/Compiler/WellTyped.lean
@@ -1527,9 +1527,10 @@ theorem compile_well_typed_call
       simp [hty_comp_x1, hty_comp_x2, hty_x1, hty_x2, TermType.ofType]
 
 /--
-Compiling a well-typed expression should produce a term of the corresponding `TermType`.
+Compiling a well-typed expression should produce a term of the corresponding `TermType`,
+assuming that the expression is well-formed in the symbolic environment.
 -/
-theorem compile_well_typed {Γ : Environment} {εnv : SymEnv} {tx : TypedExpr} :
+theorem compile_well_typed_on_wf_expr {Γ : Environment} {εnv : SymEnv} {tx : TypedExpr} :
   CompileWellTypedCondition tx Γ εnv →
   CompileWellTyped tx εnv
 := by
@@ -1541,52 +1542,52 @@ theorem compile_well_typed {Γ : Environment} {εnv : SymEnv} {tx : TypedExpr} :
     have ⟨h1, h2, h3⟩ := h.eliminate_ite
     apply compile_well_typed_ite
     any_goals apply CompileWellTyped.add_wf
-    any_goals apply compile_well_typed
+    any_goals apply compile_well_typed_on_wf_expr
     any_goals assumption
   case and =>
     have ⟨ha, hb⟩ := h.eliminate_or_and ?_
     apply (compile_well_typed_or_and ?_ ?_).right
     any_goals apply CompileWellTyped.add_wf
-    any_goals apply compile_well_typed
+    any_goals apply compile_well_typed_on_wf_expr
     any_goals assumption
     any_goals simp
   case or =>
     have ⟨ha, hb⟩ := h.eliminate_or_and ?_
     apply (compile_well_typed_or_and ?_ ?_).left
     any_goals apply CompileWellTyped.add_wf
-    any_goals apply compile_well_typed
+    any_goals apply compile_well_typed_on_wf_expr
     any_goals assumption
     any_goals simp
   case unaryApp =>
     have hcond := h.eliminate_unaryApp
     apply compile_well_typed_unaryApp
     any_goals apply CompileWellTyped.add_wf
-    any_goals apply compile_well_typed
+    any_goals apply compile_well_typed_on_wf_expr
     all_goals assumption
   case binaryApp =>
     have ⟨ha, hb⟩ := h.eliminate_binaryApp
     apply compile_well_typed_binaryApp
     any_goals apply CompileWellTyped.add_wf
-    any_goals apply compile_well_typed
+    any_goals apply compile_well_typed_on_wf_expr
     any_goals assumption
   case getAttr =>
     have hcond := h.eliminate_getAttr
     apply compile_well_typed_getAttr
     any_goals apply CompileWellTyped.add_wf
-    any_goals apply compile_well_typed
+    any_goals apply compile_well_typed_on_wf_expr
     all_goals assumption
   case hasAttr =>
     have hcond := h.eliminate_hasAttr
     apply compile_well_typed_hasAttr
     any_goals apply CompileWellTyped.add_wf
-    any_goals apply compile_well_typed
+    any_goals apply compile_well_typed_on_wf_expr
     all_goals assumption
   case set =>
     have hcond := h.eliminate_set
     apply compile_well_typed_set
     · intros x hx
       apply CompileWellTyped.add_wf
-      apply compile_well_typed (hcond x hx)
+      apply compile_well_typed_on_wf_expr (hcond x hx)
       apply hcond
       assumption
     assumption
@@ -1595,7 +1596,7 @@ theorem compile_well_typed {Γ : Environment} {εnv : SymEnv} {tx : TypedExpr} :
     apply compile_well_typed_record
     · intros a x hx
       apply CompileWellTyped.add_wf
-      apply compile_well_typed (hcond a x hx)
+      apply compile_well_typed_on_wf_expr (hcond a x hx)
       apply hcond
       assumption
     assumption
@@ -1604,7 +1605,7 @@ theorem compile_well_typed {Γ : Environment} {εnv : SymEnv} {tx : TypedExpr} :
     apply compile_well_typed_call
     · intros x hx
       apply CompileWellTyped.add_wf
-      apply compile_well_typed (hcond x hx)
+      apply compile_well_typed_on_wf_expr (hcond x hx)
       apply hcond
       assumption
     assumption

--- a/cedar-lean/Cedar/Thm/SymCC/Env/ofEnv.lean
+++ b/cedar-lean/Cedar/Thm/SymCC/Env/ofEnv.lean
@@ -532,13 +532,6 @@ theorem ofEnv_request_is_swf
   exact ofEnv_request_is_wf hwf
   exact ofEnv_request_is_basic
 
-theorem mem_eraseDups_implies_mem
-  [BEq α] [LawfulBEq α]
-  {xs : List α} {x : α}
-  (hmem : x ∈ xs.eraseDups) :
-  x ∈ xs
-:= sorry
-
 theorem ofStandardEntityType_is_wf
   {ety : EntityType} {Γ : Environment} {entry : StandardSchemaEntry}
   (hwf : Γ.WellFormed)
@@ -577,7 +570,31 @@ theorem ofStandardEntityType_is_wf
       CedarType.liftBoolTypes,
     ]
   -- Symbolic ancestors are well-formed
-  · sorry
+  · intros anc_ty sym_anc_f hfind_anc
+    have := Map.find?_mem_toList hfind_anc
+    simp only [Map.toList] at this
+    have := Map.make_mem_list_mem this
+    have ⟨anc_ty', hmem_anc', heq_anc'⟩ := List.mem_map.mp this
+    simp only [Prod.mk.injEq] at heq_anc'
+    simp only [heq_anc'.1] at hmem_anc'
+    simp only [←heq_anc'.2, heq_anc'.1]
+    and_intros
+    · exact hwf_ety
+    · simp
+      apply ofType_wf hwf
+      constructor
+      constructor
+      exact wf_env_implies_wf_ancestor hwf hfind hmem_anc'
+    · simp only [
+        UnaryFunction.argType,
+        SymEntityData.ofStandardEntityType.ancsUUF,
+      ]
+      rfl
+    · simp only [
+        UnaryFunction.outType,
+        SymEntityData.ofStandardEntityType.ancsUUF,
+      ]
+      rfl
   · exact Map.make_wf _
   -- Symbolic tags are well-formed
   · cases htags : entry.tags with
@@ -702,7 +719,7 @@ theorem ofEnv_entities_is_wf
       simp only [Prod.mk.injEq] at heq_entry
       have ⟨heq_ety, heq_es⟩ := heq_entry
       have hwf_acts := wf_env_implies_wf_acts_map hwf
-      have hmem_ety := mem_eraseDups_implies_mem hmem_ety
+      have hmem_ety := List.mem_eraseDups_implies_mem hmem_ety
       have ⟨⟨uid, entry⟩, hmem, heq⟩ := List.mem_map.mp hmem_ety
       simp only at heq
       have := (Map.in_list_iff_find?_some hwf_acts).mp hmem

--- a/cedar-lean/Cedar/Thm/SymCC/Env/ofEnv.lean
+++ b/cedar-lean/Cedar/Thm/SymCC/Env/ofEnv.lean
@@ -1119,6 +1119,11 @@ decreasing_by
     have := List.sizeOf_lt_of_mem hmem_x'
     omega
 
+/--
+Main well-formedness theorem for `SymEnv.ofEnv`,
+which says that if the input environment `Γ` is well-formed,
+then `SymEnv.ofEnv Γ` is well-formed.
+-/
 theorem ofEnv_is_wf
   {Γ : Environment}
   (hwf : Γ.WellFormed) :
@@ -1142,61 +1147,5 @@ theorem ofEnv_wf_for_expr
   constructor
   · exact ofEnv_is_wf hwf
   · exact ofEnv_entities_valid_refs_for_wt_expr hwf hwt
-
-theorem ofEnv_entities_is_acyclic
-  {Γ : Environment}
-  (hwf : Γ.WellFormed) :
-  (SymEnv.ofEnv Γ).entities.Acyclic
-:= by
-  sorry
-
-theorem ofEnv_entities_is_transitive
-  {Γ : Environment}
-  (hwf : Γ.WellFormed) :
-  (SymEnv.ofEnv Γ).entities.Transitive
-:= by
-  sorry
-
-theorem ofEnv_entities_is_partitioned
-  {Γ : Environment}
-  (hwf : Γ.WellFormed) :
-  (SymEnv.ofEnv Γ).entities.Partitioned
-:= by
-  sorry
-
-theorem ofEnv_entities_is_hierarchical
-  {Γ : Environment}
-  (hwf : Γ.WellFormed) :
-  (SymEnv.ofEnv Γ).entities.Hierarchical
-:= by
-  constructor
-  · exact ofEnv_entities_is_acyclic hwf
-  constructor
-  · exact ofEnv_entities_is_transitive hwf
-  · exact ofEnv_entities_is_partitioned hwf
-
-theorem ofEnv_entities_is_swf
-  {Γ : Environment}
-  (hwf : Γ.WellFormed) :
-  (SymEnv.ofEnv Γ).entities.StronglyWellFormed
-:= by
-  constructor
-  exact ofEnv_entities_is_wf hwf
-  exact ofEnv_entities_is_hierarchical hwf
-
-/--
-Main well-formedness theorem for `SymEnv.ofEnv`,
-which says that if the input environment `Γ` is well-formed,
-then `SymEnv.ofEnv Γ` is strongly well-formed.
--/
-theorem ofEnv_is_swf
-  {Γ : Environment}
-  (hwf : Γ.WellFormed) :
-  (SymEnv.ofEnv Γ).StronglyWellFormed
-:= by
-  simp only [SymEnv.StronglyWellFormed]
-  constructor
-  exact ofEnv_request_is_swf hwf
-  exact ofEnv_entities_is_swf hwf
 
 end Cedar.Thm

--- a/cedar-lean/Cedar/Thm/SymCC/Env/ofEnv.lean
+++ b/cedar-lean/Cedar/Thm/SymCC/Env/ofEnv.lean
@@ -1,4 +1,8 @@
+import Cedar.Thm.Validation.Typechecker.WF
+import Cedar.Thm.Validation.WellTyped.TypeLifting
+import Cedar.Thm.SymCC.Data.Hierarchy
 import Cedar.Thm.SymCC.Env.WF
+import Cedar.Thm.Data.List.Lemmas
 
 /-!
 This file contains some facts about `SymEnv.ofEnv`.
@@ -9,6 +13,7 @@ namespace Cedar.Thm
 open Cedar.Spec
 open Cedar.Validation
 open SymCC
+open Cedar.Data
 
 /--
 If some entity exists in `Γ`, then it must
@@ -17,25 +22,84 @@ also exists in `SymEnv.ofEnv Γ` with the corresponding `SymEntityData`
 theorem ofEnv_preserves_entity
   {Γ : Environment} {εnv : SymEnv} {ety : EntityType} {entry : EntitySchemaEntry}
   (hεnv : εnv = SymEnv.ofEnv Γ)
-  (hfound : Data.Map.find? Γ.ets ety = some entry) :
-  Data.Map.find? εnv.entities ety = some (SymEntityData.ofEntityType ety entry)
+  (hfind : Map.find? Γ.ets ety = some entry) :
+  Map.find? εnv.entities ety = some (SymEntityData.ofEntityType ety entry)
 := by
-  simp [hεnv, Data.Map.find?, SymEnv.ofEnv, SymEntities.ofSchema, Data.Map.toList]
-  simp [Data.Map.find?] at hfound
-  -- Simplify hfound
-  split at hfound
-  case _ _ _ hfound2 =>
-    simp only [Option.some.injEq] at hfound
-    simp only [hfound] at hfound2
-    have hfound := hfound2
-    have h := List.find?_some hfound
+  simp [hεnv, Map.find?, SymEnv.ofEnv, SymEntities.ofSchema, Map.toList]
+  simp [Map.find?] at hfind
+  -- Simplify hfind
+  split at hfind
+  case _ _ _ hfind2 =>
+    simp only [Option.some.injEq] at hfind
+    simp only [hfind] at hfind2
+    have hfind := hfind2
+    have h := List.find?_some hfind
     simp only [beq_iff_eq] at h
-    simp only [h] at hfound
-    apply Data.Map.find?_implies_make_find?
+    simp only [h] at hfind
+    apply Map.find?_implies_make_find?
     apply List.find?_implies_append_find?
     apply List.find?_implies_find?_fst_map
     assumption
   case _ => contradiction
+
+/-- An action entity type is compiled correctly -/
+theorem ofEnv_preserves_action_entity
+  {Γ : Environment} {uid : EntityUID}
+  (hwf : Γ.WellFormed)
+  (hmem : Map.contains Γ.acts uid) :
+  Map.find? (SymEnv.ofEnv Γ).entities uid.ty =
+    some (SymEntityData.ofActionType
+      uid.ty
+      (Γ.acts.toList.map λ (act, _) => act.ty).eraseDups
+      Γ.acts)
+:= by
+  sorry
+
+theorem ofActionType_contains_act
+  {Γ : Environment} {uid : EntityUID}
+  (hwf : Γ.WellFormed)
+  (hmem : Map.contains Γ.acts uid) :
+  ∃ m, (SymEntityData.ofActionType
+      uid.ty
+      (Γ.acts.toList.map λ (act, _) => act.ty).eraseDups
+      Γ.acts).members = some m ∧ m.contains uid.eid
+:= by sorry
+
+/-- A variant of `ofEnv_preserves_entity` -/
+theorem ofEnv_entity_exists
+  {Γ : Environment} {ety : EntityType}
+  (hmem : Map.contains Γ.ets ety) :
+  Map.contains (SymEnv.ofEnv Γ).entities ety
+:= by
+  apply Map.contains_iff_some_find?.mpr
+  have ⟨entry, hentry⟩ := Map.contains_iff_some_find?.mp hmem
+  exists (SymEntityData.ofEntityType ety entry)
+  exact ofEnv_preserves_entity rfl hentry
+
+/-- Similar to `ofEnv_entity_exists` but for action entities -/
+theorem ofEnv_action_entity_exists
+  {Γ : Environment} {uid : EntityUID}
+  (hwf : Γ.WellFormed)
+  (hmem : Map.contains Γ.acts uid) :
+  Map.contains (SymEnv.ofEnv Γ).entities uid.ty
+:= by
+  sorry
+
+theorem ofEnv_wf_entity
+  {Γ : Environment} {ety : EntityType}
+  (hwf : Γ.WellFormed)
+  (hwf_ety : EntityType.WellFormed Γ ety) :
+  (SymEntities.ofSchema Γ.ets Γ.acts).isValidEntityType ety
+:= by
+  simp only [SymEntities.isValidEntityType]
+  cases hwf_ety with
+  | inl hwf_ety =>
+    exact ofEnv_entity_exists hwf_ety
+  | inr hwf_ety_act =>
+    -- Principal is an action. TODO: do we allow this?
+    have ⟨uid, huid, heq⟩ := hwf_ety_act
+    simp only [←heq]
+    exact ofEnv_action_entity_exists hwf huid
 
 /--
 Lemma that if a concrete `Γ : Environment` has tags for
@@ -50,13 +114,13 @@ theorem ofEnv_preserves_tags
     τags.vals.outType = TermType.ofType ty
 := by
   simp only [EntitySchema.tags?, Option.map_eq_some_iff] at h
-  have ⟨found_entry, ⟨hfound, hty_entry⟩⟩ := h
+  have ⟨found_entry, ⟨hfind, hty_entry⟩⟩ := h
   -- The corresponding entity exists in `εnv`
   have hety_exists :
-    Data.Map.find? (SymEnv.ofEnv Γ).entities ety
+    Map.find? (SymEnv.ofEnv Γ).entities ety
     = some (SymEntityData.ofEntityType ety found_entry)
   := by
-    apply ofEnv_preserves_entity ?_ hfound
+    apply ofEnv_preserves_entity ?_ hfind
     rfl
   simp only [
     hety_exists,
@@ -85,19 +149,19 @@ theorem ofEnv_preserves_entity_attr
     εnv.entities.attrs ety = .some attrs ∧
     UnaryFunction.WellFormed εnv.entities attrs ∧
     attrs.argType = .entity ety ∧
-    attrs.outType = .record (Data.Map.mk (TermType.ofRecordType rty.1))
+    attrs.outType = .record (Map.mk (TermType.ofRecordType rty.1))
 := by
-  simp only [EntitySchema.attrs?, Data.Map.find?, Option.map_eq_some_iff] at hattrs_exists
+  simp only [EntitySchema.attrs?, Map.find?, Option.map_eq_some_iff] at hattrs_exists
   split at hattrs_exists
-  case h_1 found_ety found_entry hfound =>
+  case h_1 found_ety found_entry hfind =>
     simp only [Option.some.injEq, exists_eq_left'] at hattrs_exists
     -- The corresponding entity exists in `εnv`
     have hety_exists :
-      Data.Map.find? εnv.entities ety
+      Map.find? εnv.entities ety
       = some (SymEntityData.ofEntityType ety found_entry)
     := by
       apply ofEnv_preserves_entity hεnv
-      simp [Data.Map.find?, hfound]
+      simp [Map.find?, hfind]
     have ⟨attrs, hattrs_exists2⟩ :
       ∃ attrs : UnaryFunction, εnv.entities.attrs ety = .some attrs
     := by simp [SymEntities.attrs, hety_exists]
@@ -124,15 +188,236 @@ theorem ofEnv_preserves_entity_attr
       · simp only [
           ← hattrs_exists2,
           UnaryFunction.outType, TermType.ofType,
-          TermType.record.injEq, Data.Map.mk.injEq,
+          TermType.record.injEq, Map.mk.injEq,
         ]
         simp only [EntitySchemaEntry.attrs] at hattrs_exists
         simp [hattrs_exists]
       -- Enum entity types
       · simp only [← hattrs_exists2, UnaryFunction.outType, TermType.ofType, TermType.record.injEq]
         simp only [EntitySchemaEntry.attrs] at hattrs_exists
-        simp [← hattrs_exists, TermType.ofRecordType, Data.Map.empty]
+        simp [← hattrs_exists, TermType.ofRecordType, Map.empty]
   case _ =>
     simp at hattrs_exists
+
+/--
+`TermType.ofType` of well-formed `CedarType` is well-formed
+(under the compiled `SymEnv`).
+-/
+theorem ofType_wf
+  {Γ : Environment} {ty : CedarType}
+  (hwf : Γ.WellFormed)
+  (hwf_ty : CedarType.WellFormed Γ ty) :
+  (TermType.ofType ty).WellFormed (SymEnv.ofEnv Γ).entities
+:= sorry
+
+/--
+`TermType.ofType` is a right inverse of `CedarType.cedarType?`
+when applied to a well-formed `CedarType`.
+-/
+theorem wf_ofType_right_inverse_cedarType?
+  {Γ : Environment} {ty : CedarType}
+  (hwf : Γ.WellFormed)
+  (hwf_ty : CedarType.WellFormed Γ ty) :
+  (TermType.ofType ty).cedarType? = ty.liftBoolTypes
+:= by
+  cases ty with
+  | bool _ | int | string | entity _ | ext _ =>
+    simp only [
+      TermType.ofType, TermType.cedarType?,
+      CedarType.liftBoolTypes, BoolType.lift,
+    ]
+  | set sty =>
+    cases hwf_ty with | set_wf hwf_sty =>
+    have := wf_ofType_right_inverse_cedarType? hwf hwf_sty
+    simp [
+      TermType.ofType, TermType.cedarType?,
+      this, CedarType.liftBoolTypes,
+    ]
+  | record rty =>
+    simp only [
+      TermType.ofType, TermType.cedarType?,
+      Option.bind_eq_bind, CedarType.liftBoolTypes,
+    ]
+    rw [List.mapM₃_eq_mapM
+        (fun x =>
+          (TermType.cedarType?.qualifiedType? x.snd).bind
+          fun t => some (x.fst, t))]
+    have := ofRecordType_forall₂ rty.1 hwf_ty
+    have := List.mapM_some_iff_forall₂.mpr this
+    simp [this, RecordType.liftBoolTypes]
+termination_by sizeOf ty
+decreasing_by
+  simp [*]
+  simp [*]
+  cases rty
+  simp
+  omega
+where
+  ofRecordType_forall₂
+    (rty : List (Attr × QualifiedType))
+    (hwf : CedarType.WellFormed Γ (CedarType.record (Map.mk rty))) :
+    List.Forall₂ (fun x y =>
+      ((TermType.cedarType?.qualifiedType? x.snd).bind fun t => some (x.fst, t)) = some y)
+      (TermType.ofRecordType rty) (CedarType.liftBoolTypesRecord rty)
+  := by
+    cases hwf with | record_wf hwf_rty hwf_attrs =>
+    simp [
+      ←Map.in_list_iff_find?_some hwf_rty,
+      Map.kvs,
+    ] at hwf_attrs
+    cases hrty : rty with
+    | nil => constructor
+    | cons hd tl =>
+      simp only [hrty] at hwf_attrs hwf_rty
+      constructor
+      · have hwf_hd_snd := hwf_attrs hd.fst hd.snd
+        simp only [List.mem_cons, true_or, forall_const] at hwf_hd_snd
+        cases h : hd.snd with
+        | optional attr_ty =>
+          simp only [h] at hwf_hd_snd
+          cases hwf_hd_snd with | optional_wf hwf_hd_snd =>
+          simp only [
+            wf_ofType_right_inverse_cedarType? hwf hwf_hd_snd,
+            TermType.ofQualifiedType,
+            TermType.cedarType?.qualifiedType?,
+          ]
+          simp only [
+            Option.bind_some_fun, Option.bind_some,
+            Option.some.injEq, Prod.mk.injEq,
+            true_and, QualifiedType.liftBoolTypes,
+          ]
+        | required attr_ty =>
+          simp only [h] at hwf_hd_snd
+          cases hwf_hd_snd with | required_wf hwf_hd_snd =>
+          simp only [
+            TermType.ofQualifiedType,
+            TermType.cedarType?.qualifiedType?,
+            Option.bind_some_fun, Option.bind_some,
+            Option.some.injEq, Prod.mk.injEq,
+            true_and, QualifiedType.liftBoolTypes,
+          ]
+          unfold TermType.cedarType?.qualifiedType?
+          split
+          case _ heq =>
+            unfold TermType.ofType at heq
+            split at heq
+            all_goals contradiction
+          case _ heq =>
+            simp [wf_ofType_right_inverse_cedarType? hwf hwf_hd_snd]
+      · apply ofRecordType_forall₂
+        constructor
+        · exact Map.wf_implies_tail_wf hwf_rty
+        · intros attr qty hmem_tl
+          apply hwf_attrs
+          simp only [List.mem_cons]
+          apply Or.inr
+          apply (Map.in_list_iff_find?_some (Map.wf_implies_tail_wf hwf_rty)).mpr
+          exact hmem_tl
+  termination_by sizeOf rty
+  decreasing_by
+    any_goals
+      calc
+        sizeOf attr_ty < sizeOf hd.snd := by simp [*]
+        _ < sizeOf hd := by
+          cases hd
+          simp
+          omega
+        _ < sizeOf (hd :: tl) := by
+          simp
+          omega
+        _ = sizeOf rty := by
+          simp [*]
+    simp [*]
+    omega
+
+theorem ofEnv_request_is_wf
+  {Γ : Environment}
+  (hwf : Γ.WellFormed) :
+  (SymEnv.ofEnv Γ).request.WellFormed
+    (SymEnv.ofEnv Γ).entities
+:= by
+  simp only [
+    SymEnv.ofEnv,
+    SymRequest.ofRequestType,
+    SymRequest.WellFormed,
+    TermType.ofType,
+  ]
+  have ⟨hwf_princ, hwf_act, hwf_res, hwf_ctx⟩ := wf_env_implies_wf_request hwf
+  and_intros
+  -- Principal well-formed
+  · constructor
+    constructor
+    exact ofEnv_wf_entity hwf hwf_princ
+  -- Principal well-typed
+  · simp only [Term.typeOf, TermType.isEntityType]
+  -- Action well-formed
+  · constructor
+    constructor
+    have := ofEnv_preserves_action_entity hwf hwf_act
+    simp only [SymEnv.ofEnv] at this
+    simp only [SymEntities.isValidEntityUID, this]
+    have ⟨m, hm⟩ := ofActionType_contains_act hwf hwf_act
+    simp only [hm]
+  -- Action well-typed
+  · simp only [Term.typeOf, TermPrim.typeOf, TermType.isEntityType]
+  -- Resource well-formed
+  · constructor
+    constructor
+    exact ofEnv_wf_entity hwf hwf_res
+  -- Resource well-typed
+  · simp only [Term.typeOf, TermType.isEntityType]
+  -- Context well-formed
+  · constructor
+    exact ofType_wf hwf hwf_ctx
+  -- Context well-typed
+  · simp [Term.typeOf, TermType.isCedarRecordType]
+    have := wf_ofType_right_inverse_cedarType? hwf hwf_ctx
+    simp only [TermType.ofType] at this
+    simp [this, CedarType.liftBoolTypes]
+
+theorem ofEnv_request_is_basic
+  {Γ : Environment} :
+  (SymEnv.ofEnv Γ).request.IsBasic
+:= by
+  simp [
+    SymEnv.ofEnv,
+    SymRequest.ofRequestType,
+    SymRequest.IsBasic,
+    Term.isBasic,
+    Term.isLiteral,
+  ]
+
+theorem ofEnv_request_is_swf
+  {Γ : Environment}
+  (hwf : Γ.WellFormed) :
+  (SymEnv.ofEnv Γ).request.StronglyWellFormed
+    (SymEnv.ofEnv Γ).entities
+:= by
+  simp only [SymRequest.StronglyWellFormed]
+  constructor
+  exact ofEnv_request_is_wf hwf
+  exact ofEnv_request_is_basic
+
+theorem ofEnv_entities_is_swf
+  {Γ : Environment}
+  (hwf : Γ.WellFormed) :
+  (SymEnv.ofEnv Γ).entities.StronglyWellFormed
+:= by
+  sorry
+
+/--
+Main well-formedness theorem for `SymEnv.ofEnv`,
+which says that if the input environment `Γ` is well-formed,
+then `SymEnv.ofEnv Γ` is strongly well-formed.
+-/
+theorem ofEnv_is_swf
+  {Γ : Environment}
+  (hwf : Γ.WellFormed) :
+  (SymEnv.ofEnv Γ).StronglyWellFormed
+:= by
+  simp only [SymEnv.StronglyWellFormed]
+  constructor
+  exact ofEnv_request_is_swf hwf
+  exact ofEnv_entities_is_swf hwf
 
 end Cedar.Thm

--- a/cedar-lean/Cedar/Thm/SymCC/Env/ofEnv.lean
+++ b/cedar-lean/Cedar/Thm/SymCC/Env/ofEnv.lean
@@ -43,21 +43,50 @@ theorem ofEnv_preserves_entity
   case _ => contradiction
 
 theorem map_make_append_find_disjoint
-  [BEq α] [LT α] [DecidableLT α] [SizeOf α] [SizeOf β]
+  [LT α] [StrictLT α] [DecidableEq α] [DecidableLT α]
+  [SizeOf α] [SizeOf β]
   {l₁ : List (α × β)} {l₂ : List (α × β)} {k : α}
   (hfind₁ : l₁.find? (λ ⟨k', _⟩ => k' == k) = none)
   (hfind₂ : (l₂.find? (λ ⟨k', _⟩ => k' == k)).isSome) :
   ∃ v,
     (Map.make (l₁ ++ l₂)).find? k = some v ∧
     (k, v) ∈ l₂
-:= sorry
-
-theorem mem_eraseDups
-  [BEq α]
-  {xs : List α} {x : α}
-  {hmem : x ∈ xs} :
-  x ∈ xs.eraseDups
-:= sorry
+:= by
+  have hwf : (Map.make (l₁ ++ l₂)).WellFormed := by
+    exact Map.make_wf _
+  have hsub :
+    (Map.make (l₁ ++ l₂)).kvs ⊆ l₁ ++ l₂
+  := by
+    apply List.canonicalize_subseteq
+  simp [Subset, List.Subset] at hsub
+  have ⟨v, hv⟩ :
+    ∃ v, (Map.make (l₁ ++ l₂)).find? k = some v
+  := by
+    simp only [Option.isSome] at hfind₂
+    split at hfind₂
+    rotate_left
+    contradiction
+    rename_i kv hkv
+    exists kv.snd
+    apply Map.find?_implies_make_find?
+    simp [List.find?_append]
+    apply Or.inr
+    constructor
+    · simp only [List.find?_eq_none, beq_iff_eq, Prod.forall] at hfind₁
+      exact hfind₁
+    have := List.find?_some hkv
+    simp only [beq_iff_eq] at this
+    simp only [hkv]
+    simp [←this]
+  simp only [hv, Option.some.injEq, exists_eq_left']
+  have := Map.find?_mem_toList hv
+  have := hsub k v this
+  cases this with
+  | inl hmem₁ =>
+    have := List.find?_eq_none.mp hfind₁
+    specialize this (k, v) hmem₁
+    simp at this
+  | inr h => exact h
 
 /-- An action entity type is compiled correctly -/
 theorem ofEnv_preserves_action_entity
@@ -112,7 +141,7 @@ theorem ofEnv_preserves_action_entity
     exists uid.ty
     simp only [true_and]
     constructor
-    · apply mem_eraseDups
+    · apply List.mem_implies_mem_eraseDups
       apply List.mem_map.mpr
       have ⟨entry, hmem_entry⟩ := Map.contains_iff_some_find?.mp hmem
       exists (uid, entry)

--- a/cedar-lean/Cedar/Thm/SymCC/Env/ofEnv.lean
+++ b/cedar-lean/Cedar/Thm/SymCC/Env/ofEnv.lean
@@ -663,7 +663,42 @@ theorem ofEnumEntityType_is_wf
     (SymEnv.ofEnv Γ).entities
     ety
     (SymEntityData.ofEnumEntityType ety eids)
-:= sorry
+:= by
+  and_intros
+  all_goals simp only [
+    SymEntityData.ofEnumEntityType,
+    Map.empty, Map.toList, Map.kvs,
+  ]
+  · constructor
+    · intros _ _ h
+      simp [Map.empty, Map.toList, Map.kvs] at h
+    · simp [Map.WellFormed, Map.make, Map.empty, List.canonicalize, Map.toList]
+  · simp only [
+      Map.empty, Term.isLiteral,
+      List.nil.sizeOf_spec, Nat.reduceAdd,
+      List.all_eq_true,
+      Subtype.forall, Prod.forall,
+    ]
+    intros _ _ _ h
+    simp [List.attach₃] at h
+  · simp [Term.typeOf, Map.empty, List.attach₃]
+  · simp [Map.WellFormed, Map.make, Map.empty, List.canonicalize, Map.toList]
+  · intros _ _ h
+    contradiction
+  · simp only [UnaryFunction.argType, SymEntityData.emptyAttrs, TermType.ofType]
+  · simp [
+      UnaryFunction.outType, SymEntityData.emptyAttrs,
+      TermType.ofType, TermType.isCedarRecordType,
+      Map.empty, TermType.cedarType?, List.mapM₃,
+      List.attach₃,
+    ]
+  · intros _ _ h
+    simp [Map.empty, Map.toList, Map.kvs, Map.find?] at h
+  · simp [Map.WellFormed, Map.make, Map.empty, List.canonicalize, Map.toList]
+  · intros _ h
+    contradiction
+  · have ⟨_, h⟩ := wf_env_implies_wf_entity_entry hwf hfind
+    simp [h]
 
 theorem ofEntityType_is_wf
   {ety : EntityType} {Γ : Environment} {entry : EntitySchemaEntry}

--- a/cedar-lean/Cedar/Thm/SymCC/Env/ofEnv.lean
+++ b/cedar-lean/Cedar/Thm/SymCC/Env/ofEnv.lean
@@ -986,12 +986,47 @@ theorem ofEnv_entities_is_wf
       simp only [←heq, ←heq_es, heq_ety]
       exact ofActionType_is_wf hwf this
 
+theorem ofEnv_is_wf
+  {Γ : Environment}
+  (hwf : Γ.WellFormed) :
+  (SymEnv.ofEnv Γ).WellFormed
+:= by
+  simp only [SymEnv.WellFormed]
+  constructor
+  · exact (ofEnv_request_is_swf hwf).1
+  · exact ofEnv_entities_is_wf hwf
+
+theorem ofEnv_entities_is_acyclic
+  {Γ : Environment}
+  (hwf : Γ.WellFormed) :
+  (SymEnv.ofEnv Γ).entities.Acyclic
+:= by
+  sorry
+
+theorem ofEnv_entities_is_transitive
+  {Γ : Environment}
+  (hwf : Γ.WellFormed) :
+  (SymEnv.ofEnv Γ).entities.Transitive
+:= by
+  sorry
+
+theorem ofEnv_entities_is_partitioned
+  {Γ : Environment}
+  (hwf : Γ.WellFormed) :
+  (SymEnv.ofEnv Γ).entities.Partitioned
+:= by
+  sorry
+
 theorem ofEnv_entities_is_hierarchical
   {Γ : Environment}
   (hwf : Γ.WellFormed) :
   (SymEnv.ofEnv Γ).entities.Hierarchical
 := by
-  sorry
+  constructor
+  · exact ofEnv_entities_is_acyclic hwf
+  constructor
+  · exact ofEnv_entities_is_transitive hwf
+  · exact ofEnv_entities_is_partitioned hwf
 
 theorem ofEnv_entities_is_swf
   {Γ : Environment}

--- a/cedar-lean/Cedar/Thm/Validation/Typechecker/WF.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Typechecker/WF.lean
@@ -306,4 +306,28 @@ theorem wf_env_implies_wf_ets_map
   have ⟨hwf_ets, _, _⟩ := hwf
   exact hwf_ets.1
 
+theorem wf_env_implies_wf_ancestor
+  {env : Environment} {entry : EntitySchemaEntry}
+  {ety : EntityType} {anc : EntityType}
+  (hwf : env.WellFormed)
+  (hfind : env.ets.find? ety = some entry)
+  (hanc : anc ∈ entry.ancestors) :
+  EntityType.WellFormed env anc
+:= by
+  have ⟨hwf_ets, _⟩ := hwf
+  have hwf_entry := hwf_ets.2 ety entry hfind
+  cases entry with
+  | standard entry =>
+    simp only [EntitySchemaEntry.WellFormed] at hwf_entry
+    have := hwf_entry.2.1
+    have ⟨_, hanc_entry, _⟩ := this anc hanc
+    apply Or.inl
+    simp only [EntitySchema.contains, hanc_entry, Option.isSome]
+  | enum es =>
+    simp [
+      EntitySchemaEntry.ancestors, Membership.mem,
+      Set.elts, Set.empty,
+    ] at hanc
+    contradiction
+
 end Cedar.Validation

--- a/cedar-lean/Cedar/Thm/Validation/Typechecker/WF.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Typechecker/WF.lean
@@ -290,4 +290,20 @@ theorem wf_env_implies_wf_request
     simp [Set.contains, hwf_res, Membership.mem]
   · simp [hwf_ctx, hwf_ctx_ty]
 
+theorem wf_env_implies_wf_acts_map
+  {env : Environment}
+  (hwf : env.WellFormed) :
+  Map.WellFormed env.acts
+:= by
+  have ⟨_, hwf_acts, _⟩ := hwf
+  exact hwf_acts.1
+
+theorem wf_env_implies_wf_ets_map
+  {env : Environment}
+  (hwf : env.WellFormed) :
+  Map.WellFormed env.ets
+:= by
+  have ⟨hwf_ets, _, _⟩ := hwf
+  exact hwf_ets.1
+
 end Cedar.Validation

--- a/cedar-lean/Cedar/Thm/Validation/Typechecker/WF.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Typechecker/WF.lean
@@ -306,6 +306,15 @@ theorem wf_env_implies_wf_ets_map
   have ⟨hwf_ets, _, _⟩ := hwf
   exact hwf_ets.1
 
+theorem wf_env_implies_wf_entity_entry
+  {env : Environment} {ety : EntityType} {entry : EntitySchemaEntry}
+  (hwf : env.WellFormed)
+  (hfind : env.ets.find? ety = some entry) :
+  entry.WellFormed env
+:= by
+  have ⟨hwf_ets, _⟩ := hwf
+  exact hwf_ets.2 ety entry hfind
+
 theorem wf_env_implies_wf_ancestor
   {env : Environment} {entry : EntitySchemaEntry}
   {ety : EntityType} {anc : EntityType}

--- a/cedar-lean/Cedar/Thm/Validation/Typechecker/WF.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Typechecker/WF.lean
@@ -315,6 +315,35 @@ theorem wf_env_implies_wf_entity_entry
   have ⟨hwf_ets, _⟩ := hwf
   exact hwf_ets.2 ety entry hfind
 
+theorem wf_env_implies_wf_action_entity_entry
+  {env : Environment} {uid : EntityUID} {entry : ActionSchemaEntry}
+  (hwf : env.WellFormed)
+  (hfind : env.acts.find? uid = some entry) :
+  entry.WellFormed env
+:= by
+  have ⟨_, hwf_acts, _⟩ := hwf
+  exact hwf_acts.2.1 uid entry hfind
+
+/-- Ancestor of an action entity should also be an action entity -/
+theorem wf_env_implies_wf_action_entity_ancestor
+  {env : Environment} {uid : EntityUID} {anc : EntityUID}
+  {entry : ActionSchemaEntry}
+  (hwf : env.WellFormed)
+  (hfind : env.acts.find? uid = some entry)
+  (hanc : anc ∈ entry.ancestors) :
+  ∃ anc_entry,
+    env.acts.find? anc = some anc_entry ∧
+    anc_entry.WellFormed env
+:= by
+  have ⟨_, _, _, _, _, hwf_anc, _⟩ := wf_env_implies_wf_action_entity_entry hwf hfind
+  have := hwf_anc anc hanc
+  simp only [ActionSchema.contains, Option.isSome] at this
+  split at this
+  · rename_i h
+    simp only [h, Option.some.injEq, exists_eq_left']
+    exact wf_env_implies_wf_action_entity_entry hwf h
+  contradiction
+
 theorem wf_env_implies_wf_ancestor
   {env : Environment} {entry : EntitySchemaEntry}
   {ety : EntityType} {anc : EntityType}

--- a/cedar-lean/README.md
+++ b/cedar-lean/README.md
@@ -92,7 +92,9 @@ Sound level-based entity slicing ([`Cedar/Thm/Validation/Levels.lean`](Cedar/Thm
 Sound and complete symbolic compilation ([`Cedar/Thm/SymbolicCompilation.lean`](Cedar/Thm/SymbolicCompilation.lean))
 
 * Compiling an expression results in an SMT term that both overapproximates (soundness) and underapproximates (completeness) the semantics of that expression.
+* Symbolic compilation always succeeds on a well-typed Cedar expression and produces a well-formed and well-typed term.
 
 Sound and complete verification ([`Cedar/Thm/Verification.lean`](Cedar/Thm/Verification.lean))
 
 * Verification checks (such as equivalence, implication, etc.) based on the symbolic compiler are sound (no false negatives) and complete (no false positives).
+


### PR DESCRIPTION
This PR proves these theorems (`Cedar/Thm/SymCC/Env/ofEnv.lean`):
```
theorem ofEnv_is_wf
  {Γ : Environment}
  (hwf : Γ.WellFormed) :
  (SymEnv.ofEnv Γ).WellFormed

theorem ofEnv_wf_for_expr
  {Γ : Environment} {tx : TypedExpr}
  (hwf : Γ.WellFormed)
  (hwt : TypedExpr.WellTyped Γ tx) :
  (SymEnv.ofEnv Γ).WellFormedFor tx.toExpr
```

and it also improves the theorem `compile_well_typed` from a previous PR #646 to the following statement (replacing `(SymEnv.ofEnv Γ).WellFormedFor (tx.toExpr)` by `Γ.WellFormed`)
```
theorem compile_well_typed {tx : TypedExpr} {Γ : Environment} :
  Γ.WellFormed →
  TypedExpr.WellTyped Γ tx →
  ∃ t : Term,
    compile tx.toExpr (SymEnv.ofEnv Γ) = .ok t ∧
    t.WellFormed (SymEnv.ofEnv Γ).entities ∧
    t.typeOf = .option (TermType.ofType tx.typeOf)
```

This PR is dependent on two previous unmerged PRs #658 and #659, so it's not ready for merging yet; but it is ready for review.

Thank you!