### PR TITLE
Adds a fix to fuzz target generation for mismatched authorization errors during corpus generation.

### DIFF
--- a/cedar-drt/fuzz/fuzz_targets/abac-type-directed.rs
+++ b/cedar-drt/fuzz/fuzz_targets/abac-type-directed.rs
@@ -83,7 +83,7 @@ impl<'a> Arbitrary<'a> for FuzzTargetInput {
                 .map_err(|e| Error::SchemaError(e))?;
         let actions = validator_schema
             .action_entities()
-            .map_err(|_| Error::EntitiesError("Error fetching action entities".into()))?;
+            .map_err(|e| Error::EntitiesError(format!("Error fetching action entities: {e}")))?;
         let entities = entities
             .add_entities(
                 actions.into_iter().map(|e| std::sync::Arc::new(e)),
@@ -91,7 +91,7 @@ impl<'a> Arbitrary<'a> for FuzzTargetInput {
                 cedar_policy_core::entities::TCComputation::AssumeAlreadyComputed,
                 cedar_policy_core::extensions::Extensions::all_available(),
             )
-            .map_err(|_| Error::EntitiesError("Error adding action entities to entities".into()))?;
+            .map_err(|e| Error::EntitiesError(format!("Error adding action entities to entities: {e}")))?;
         Ok(Self {
             schema,
             entities,

--- a/cedar-drt/fuzz/fuzz_targets/abac-type-directed.rs
+++ b/cedar-drt/fuzz/fuzz_targets/abac-type-directed.rs
@@ -91,7 +91,9 @@ impl<'a> Arbitrary<'a> for FuzzTargetInput {
                 cedar_policy_core::entities::TCComputation::AssumeAlreadyComputed,
                 cedar_policy_core::extensions::Extensions::all_available(),
             )
-            .map_err(|e| Error::EntitiesError(format!("Error adding action entities to entities: {e}")))?;
+            .map_err(|e| {
+                Error::EntitiesError(format!("Error adding action entities to entities: {e}"))
+            })?;
         Ok(Self {
             schema,
             entities,

--- a/cedar-drt/fuzz/fuzz_targets/abac-type-directed.rs
+++ b/cedar-drt/fuzz/fuzz_targets/abac-type-directed.rs
@@ -78,6 +78,20 @@ impl<'a> Arbitrary<'a> for FuzzTargetInput {
         ];
         let all_entities = Entities::try_from(hierarchy).map_err(|_| Error::NotEnoughData)?;
         let entities = drop_some_entities(all_entities, u)?;
+        let validator_schema =
+            cedar_policy_core::validator::ValidatorSchema::try_from(schema.clone())
+                .map_err(|e| Error::SchemaError(e))?;
+        let actions = validator_schema
+            .action_entities()
+            .map_err(|_| Error::EntitiesError("Error fetching action entities".into()))?;
+        let entities = entities
+            .add_entities(
+                actions.into_iter().map(|e| std::sync::Arc::new(e)),
+                None::<&cedar_policy_core::validator::CoreSchema>,
+                cedar_policy_core::entities::TCComputation::AssumeAlreadyComputed,
+                cedar_policy_core::extensions::Extensions::all_available(),
+            )
+            .map_err(|_| Error::EntitiesError("Error adding action entities to entities".into()))?;
         Ok(Self {
             schema,
             entities,

--- a/cedar-drt/fuzz/fuzz_targets/abac.rs
+++ b/cedar-drt/fuzz/fuzz_targets/abac.rs
@@ -85,7 +85,7 @@ impl<'a> Arbitrary<'a> for FuzzTargetInput {
                 .map_err(|e| Error::SchemaError(e))?;
         let actions = validator_schema
             .action_entities()
-            .map_err(|_| Error::EntitiesError("Error fetching action entities".into()))?;
+            .map_err(|e| Error::EntitiesError(format!("Error fetching action entities: {e}")))?;
         let entities = entities
             .add_entities(
                 actions.into_iter().map(|e| std::sync::Arc::new(e)),
@@ -93,7 +93,7 @@ impl<'a> Arbitrary<'a> for FuzzTargetInput {
                 cedar_policy_core::entities::TCComputation::AssumeAlreadyComputed,
                 cedar_policy_core::extensions::Extensions::all_available(),
             )
-            .map_err(|_| Error::EntitiesError("Error adding action entities to entities".into()))?;
+            .map_err(|e| Error::EntitiesError(format!("Error adding action entities to entities: {e}")))?;
 
         Ok(Self {
             schema,

--- a/cedar-drt/fuzz/fuzz_targets/abac.rs
+++ b/cedar-drt/fuzz/fuzz_targets/abac.rs
@@ -22,7 +22,8 @@ use cedar_policy_core::authorizer::Authorizer;
 use cedar_policy_core::entities::Entities;
 use cedar_policy_generators::{
     abac::{ABACPolicy, ABACRequest},
-    hierarchy::{Hierarchy, HierarchyGenerator},
+    err::Error,
+    hierarchy::HierarchyGenerator,
     schema::Schema,
     settings::ABACSettings,
 };
@@ -37,7 +38,7 @@ pub struct FuzzTargetInput {
     /// generated schema
     pub schema: Schema,
     /// generated hierarchy
-    pub hierarchy: Hierarchy,
+    pub entities: Entities,
     /// generated policy
     pub policy: ABACPolicy,
     /// the requests to try for this hierarchy and policy. We try 8 requests per
@@ -77,9 +78,26 @@ impl<'a> Arbitrary<'a> for FuzzTargetInput {
             schema.arbitrary_request(&hierarchy, u)?,
             schema.arbitrary_request(&hierarchy, u)?,
         ];
+
+        let entities = Entities::try_from(hierarchy).map_err(|_| Error::NotEnoughData)?;
+        let validator_schema =
+            cedar_policy_core::validator::ValidatorSchema::try_from(schema.clone())
+                .map_err(|e| Error::SchemaError(e))?;
+        let actions = validator_schema
+            .action_entities()
+            .map_err(|_| Error::EntitiesError("Error fetching action entities".into()))?;
+        let entities = entities
+            .add_entities(
+                actions.into_iter().map(|e| std::sync::Arc::new(e)),
+                None::<&cedar_policy_core::validator::CoreSchema>,
+                cedar_policy_core::entities::TCComputation::AssumeAlreadyComputed,
+                cedar_policy_core::extensions::Extensions::all_available(),
+            )
+            .map_err(|_| Error::EntitiesError("Error adding action entities to entities".into()))?;
+
         Ok(Self {
             schema,
-            hierarchy,
+            entities,
             policy,
             requests,
         })
@@ -108,47 +126,46 @@ impl<'a> Arbitrary<'a> for FuzzTargetInput {
 fuzz_target!(|input: FuzzTargetInput| {
     initialize_log();
     let def_impl = LeanDefinitionalEngine::new();
-    if let Ok(entities) = Entities::try_from(input.hierarchy) {
-        let mut policyset = ast::PolicySet::new();
-        let policy: ast::StaticPolicy = input.policy.into();
-        policyset.add_static(policy.clone()).unwrap();
-        debug!("Policies: {policyset}");
-        debug!("Entities: {entities}");
-        let requests = input
-            .requests
-            .into_iter()
-            .map(Into::into)
-            .collect::<Vec<_>>();
+    let entities = input.entities;
+    let mut policyset = ast::PolicySet::new();
+    let policy: ast::StaticPolicy = input.policy.into();
+    policyset.add_static(policy.clone()).unwrap();
+    debug!("Policies: {policyset}");
+    debug!("Entities: {entities}");
+    let requests = input
+        .requests
+        .into_iter()
+        .map(Into::into)
+        .collect::<Vec<_>>();
 
-        for request in requests.iter().cloned() {
-            debug!("Request: {request}");
-            let (_, total_dur) =
-                time_function(|| run_auth_test(&def_impl, request, &policyset, &entities));
-            info!("{}{}", TOTAL_MSG, total_dur.as_nanos());
-        }
-        if let Ok(test_name) = std::env::var("DUMP_TEST_NAME") {
-            // When the corpus is re-parsed, the policy will be given id "policy0".
-            // Recreate the policy set and compute responses here to account for this.
-            let mut policyset = ast::PolicySet::new();
-            let policy = policy.new_id(ast::PolicyID::from_string("policy0"));
-            policyset.add_static(policy).unwrap();
-            let responses = requests
-                .iter()
-                .map(|request| {
-                    let authorizer = Authorizer::new();
-                    authorizer.is_authorized(request.clone(), &policyset, &entities)
-                })
-                .collect::<Vec<_>>();
-            let dump_dir = std::env::var("DUMP_TEST_DIR").unwrap_or_else(|_| ".".to_string());
-            dump(
-                dump_dir,
-                &test_name,
-                &input.schema.into(),
-                &policyset,
-                &entities,
-                std::iter::zip(requests, responses),
-            )
-            .expect("failed to dump test case");
-        }
+    for request in requests.iter().cloned() {
+        debug!("Request: {request}");
+        let (_, total_dur) =
+            time_function(|| run_auth_test(&def_impl, request, &policyset, &entities));
+        info!("{}{}", TOTAL_MSG, total_dur.as_nanos());
+    }
+    if let Ok(test_name) = std::env::var("DUMP_TEST_NAME") {
+        // When the corpus is re-parsed, the policy will be given id "policy0".
+        // Recreate the policy set and compute responses here to account for this.
+        let mut policyset = ast::PolicySet::new();
+        let policy = policy.new_id(ast::PolicyID::from_string("policy0"));
+        policyset.add_static(policy).unwrap();
+        let responses = requests
+            .iter()
+            .map(|request| {
+                let authorizer = Authorizer::new();
+                authorizer.is_authorized(request.clone(), &policyset, &entities)
+            })
+            .collect::<Vec<_>>();
+        let dump_dir = std::env::var("DUMP_TEST_DIR").unwrap_or_else(|_| ".".to_string());
+        dump(
+            dump_dir,
+            &test_name,
+            &input.schema.into(),
+            &policyset,
+            &entities,
+            std::iter::zip(requests, responses),
+        )
+        .expect("failed to dump test case");
     }
 });

--- a/cedar-drt/fuzz/fuzz_targets/abac.rs
+++ b/cedar-drt/fuzz/fuzz_targets/abac.rs
@@ -93,7 +93,9 @@ impl<'a> Arbitrary<'a> for FuzzTargetInput {
                 cedar_policy_core::entities::TCComputation::AssumeAlreadyComputed,
                 cedar_policy_core::extensions::Extensions::all_available(),
             )
-            .map_err(|e| Error::EntitiesError(format!("Error adding action entities to entities: {e}")))?;
+            .map_err(|e| {
+                Error::EntitiesError(format!("Error adding action entities to entities: {e}"))
+            })?;
 
         Ok(Self {
             schema,

--- a/cedar-drt/fuzz/fuzz_targets/entity-slicing-drt-type-directed.rs
+++ b/cedar-drt/fuzz/fuzz_targets/entity-slicing-drt-type-directed.rs
@@ -92,7 +92,9 @@ impl<'a> Arbitrary<'a> for FuzzTargetInput {
                 cedar_policy_core::entities::TCComputation::AssumeAlreadyComputed,
                 cedar_policy_core::extensions::Extensions::all_available(),
             )
-            .map_err(|e| Error::EntitiesError(format!("Error adding action entities to entities: {e}")))?;
+            .map_err(|e| {
+                Error::EntitiesError(format!("Error adding action entities to entities: {e}"))
+            })?;
 
         Ok(Self {
             schema,

--- a/cedar-drt/fuzz/fuzz_targets/entity-slicing-drt-type-directed.rs
+++ b/cedar-drt/fuzz/fuzz_targets/entity-slicing-drt-type-directed.rs
@@ -84,7 +84,7 @@ impl<'a> Arbitrary<'a> for FuzzTargetInput {
                 .map_err(|e| Error::SchemaError(e))?;
         let actions = validator_schema
             .action_entities()
-            .map_err(|_| Error::EntitiesError("Error fetching action entities".into()))?;
+            .map_err(|e| Error::EntitiesError(format!("Error fetching action entities: {e}")))?;
         let entities = entities
             .add_entities(
                 actions.into_iter().map(|e| std::sync::Arc::new(e)),
@@ -92,7 +92,7 @@ impl<'a> Arbitrary<'a> for FuzzTargetInput {
                 cedar_policy_core::entities::TCComputation::AssumeAlreadyComputed,
                 cedar_policy_core::extensions::Extensions::all_available(),
             )
-            .map_err(|_| Error::EntitiesError("Error adding action entities to entities".into()))?;
+            .map_err(|e| Error::EntitiesError(format!("Error adding action entities to entities: {e}")))?;
 
         Ok(Self {
             schema,

--- a/cedar-drt/fuzz/fuzz_targets/eval-type-directed.rs
+++ b/cedar-drt/fuzz/fuzz_targets/eval-type-directed.rs
@@ -78,7 +78,7 @@ impl<'a> Arbitrary<'a> for FuzzTargetInput {
                 .map_err(|e| Error::SchemaError(e))?;
         let actions = validator_schema
             .action_entities()
-            .map_err(|_| Error::EntitiesError("Error fetching action entities".into()))?;
+            .map_err(|e| Error::EntitiesError(format!("Error fetching action entities: {e}")))?;
         let entities = entities
             .add_entities(
                 actions.into_iter().map(|e| std::sync::Arc::new(e)),
@@ -86,7 +86,7 @@ impl<'a> Arbitrary<'a> for FuzzTargetInput {
                 cedar_policy_core::entities::TCComputation::AssumeAlreadyComputed,
                 cedar_policy_core::extensions::Extensions::all_available(),
             )
-            .map_err(|_| Error::EntitiesError("Error adding action entities to entities".into()))?;
+            .map_err(|e| Error::EntitiesError(format!("Error adding action entities to entities: {e}")))?;
 
         Ok(Self {
             schema,

--- a/cedar-drt/fuzz/fuzz_targets/eval-type-directed.rs
+++ b/cedar-drt/fuzz/fuzz_targets/eval-type-directed.rs
@@ -86,7 +86,9 @@ impl<'a> Arbitrary<'a> for FuzzTargetInput {
                 cedar_policy_core::entities::TCComputation::AssumeAlreadyComputed,
                 cedar_policy_core::extensions::Extensions::all_available(),
             )
-            .map_err(|e| Error::EntitiesError(format!("Error adding action entities to entities: {e}")))?;
+            .map_err(|e| {
+                Error::EntitiesError(format!("Error adding action entities to entities: {e}"))
+            })?;
 
         Ok(Self {
             schema,

--- a/cedar-drt/fuzz/fuzz_targets/protobuf-roundtrip.rs
+++ b/cedar-drt/fuzz/fuzz_targets/protobuf-roundtrip.rs
@@ -83,7 +83,9 @@ impl<'a> Arbitrary<'a> for FuzzTargetInput {
                 cedar_policy_core::entities::TCComputation::AssumeAlreadyComputed,
                 cedar_policy_core::extensions::Extensions::all_available(),
             )
-            .map_err(|e| Error::EntitiesError(format!("Error adding action entities to entities: {e}")))?;
+            .map_err(|e| {
+                Error::EntitiesError(format!("Error adding action entities to entities: {e}"))
+            })?;
 
         Ok(Self {
             request,

--- a/cedar-drt/fuzz/fuzz_targets/protobuf-roundtrip.rs
+++ b/cedar-drt/fuzz/fuzz_targets/protobuf-roundtrip.rs
@@ -29,7 +29,7 @@ use cedar_policy_core::{
     extensions::Extensions,
 };
 use cedar_policy_generators::{
-    abac::ABACPolicy, abac::ABACRequest, hierarchy::HierarchyGenerator, schema::Schema,
+    abac::ABACPolicy, abac::ABACRequest, err::Error, hierarchy::HierarchyGenerator, schema::Schema,
     settings::ABACSettings,
 };
 
@@ -71,13 +71,25 @@ impl<'a> Arbitrary<'a> for FuzzTargetInput {
         )
         .expect("Failed to create entities");
 
+        let schema = cedar_policy_core::validator::ValidatorSchema::try_from(schema.clone())
+            .map_err(|e| Error::SchemaError(e))?;
+        let actions = schema
+            .action_entities()
+            .map_err(|_| Error::EntitiesError("Error fetching action entities".into()))?;
+        let entities = entities
+            .add_entities(
+                actions.into_iter().map(|e| std::sync::Arc::new(e)),
+                None::<&cedar_policy_core::validator::CoreSchema>,
+                cedar_policy_core::entities::TCComputation::AssumeAlreadyComputed,
+                cedar_policy_core::extensions::Extensions::all_available(),
+            )
+            .map_err(|_| Error::EntitiesError("Error adding action entities to entities".into()))?;
+
         Ok(Self {
             request,
             policy,
             entities,
-            schema: schema
-                .try_into()
-                .expect("Failed to convert schema to ValidatorSchema"),
+            schema,
         })
     }
 

--- a/cedar-drt/fuzz/fuzz_targets/protobuf-roundtrip.rs
+++ b/cedar-drt/fuzz/fuzz_targets/protobuf-roundtrip.rs
@@ -75,7 +75,7 @@ impl<'a> Arbitrary<'a> for FuzzTargetInput {
             .map_err(|e| Error::SchemaError(e))?;
         let actions = schema
             .action_entities()
-            .map_err(|_| Error::EntitiesError("Error fetching action entities".into()))?;
+            .map_err(|e| Error::EntitiesError(format!("Error fetching action entities: {e}")))?;
         let entities = entities
             .add_entities(
                 actions.into_iter().map(|e| std::sync::Arc::new(e)),
@@ -83,7 +83,7 @@ impl<'a> Arbitrary<'a> for FuzzTargetInput {
                 cedar_policy_core::entities::TCComputation::AssumeAlreadyComputed,
                 cedar_policy_core::extensions::Extensions::all_available(),
             )
-            .map_err(|_| Error::EntitiesError("Error adding action entities to entities".into()))?;
+            .map_err(|e| Error::EntitiesError(format!("Error adding action entities to entities: {e}")))?;
 
         Ok(Self {
             request,


### PR DESCRIPTION
Changes fuzz target generation for targets that may dump a cedar-test-json format (e.g., may be used for corpus generation) to ensure that the generated `Entities` always includes actions generated during `Schema` generation.

This fixes an error in which action entities were not considered when calculating the expected authorization decision but were considered when actually performing an integration test (causing an assertion violation during corpus generation).