### PR TITLE
Add an action to test corpus generatrion for both abac and abac-type-directed fuzz-targets.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,13 @@ jobs:
       cedar_spec_ref: ${{ github.ref }}
       cedar_policy_ref: ${{ needs.get-branch-name.outputs.branch_name }}
 
+  test_corpus_generation:
+    needs: get-branch-name
+    uses: ./.github/workflows/corpus_generation_test_reusable.yml
+    with:
+      cedar_spec_ref: ${{ github.ref }}
+      cedar_policy_ref: ${{ needs.get-branch-name.outputs.branch_name }}
+
   build_and_test_ffi:
     needs: get-branch-name
     uses: ./.github/workflows/build_and_test_ffi_reusable.yml

--- a/.github/workflows/corpus_generation_test_reusable.yml
+++ b/.github/workflows/corpus_generation_test_reusable.yml
@@ -1,0 +1,102 @@
+name: Test Corpus Generation
+on:
+  workflow_call:
+    inputs:
+      cedar_spec_ref:
+        required: false
+        default: "main"
+        type: string
+      cedar_policy_ref:
+        required: false
+        default: "main"
+        type: string
+
+jobs:
+  abac_generation:
+    name: Test Corpus Generation (ABAC)
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        toolchain:
+          - stable
+    steps:
+      - name: 
+      - name: Checkout cedar-spec
+        uses: actions/checkout@v4
+        with:
+          repository: cedar-policy/cedar-spec
+          ref: ${{ inputs.cedar_spec_ref }}
+          path: ./cedar-spec
+      - name: checkout cedar
+        uses: actions/checkout@v4
+        with:
+          repository: cedar-policy/cedar
+          path: ./cedar-spec/cedar
+          ref: ${{ inputs.cedar_policy_ref }}
+      - name: Setup Cargo config for local Cedar
+        working-directory: ./cedar-spec/cedar-lean-ffi
+        run: |
+          mkdir -p .cargo
+          cat > .cargo/config.toml << EOF
+          [patch.crates-io]
+          cedar-policy = { path = "../cedar/cedar-policy" }
+          EOF
+      - name: Install Lean
+        shell: bash
+        run: |
+              wget https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh
+              bash elan-init.sh -y
+      - name: Install protoc
+        run: sudo apt-get install protobuf-compiler
+      - name: Prepare Rust build
+        run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
+      - name: Build Lean libraries
+        working-directory: ./cedar-spec/cedar-lean
+        run: source ~/.profile && ../cedar-drt/build_lean_lib.sh
+      - name: Generate Corpus (ABAC)
+        working-directory: ./cedar-spec/cedar-drt
+        run: source ~/.profile && source set_env_vars.sh && FUZZ_TARGET=abac ./create_corpus.sh
+  abac_type_directed_generation:
+    name: Test Corpus Generation (ABAC Type Directed)
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        toolchain:
+          - stable
+    steps:
+      - name: 
+      - name: Checkout cedar-spec
+        uses: actions/checkout@v4
+        with:
+          repository: cedar-policy/cedar-spec
+          ref: ${{ inputs.cedar_spec_ref }}
+          path: ./cedar-spec
+      - name: checkout cedar
+        uses: actions/checkout@v4
+        with:
+          repository: cedar-policy/cedar
+          path: ./cedar-spec/cedar
+          ref: ${{ inputs.cedar_policy_ref }}
+      - name: Setup Cargo config for local Cedar
+        working-directory: ./cedar-spec/cedar-lean-ffi
+        run: |
+          mkdir -p .cargo
+          cat > .cargo/config.toml << EOF
+          [patch.crates-io]
+          cedar-policy = { path = "../cedar/cedar-policy" }
+          EOF
+      - name: Install Lean
+        shell: bash
+        run: |
+              wget https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh
+              bash elan-init.sh -y
+      - name: Install protoc
+        run: sudo apt-get install protobuf-compiler
+      - name: Prepare Rust build
+        run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
+      - name: Build Lean libraries
+        working-directory: ./cedar-spec/cedar-lean
+        run: source ~/.profile && ../cedar-drt/build_lean_lib.sh
+      - name: Generate Corpus (ABAC Type Directed)
+        working-directory: ./cedar-spec/cedar-drt
+        run: source ~/.profile && source set_env_vars.sh && FUZZ_TARGET=abac-type-directed ./create_corpus.sh

--- a/.github/workflows/corpus_generation_test_reusable.yml
+++ b/.github/workflows/corpus_generation_test_reusable.yml
@@ -20,7 +20,6 @@ jobs:
         toolchain:
           - stable
     steps:
-      - name: 
       - name: Checkout cedar-spec
         uses: actions/checkout@v4
         with:
@@ -64,7 +63,6 @@ jobs:
         toolchain:
           - stable
     steps:
-      - name: 
       - name: Checkout cedar-spec
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/corpus_generation_test_reusable.yml
+++ b/.github/workflows/corpus_generation_test_reusable.yml
@@ -56,7 +56,7 @@ jobs:
         run: source ~/.profile && ../cedar-drt/build_lean_lib.sh
       - name: Generate Corpus (ABAC)
         working-directory: ./cedar-spec/cedar-drt
-        run: source ~/.profile && source set_env_vars.sh && FUZZ_TARGET=abac ./create_corpus.sh
+        run: source ~/.profile && source set_env_vars.sh && TIMEOUT=5 FUZZ_TARGET=abac ./create_corpus.sh
   abac_type_directed_generation:
     name: Test Corpus Generation (ABAC Type Directed)
     runs-on: ubuntu-latest
@@ -101,4 +101,4 @@ jobs:
         run: source ~/.profile && ../cedar-drt/build_lean_lib.sh
       - name: Generate Corpus (ABAC Type Directed)
         working-directory: ./cedar-spec/cedar-drt
-        run: source ~/.profile && source set_env_vars.sh && FUZZ_TARGET=abac-type-directed ./create_corpus.sh
+        run: source ~/.profile && source set_env_vars.sh && TIMEOUT=5 FUZZ_TARGET=abac-type-directed ./create_corpus.sh

--- a/.github/workflows/corpus_generation_test_reusable.yml
+++ b/.github/workflows/corpus_generation_test_reusable.yml
@@ -49,6 +49,8 @@ jobs:
         run: sudo apt-get install protobuf-compiler
       - name: Prepare Rust build
         run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
+      - name: Install cargo-fuzz
+        run: cargo install cargo-fuzz
       - name: Build Lean libraries
         working-directory: ./cedar-spec/cedar-lean
         run: source ~/.profile && ../cedar-drt/build_lean_lib.sh
@@ -92,6 +94,8 @@ jobs:
         run: sudo apt-get install protobuf-compiler
       - name: Prepare Rust build
         run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
+      - name: Install cargo-fuzz
+        run: cargo install cargo-fuzz
       - name: Build Lean libraries
         working-directory: ./cedar-spec/cedar-lean
         run: source ~/.profile && ../cedar-drt/build_lean_lib.sh


### PR DESCRIPTION
Adds actions to CI to ensure that changes to cedar-spec do not cause corpus generation to fail.

The action performs corpus generation (using the default of 15 minutes for fuzzing) for both the `abac` and `abac-type-directed` fuzzing targets. Currently these are the only targets that can be used to generate a testing corpus (i.e., these are the only fuzz-targets that include a call to `dump`).

The new CI actions are unlikely to pass until PRs #663 and #665 are merged.