### PR TITLE
 [3.4.x] Avoid repeatedly parsing trivial policies in rbac-authorizer target

### DIFF
--- a/cedar-drt/fuzz/fuzz_targets/rbac-authorizer.rs
+++ b/cedar-drt/fuzz/fuzz_targets/rbac-authorizer.rs
@@ -15,12 +15,12 @@
  */
 
 #![no_main]
+use cedar_drt::ast::PolicyID;
 use cedar_drt::*;
 use cedar_drt_inner::*;
 use cedar_policy_core::ast;
 use cedar_policy_core::entities::Entities;
 use cedar_policy_core::extensions::Extensions;
-use cedar_policy_core::parser;
 use libfuzzer_sys::arbitrary::{self, Arbitrary};
 use serde::Serialize;
 
@@ -46,38 +46,57 @@ enum AbstractPolicy {
     ForbidError,
 }
 
+mod concrete_policies {
+    use cedar_policy_core::{ast, parser};
+    use std::sync::LazyLock;
+
+    pub static PERMIT_TRUE: LazyLock<ast::StaticPolicy> = LazyLock::new(|| {
+        parser::parse_policy(None, "permit(principal, action, resource);")
+            .expect("should be a valid policy")
+    });
+
+    pub static PERMIT_FALSE: LazyLock<ast::StaticPolicy> = LazyLock::new(|| {
+        parser::parse_policy(None, "permit(principal, action, resource) when { 1 == 0 };")
+            .expect("should be a valid policy")
+    });
+
+    pub static PERMIT_ERROR: LazyLock<ast::StaticPolicy> = LazyLock::new(|| {
+        parser::parse_policy(
+            None,
+            "permit(principal, action, resource) when { 1 < \"hello\" };",
+        )
+        .expect("should be a valid policy")
+    });
+
+    pub static FORBID_TRUE: LazyLock<ast::StaticPolicy> = LazyLock::new(|| {
+        parser::parse_policy(None, "forbid(principal, action, resource);")
+            .expect("should be a valid policy")
+    });
+
+    pub static FORBID_FALSE: LazyLock<ast::StaticPolicy> = LazyLock::new(|| {
+        parser::parse_policy(None, "forbid(principal, action, resource) when { 1 == 0 };")
+            .expect("should be a valid policy")
+    });
+
+    pub static FORBID_ERROR: LazyLock<ast::StaticPolicy> = LazyLock::new(|| {
+        parser::parse_policy(
+            None,
+            "forbid(principal, action, resource) when { 1 < \"hello\" };",
+        )
+        .expect("should be a valid policy")
+    });
+}
+
 impl AbstractPolicy {
     /// Convert the `AbstractPolicy` into a `Policy` with the given `id`
-    fn into_policy(self, id: String) -> ast::StaticPolicy {
+    fn into_policy(self, id: PolicyID) -> ast::StaticPolicy {
         match self {
-            AbstractPolicy::PermitTrue => {
-                parser::parse_policy(Some(id), "permit(principal, action, resource);")
-                    .expect("should be a valid policy")
-            }
-            AbstractPolicy::PermitFalse => parser::parse_policy(
-                Some(id),
-                "permit(principal, action, resource) when { 1 == 0 };",
-            )
-            .expect("should be a valid policy"),
-            AbstractPolicy::PermitError => parser::parse_policy(
-                Some(id),
-                "permit(principal, action, resource) when { 1 < \"hello\" };",
-            )
-            .expect("should be a valid policy"),
-            AbstractPolicy::ForbidTrue => {
-                parser::parse_policy(Some(id), "forbid(principal, action, resource);")
-                    .expect("should be a valid policy")
-            }
-            AbstractPolicy::ForbidFalse => parser::parse_policy(
-                Some(id),
-                "forbid(principal, action, resource) when { 1 == 0 };",
-            )
-            .expect("should be a valid policy"),
-            AbstractPolicy::ForbidError => parser::parse_policy(
-                Some(id),
-                "forbid(principal, action, resource) when { 1 < \"hello\" };",
-            )
-            .expect("should be a valid policy"),
+            AbstractPolicy::PermitTrue => concrete_policies::PERMIT_TRUE.new_id(id),
+            AbstractPolicy::PermitFalse => concrete_policies::PERMIT_FALSE.new_id(id),
+            AbstractPolicy::PermitError => concrete_policies::PERMIT_ERROR.new_id(id),
+            AbstractPolicy::ForbidTrue => concrete_policies::FORBID_TRUE.new_id(id),
+            AbstractPolicy::ForbidFalse => concrete_policies::FORBID_FALSE.new_id(id),
+            AbstractPolicy::ForbidError => concrete_policies::FORBID_ERROR.new_id(id),
         }
     }
 }
@@ -93,7 +112,7 @@ fuzz_target!(|input: AuthorizerInputAbstractEvaluator| {
         .iter()
         .cloned()
         .enumerate()
-        .map(|(i, p)| p.into_policy(format!("policy{i}")));
+        .map(|(i, p)| p.into_policy(PolicyID::from_string(format!("policy{i}"))));
     let mut policyset = ast::PolicySet::new();
     for policy in policies {
         policyset.add_static(policy).unwrap();


### PR DESCRIPTION
See #664 


