### PR TITLE
[2.5.x] Limit number of abstract policies generated for `rbac-authorizer`

### DIFF
--- a/cedar-drt/fuzz/fuzz_targets/rbac-authorizer.rs
+++ b/cedar-drt/fuzz/fuzz_targets/rbac-authorizer.rs
@@ -23,10 +23,23 @@ use cedar_policy_core::authorizer::{Authorizer, Diagnostics, Response};
 use cedar_policy_core::entities::Entities;
 use libfuzzer_sys::arbitrary::{self, Arbitrary};
 
-#[derive(Arbitrary, Debug)]
+#[derive(Debug)]
 struct AuthorizerInputAbstractEvaluator {
     /// Set of AbstractPolicy objects
     policies: Vec<AbstractPolicy>,
+}
+
+static MAX_ABSTRACT_POLICIES: usize = 100;
+
+impl<'a> Arbitrary<'a> for AuthorizerInputAbstractEvaluator {
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        Ok(Self {
+            policies: u
+                .arbitrary_iter()?
+                .take(MAX_ABSTRACT_POLICIES)
+                .collect::<Result<_, _>>()?,
+        })
+    }
 }
 
 #[derive(Arbitrary, Debug, PartialEq, Eq, Clone)]


### PR DESCRIPTION
Our nightly tests for the 2.5.x release branch regularly find slow units for `rbac-authorizer` when given input using ~400 abstract policies. I assume that testing with this many  of policies doesn't meaningfully increase the assurance of our tests over limiting it to something like 100.

I'm not going to apply this patch to the 3.4.x, 4.5.x, or main branches because these do not have slow units on this target, though it wouldn't be an unreasonable change