### PR TITLE
Batched evaluation algorithm (without proofs)

### DIFF
--- a/cedar-lean/Cedar/Data/List.lean
+++ b/cedar-lean/Cedar/Data/List.lean
@@ -96,6 +96,14 @@ def mapM₃ {m : Type u → Type v} [Monad m] {γ : Type u} [SizeOf α] [SizeOf 
 def mapUnion {α β} [Union α] [EmptyCollection α] (f : β → α) (bs : List β) : α :=
   bs.foldl (λ a b => a ∪ f b) ∅
 
+def mapUnion₁ {α β} [Union α] [EmptyCollection α]
+  (xs : List β) (f : {x : β // x ∈ xs} → α) : α :=
+  xs.attach.foldl (λ a b => a ∪ f b) ∅
+
+def mapUnion₂ {α β γ} [Union α] [EmptyCollection α] [SizeOf β] [SizeOf γ]
+  (xs : List (β × γ)) (f : {x : β × γ // sizeOf x.snd < 1 + sizeOf xs} → α) : α :=
+  xs.attach₂.foldl (λ a b => a ∪ f b) ∅
+
 def isSortedBy {α β} [LT β] [DecidableLT β] (l : List α) (f : α → β) : Bool :=
   match l with
   | [] => true

--- a/cedar-lean/Cedar/Data/Map.lean
+++ b/cedar-lean/Cedar/Data/Map.lean
@@ -15,7 +15,6 @@
 -/
 
 import Cedar.Data.Set
-import Cedar.Data.List
 /-!
 
 This file defines a simple map data types, backed by a sorted duplicate-free
@@ -53,7 +52,7 @@ def toList {α : Type u} {β : Type v} (m : Map α β) : List (Prod α β) := m.
 def insert {α β} [LT α] [DecidableLT α] (m : Map α β) (k : α) (v : β) : Map α β :=
   -- TODO more efficient implementation
   -- right now just rebuilds the map
-  Map.mk (((Prod.mk k v) :: m.kvs).canonicalize Prod.fst)
+  Map.make ((k, v) :: m.kvs)
 
 /-- Returns the keys of `m` as a set. -/
 def keys {α β} (m : Map α β) : Set α :=

--- a/cedar-lean/Cedar/Data/Map.lean
+++ b/cedar-lean/Cedar/Data/Map.lean
@@ -114,6 +114,9 @@ instance decLt [LT (Prod α β)] [DecidableEq (Prod α β)] [DecidableLT (Prod �
 instance : Membership α (Map α β) where
   mem m a := List.Mem a (m.kvs.map Prod.fst)
 
+instance [LT α] [DecidableLT α] : HAppend (Map α β) (Map α β) (Map α β) where
+  hAppend a b := Map.make (a.kvs ++ b.kvs)
+
 end Map
 
 end Cedar.Data

--- a/cedar-lean/Cedar/Data/Map.lean
+++ b/cedar-lean/Cedar/Data/Map.lean
@@ -15,6 +15,7 @@
 -/
 
 import Cedar.Data.Set
+import Cedar.Data.List
 /-!
 
 This file defines a simple map data types, backed by a sorted duplicate-free
@@ -47,6 +48,12 @@ def empty {α β} : Map α β := .mk []
 /-- Returns an ordered and duplicate free list provided the given map is well-formed. -/
 def toList {α : Type u} {β : Type v} (m : Map α β) : List (Prod α β) := m.kvs
 
+
+/-- inserts an element, overwriting any existing element -/
+def insert {α β} [LT α] [DecidableLT α] (m : Map α β) (k : α) (v : β) : Map α β :=
+  -- TODO more efficient implementation
+  -- right now just rebuilds the map
+  Map.mk (((Prod.mk k v) :: m.kvs).canonicalize Prod.fst)
 
 /-- Returns the keys of `m` as a set. -/
 def keys {α β} (m : Map α β) : Set α :=

--- a/cedar-lean/Cedar/Data/Map.lean
+++ b/cedar-lean/Cedar/Data/Map.lean
@@ -48,12 +48,6 @@ def empty {α β} : Map α β := .mk []
 def toList {α : Type u} {β : Type v} (m : Map α β) : List (Prod α β) := m.kvs
 
 
-/-- inserts an element, overwriting any existing element -/
-def insert {α β} [LT α] [DecidableLT α] (m : Map α β) (k : α) (v : β) : Map α β :=
-  -- TODO more efficient implementation
-  -- right now just rebuilds the map
-  Map.make ((k, v) :: m.kvs)
-
 /-- Returns the keys of `m` as a set. -/
 def keys {α β} (m : Map α β) : Set α :=
   Set.mk (m.kvs.map Prod.fst) -- well-formed by construction

--- a/cedar-lean/Cedar/TPE.lean
+++ b/cedar-lean/Cedar/TPE.lean
@@ -17,3 +17,4 @@
 import Cedar.TPE.Input
 import Cedar.TPE.Residual
 import Cedar.TPE.Evaluator
+import Cedar.TPE.BatchedEvaluator

--- a/cedar-lean/Cedar/TPE/BatchedEvaluator.lean
+++ b/cedar-lean/Cedar/TPE/BatchedEvaluator.lean
@@ -37,7 +37,7 @@ def Residual.allLiteralUIDs (x : Residual) : Set EntityUID :=
   | .error _e                          => Set.empty
   | .var _ _                           => Set.empty
   | .ite x₁ x₂ x₃ _      =>
-    x₁.allLiteralUIDs ∪ x₂.allLiteralUIDs ∪ x₃.allLiteralUIDs
+    Residual.allLiteralUIDs x₁ ∪ Residual.allLiteralUIDs x₂ ∪ Residual.allLiteralUIDs x₃
   | .and x₁ x₂ _         =>
     Residual.allLiteralUIDs x₁ ∪ Residual.allLiteralUIDs x₂
   | .or x₁ x₂ _          =>
@@ -82,7 +82,7 @@ partial def batchedEvalLoop
   let toLoad := (Residual.allLiteralUIDs residual).filter (λ uid => (store.find? uid).isNone)
   let newEntities := loader toLoad
   let newStore := Map.make (newEntities.kvs ++ store.kvs)
-  let newRes := Cedar.TPE.evaluate residual req.asPartialRequest newStore
+  let newRes := Cedar.TPE.evaluate residual (Request.asPartialRequest req) newStore
 
   match newRes with
   | .val v _ty => .ok v

--- a/cedar-lean/Cedar/TPE/BatchedEvaluator.lean
+++ b/cedar-lean/Cedar/TPE/BatchedEvaluator.lean
@@ -56,16 +56,12 @@ def Residual.allLiteralUIDs (x : Residual) : Set EntityUID :=
     x.mapUnion₁ (λ ⟨v, _⟩ => Residual.allLiteralUIDs v)
 termination_by sizeOf x
 decreasing_by
-  repeat case _ =>
-    simp [*]; try omega
-  . rename_i h
-    let so := List.sizeOf_lt_of_mem h
+  any_goals
     simp
-    omega
-  . rename_i h
-    simp at *
-    omega
-  . rename_i h
+    try simp at *
+    try omega
+  all_goals
+    rename_i h
     let so := List.sizeOf_lt_of_mem h
     simp at *
     omega

--- a/cedar-lean/Cedar/TPE/BatchedEvaluator.lean
+++ b/cedar-lean/Cedar/TPE/BatchedEvaluator.lean
@@ -37,7 +37,7 @@ def Residual.allLiteralUIDs (x : Residual) : Set EntityUID :=
   | .error _e                          => Set.empty
   | .var _ _                           => Set.empty
   | .ite x₁ x₂ x₃ _      =>
-    Residual.allLiteralUIDs x₁ ∪ Residual.allLiteralUIDs x₂ ∪ Residual.allLiteralUIDs x₃
+    x₁.allLiteralUIDs ∪ x₂.allLiteralUIDs ∪ x₃.allLiteralUIDs
   | .and x₁ x₂ _         =>
     Residual.allLiteralUIDs x₁ ∪ Residual.allLiteralUIDs x₂
   | .or x₁ x₂ _          =>

--- a/cedar-lean/Cedar/TPE/BatchedEvaluator.lean
+++ b/cedar-lean/Cedar/TPE/BatchedEvaluator.lean
@@ -66,6 +66,14 @@ def batchedEvaluate
   -- start the batched evaluation loop
   batchedEvalLoop residual req loader Map.empty
 
+/--
+Create an entity loader for an entity store Entities.
+This is used to model user-provided entity loaders which
+load entities from a backing database.
+
+Given Entities es, the entity loader provides the requested
+entities specified by a set of entity ids.
+-/
 def entityLoaderFor (es: Entities) (uids : Set EntityUID) :=
   Map.make (uids.toList.map (λ uid =>
         match (es.find? uid) with

--- a/cedar-lean/Cedar/TPE/BatchedEvaluator.lean
+++ b/cedar-lean/Cedar/TPE/BatchedEvaluator.lean
@@ -99,10 +99,9 @@ def batchedEvaluate
   (req : Request)
   (loader : EntityLoader)
   : Result Value :=
-  let emptyStore : PartialEntities := Map.mk []
   let residual := Cedar.TPE.evaluate (TypedExpr.toResidual x) (Request.asPartialRequest req) Map.empty
   -- start the batched evaluation loop
-  batchedEvalLoop residual req loader emptyStore
+  batchedEvalLoop residual req loader Map.empty
 
 def entityLoaderFor (es: Entities) (uids : Set EntityUID) :=
   Map.make (uids.toList.map (λ uid =>

--- a/cedar-lean/Cedar/TPE/BatchedEvaluator.lean
+++ b/cedar-lean/Cedar/TPE/BatchedEvaluator.lean
@@ -109,4 +109,4 @@ def entityLoaderFor (es: Entities) (uids : Set EntityUID) :=
         | .some data =>
           (uid, EntityData.asPartial data)
         | .none =>
-          (uid, PartialEntityData.abset)))
+          (uid, PartialEntityData.absent)))

--- a/cedar-lean/Cedar/TPE/BatchedEvaluator.lean
+++ b/cedar-lean/Cedar/TPE/BatchedEvaluator.lean
@@ -1,0 +1,123 @@
+/-
+ Copyright Cedar Contributors
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-/
+
+
+import Cedar.Spec
+import Cedar.Data
+import Cedar.TPE.Residual
+import Cedar.TPE.Evaluator
+import Cedar.TPE.Input
+
+namespace Cedar.TPE
+
+open Cedar.Data
+open Cedar.Spec
+open Cedar.Validation
+
+
+def EntityLoader : Type := Set EntityUID → Map EntityUID PartialEntityData
+
+def Residual.allLiteralUIDs (x : Residual) : Set EntityUID :=
+  match x with
+  | .val v _ty =>
+    match v with
+    | .prim (.entityUID uid) => Set.singleton uid
+    | _ => Set.empty
+  | .error _e =>
+    Set.empty
+  | .var v _ =>
+    -- these cases should not happen, since the request was fully concrete
+    match v with
+    | .principal => Set.empty
+    | .resource  => Set.empty
+    | .action    => Set.empty
+    | .context   => Set.empty
+  | .ite c t e _ => Residual.allLiteralUIDs c ∪ Residual.allLiteralUIDs t ∪ Residual.allLiteralUIDs e
+  | .and a b _   => Residual.allLiteralUIDs a ∪ Residual.allLiteralUIDs b
+  | .or a b _    => Residual.allLiteralUIDs a ∪ Residual.allLiteralUIDs b
+  | .unaryApp _ e _ => Residual.allLiteralUIDs e
+  | .binaryApp _ a b _ => Residual.allLiteralUIDs a ∪ Residual.allLiteralUIDs b
+  | .getAttr e _ _ => Residual.allLiteralUIDs e
+  | .hasAttr e _ _ => Residual.allLiteralUIDs e
+  | .set ls _ => ls.mapUnion₁ (λ ⟨v, _⟩ => Residual.allLiteralUIDs v)
+  | .record m _ => m.mapUnion₂ (λ ⟨⟨_attr, v⟩, _⟩ => Residual.allLiteralUIDs v)
+  | .call _ ls _ => ls.mapUnion₁ (λ ⟨v, _⟩ => Residual.allLiteralUIDs v)
+termination_by sizeOf x
+decreasing_by
+  repeat case _ =>
+    simp [*]; try omega
+  . rename_i h
+    let so := List.sizeOf_lt_of_mem h
+    simp
+    omega
+  . rename_i h
+    simp at *
+    omega
+  . rename_i h
+    let so := List.sizeOf_lt_of_mem h
+    simp at *
+    omega
+
+
+/--
+The batched evaluation loop
+  1. Asks for any new entities referenced by the residual
+  2. Partially evaluates now that new entities are loaded
+  3. Exits if a value has been found
+-/
+partial def batchedEvalLoop
+  (residual : Residual)
+  (req : Request)
+  (loader : EntityLoader)
+  (store : PartialEntities)
+  : Result Value :=
+  let toLoad := (Residual.allLiteralUIDs residual).filter (λ uid => (store.find? uid).isNone)
+  let newEntities := loader toLoad
+  let newStore := newEntities.kvs.foldl (λ acc ed => acc.insert ed.1 ed.2) store
+  let newRes := Cedar.TPE.evaluate residual (Request.asPartialRequest req) newStore
+
+  match newRes with
+  | .val v _ty => .ok v
+  | _ =>
+    batchedEvalLoop newRes req loader newStore
+
+
+/--
+Evaluate a cedar expression using an EntityLoader
+instead of a full Entities store.
+This algorithm minimizes the number of calls to the EntityLoader using partial evaluation.
+-/
+def batchedEvaluate
+  (x : TypedExpr)
+  (req : Request)
+  (loader : EntityLoader)
+  : Result Value :=
+  let emptyStore : PartialEntities := Map.mk []
+  let residual := TypedExpr.toResidual x
+  -- an initial partial evaluation, removing all variables
+  let residual₂ := Cedar.TPE.evaluate residual (Request.asPartialRequest req) emptyStore
+  -- start the batched evaluation loop
+  batchedEvalLoop residual₂ req loader emptyStore
+
+def entityLoaderFor : (e: Entities) -> EntityLoader :=
+  fun e =>
+   fun uids =>
+    Map.make (uids.toList.map (fun uid =>
+      match (e.find? uid) with
+      | .some data =>
+        (uid, EntityData.asPartial data)
+      | .none =>
+        (uid, PartialEntityData.MissingEntity)))

--- a/cedar-lean/Cedar/TPE/BatchedEvaluator.lean
+++ b/cedar-lean/Cedar/TPE/BatchedEvaluator.lean
@@ -32,23 +32,28 @@ abbrev EntityLoader := Set EntityUID → Map EntityUID PartialEntityData
 
 def Residual.allLiteralUIDs (x : Residual) : Set EntityUID :=
   match x with
-  | .val v _ty =>
-    match v with
-    | .prim (.entityUID uid) => Set.singleton uid
-    | _ => Set.empty
-  | .error _e =>
-    Set.empty
-  | .var _ _ => Set.empty
-  | .ite x₁ x₂ x₃ _ => Residual.allLiteralUIDs x₁ ∪ Residual.allLiteralUIDs x₂ ∪ Residual.allLiteralUIDs x₃
-  | .and x₁ x₂ _   => Residual.allLiteralUIDs x₁ ∪ Residual.allLiteralUIDs x₂
-  | .or x₁ x₂ _    => Residual.allLiteralUIDs x₁ ∪ Residual.allLiteralUIDs x₂
-  | .unaryApp _ x _ => Residual.allLiteralUIDs x
-  | .binaryApp _ x₁ x₂ _ => Residual.allLiteralUIDs x₁ ∪ Residual.allLiteralUIDs x₂
-  | .getAttr x _ _ => Residual.allLiteralUIDs x
-  | .hasAttr x _ _ => Residual.allLiteralUIDs x
-  | .set x _ => x.mapUnion₁ (λ ⟨v, _⟩ => Residual.allLiteralUIDs v)
-  | .record x _ => x.mapUnion₂ (λ ⟨⟨_attr, v⟩, _⟩ => Residual.allLiteralUIDs v)
-  | .call _ x _ => x.mapUnion₁ (λ ⟨v, _⟩ => Residual.allLiteralUIDs v)
+  | .val (.prim (.entityUID uid)) _ty  => Set.singleton uid
+  | .val _ _                           => Set.empty
+  | .error _e                          => Set.empty
+  | .var _ _                           => Set.empty
+  | .ite x₁ x₂ x₃ _      =>
+    Residual.allLiteralUIDs x₁ ∪ Residual.allLiteralUIDs x₂ ∪ Residual.allLiteralUIDs x₃
+  | .and x₁ x₂ _         =>
+    Residual.allLiteralUIDs x₁ ∪ Residual.allLiteralUIDs x₂
+  | .or x₁ x₂ _          =>
+    Residual.allLiteralUIDs x₁ ∪ Residual.allLiteralUIDs x₂
+  | .unaryApp _ x _      =>
+    Residual.allLiteralUIDs x
+  | .binaryApp _ x₁ x₂ _ =>
+    Residual.allLiteralUIDs x₁ ∪ Residual.allLiteralUIDs x₂
+  | .getAttr x _ _       => Residual.allLiteralUIDs x
+  | .hasAttr x _ _       => Residual.allLiteralUIDs x
+  | .set x _             =>
+    x.mapUnion₁ (λ ⟨v, _⟩ => Residual.allLiteralUIDs v)
+  | .record x _          =>
+    x.mapUnion₂ (λ ⟨⟨_attr, v⟩, _⟩ => Residual.allLiteralUIDs v)
+  | .call _ x _          =>
+    x.mapUnion₁ (λ ⟨v, _⟩ => Residual.allLiteralUIDs v)
 termination_by sizeOf x
 decreasing_by
   repeat case _ =>

--- a/cedar-lean/Cedar/TPE/BatchedEvaluator.lean
+++ b/cedar-lean/Cedar/TPE/BatchedEvaluator.lean
@@ -44,8 +44,8 @@ partial def batchedEvalLoop
   : Result Value :=
   let toLoad := residual.allLiteralUIDs.filter (λ uid => (store.find? uid).isNone)
   let newEntities := loader toLoad
-  let newStore := Map.make (newEntities.kvs ++ store.kvs)
-  let newRes := Cedar.TPE.evaluate residual (Request.asPartialRequest req) newStore
+  let newStore := newEntities ++ store
+  let newRes := Cedar.TPE.evaluate residual req.asPartialRequest newStore
 
   match newRes with
   | .val v _ty => .ok v
@@ -62,7 +62,7 @@ def batchedEvaluate
   (req : Request)
   (loader : EntityLoader)
   : Result Value :=
-  let residual := Cedar.TPE.evaluate (TypedExpr.toResidual x) (Request.asPartialRequest req) Map.empty
+  let residual := Cedar.TPE.evaluate (TypedExpr.toResidual x) req.asPartialRequest Map.empty
   -- start the batched evaluation loop
   batchedEvalLoop residual req loader Map.empty
 

--- a/cedar-lean/Cedar/TPE/BatchedEvaluator.lean
+++ b/cedar-lean/Cedar/TPE/BatchedEvaluator.lean
@@ -99,7 +99,7 @@ def batchedEvaluate
   (req : Request)
   (loader : EntityLoader)
   : Result Value :=
-  let residual := Cedar.TPE.evaluate x.toResidual req.asPartialRequest Map.empty
+  let residual := Cedar.TPE.evaluate (TypedExpr.toResidual x) (Request.asPartialRequest req) Map.empty
   -- start the batched evaluation loop
   batchedEvalLoop residual req loader Map.empty
 

--- a/cedar-lean/Cedar/TPE/BatchedEvaluator.lean
+++ b/cedar-lean/Cedar/TPE/BatchedEvaluator.lean
@@ -99,7 +99,7 @@ def batchedEvaluate
   (req : Request)
   (loader : EntityLoader)
   : Result Value :=
-  let residual := Cedar.TPE.evaluate (TypedExpr.toResidual x) (Request.asPartialRequest req) Map.empty
+  let residual := Cedar.TPE.evaluate x.toResidual req.asPartialRequest Map.empty
   -- start the batched evaluation loop
   batchedEvalLoop residual req loader Map.empty
 

--- a/cedar-lean/Cedar/TPE/BatchedEvaluator.lean
+++ b/cedar-lean/Cedar/TPE/BatchedEvaluator.lean
@@ -62,7 +62,7 @@ def batchedEvaluate
   (req : Request)
   (loader : EntityLoader)
   : Result Value :=
-  let residual := Cedar.TPE.evaluate (TypedExpr.toResidual x) req.asPartialRequest Map.empty
+  let residual := Cedar.TPE.evaluate x.toResidual req.asPartialRequest Map.empty
   -- start the batched evaluation loop
   batchedEvalLoop residual req loader Map.empty
 
@@ -78,6 +78,6 @@ def entityLoaderFor (es: Entities) (uids : Set EntityUID) :=
   Map.make (uids.toList.map (λ uid =>
         match (es.find? uid) with
         | .some data =>
-          (uid, EntityData.asPartial data)
+          (uid, data.asPartial)
         | .none =>
           (uid, PartialEntityData.absent)))

--- a/cedar-lean/Cedar/TPE/BatchedEvaluator.lean
+++ b/cedar-lean/Cedar/TPE/BatchedEvaluator.lean
@@ -82,7 +82,7 @@ partial def batchedEvalLoop
   let toLoad := (Residual.allLiteralUIDs residual).filter (λ uid => (store.find? uid).isNone)
   let newEntities := loader toLoad
   let newStore := Map.make (newEntities.kvs ++ store.kvs)
-  let newRes := Cedar.TPE.evaluate residual (Request.asPartialRequest req) newStore
+  let newRes := Cedar.TPE.evaluate residual req.asPartialRequest newStore
 
   match newRes with
   | .val v _ty => .ok v

--- a/cedar-lean/Cedar/TPE/BatchedEvaluator.lean
+++ b/cedar-lean/Cedar/TPE/BatchedEvaluator.lean
@@ -28,7 +28,7 @@ open Cedar.Spec
 open Cedar.Validation
 
 
-def EntityLoader : Type := Set EntityUID → Map EntityUID PartialEntityData
+abbrev EntityLoader := Set EntityUID → Map EntityUID PartialEntityData
 
 def Residual.allLiteralUIDs (x : Residual) : Set EntityUID :=
   match x with
@@ -38,23 +38,17 @@ def Residual.allLiteralUIDs (x : Residual) : Set EntityUID :=
     | _ => Set.empty
   | .error _e =>
     Set.empty
-  | .var v _ =>
-    -- these cases should not happen, since the request was fully concrete
-    match v with
-    | .principal => Set.empty
-    | .resource  => Set.empty
-    | .action    => Set.empty
-    | .context   => Set.empty
-  | .ite c t e _ => Residual.allLiteralUIDs c ∪ Residual.allLiteralUIDs t ∪ Residual.allLiteralUIDs e
-  | .and a b _   => Residual.allLiteralUIDs a ∪ Residual.allLiteralUIDs b
-  | .or a b _    => Residual.allLiteralUIDs a ∪ Residual.allLiteralUIDs b
-  | .unaryApp _ e _ => Residual.allLiteralUIDs e
-  | .binaryApp _ a b _ => Residual.allLiteralUIDs a ∪ Residual.allLiteralUIDs b
-  | .getAttr e _ _ => Residual.allLiteralUIDs e
-  | .hasAttr e _ _ => Residual.allLiteralUIDs e
-  | .set ls _ => ls.mapUnion₁ (λ ⟨v, _⟩ => Residual.allLiteralUIDs v)
-  | .record m _ => m.mapUnion₂ (λ ⟨⟨_attr, v⟩, _⟩ => Residual.allLiteralUIDs v)
-  | .call _ ls _ => ls.mapUnion₁ (λ ⟨v, _⟩ => Residual.allLiteralUIDs v)
+  | .var _ _ => Set.empty
+  | .ite x₁ x₂ x₃ _ => Residual.allLiteralUIDs x₁ ∪ Residual.allLiteralUIDs x₂ ∪ Residual.allLiteralUIDs x₃
+  | .and x₁ x₂ _   => Residual.allLiteralUIDs x₁ ∪ Residual.allLiteralUIDs x₂
+  | .or x₁ x₂ _    => Residual.allLiteralUIDs x₁ ∪ Residual.allLiteralUIDs x₂
+  | .unaryApp _ x _ => Residual.allLiteralUIDs x
+  | .binaryApp _ x₁ x₂ _ => Residual.allLiteralUIDs x₁ ∪ Residual.allLiteralUIDs x₂
+  | .getAttr x _ _ => Residual.allLiteralUIDs x
+  | .hasAttr x _ _ => Residual.allLiteralUIDs x
+  | .set x _ => x.mapUnion₁ (λ ⟨v, _⟩ => Residual.allLiteralUIDs v)
+  | .record x _ => x.mapUnion₂ (λ ⟨⟨_attr, v⟩, _⟩ => Residual.allLiteralUIDs v)
+  | .call _ x _ => x.mapUnion₁ (λ ⟨v, _⟩ => Residual.allLiteralUIDs v)
 termination_by sizeOf x
 decreasing_by
   repeat case _ =>

--- a/cedar-lean/Cedar/TPE/Evaluator.lean
+++ b/cedar-lean/Cedar/TPE/Evaluator.lean
@@ -240,8 +240,6 @@ decreasing_by
     omega
 
 
-
-
 open Cedar.Spec Cedar.Validation
 
 /-- Partially evaluating a policy.

--- a/cedar-lean/Cedar/TPE/Evaluator.lean
+++ b/cedar-lean/Cedar/TPE/Evaluator.lean
@@ -217,29 +217,6 @@ decreasing_by
     try simp at h
     omega
 
-
-def TypedExpr.toResidual : TypedExpr → Residual
-  | .lit p ty => .val (.prim p) ty
-  | .var v ty => .var v ty
-  | .ite x₁ x₂ x₃ ty => .ite (TypedExpr.toResidual x₁) (TypedExpr.toResidual x₂) (TypedExpr.toResidual x₃) ty
-  | .and a b ty => .and (TypedExpr.toResidual a) (TypedExpr.toResidual b) ty
-  | .or a b ty => .or (TypedExpr.toResidual a) (TypedExpr.toResidual b) ty
-  | .unaryApp op expr ty => .unaryApp op (TypedExpr.toResidual expr) ty
-  | .binaryApp op a b ty => .binaryApp op (TypedExpr.toResidual a) (TypedExpr.toResidual b) ty
-  | .getAttr expr attr ty => .getAttr (TypedExpr.toResidual expr) attr ty
-  | .hasAttr expr attr ty => .hasAttr (TypedExpr.toResidual expr) attr ty
-  | .set ls ty => .set (ls.map₁ (λ ⟨e, _⟩ => TypedExpr.toResidual e)) ty
-  | .record ls ty => .record (ls.attach₂.map (λ ⟨(a, e), _⟩ => (a, TypedExpr.toResidual e))) ty
-  | .call xfn args ty => .call xfn (args.map₁ (λ ⟨e, _⟩ => TypedExpr.toResidual e)) ty
-decreasing_by
-  all_goals (simp_wf ; try omega)
-  all_goals
-    rename_i h
-    try simp at h
-    try replace h := List.sizeOf_lt_of_mem h
-    omega
-
-
 open Cedar.Spec Cedar.Validation
 
 /-- Partially evaluating a policy.
@@ -266,7 +243,7 @@ def evaluatePolicy (schema : Schema)
         do
           let expr := substituteAction env.reqty.action p.toExpr
           let (te, _) ← (typeOf expr ∅ env).mapError Error.invalidPolicy
-          .ok (evaluate (TypedExpr.toResidual te.liftBoolTypes) req es)
+          .ok (evaluate te.liftBoolTypes.toResidual req es)
       else .error .invalidRequestOrEntities
     | .none => .error .invalidEnvironment
 

--- a/cedar-lean/Cedar/TPE/Input.lean
+++ b/cedar-lean/Cedar/TPE/Input.lean
@@ -53,7 +53,7 @@ def Request.asPartialRequest (req : Request) : PartialRequest :=
 -- We don't need type annotations here following the rationale above
 inductive PartialEntityData where
   | present (attrs : Option (Map Attr Value)) (ancestors : Option (Set EntityUID)) (tags : Option (Map Attr Value))
-  | abset
+  | absent
 
 def EntityData.asPartial (data : EntityData) : PartialEntityData :=
   .present (.some data.attrs) (.some data.ancestors) (.some data.tags)
@@ -68,15 +68,15 @@ def PartialEntities.get (es : PartialEntities) (uid : EntityUID) (f : PartialEnt
 
 def PartialEntityData.ancestors : PartialEntityData → Option (Set EntityUID)
   | .present _ ancestors _ => ancestors
-  | .abset => .some Set.empty
+  | .absent => .some Set.empty
 
-def PartialEntityData.tags : PartialEntityData → Option (Map Attr Value)
+def PartialEntityData.tags : PartialEntityData → Option (Map Tag Value)
   | .present _ _ tags => tags
-  | .abset => .some Map.empty
+  | .absent => .some Map.empty
 
 def PartialEntityData.attrs : PartialEntityData → Option (Map Attr Value)
   | .present attrs _ _ => attrs
-  | .abset => .some Map.empty
+  | .absent => .some Map.empty
 
 def PartialEntities.ancestors (es : PartialEntities) (uid : EntityUID) : Option (Set EntityUID) := es.get uid PartialEntityData.ancestors
 

--- a/cedar-lean/Cedar/TPE/Input.lean
+++ b/cedar-lean/Cedar/TPE/Input.lean
@@ -49,13 +49,7 @@ inductive PartialEntityData where
   | present (attrs : Option (Map Attr Value)) (ancestors : Option (Set EntityUID)) (tags : Option (Map Attr Value))
   | absent
 
-def EntityData.asPartial (data : EntityData) : PartialEntityData :=
-  .present (.some data.attrs) (.some data.ancestors) (.some data.tags)
-
 abbrev PartialEntities := Map EntityUID PartialEntityData
-
-def Entities.asPartial (entities: Entities) : PartialEntities :=
-  entities.mapOnValues EntityData.asPartial
 
 def PartialEntities.get (es : PartialEntities) (uid : EntityUID) (f : PartialEntityData → Option α) : Option α :=
   (es.find? uid).bind f
@@ -185,5 +179,17 @@ def Request.asPartialRequest (req : Request) : PartialRequest :=
   , context   := req.context }
 
 
+
+end Cedar.Spec
+
+
+namespace Cedar.Spec
+open Cedar.TPE
+
+def EntityData.asPartial (data : EntityData) : PartialEntityData :=
+  .present (.some data.attrs) (.some data.ancestors) (.some data.tags)
+
+def Entities.asPartial (entities: Entities) : PartialEntities :=
+  entities.mapOnValues EntityData.asPartial
 
 end Cedar.Spec

--- a/cedar-lean/Cedar/TPE/Input.lean
+++ b/cedar-lean/Cedar/TPE/Input.lean
@@ -53,7 +53,7 @@ def Request.asPartialRequest (req : Request) : PartialRequest :=
 -- We don't need type annotations here following the rationale above
 inductive PartialEntityData where
   | present (attrs : Option (Map Attr Value)) (ancestors : Option (Set EntityUID)) (tags : Option (Map Attr Value))
-  | MissingEntity
+  | abset
 
 def EntityData.asPartial (data : EntityData) : PartialEntityData :=
   .present (.some data.attrs) (.some data.ancestors) (.some data.tags)
@@ -68,15 +68,15 @@ def PartialEntities.get (es : PartialEntities) (uid : EntityUID) (f : PartialEnt
 
 def PartialEntityData.ancestors : PartialEntityData → Option (Set EntityUID)
   | .present _ ancestors _ => ancestors
-  | .MissingEntity => .some Set.empty
+  | .abset => .some Set.empty
 
 def PartialEntityData.tags : PartialEntityData → Option (Map Attr Value)
   | .present _ _ tags => tags
-  | .MissingEntity => .some Map.empty
+  | .abset => .some Map.empty
 
 def PartialEntityData.attrs : PartialEntityData → Option (Map Attr Value)
   | .present attrs _ _ => attrs
-  | .MissingEntity => .some Map.empty
+  | .abset => .some Map.empty
 
 def PartialEntities.ancestors (es : PartialEntities) (uid : EntityUID) : Option (Set EntityUID) := es.get uid PartialEntityData.ancestors
 

--- a/cedar-lean/Cedar/TPE/Input.lean
+++ b/cedar-lean/Cedar/TPE/Input.lean
@@ -43,12 +43,6 @@ structure PartialRequest where
   -- (typed) `Residual`
   context   : Option (Map Attr Value)
 
-def Request.asPartialRequest (req : Request) : PartialRequest :=
-  { principal := { ty := req.principal.ty, id := .some req.principal.eid }
-  , action    := req.action
-  , resource  := { ty := req.resource.ty, id := .some req.resource.eid }
-  , context   := req.context }
-
 
 -- We don't need type annotations here following the rationale above
 inductive PartialEntityData where
@@ -174,4 +168,22 @@ where
     else
       .ok ()
 
+
 end Cedar.TPE
+
+namespace Cedar.Spec
+
+open Cedar.Data
+open Cedar.Spec
+open Cedar.Validation
+open Cedar.TPE
+
+def Request.asPartialRequest (req : Request) : PartialRequest :=
+  { principal := { ty := req.principal.ty, id := .some req.principal.eid }
+  , action    := req.action
+  , resource  := { ty := req.resource.ty, id := .some req.resource.eid }
+  , context   := req.context }
+
+
+
+end Cedar.Spec

--- a/cedar-lean/Cedar/TPE/Input.lean
+++ b/cedar-lean/Cedar/TPE/Input.lean
@@ -163,10 +163,9 @@ where
       es₂.kvs.all λ (a₂, e₂) => match es₁.find? a₂ with
         | .some e₁ =>
           let ⟨attrs₁, ancestors₁, tags₁⟩ := e₁
-          let (attrs₂, ancestors₂, tags₂) := (e₂.attrs, e₂.ancestors, e₂.tags)
-          partialIsValid attrs₂ (· = attrs₁) &&
-          partialIsValid ancestors₂ (· = ancestors₁) &&
-          partialIsValid tags₂ (· = tags₁)
+          partialIsValid e₂.attrs (· = attrs₁) &&
+          partialIsValid e₂.ancestors (· = ancestors₁) &&
+          partialIsValid e₂.tags (· = tags₁)
         | .none => false
   envIsWellFormed env : Except ConcretizationError Unit :=
     if !env.validateWellFormed.isOk

--- a/cedar-lean/Cedar/TPE/Residual.lean
+++ b/cedar-lean/Cedar/TPE/Residual.lean
@@ -131,6 +131,45 @@ decreasing_by
     try simp at h
     omega
 
+
+def Residual.allLiteralUIDs (x : Residual) : Set EntityUID :=
+  match x with
+  | .val (.prim (.entityUID uid)) _ty  => Set.singleton uid
+  | .val _ _                           => Set.empty
+  | .error _e                          => Set.empty
+  | .var _ _                           => Set.empty
+  | .ite x₁ x₂ x₃ _      =>
+    x₁.allLiteralUIDs ∪ x₂.allLiteralUIDs ∪ x₃.allLiteralUIDs
+  | .and x₁ x₂ _         =>
+    x₁.allLiteralUIDs ∪ x₂.allLiteralUIDs
+  | .or x₁ x₂ _          =>
+    x₁.allLiteralUIDs ∪ x₂.allLiteralUIDs
+  | .unaryApp _ x _      =>
+    x.allLiteralUIDs
+  | .binaryApp _ x₁ x₂ _ =>
+    x₁.allLiteralUIDs ∪ x₂.allLiteralUIDs
+  | .getAttr x _ _       => Residual.allLiteralUIDs x
+  | .hasAttr x _ _       => Residual.allLiteralUIDs x
+  | .set x _             =>
+    x.mapUnion₁ (λ ⟨v, _⟩ => Residual.allLiteralUIDs v)
+  | .record x _          =>
+    x.mapUnion₂ (λ ⟨⟨_attr, v⟩, _⟩ => Residual.allLiteralUIDs v)
+  | .call _ x _          =>
+    x.mapUnion₁ (λ ⟨v, _⟩ => Residual.allLiteralUIDs v)
+termination_by sizeOf x
+decreasing_by
+  any_goals
+    simp
+    try simp at *
+    try omega
+  all_goals
+    rename_i h
+    let so := List.sizeOf_lt_of_mem h
+    simp at *
+    omega
+
+
+
 mutual
 
 def decResidual (x y : Residual) : Decidable (x = y) := by

--- a/cedar-lean/Cedar/TPE/Residual.lean
+++ b/cedar-lean/Cedar/TPE/Residual.lean
@@ -239,3 +239,32 @@ end
 instance : DecidableEq Residual := decResidual
 
 end Cedar.Spec
+
+namespace Cedar.Validation
+
+open Cedar.Data
+open Cedar.Spec
+
+
+def TypedExpr.toResidual : TypedExpr → Residual
+  | .lit p ty => .val (.prim p) ty
+  | .var v ty => .var v ty
+  | .ite x₁ x₂ x₃ ty => .ite (TypedExpr.toResidual x₁) (TypedExpr.toResidual x₂) (TypedExpr.toResidual x₃) ty
+  | .and a b ty => .and (TypedExpr.toResidual a) (TypedExpr.toResidual b) ty
+  | .or a b ty => .or (TypedExpr.toResidual a) (TypedExpr.toResidual b) ty
+  | .unaryApp op expr ty => .unaryApp op (TypedExpr.toResidual expr) ty
+  | .binaryApp op a b ty => .binaryApp op (TypedExpr.toResidual a) (TypedExpr.toResidual b) ty
+  | .getAttr expr attr ty => .getAttr (TypedExpr.toResidual expr) attr ty
+  | .hasAttr expr attr ty => .hasAttr (TypedExpr.toResidual expr) attr ty
+  | .set ls ty => .set (ls.map₁ (λ ⟨e, _⟩ => TypedExpr.toResidual e)) ty
+  | .record ls ty => .record (ls.attach₂.map (λ ⟨(a, e), _⟩ => (a, TypedExpr.toResidual e))) ty
+  | .call xfn args ty => .call xfn (args.map₁ (λ ⟨e, _⟩ => TypedExpr.toResidual e)) ty
+decreasing_by
+  all_goals (simp_wf ; try omega)
+  all_goals
+    rename_i h
+    try simp at h
+    try replace h := List.sizeOf_lt_of_mem h
+    omega
+
+end Cedar.Validation

--- a/cedar-lean/Cedar/Thm/Data/Map.lean
+++ b/cedar-lean/Cedar/Thm/Data/Map.lean
@@ -757,7 +757,7 @@ theorem in_kvs_in_mapOnValues [LT α] [DecidableLT α] [DecidableEq α] {f : β 
   Given a hypothesis like:
     h: Data.Map.find? es uid = none
   Proves something like:
-    Data.Map.findOrErr es uid Error.entityDoesNotExist
+    Data.Map.findOrErr es uid Error.entityDoesNotExist = .error .entityDoesNotExist
 -/
 theorem find?_none_implies_findorErr_errors [LT α] [DecidableLT α] [DecidableEq α] {m : Map α β} {k : α} (e : Error) :
   m.find? k = none → m.findOrErr k e = .error e

--- a/cedar-lean/Cedar/Thm/Data/Map.lean
+++ b/cedar-lean/Cedar/Thm/Data/Map.lean
@@ -759,11 +759,21 @@ theorem in_kvs_in_mapOnValues [LT α] [DecidableLT α] [DecidableEq α] {f : β 
   Proves something like:
     Data.Map.findOrErr es uid Error.entityDoesNotExist = .error .entityDoesNotExist
 -/
-theorem find?_none_implies_findorErr_errors [LT α] [DecidableLT α] [DecidableEq α] {m : Map α β} {k : α} (e : Error) :
-  m.find? k = none → m.findOrErr k e = .error e
+theorem find?_none_iff_findorErr_errors [LT α] [DecidableLT α] [DecidableEq α] {m : Map α β} {k : α} (e : Error) :
+  m.find? k = none ↔ m.findOrErr k e = .error e
 := by
-  intro h
-  simp only [findOrErr, h]
+  constructor
+  case mp =>
+    intro h
+    simp only [findOrErr, h]
+  case mpr =>
+    intro h₁
+    simp only [findOrErr] at h₁
+    cases h₂: m.find? k
+    case none => simp
+    case some =>
+      rw [h₂] at h₁
+      simp at h₁
 
 /--
   Converse of `in_kvs_in_mapOnValues`; requires the extra preconditions that `m`

--- a/cedar-lean/Cedar/Thm/Data/Map.lean
+++ b/cedar-lean/Cedar/Thm/Data/Map.lean
@@ -752,6 +752,19 @@ theorem in_kvs_in_mapOnValues [LT α] [DecidableLT α] [DecidableEq α] {f : β 
   simp only [kvs, List.mem_map, Prod.mk.injEq]
   exists (k, v)
 
+
+/--
+  Given a hypothesis like:
+    h: Data.Map.find? es uid = none
+  Proves something like:
+    Data.Map.findOrErr es uid Error.entityDoesNotExist
+-/
+theorem find?_none_implies_findorErr_errors [LT α] [DecidableLT α] [DecidableEq α] {m : Map α β} {k : α} (e : Error) :
+  m.find? k = none → m.findOrErr k e = .error e
+:= by
+  intro h
+  simp only [findOrErr, h]
+
 /--
   Converse of `in_kvs_in_mapOnValues`; requires the extra preconditions that `m`
   is `WellFormed` and `f` is injective

--- a/cedar-lean/Cedar/Thm/TPE/Input.lean
+++ b/cedar-lean/Cedar/Thm/TPE/Input.lean
@@ -62,7 +62,7 @@ def RequestRefines (req : Request) (preq : PartialRequest) : Prop :=
 
 def EntitiesRefine (es : Entities) (pes : PartialEntities) : Prop :=
    ∀ a e₂, pes.find? a = some e₂ →
-    ((e₂ = PartialEntityData.abset ∧ (es.find? a = .none)) ∨
+    ((e₂ = PartialEntityData.absent ∧ (es.find? a = .none)) ∨
      (∃ e₁, es.find? a = some e₁ ∧
        PartialIsValid (· = e₁.attrs) e₂.attrs ∧
        PartialIsValid (· = e₁.ancestors) e₂.ancestors  ∧

--- a/cedar-lean/Cedar/Thm/TPE/Input.lean
+++ b/cedar-lean/Cedar/Thm/TPE/Input.lean
@@ -61,10 +61,12 @@ def RequestRefines (req : Request) (preq : PartialRequest) : Prop :=
   PartialIsValid (· = req.context) preq.context
 
 def EntitiesRefine (es : Entities) (pes : PartialEntities) : Prop :=
-   ∀ a e₂, pes.find? a = some e₂ → (∃ e₁, es.find? a = some e₁ ∧
-    PartialIsValid (· = e₁.attrs) e₂.attrs ∧
-    PartialIsValid (· = e₁.ancestors) e₂.ancestors  ∧
-    PartialIsValid (· = e₁.tags) e₂.tags)
+   ∀ a e₂, pes.find? a = some e₂ →
+    ((e₂ = PartialEntityData.MissingEntity ∧ (es.find? a = .none)) ∨
+     (∃ e₁, es.find? a = some e₁ ∧
+       PartialIsValid (· = e₁.attrs) e₂.attrs ∧
+       PartialIsValid (· = e₁.ancestors) e₂.ancestors  ∧
+       PartialIsValid (· = e₁.tags) e₂.tags))
 
 /-- Concrete request `req` and entities `es` refine their partial counterparts
 `peq` and `pes`.
@@ -114,6 +116,7 @@ theorem consistent_checks_ensure_refinement {schema : Schema} {req : Request} {e
     split at h₂ <;> simp at h₂
     rcases h₂ with ⟨⟨h₂₁, h₂₂⟩, h₂₃⟩
     rename_i data₁ heq
+    right
     exists data₁
     constructor
     exact heq

--- a/cedar-lean/Cedar/Thm/TPE/Input.lean
+++ b/cedar-lean/Cedar/Thm/TPE/Input.lean
@@ -62,7 +62,7 @@ def RequestRefines (req : Request) (preq : PartialRequest) : Prop :=
 
 def EntitiesRefine (es : Entities) (pes : PartialEntities) : Prop :=
    ∀ a e₂, pes.find? a = some e₂ →
-    ((e₂ = PartialEntityData.MissingEntity ∧ (es.find? a = .none)) ∨
+    ((e₂ = PartialEntityData.abset ∧ (es.find? a = .none)) ∨
      (∃ e₁, es.find? a = some e₁ ∧
        PartialIsValid (· = e₁.attrs) e₂.attrs ∧
        PartialIsValid (· = e₁.ancestors) e₂.ancestors  ∧

--- a/cedar-lean/Cedar/Thm/TPE/Soundness.lean
+++ b/cedar-lean/Cedar/Thm/TPE/Soundness.lean
@@ -733,8 +733,8 @@ theorem partial_evaluate_is_sound_binary_app
           simp [PartialEntityData.tags] at heq₃
           rw [← heq₃]
           simp [Data.Map.find?, Data.Map.kvs, Data.Map.empty, Residual.evaluate, Except.toOption, Spec.getTag, Entities.tags]
-          have h₆ := Data.Map.find?_none_implies_findorErr_errors Error.entityDoesNotExist h₄₂
-          rw [h₆]
+          rw [Data.Map.find?_none_iff_findorErr_errors] at h₄₂
+          rw [h₄₂]
           simp
         · rw [heq₃] at h₄₂
           cases h₄₂
@@ -860,8 +860,8 @@ theorem partial_evaluate_is_sound_get_attr
       specialize h₄ uid data heq₂
       rcases h₄ with ⟨h₄₁, h₄₂⟩ | ⟨_, h₄₁, h₄₂, _⟩
       · simp [Entities.attrs]
-        have h₆ := Data.Map.find?_none_implies_findorErr_errors Error.entityDoesNotExist h₄₂
-        rw [h₆]
+        rw [Data.Map.find?_none_iff_findorErr_errors] at h₄₂
+        rw [h₄₂]
         simp [Except.toOption]
         rw [h₄₁] at heq₃
         simp [PartialEntityData.attrs] at heq₃

--- a/cedar-lean/Cedar/Thm/TPE/Soundness.lean
+++ b/cedar-lean/Cedar/Thm/TPE/Soundness.lean
@@ -586,14 +586,25 @@ theorem partial_evaluate_is_sound_binary_app
           simp [RequestAndEntitiesRefine, EntitiesRefine] at h₄
           rcases h₄ with ⟨_, h₄⟩
           specialize h₄ uid₁ data heq₅₁
-          rcases h₄ with ⟨_, h₄₁, _, h₄₂, _⟩
-          rw [heq₅₂] at h₄₂
-          cases h₄₂
-          rename_i h₄₂
-          simp [Spec.inₑ, Entities.ancestorsOrEmpty, h₄₁, ←h₄₂]
-          have : (uid₁ == uid₂) = false := by
-            simp only [beq_eq_false_iff_ne, ne_eq, heq₄, not_false_eq_true]
-          simp only [this, Bool.false_or]
+          rcases h₄ with ⟨h₄₁, h₄₂⟩ | ⟨_, h₄₁, _, h₄₂, _⟩
+          · rw [h₄₁] at heq₅₂
+            simp [PartialEntityData.ancestors] at heq₅₂
+            rw [←heq₅₂]
+            simp [Data.Set.empty, Spec.inₑ, BEq.beq]
+            have h_decide_false : decide (uid₁ = uid₂) = false := by
+              apply decide_eq_false
+              exact heq₄
+            rw [h_decide_false]
+            simp [Entities.ancestorsOrEmpty]
+            rw [h₄₂]
+            simp [Data.Set.empty]
+          · rw [heq₅₂] at h₄₂
+            cases h₄₂
+            rename_i h₄₂
+            simp [Spec.inₑ, Entities.ancestorsOrEmpty, h₄₁, ←h₄₂]
+            have : (uid₁ == uid₂) = false := by
+              simp only [beq_eq_false_iff_ne, ne_eq, heq₄, not_false_eq_true]
+            simp only [this, Bool.false_or]
       case _ heq₃ =>
         simp only [Residual.evaluate, Spec.apply₂, Except.bind_ok]
     case _ =>
@@ -652,13 +663,23 @@ theorem partial_evaluate_is_sound_binary_app
               split at h₂ <;> try cases h₂
               rename_i data heq₁
               specialize h₄ uid data heq₁
-              rcases h₄ with ⟨e, h₄, _, h₅, _⟩
-              rw [h₂] at h₅
-              cases h₅
-              rename_i heq₂
-              rw [heq₂] at h₃
-              simp only [Entities.ancestorsOrEmpty, h₄, h₃, Bool.or_eq_right_iff_imp, beq_iff_eq, heq,
-                false_implies]
+              rcases h₄ with ⟨h₄₁, h₄₂⟩ | ⟨e, h₄, _, h₅, _⟩
+              · simp [Entities.ancestorsOrEmpty]
+                rw [h₄₂]
+                simp [Data.Set.empty, Data.Set.contains, Data.Set.elts]
+                rw [h₄₁] at h₂
+                simp [PartialEntityData.ancestors] at h₂
+                rw [←h₂] at h₃
+                simp [Data.Set.empty, Data.Set.contains, Data.Set.elts] at h₃
+                rw [h₃]
+                simp [BEq.beq]
+                exact heq
+              · rw [h₂] at h₅
+                cases h₅
+                rename_i heq₂
+                rw [heq₂] at h₃
+                simp only [Entities.ancestorsOrEmpty, h₄, h₃, Bool.or_eq_right_iff_imp, beq_iff_eq, heq,
+                  false_implies]
           replace heq₃₂ := anyM_some_implies_any (fun x => if uid = x then some true else Option.map (fun y => y.contains x) (pes.ancestors uid))
             (fun x => uid == x || (es.ancestorsOrEmpty uid).contains x) this heq₃₂
           subst heq₃₂
@@ -682,12 +703,19 @@ theorem partial_evaluate_is_sound_binary_app
         simp [RequestAndEntitiesRefine, EntitiesRefine] at h₄
         rcases h₄ with ⟨_, h₄⟩
         specialize h₄ uid data heq₃
-        rcases h₄ with ⟨_, h₄₁, _, _, h₄₂⟩
-        rw [heq₄] at h₄₂
-        cases h₄₂
-        rename_i heq₅
-        subst heq₅
-        simp only [Spec.hasTag, Entities.tagsOrEmpty, h₄₁, Residual.evaluate]
+        rcases h₄ with ⟨h₄₁, h₄₂⟩ | ⟨_, h₄₁, _, _, h₄₂⟩
+        · simp [Spec.hasTag, Entities.tagsOrEmpty]
+          rw [h₄₂]
+          simp [Data.Map.empty, Data.Map.contains, Data.Map.find?, Data.Map.kvs]
+          rw [h₄₁] at heq₄
+          simp [PartialEntityData.tags] at heq₄
+          rw [← heq₄]
+          simp [Data.Map.empty, Except.toOption, Residual.val, Residual.evaluate]
+        · rw [heq₄] at h₄₂
+          cases h₄₂
+          rename_i heq₅
+          subst heq₅
+          simp only [Spec.hasTag, Entities.tagsOrEmpty, h₄₁, Residual.evaluate]
       case _ =>
         simp only [heq₁, heq₂, Residual.evaluate, Spec.apply₂, Except.bind_ok]
     case _ uid _ =>
@@ -700,14 +728,21 @@ theorem partial_evaluate_is_sound_binary_app
         simp [RequestAndEntitiesRefine, EntitiesRefine] at h₄
         rcases h₄ with ⟨_, h₄⟩
         specialize h₄ uid data heq₂
-        rcases h₄ with ⟨_, h₄₁, _, _, h₄₂⟩
-        rw [heq₃] at h₄₂
-        cases h₄₂
-        rename_i heq₄
-        subst heq₄
-        simp only [Spec.getTag, Entities.tags, Data.Map.findOrErr, h₄₁]
-        split <;>
-        (rename_i heq₁; simp [heq₁, Residual.evaluate, Except.toOption])
+        rcases h₄ with ⟨h₄₁, h₄₂⟩ | ⟨_, h₄₁, _, _, h₄₂⟩
+        · rw [h₄₁] at heq₃
+          simp [PartialEntityData.tags] at heq₃
+          rw [← heq₃]
+          simp [Data.Map.find?, Data.Map.kvs, Data.Map.empty, Residual.evaluate, Except.toOption, Spec.getTag, Entities.tags]
+          have h₆ := Data.Map.find?_none_implies_findorErr_errors Error.entityDoesNotExist h₄₂
+          rw [h₆]
+          simp
+        · rw [heq₃] at h₄₂
+          cases h₄₂
+          rename_i heq₄
+          subst heq₄
+          simp only [Spec.getTag, Entities.tags, Data.Map.findOrErr, h₄₁]
+          split <;>
+          (rename_i heq₁; simp [heq₁, Residual.evaluate, Except.toOption])
       case _ =>
         simp only [Residual.evaluate, Spec.apply₂, Except.bind_ok]
     case _ => simp [Except.toOption]
@@ -764,12 +799,17 @@ theorem partial_evaluate_is_sound_has_attr
       simp [RequestAndEntitiesRefine, EntitiesRefine] at h₄
       rcases h₄ with ⟨_, h₄⟩
       specialize h₄ uid data heq₂
-      rcases h₄ with ⟨_, h₄₁, h₄₂, _⟩
-      rw [heq₃] at h₄₂
-      rcases h₄₂
-      rename_i h₄
-      subst h₄
-      simp [Entities.attrsOrEmpty, h₄₁]
+      rcases h₄ with ⟨h₄₁, h₄₂⟩ | ⟨_, h₄₁, h₄₂, _⟩
+      · rw [h₄₁] at heq₃
+        simp [PartialEntityData.attrs] at heq₃
+        simp [Entities.attrsOrEmpty]
+        rw [h₄₂]
+        rw [←heq₃]
+      · rw [heq₃] at h₄₂
+        rcases h₄₂
+        rename_i h₄
+        subst h₄
+        simp [Entities.attrsOrEmpty, h₄₁]
     case _ => cases heq
   case _ =>
     simp [Residual.evaluate]
@@ -818,14 +858,22 @@ theorem partial_evaluate_is_sound_get_attr
       simp [RequestAndEntitiesRefine, EntitiesRefine] at h₄
       rcases h₄ with ⟨_, h₄⟩
       specialize h₄ uid data heq₂
-      rcases h₄ with ⟨_, h₄₁, h₄₂, _⟩
-      rw [heq₃] at h₄₂
-      rcases h₄₂
-      rename_i data' _ h₄
-      subst h₄
-      simp [Entities.attrs, Data.Map.findOrErr, h₄₁]
-      generalize h₄ : data'.attrs.find? attr = res
-      cases res <;> simp [someOrError, Residual.evaluate, Except.toOption]
+      rcases h₄ with ⟨h₄₁, h₄₂⟩ | ⟨_, h₄₁, h₄₂, _⟩
+      · simp [Entities.attrs]
+        have h₆ := Data.Map.find?_none_implies_findorErr_errors Error.entityDoesNotExist h₄₂
+        rw [h₆]
+        simp [Except.toOption]
+        rw [h₄₁] at heq₃
+        simp [PartialEntityData.attrs] at heq₃
+        rw [← heq₃]
+        simp [Data.Map.empty, Data.Map.find?, Data.Map.kvs, someOrError, Residual.evaluate]
+      · rw [heq₃] at h₄₂
+        rcases h₄₂
+        rename_i data' _ h₄
+        subst h₄
+        simp [Entities.attrs, Data.Map.findOrErr, h₄₁]
+        generalize h₄ : data'.attrs.find? attr = res
+        cases res <;> simp [someOrError, Residual.evaluate, Except.toOption]
     case _ => cases heq
   case _ =>
     simp [Residual.evaluate]

--- a/cedar-lean/UnitTest/BatchedEvaluator.lean
+++ b/cedar-lean/UnitTest/BatchedEvaluator.lean
@@ -1,0 +1,136 @@
+/-
+ Copyright Cedar Contributors
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-/
+
+import Cedar.Spec.Evaluator
+import Cedar.TPE.BatchedEvaluator
+import Cedar.Spec.Expr
+import Cedar.Validation.Types
+import Cedar.Data.Map
+import UnitTest.Run
+
+namespace UnitTest.BatchedEvaluator
+
+open Cedar.Spec
+open Cedar.TPE
+open Cedar.Validation
+open Cedar.Data
+
+def ActionType : EntityType := ⟨"Action", []⟩
+def UserType : EntityType := ⟨"User", []⟩
+def DocumentType : EntityType := ⟨"Document", []⟩
+
+def entity_schema : EntitySchema :=
+  Map.make [
+    (ActionType, .standard ⟨default, default, default⟩),
+    (UserType, .standard ⟨default, Map.make [("name", .required .string), ("isAdmin", .required (.bool .anyBool))], (.some (.entity UserType))⟩),
+    (DocumentType, .standard ⟨default, default, default⟩)
+  ]
+
+def action_schema : ActionSchema :=
+  Map.make [
+    (⟨ActionType, "Read"⟩, ⟨
+      Set.singleton UserType,
+      Set.singleton DocumentType,
+      default,
+      default
+    ⟩)
+  ]
+
+def reqty : RequestType := ⟨UserType, ⟨ActionType, "Read"⟩, DocumentType, Map.empty⟩
+def type_env : TypeEnv := ⟨entity_schema, action_schema, reqty⟩
+
+-- Test that evaluate and batched_evaluate produce the same results
+def testBatchedEvaluatorEquivalence (name : String) (expr : Expr) (req : Request) (entities : Entities) (loader : EntityLoader) : TestCase IO :=
+  test name ⟨λ _ => do
+    let regularResult := Cedar.Spec.evaluate expr req entities
+    -- Create a minimal TypeEnv for typechecking
+    match typeOf expr ∅ type_env with
+    | .ok (typedExpr, _) =>
+      let batchedResult := batchedEvaluate typedExpr req loader
+      match (batchedResult, regularResult) with
+      | (.ok br, .ok rr) => checkEq br rr
+      | (.error _, .error _) => (.ok (.ok ()))
+      | _ => checkEq batchedResult regularResult
+    | .error e =>
+      .error s!"Type error: {repr e}"
+  ⟩
+
+-- Translate the first Rust test: test_simple_entity_manifest
+-- Policy: permit(principal, action, resource) when { principal.name == "John" }
+
+def testRequest : Request :=
+  ⟨
+    ⟨UserType, "oliver"⟩,
+    ⟨ActionType, "Read"⟩,
+    ⟨DocumentType, "dummy"⟩,
+    Map.empty
+  ⟩
+
+def testEntities : Entities :=
+  Map.make [
+    (⟨UserType, "oliver"⟩, ⟨Map.make [("name", "Oliver"), ("isAdmin", true)], Set.empty, Map.mk [⟨"friend", (.prim (.entityUID ⟨UserType, "emina"⟩))⟩]⟩),
+    (⟨UserType, "emina"⟩, ⟨Map.make [("name", "emina"), ("isAdmin", true)], Set.empty, Map.empty⟩),
+    (⟨ActionType, "Read"⟩, ⟨Map.empty, Set.empty, Map.empty⟩),
+    (⟨DocumentType, "dummy"⟩, ⟨Map.empty, Set.empty, Map.empty⟩)
+  ]
+
+def testLoader : EntityLoader := entityLoaderFor testEntities
+
+def has_expr_doesnt_eval: Expr := (.binaryApp .hasTag (.lit (.entityUID ⟨UserType, "nonexistent"⟩)) (.lit (.string "randomtag")))
+def delayed_friend_string: Expr := (.ite has_expr_doesnt_eval (.lit (.string "friend")) (.lit (.string "friend")))
+
+def oliver: Expr := (.lit (.entityUID ⟨UserType, "oliver"⟩))
+
+def getTag (e: Expr) (t: Expr) : Expr := (.binaryApp .getTag e t)
+def hasTag (e: Expr) (t: Expr) : Expr := (.binaryApp .hasTag e t)
+
+
+def tests :=
+  suite "BatchedEvaluator equivalence tests"
+  [
+    testBatchedEvaluatorEquivalence
+      "simple entity manifest - principal.name == \"John\""
+      (.binaryApp .eq (.getAttr (.var .principal) "name") (.lit (.string "John")))
+      testRequest
+      testEntities
+      testLoader,
+    -- Second test: empty entity manifest (permit with no conditions)
+    testBatchedEvaluatorEquivalence
+      "empty entity manifest - permit with no conditions"
+      (.lit (.bool true))
+      testRequest
+      testEntities
+      testLoader,
+    testBatchedEvaluatorEquivalence
+     "missing entity - User::\"nonexistent\".name == \"test\""
+      (.binaryApp .eq (.getAttr (.lit (.entityUID ⟨UserType, "nonexistent"⟩)) "name") (.lit (.string "test")))
+      testRequest
+      testEntities
+      testLoader,
+    -- handling has on entity that isn't there
+    testBatchedEvaluatorEquivalence
+      "missing entity has attribute"
+      (.and (hasTag oliver delayed_friend_string) (
+        (.getAttr
+          (getTag oliver delayed_friend_string) "isAdmin")))
+      testRequest
+      testEntities
+      testLoader
+  ]
+
+#eval do TestSuite.runAll [tests]
+
+end UnitTest.BatchedEvaluator

--- a/cedar-lean/UnitTest/TPE.lean
+++ b/cedar-lean/UnitTest/TPE.lean
@@ -213,9 +213,9 @@ def req : PartialRequest :=
 
 def es : PartialEntities :=
   Map.make [
-     (⟨ActionType, "View"⟩, ⟨.some default, .some default, .some default⟩),
-     (⟨ActionType, "Delete"⟩, ⟨.some default, .some default, .some default⟩),
-     (⟨UserType, "Alice"⟩, ⟨.some default, .some default, default⟩)
+     (⟨ActionType, "View"⟩, (.present (.some default) (.some default) (.some default))),
+     (⟨ActionType, "Delete"⟩, (.present (.some default) (.some default) (.some default))),
+     (⟨UserType, "Alice"⟩, (.present (.some default) (.some default) (.some default)))
   ]
 
 def tests :=
@@ -354,8 +354,8 @@ def req : PartialRequest :=
 
 def es : PartialEntities :=
   Map.make [
-     (⟨ActionType, "PickUp"⟩, ⟨.some default, .some default, .some default⟩),
-     (⟨UserType, "Alice"⟩, ⟨.some $ Map.make [("address", .record $ Map.make [("street", "Sesame Street")])], .some default, default⟩)
+     (⟨ActionType, "PickUp"⟩, (.present (.some default) (.some default) (.some default))),
+     (⟨UserType, "Alice"⟩, (.present (.some $ Map.make [("address", .record $ Map.make [("street", "Sesame Street")])]) (.some default) default))
   ]
 
 def tests :=
@@ -419,7 +419,7 @@ def schema : Schema :=
 
 def es : PartialEntities :=
   Map.make [
-     (⟨ActionType, "a"⟩, ⟨.some default, .some default, .some default⟩),
+     (⟨ActionType, "a"⟩, (.present (.some default) (.some default) (.some default))),
   ]
 
 def req : PartialRequest :=


### PR DESCRIPTION
This PR adds a batched evaluation algorithm for cedar expressions.
This will enable efficient loading of entities from a backing database during a request. Compared to entity manifests, the algorithm is simple and it will load the same or fewer entities.


To make batched evaluation sound, it was necessary to extend partial evaluation so that the user can include `MissingEntity` objects in the partial entities store.