### PR TITLE
Update CI

### DIFF
--- a/.github/workflows/build_and_test_cli_reusable.yml
+++ b/.github/workflows/build_and_test_cli_reusable.yml
@@ -33,14 +33,6 @@ jobs:
           repository: cedar-policy/cedar
           path: ./cedar-spec/cedar
           ref: ${{ inputs.cedar_policy_ref }}
-      - name: Setup Cargo config for local Cedar
-        working-directory: ./cedar-spec/cedar-lean-ffi
-        run: |
-          mkdir -p .cargo
-          cat > .cargo/config.toml << EOF
-          [patch.crates-io]
-          cedar-policy = { path = "../cedar/cedar-policy" }
-          EOF
       - name: Install Lean
         shell: bash
         run: |

--- a/.github/workflows/build_and_test_ffi_reusable.yml
+++ b/.github/workflows/build_and_test_ffi_reusable.yml
@@ -33,14 +33,6 @@ jobs:
           repository: cedar-policy/cedar
           path: ./cedar-spec/cedar
           ref: ${{ inputs.cedar_policy_ref }}
-      - name: Setup Cargo config for local Cedar
-        working-directory: ./cedar-spec/cedar-lean-ffi
-        run: |
-          mkdir -p .cargo
-          cat > .cargo/config.toml << EOF
-          [patch.crates-io]
-          cedar-policy = { path = "../cedar/cedar-policy" }
-          EOF
       - name: Install Lean
         shell: bash
         run: |

--- a/.github/workflows/corpus_generation_test_reusable.yml
+++ b/.github/workflows/corpus_generation_test_reusable.yml
@@ -32,14 +32,6 @@ jobs:
           repository: cedar-policy/cedar
           path: ./cedar-spec/cedar
           ref: ${{ inputs.cedar_policy_ref }}
-      - name: Setup Cargo config for local Cedar
-        working-directory: ./cedar-spec/cedar-lean-ffi
-        run: |
-          mkdir -p .cargo
-          cat > .cargo/config.toml << EOF
-          [patch.crates-io]
-          cedar-policy = { path = "../cedar/cedar-policy" }
-          EOF
       - name: Install Lean
         shell: bash
         run: |
@@ -77,14 +69,6 @@ jobs:
           repository: cedar-policy/cedar
           path: ./cedar-spec/cedar
           ref: ${{ inputs.cedar_policy_ref }}
-      - name: Setup Cargo config for local Cedar
-        working-directory: ./cedar-spec/cedar-lean-ffi
-        run: |
-          mkdir -p .cargo
-          cat > .cargo/config.toml << EOF
-          [patch.crates-io]
-          cedar-policy = { path = "../cedar/cedar-policy" }
-          EOF
       - name: Install Lean
         shell: bash
         run: |


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

#685 added the following to `Cargo.toml` files of `cedar-lean-ffi` and `cedar-lean-cli` so that it is not needed in CI.

```
[patch.crates-io]
cedar-policy = { path = "../cedar/cedar-policy" }
```

In other words, both packages essentially depends on the version of `cedar-policy` on the main branch, as opposed to the one on crates.io.
