### PR TITLE
`SymEnv.ofEnv` is complete

### DIFF
--- a/cedar-lean/Cedar/Thm/Data/Map.lean
+++ b/cedar-lean/Cedar/Thm/Data/Map.lean
@@ -1323,4 +1323,14 @@ theorem map_keys_empty_implies_map_empty
     simp only [Map.keys, Map.kvs, List.map, Set.toList, Set.elts] at h
     contradiction
 
+theorem toList_congr
+  {m₁ m₂ : Map α β}
+  (h : m₁.toList = m₂.toList) :
+  m₁ = m₂
+:= by
+  cases m₁ with | mk m₁
+  cases m₂ with | mk m₂
+  simp only [Map.toList, Map.kvs] at h
+  simp [h]
+
 end Cedar.Data.Map

--- a/cedar-lean/Cedar/Thm/Data/Map.lean
+++ b/cedar-lean/Cedar/Thm/Data/Map.lean
@@ -1282,6 +1282,24 @@ theorem map_find?_to_list_find?
     simp [this]
   · contradiction
 
+/-- A variant of `map_make_append_find_disjoint`. -/
+theorem map_make_append_find_disjoint'
+  [LT α] [StrictLT α] [DecidableEq α] [DecidableLT α]
+  [SizeOf α] [SizeOf β]
+  {l₁ : List (α × β)} {l₂ : List (α × β)} {k : α} {v : β}
+  (hfind₁ : l₁.find? (λ ⟨k', _⟩ => k' == k) = none)
+  (hfind₂ : l₂.find? (λ ⟨k', _⟩ => k' == k) = .some (k, v))
+  (heq : ∀ x₁ x₂, x₁ ∈ l₂ → x₂ ∈ l₂ → x₁.fst = x₂.fst → x₁ = x₂) :
+  (Map.make (l₁ ++ l₂)).find? k = some v
+:= by
+  have : (l₂.find? (λ ⟨k', _⟩ => k' == k)).isSome
+  := by simp only [hfind₂, Option.isSome]
+  have ⟨v', hfind_k, hmem⟩ := map_make_append_find_disjoint hfind₁ this
+  have := List.mem_of_find?_eq_some hfind₂
+  have := heq _ _ this hmem
+  simp only [Prod.mk.injEq, true_and, forall_const] at this
+  simp only [this, hfind_k]
+
 theorem map_find?_implies_find?_weaker_pred
   [BEq α] [LawfulBEq α]
   {m : Map α β} {k : α} {v : β} {f : α × β → Bool}

--- a/cedar-lean/Cedar/Thm/Data/Map.lean
+++ b/cedar-lean/Cedar/Thm/Data/Map.lean
@@ -70,6 +70,10 @@ theorem wf_implies_tail_wf {α β} [LT α] [DecidableLT α] [StrictLT α]
     simp only [Map.toList, Map.kvs]
     assumption
 
+theorem wf_empty {α β} [LT α] [DecidableLT α] :
+  (Map.empty : Map α β).WellFormed
+:= by simp [Map.WellFormed, Map.make, Map.empty, List.canonicalize, Map.toList]
+
 /--
   In well-formed maps, if there are two pairs with the same key, then they have
   the same value

--- a/cedar-lean/Cedar/Thm/SymCC/Compiler/Binary.lean
+++ b/cedar-lean/Cedar/Thm/SymCC/Compiler/Binary.lean
@@ -1179,11 +1179,11 @@ private theorem compileApp₂_hasTag_implies_apply₂ {t₁ t₂ t₃ : Term} {v
       cases ht : d.tags.find? tag
       case none =>
         simp only [Map.contains, ht, Option.isSome_none]
-        rw [heq.left tag] at ht
+        rw [heq.right.left tag] at ht
         simp only [ht, same_ok_bool]
       case some val =>
         simp only [Map.contains, ht, Option.isSome_some]
-        replace heq := heq.right tag val ht
+        replace heq := heq.right.right tag val ht
         simp only [heq.left, same_ok_bool]
     case _ hd' => simp only [hd, reduceCtorEq] at hd'
 
@@ -1221,12 +1221,12 @@ private theorem compileApp₂_getTag_implies_apply₂ {t₁ t₂ t₃ : Term} {v
   simp only [SymTags.getTag]
   cases ht : d.tags.find? tag <;> simp only
   case none =>
-    rw [heq.left tag] at ht
+    rw [heq.right.left tag] at ht
     simp only [ht, pe_ifTrue_false]
     apply same_error_implied_by
     simp only [not_false_eq_true, reduceCtorEq]
   case some val =>
-    replace heq := heq.right tag val ht
+    replace heq := heq.right.right tag val ht
     simp only [Same.same, SameResults, heq.left, pe_ifTrue_true, heq.right]
 
 private theorem compileApp₂_implies_apply₂ {op₂ : BinaryOp} {t₁ t₂ t₃ : Term} {v₁ v₂ : Value} {es : Entities} {εs : SymEntities}

--- a/cedar-lean/Cedar/Thm/SymCC/Compiler/WellTyped.lean
+++ b/cedar-lean/Cedar/Thm/SymCC/Compiler/WellTyped.lean
@@ -2,6 +2,7 @@ import Cedar.Thm.Validation.WellTyped.Definition
 import Cedar.Thm.SymCC.Compiler.WF
 import Cedar.Thm.SymCC.Env.ofEnv
 import Cedar.Thm.SymCC.Env.WF
+import Cedar.Thm.SymCC.Term.ofType
 
 /-!
 This file contains theorems saying that `compile` succeeds
@@ -1343,15 +1344,7 @@ theorem compile_well_typed_record
       TermType.option.injEq, TermType.record.injEq,
       Data.Map.mk.injEq,
     ]
-    -- Rephrase `TermType.ofRecordType` with `List.map`
-    have e (rty : List (Attr × QualifiedType)) :
-      TermType.ofRecordType rty
-      = rty.map λ (a, qty) => (a, TermType.ofQualifiedType qty)
-    := by
-      induction rty with
-      | nil => simp [TermType.ofRecordType]
-      | cons => simp [TermType.ofRecordType]; assumption
-    simp only [e rty.1]
+    simp only [ofRecordType_as_map rty.1]
     simp only [hrty, Data.Map.make]
     simp only [List.attach₃]
     simp only [List.map_pmap]

--- a/cedar-lean/Cedar/Thm/SymCC/Concretizer/Same.lean
+++ b/cedar-lean/Cedar/Thm/SymCC/Concretizer/Same.lean
@@ -362,7 +362,11 @@ private theorem concretize?_some_same_entity_data {uid : EntityUID} {d : EntityD
   · constructor
     · intro ancTy ancUF hf'
       exact concretize?_some_InAncestors hf' hwδ hwt ha
-    · exact concretize?_some_same_tags hwδ hwt ht
+    · constructor
+      · intros mems hmems
+        simp only [SymEntityData.concretize?.isValidEntityUID, hmems] at hvd
+        exact Set.contains_prop_bool_equiv.mp hvd
+      · exact concretize?_some_same_tags hwδ hwt ht
 
 private theorem concretize?_some_same_entities {uids : Set EntityUID} {es : Entities} {εs : SymEntities} :
   εs.WellFormed →

--- a/cedar-lean/Cedar/Thm/SymCC/Data/Basic.lean
+++ b/cedar-lean/Cedar/Thm/SymCC/Data/Basic.lean
@@ -600,6 +600,7 @@ def SameEntityData (uid : EntityUID) (d : EntityData) (δ : SymEntityData) : Pro
   SameValues (.record d.attrs) (app δ.attrs uid) ∧
   (∀ anc, anc ∈ d.ancestors → InSymAncestors anc) ∧
   (∀ ancTy ancUF, δ.ancestors.find? ancTy = .some ancUF → InAncestors ancUF ancTy) ∧
+  (∀ mems, δ.members = .some mems → uid.eid ∈ mems) ∧
   SameTags uid d δ
 where
   InSymAncestors (anc : EntityUID) : Prop :=

--- a/cedar-lean/Cedar/Thm/SymCC/Data/Basic.lean
+++ b/cedar-lean/Cedar/Thm/SymCC/Data/Basic.lean
@@ -715,5 +715,18 @@ def memOfSymEnv (env : Env) (εnv : SymEnv) : Prop :=
 
 infixl:50 "∈ᵢ" => memOfSymEnv
 
+/--
+This is a condition that `env` contains all enum entities
+(including actions) specified in `εnv`. It's required for
+completeness (of `SymEnv.ofEnv`) and satisfied by the
+concretizer, but it's not required for the soundness, so
+we keep it as a separate definition here.
+-/
+def Env.EnumCompleteFor (env : Env) (εnv : SymEnv) : Prop :=
+  ∀ (uid : EntityUID) (δ : SymEntityData) (eids : Set String),
+    εnv.entities.find? uid.ty = .some δ →
+    δ.members = .some eids →
+    uid.eid ∈ eids →
+    ∃ data, env.entities.find? uid = .some data
 
 end Cedar.SymCC

--- a/cedar-lean/Cedar/Thm/SymCC/Env/Completeness.lean
+++ b/cedar-lean/Cedar/Thm/SymCC/Env/Completeness.lean
@@ -34,7 +34,7 @@ open Cedar.Data
 /--
 Inverse of `entity_uid_wf_implies_sym_entities_is_valid_entity_uid`
 -/
-theorem sym_entities_is_valid_entity_uid_implies_entity_uid_wf
+private theorem sym_entities_is_valid_entity_uid_implies_entity_uid_wf
   {Γ : TypeEnv} {uid : EntityUID}
   (hwf : Γ.WellFormed)
   (huid : (SymEnv.ofEnv Γ).entities.isValidEntityUID uid) :
@@ -93,7 +93,7 @@ theorem sym_entities_is_valid_entity_uid_implies_entity_uid_wf
   · contradiction
 
 /-- `TermPrim` case of `ofType_typeOf_pullback`. -/
-theorem ofType_typeOf_pullback_prim
+private theorem ofType_typeOf_pullback_prim
   {Γ : TypeEnv}
   {p : TermPrim} {ty : CedarType} {v : Value}
   (hwf_Γ : Γ.WellFormed)
@@ -165,7 +165,7 @@ theorem ofType_typeOf_pullback_prim
       constructor
       simp only [InstanceOfExtType]
 
-theorem value?_some_implies_typeOf_not_option
+private theorem value?_some_implies_typeOf_not_option
   {t : Term} {v : Value} {ty : TermType}
   (hsome : t.value? = .some v)
   (hopt : t.typeOf = .option ty) :
@@ -209,7 +209,7 @@ TermType <----- CedarType
  Term ---------> Value
         value?
 -/
-theorem ofType_typeOf_pullback
+private theorem ofType_typeOf_pullback
   {Γ : TypeEnv}
   {t : Term} {ty : CedarType} {v : Value}
   (hwf_Γ : Γ.WellFormed)
@@ -499,7 +499,7 @@ decreasing_by
         have := List.sizeOf_lt_of_mem hmem_attr_t'
         omega
 
-theorem ofEnv_request_completeness
+private theorem ofEnv_request_completeness
   {Γ : TypeEnv} {env : Env} {I : Interpretation}
   (hwf_Γ : Γ.WellFormed)
   (hwf_I : I.WellFormed (SymEnv.ofEnv Γ).entities)
@@ -570,7 +570,7 @@ theorem ofEnv_request_completeness
     have hlifted_ctx := wf_env_implies_ctx_lifted hwf_Γ
     apply ofType_typeOf_pullback hwf_Γ hwt_ctx hlifted_ctx hwf_I_ctx hwt_I_ctx hsame_I_ctx
 
-theorem ets_find_some_standard_entry_implies_valid_uid
+private theorem ets_find_some_standard_entry_implies_valid_uid
   {Γ : TypeEnv} {uid : EntityUID} {entry : StandardSchemaEntry}
   (hfind_uid : Γ.ets.find? uid.ty = .some (.standard entry)) :
   (SymEnv.ofEnv Γ).entities.isValidEntityUID uid
@@ -584,7 +584,7 @@ theorem ets_find_some_standard_entry_implies_valid_uid
     exact hfind_uid
   simp only [this, SymEntityData.ofEntityType, SymEntityData.ofStandardEntityType]
 
-theorem ets_find_some_standard_entry_implies_valid_uid_ty
+private theorem ets_find_some_standard_entry_implies_valid_uid_ty
   {Γ : TypeEnv} {uid : EntityUID} {entry : StandardSchemaEntry}
   (hfind_uid : Γ.ets.find? uid.ty = .some (.standard entry)) :
   (SymEnv.ofEnv Γ).entities.isValidEntityType uid.ty
@@ -596,7 +596,7 @@ theorem ets_find_some_standard_entry_implies_valid_uid_ty
     simp only [SymEntities.isValidEntityType, Map.contains, heq, Option.isSome]
   · contradiction
 
-theorem ofEnv_entity_completeness_standard_inst_tags
+private theorem ofEnv_entity_completeness_standard_inst_tags
   {Γ : TypeEnv} {I : Interpretation} {entities : Entities}
   {uid : EntityUID} {entry : StandardSchemaEntry}
   {δ δ' : SymEntityData} {data : EntityData}
@@ -794,7 +794,7 @@ theorem ofEnv_entity_completeness_standard_inst_tags
         SymEntityData.ofStandardEntityType.symTags,
       ]
 
-theorem ofEnv_entity_completeness_standard
+private theorem ofEnv_entity_completeness_standard
   {Γ : TypeEnv} {I : Interpretation} {entities : Entities}
   {uid : EntityUID} {entry : StandardSchemaEntry}
   {δ δ' : SymEntityData} {data : EntityData}
@@ -892,7 +892,7 @@ theorem ofEnv_entity_completeness_standard
   · exact ofEnv_entity_completeness_standard_inst_tags
       hwf_Γ hwf_data hwf_I hfind_uid hδ' hδ hsame_δ hfind_δ
 
-theorem ofEnv_entity_completeness_enum
+private theorem ofEnv_entity_completeness_enum
   {Γ : TypeEnv} {I : Interpretation}
   {uid : EntityUID} {eids : Set String}
   {δ δ' : SymEntityData} {data : EntityData}
@@ -977,7 +977,7 @@ theorem ofEnv_entity_completeness_enum
     simp only [InstanceOfEntityTags, EntitySchemaEntry.tags?]
     exact hsame_tags
 
-theorem ofEnv_entity_completeness_ordinary
+private theorem ofEnv_entity_completeness_ordinary
   {Γ : TypeEnv} {I : Interpretation} {entities : Entities}
   {uid : EntityUID} {entry : EntitySchemaEntry}
   {δ δ' : SymEntityData} {data : EntityData}
@@ -997,7 +997,7 @@ theorem ofEnv_entity_completeness_ordinary
   | enum eids =>
     exact ofEnv_entity_completeness_enum hwf_Γ hwf_I hfind_uid hδ' hδ hsame_δ
 
-theorem ofEnv_entity_completeness_action
+private theorem ofEnv_entity_completeness_action
   {Γ : TypeEnv} {I : Interpretation} {entities : Entities}
   {uid : EntityUID} {entry : ActionSchemaEntry}
   {δ δ' : SymEntityData} {data : EntityData}
@@ -1149,7 +1149,7 @@ theorem ofEnv_entity_completeness_action
       have := (Set.in_list_iff_in_set _ _).mpr hmem_entry_anc
       simp [Set.toList, this, true_and, SymEntityData.ofActionType.termOfType?]
 
-theorem ofEnv_entity_completeness
+private theorem ofEnv_entity_completeness
   {Γ : TypeEnv} {I : Interpretation} {entities : Entities}
   {uid : EntityUID} {δ : SymEntityData} {data : EntityData}
   (hwf_Γ : Γ.WellFormed)
@@ -1208,7 +1208,7 @@ theorem ofEnv_entity_completeness
     have hfind_uid := (Map.in_list_iff_find?_some hwf_acts).mp hmem_uid'
     exact ofEnv_entity_completeness_action hwf_Γ hwf_data hfind_uid (Eq.symm heq_δ') hδ' hsame_δ
 
-theorem enum_complete_implies_has_all_actions
+private theorem enum_complete_implies_has_all_actions
   {Γ : TypeEnv} {env : Env}
   (hwf_Γ : Γ.WellFormed)
   (henum_comp : Env.EnumCompleteFor env (SymEnv.ofEnv Γ)) :
@@ -1270,7 +1270,7 @@ theorem enum_complete_implies_has_all_actions
     simp only [↓reduceIte, and_true]
     exact Map.find?_mem_toList hfind_uid
 
-theorem ofEnv_entities_completeness
+private theorem ofEnv_entities_completeness
   {Γ : TypeEnv} {env : Env} {I : Interpretation}
   (hwf_Γ : Γ.WellFormed)
   (hwf_env : env.StronglyWellFormed)

--- a/cedar-lean/Cedar/Thm/SymCC/Env/Completeness.lean
+++ b/cedar-lean/Cedar/Thm/SymCC/Env/Completeness.lean
@@ -16,6 +16,7 @@
 
 import Cedar.Thm.SymCC.Env.ofEnv
 import Cedar.Thm.SymCC.Term.Interpret.WF
+import Cedar.Thm.SymCC.Term.ofType
 
 /-!
 This file contains the soundness theorems of `Sym.ofEnv`
@@ -40,13 +41,89 @@ theorem sym_entities_is_valid_entity_uid_implies_entity_uid_wf
 := by
   sorry
 
+/-- `TermPrim` case of `ofType_typeOf_pullback`. -/
+theorem ofType_typeOf_pullback_prim
+  {Γ : TypeEnv}
+  {p : TermPrim} {ty : CedarType} {v : Value}
+  (hwf_Γ : Γ.WellFormed)
+  (hwf_ty : ty.WellFormed Γ)
+  (hlift_ty : ty.IsLifted)
+  (hwf_t : (Term.prim p).WellFormed (SymEnv.ofEnv Γ).entities)
+  (heq_ty : (Term.prim p).typeOf = TermType.ofType ty)
+  (hval : (Term.prim p).value? = .some v) :
+  InstanceOfType Γ v ty
+:= by
+  cases p with
+  | bool b =>
+    simp only [Term.typeOf, TermPrim.typeOf, TermType.bool] at heq_ty
+    unfold TermType.ofType at heq_ty
+    split at heq_ty
+    rename_i bty
+    cases hlift_ty
+    any_goals simp only [TermType.prim.injEq, reduceCtorEq] at heq_ty
+    simp only [Term.value?, TermPrim.value?, Option.some.injEq] at hval
+    simp only [←hval]
+    constructor
+    simp [InstanceOfBoolType]
+  | bitvec bv =>
+    rename_i n
+    simp only [Term.typeOf, TermPrim.typeOf, TermType.bitvec, BitVec.width] at heq_ty
+    unfold TermType.ofType at heq_ty
+    split at heq_ty
+    any_goals simp only [TermType.prim.injEq, TermPrimType.bitvec.injEq, reduceCtorEq] at heq_ty
+    simp only [
+      Term.value?, TermPrim.value?, BitVec.int64?,
+      heq_ty, ↓reduceIte, Option.pure_def,
+      Option.bind_some_fun, Option.some.injEq,
+    ] at hval
+    simp only [←hval]
+    constructor
+  | string =>
+    simp only [Term.typeOf, TermPrim.typeOf, TermType.string] at heq_ty
+    unfold TermType.ofType at heq_ty
+    split at heq_ty
+    any_goals simp only [TermType.prim.injEq, reduceCtorEq] at heq_ty
+    simp only [Term.value?, TermPrim.value?, Option.some.injEq] at hval
+    simp only [←hval]
+    constructor
+  | entity uid =>
+    simp only [Term.typeOf, TermPrim.typeOf, TermType.entity] at heq_ty
+    unfold TermType.ofType at heq_ty
+    split at heq_ty
+    any_goals simp only [TermType.prim.injEq, TermPrimType.entity.injEq, reduceCtorEq] at heq_ty
+    simp only [Term.value?, TermPrim.value?, Option.some.injEq] at hval
+    simp only [←hval]
+    constructor
+    simp only [←heq_ty, InstanceOfEntityType, true_and]
+    cases hwf_t with | prim_wf hwf_t =>
+    cases hwf_t with | entity_wf hwf_t =>
+    exact sym_entities_is_valid_entity_uid_implies_entity_uid_wf hwf_Γ hwf_t
+  | ext =>
+    simp only [Term.typeOf, TermPrim.typeOf] at heq_ty
+    split at heq_ty
+    any_goals contradiction
+    all_goals
+      unfold TermType.ofType at heq_ty
+      rename_i hp
+      split at heq_ty
+      any_goals simp only [TermType.prim.injEq, reduceCtorEq] at heq_ty
+      simp only [Term.value?, TermPrim.value?, Option.some.injEq] at hval
+      injection heq_ty with heq_ty
+      injection hp with hp
+      simp only [←hval, ←heq_ty, hp]
+      constructor
+      simp only [InstanceOfExtType]
+
 /--
-If a term type is both the result of
-`TermType.ofType` and `Term.typeOf`
+If a term type is both the result of `TermType.ofType` and `Term.typeOf`
 for some well-formed `CedarType`
 and well-formed `Term`,
 then the if the the term is conretizable (via `value?`),
 the resulting `Value` should be well-typed.
+
+i.e., if we know "--->"'s below,
+then we know "***>", such that the
+diagram "commutes."
 
          ofType
 TermType <----- CedarType
@@ -63,32 +140,160 @@ theorem ofType_typeOf_pullback
   {t : Term} {ty : CedarType} {v : Value}
   (hwf_Γ : Γ.WellFormed)
   (hwf_ty : ty.WellFormed Γ)
+  (hlift_ty : ty.IsLifted)
   (hwf_t : t.WellFormed (SymEnv.ofEnv Γ).entities)
-  (heq : t.typeOf = TermType.ofType ty)
+  (heq_ty : t.typeOf = TermType.ofType ty)
   (hval : t.value? = .some v) :
   InstanceOfType Γ v ty
 := by
   cases t with
-  | prim p =>
-    cases p with
-    | bool b =>
-      simp only [Term.typeOf, TermPrim.typeOf, TermType.bool] at heq
-      unfold TermType.ofType at heq
-      split at heq
-      any_goals simp only [TermType.prim.injEq, reduceCtorEq] at heq
-      simp only [Term.value?, TermPrim.value?, Option.some.injEq] at hval
-      simp only [←hval]
-      constructor
-
+  | prim p => exact ofType_typeOf_pullback_prim hwf_Γ hwf_ty hlift_ty hwf_t heq_ty hval
+  | var var | none | some | app =>
+    simp only [Term.value?] at hval
+    contradiction
+  | set ts ty' =>
+    cases ts with | mk ts_set =>
+    simp only [Term.value?, bind, Option.bind] at hval
+    split at hval
+    contradiction
+    simp only [Option.some.injEq] at hval
+    rename_i val_ts hval_ts
+    simp only [List.mapM₁_eq_mapM] at hval_ts
+    simp only [Term.typeOf] at heq_ty
+    unfold TermType.ofType at heq_ty
+    split at heq_ty
+    any_goals contradiction
+    rename_i ty_ts
+    injection heq_ty with heq_ty
+    cases hlift_ty with | set_wf hlift_ty_ts =>
+    cases hwf_ty with | set_wf hwf_ty_ts =>
+    cases hwf_t with | set_wf hwf_ts heq_ty_ts =>
+    simp only [←hval]
+    constructor
+    intros v_ts hmem_v_ts
+    have ⟨t', hmem_t', hval_t'⟩ := List.mapM_some_implies_all_from_some
+      hval_ts v_ts ((Set.make_mem _ _).mpr hmem_v_ts)
+    have hwf_t' := hwf_ts t' hmem_t'
+    apply ofType_typeOf_pullback hwf_Γ hwf_ty_ts hlift_ty_ts hwf_t' _ hval_t'
+    have heq_ty_t' := heq_ty_ts t' hmem_t'
+    simp only [heq_ty_t', ←heq_ty]
+  | record rec =>
+    cases rec with | mk rec_map =>
+    simp only [Term.value?, bind, Option.bind] at hval
+    split at hval
+    contradiction
+    simp only [Option.some.injEq] at hval
+    rename_i val_rec hval_rec
+    simp only [List.mapM₂_eq_mapM (λ x => Term.value?.attrValue? x.fst x.snd)] at hval_rec
+    simp only [Term.typeOf] at heq_ty
+    unfold TermType.ofType at heq_ty
+    split at heq_ty
+    any_goals contradiction
+    simp only [TermType.record.injEq, Map.mk.injEq] at heq_ty
+    rename_i ty_rec
+    cases hlift_ty with | record_wf hlift_ty_rec =>
+    cases hwf_ty with | record_wf hwf_ty_rec_map hwf_ty_rec =>
+    cases hwf_t with | record_wf hwf_rec heq_ty_rec =>
+    simp only [←hval]
+    simp only [List.map_attach₃_snd] at heq_ty
+    constructor
+    · intros attr hcont_attr
+      have ⟨v, hfind_v⟩ := Map.contains_iff_some_find?.mp hcont_attr
+      have hmem_v := Map.find?_mem_toList hfind_v
+      simp only [Map.toList, Map.kvs] at hmem_v
+      have ⟨attr_v, hmem_attr_v, hattr_v⟩ := List.mem_filterMap.mp hmem_v
+      have ⟨attr_t', hmem_attr_t', hattr_t'⟩ := List.mapM_some_implies_all_from_some hval_rec attr_v hmem_attr_v
+      have : (attr_t'.fst, attr_t'.snd.typeOf) ∈ TermType.ofRecordType ty_rec
+      := by
+        simp only [←heq_ty]
+        apply List.mem_map.mpr
+        exists attr_t'
+      simp only [ofRecordType_as_map ty_rec] at this
+      have ⟨attr_ty, hmem_attr_ty, hattr_ty⟩ := List.mem_map.mp this
+      have : attr = attr_v.fst := by
+        simp only [Option.map] at hattr_v
+        split at hattr_v
+        · simp only [Option.some.injEq, Prod.mk.injEq] at hattr_v
+          simp [hattr_v.1]
+        · contradiction
+      have : attr = attr_t'.fst := by
+        simp only [this]
+        unfold Term.value?.attrValue? at hattr_t'
+        split at hattr_t'
+        · simp only [bind, Option.bind] at hattr_t'
+          split at hattr_t'
+          contradiction
+          simp only [Option.some.injEq] at hattr_t'
+          simp only [←hattr_t']
+        · simp only [Option.some.injEq] at hattr_t'
+          simp only [←hattr_t']
+        · simp only [bind, Option.bind] at hattr_t'
+          split at hattr_t'
+          contradiction
+          simp only [Option.some.injEq] at hattr_t'
+          simp only [←hattr_t']
+      have : attr = attr_ty.fst := by
+        simp only [this]
+        simp only [Prod.mk.injEq] at hattr_ty
+        simp only [hattr_ty.1]
+      simp only [this]
+      apply Map.contains_iff_some_find?.mpr
+      exists attr_ty.snd
+      apply (Map.in_list_iff_find?_some hwf_ty_rec_map).mp
+      exact hmem_attr_ty
+    · intros attr val qty hfind_val hfind_qty
+      have hwf_ty' := hwf_ty_rec attr qty hfind_qty
+      have hlift_ty' := hlift_ty_rec attr qty (Map.find?_mem_toList hfind_qty)
+      cases qty with
+      | optional ty' | required ty' =>
+      cases hwf_ty'
+      rename_i hwf_ty'
+      cases hlift_ty'
+      rename_i hlift_ty'
+      have := Map.find?_mem_toList hfind_val
+      have ⟨attr_v, hmem_attr_v, hattr_v⟩ := List.mem_filterMap.mp this
+      have ⟨attr_t', hmem_attr_t', hattr_t'⟩ := List.mapM_some_implies_all_from_some hval_rec attr_v hmem_attr_v
+      simp only [Option.map] at hattr_v
+      have heq_attr : attr = attr_t'.fst := sorry
       sorry
-    | _ =>
-      sorry
-  | _ => sorry
+      -- split at hattr_v
+      -- · rename_i v hv
+      --   unfold Term.value?.attrValue? at hattr_t'
+      --   split at hattr_t'
+      --   · simp only [bind, Option.bind] at hattr_t'
+      --     split at hattr_t'
+      --     contradiction
+      --     rename_i v' hv'
+      --     have hwf_t' := hwf_rec attr_t'.fst attr_t'.snd hmem_attr_t'
+      --     simp only [Qualified.getType]
+      --     simp only [Option.some.injEq] at hattr_t'
+      --     simp only [←hattr_t', Option.some.injEq] at hv
+      --     simp only [hv] at hv'
+      --     simp only [Option.some.injEq, Prod.mk.injEq] at hattr_v
+      --     simp only [hattr_v.2] at hv'
+      --     apply ofType_typeOf_pullback hwf_Γ hwf_ty' hlift_ty' hwf_t' _ hv'
+      --     sorry
+      --   · simp only [Option.some.injEq] at hattr_t'
+      --     simp [←hattr_t'] at hv
+      --   · simp only [bind, Option.bind] at hattr_t'
+      --     split at hattr_t'
+      --     contradiction
+      --     rename_i v' hv'
+      --     have hwf_t' := hwf_rec attr_t'.fst attr_t'.snd hmem_attr_t'
+      --     simp only [Qualified.getType]
+      --     simp only [Option.some.injEq] at hattr_t'
+      --     simp only [←hattr_t', Option.some.injEq] at hv
+      --     simp only [hv] at hv'
+      --     simp only [Option.some.injEq, Prod.mk.injEq] at hattr_v
+      --     simp only [hattr_v.2] at hv'
+      --     apply ofType_typeOf_pullback hwf_Γ hwf_ty' hlift_ty' hwf_t' _ hv'
+      --     all_goals sorry
+      -- · contradiction
+    · sorry
 
 theorem ofEnv_request_completeness
   {Γ : TypeEnv} {env : Env} {I : Interpretation}
   (hwf_Γ : Γ.WellFormed)
-  (hwf_env : env.StronglyWellFormed)
   (hwf_I : I.WellFormed (SymEnv.ofEnv Γ).entities)
   (hsame_I : env ∼ SymEnv.interpret I (SymEnv.ofEnv Γ)) :
   InstanceOfRequestType env.request Γ
@@ -154,7 +359,8 @@ theorem ofEnv_request_completeness
       SymRequest.ofRequestType,
     ] at hsame_I_ctx
     have ⟨_, _, _, hwt_ctx⟩ := wf_env_implies_wf_request hwf_Γ
-    apply ofType_typeOf_pullback hwf_Γ hwt_ctx hwf_I_ctx hwt_I_ctx hsame_I_ctx
+    have hlifted_ctx := wf_env_implies_ctx_lifted hwf_Γ
+    apply ofType_typeOf_pullback hwf_Γ hwt_ctx hlifted_ctx hwf_I_ctx hwt_I_ctx hsame_I_ctx
     -- Ideally we should have the "commuting" diagram (modulo `.some`)
     --        cedarType?
     --          ----->
@@ -181,7 +387,7 @@ theorem ofEnv_completeness
   · exact hwf
   have ⟨I, hwf_I, hsame_I⟩ := hinst
   constructor
-  · exact ofEnv_request_completeness hwf hwf_env hwf_I hsame_I
+  · exact ofEnv_request_completeness hwf hwf_I hsame_I
   · sorry
 
 end Cedar.Thm

--- a/cedar-lean/Cedar/Thm/SymCC/Env/Completeness.lean
+++ b/cedar-lean/Cedar/Thm/SymCC/Env/Completeness.lean
@@ -639,6 +639,7 @@ theorem ofEnv_entity_completeness
     simp only at hact
     have hwf_acts := wf_env_implies_wf_acts_map hwf_Γ
     have hfind_act := (Map.in_list_iff_find?_some hwf_acts).mp hmem_act
+
     -- δ' = SymEntityData.ofActionType uid.ty (List.map (fun x => x.fst.ty) (Map.toList Γ.acts)).eraseDups Γ.acts
     sorry
 

--- a/cedar-lean/Cedar/Thm/SymCC/Env/Completeness.lean
+++ b/cedar-lean/Cedar/Thm/SymCC/Env/Completeness.lean
@@ -20,7 +20,7 @@ import Cedar.Thm.SymCC.Term.Interpret.WF
 import Cedar.Thm.SymCC.Term.ofType
 
 /-!
-This file contains the soundness theorems of `Sym.ofEnv`
+This file contains the completeness theorems of `Sym.ofEnv`
 -/
 
 namespace Cedar.Thm

--- a/cedar-lean/Cedar/Thm/SymCC/Env/Completeness.lean
+++ b/cedar-lean/Cedar/Thm/SymCC/Env/Completeness.lean
@@ -192,7 +192,7 @@ private theorem value?_some_implies_typeOf_not_option
 /--
 If a term type is both the result of `TermType.ofType` and `Term.typeOf`
 for some well-formed `CedarType` and well-formed `Term`,
-then the if the the term is conretizable (via `value?`),
+then the if the the term is concretizable (via `value?`),
 the resulting `Value` should be well-typed.
 
 i.e., if we know "--->"'s below,

--- a/cedar-lean/Cedar/Thm/SymCC/Env/Completeness.lean
+++ b/cedar-lean/Cedar/Thm/SymCC/Env/Completeness.lean
@@ -808,7 +808,7 @@ theorem ofEnv_entity_completeness_standard
   (hfind_δ : Map.find? (SymEnv.interpret I (SymEnv.ofEnv Γ)).entities uid.ty = some δ) :
   InstanceOfEntitySchemaEntry uid data Γ
 := by
-  have ⟨hsame_attrs, _, _, hvalid_eid, hsame_tags⟩ := hsame_δ
+  have ⟨hsame_attrs, hanc₁, _, hvalid_eid, hsame_tags⟩ := hsame_δ
   have ⟨_, hwf_funs⟩ := hwf_I
   have hwf_ofEnv_Γ := ofEnv_is_wf hwf_Γ
   have ⟨_, ⟨_, hwf_I_ents⟩⟩ := interpret_εnv_wf hwf_ofEnv_Γ hwf_I
@@ -872,7 +872,23 @@ theorem ofEnv_entity_completeness_standard
     · simp only [hwf_app.2, UnaryFunction.outType, ←hudf_out]
       simp only [←huuf]
       rfl
-  · sorry
+  -- Ancestor type matches
+  · intros anc hmem_data_anc
+    simp only [EntitySchemaEntry.ancestors]
+    have ⟨ancUF, hfind_ancUF, ⟨ts, happ_ancUF, hmem_ts⟩⟩ := hanc₁ anc hmem_data_anc
+    simp only [
+      hδ, hδ',
+      SymEntityData.interpret,
+      SymEntityData.ofEntityType,
+      SymEntityData.ofStandardEntityType,
+    ] at hfind_ancUF
+    have ⟨f, hfind_f, _⟩ := Map.find?_mapOnValues_some' _ hfind_ancUF
+    have := Map.find?_mem_toList hfind_f
+    have := Map.make_mem_list_mem this
+    have ⟨ancTy, hfind_ancTy, hancTy⟩ := List.mem_map.mp this
+    simp only [Prod.mk.injEq] at hancTy
+    simp only [hancTy.1] at hfind_ancTy
+    exact hfind_ancTy
   · exact ofEnv_entity_completeness_standard_inst_tags
       hwf_Γ hwf_data hwf_I hfind_uid hδ' hδ hsame_δ hfind_δ
 

--- a/cedar-lean/Cedar/Thm/SymCC/Env/Completeness.lean
+++ b/cedar-lean/Cedar/Thm/SymCC/Env/Completeness.lean
@@ -1,0 +1,187 @@
+/-
+ Copyright Cedar Contributors
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-/
+
+import Cedar.Thm.SymCC.Env.ofEnv
+import Cedar.Thm.SymCC.Term.Interpret.WF
+
+/-!
+This file contains the soundness theorems of `Sym.ofEnv`
+-/
+
+namespace Cedar.Thm
+
+open Cedar.Thm
+open Cedar.Spec
+open Cedar.SymCC
+open Cedar.Validation
+open Cedar.Data
+
+/--
+Inverse of `entity_uid_wf_implies_sym_entities_is_valid_entity_uid`
+-/
+theorem sym_entities_is_valid_entity_uid_implies_entity_uid_wf
+  {Γ : TypeEnv} {uid : EntityUID}
+  (hwf : Γ.WellFormed)
+  (huid : (SymEnv.ofEnv Γ).entities.isValidEntityUID uid) :
+  EntityUID.WellFormed Γ uid
+:= by
+  sorry
+
+/--
+If a term type is both the result of
+`TermType.ofType` and `Term.typeOf`
+for some well-formed `CedarType`
+and well-formed `Term`,
+then the if the the term is conretizable (via `value?`),
+the resulting `Value` should be well-typed.
+
+         ofType
+TermType <----- CedarType
+   ^               ^
+   |               *
+   | typeOf        * InstanceOfType
+   |               *
+   |               *
+ Term ---------> Value
+        value?
+-/
+theorem ofType_typeOf_pullback
+  {Γ : TypeEnv}
+  {t : Term} {ty : CedarType} {v : Value}
+  (hwf_Γ : Γ.WellFormed)
+  (hwf_ty : ty.WellFormed Γ)
+  (hwf_t : t.WellFormed (SymEnv.ofEnv Γ).entities)
+  (heq : t.typeOf = TermType.ofType ty)
+  (hval : t.value? = .some v) :
+  InstanceOfType Γ v ty
+:= by
+  cases t with
+  | prim p =>
+    cases p with
+    | bool b =>
+      simp only [Term.typeOf, TermPrim.typeOf, TermType.bool] at heq
+      unfold TermType.ofType at heq
+      split at heq
+      any_goals simp only [TermType.prim.injEq, reduceCtorEq] at heq
+      simp only [Term.value?, TermPrim.value?, Option.some.injEq] at hval
+      simp only [←hval]
+      constructor
+
+      sorry
+    | _ =>
+      sorry
+  | _ => sorry
+
+theorem ofEnv_request_completeness
+  {Γ : TypeEnv} {env : Env} {I : Interpretation}
+  (hwf_Γ : Γ.WellFormed)
+  (hwf_env : env.StronglyWellFormed)
+  (hwf_I : I.WellFormed (SymEnv.ofEnv Γ).entities)
+  (hsame_I : env ∼ SymEnv.interpret I (SymEnv.ofEnv Γ)) :
+  InstanceOfRequestType env.request Γ
+:= by
+  have ⟨hwf_I_vars, _⟩ := hwf_I
+  have ⟨⟨hsame_I_princ, hsame_I_act, hsame_I_res, hsame_I_ctx⟩, _⟩ := hsame_I
+  have hwf_sym_req := ofEnv_request_is_swf hwf_Γ
+  have ⟨⟨hwf_sym_princ, _, hwf_sym_act, _, hwf_sym_res, _, hwf_sym_ctx, _⟩, _⟩ := hwf_sym_req
+  simp only [
+    SymEnv.interpret,
+    SymRequest.interpret,
+  ] at hsame_I_princ hsame_I_act hsame_I_res hsame_I_ctx
+  and_intros
+  -- Well-formed symbolic principal => well-formed concrete principal
+  · have ⟨_, hwt_I_princ⟩ := interpret_term_wf hwf_I hwf_sym_princ
+    simp only [hsame_I_princ, Term.typeOf, TermPrim.typeOf] at hwt_I_princ
+    simp only [
+      SymEnv.ofEnv,
+      SymRequest.ofRequestType,
+      Term.typeOf,
+      TermType.ofType,
+    ] at hwt_I_princ
+    simp only [TermType.prim.injEq, TermPrimType.entity.injEq] at hwt_I_princ
+    simp [hwt_I_princ]
+  · have ⟨hwf_I_princ, _⟩ := interpret_term_wf hwf_I hwf_sym_princ
+    simp only [hsame_I_princ] at hwf_I_princ
+    cases hwf_I_princ with | prim_wf hwf_I_princ =>
+    cases hwf_I_princ with | entity_wf hwf_I_princ =>
+    exact sym_entities_is_valid_entity_uid_implies_entity_uid_wf hwf_Γ hwf_I_princ
+  -- Well-formed symbolic action => well-formed concrete action
+  · simp only [
+      Term.interpret,
+      SymEnv.ofEnv,
+      SymRequest.ofRequestType,
+    ] at hsame_I_act
+    simp only [Term.prim.injEq, TermPrim.entity.injEq] at hsame_I_act
+    simp [hsame_I_act]
+  -- Well-formed symbolic resource => well-formed concrete resource
+  · have ⟨_, hwt_I_res⟩ := interpret_term_wf hwf_I hwf_sym_res
+    simp only [hsame_I_res, Term.typeOf, TermPrim.typeOf] at hwt_I_res
+    simp only [
+      SymEnv.ofEnv,
+      SymRequest.ofRequestType,
+      Term.typeOf,
+      TermType.ofType,
+    ] at hwt_I_res
+    simp only [TermType.prim.injEq, TermPrimType.entity.injEq] at hwt_I_res
+    simp [hwt_I_res]
+  · have ⟨hwf_I_res, _⟩ := interpret_term_wf hwf_I hwf_sym_res
+    simp only [hsame_I_res] at hwf_I_res
+    cases hwf_I_res with | prim_wf hwf_I_res =>
+    cases hwf_I_res with | entity_wf hwf_I_res =>
+    exact sym_entities_is_valid_entity_uid_implies_entity_uid_wf hwf_Γ hwf_I_res
+  · have ⟨hwf_I_ctx, hwt_I_ctx⟩ := interpret_term_wf hwf_I hwf_sym_ctx
+    simp only [
+      SymEnv.ofEnv,
+      SymRequest.ofRequestType,
+      Term.typeOf,
+    ] at hwt_I_ctx
+    simp only [
+      SameValues,
+      SymEnv.ofEnv,
+      SymRequest.ofRequestType,
+    ] at hsame_I_ctx
+    have ⟨_, _, _, hwt_ctx⟩ := wf_env_implies_wf_request hwf_Γ
+    apply ofType_typeOf_pullback hwf_Γ hwt_ctx hwf_I_ctx hwt_I_ctx hsame_I_ctx
+    -- Ideally we should have the "commuting" diagram (modulo `.some`)
+    --        cedarType?
+    --          ----->
+    --          ofType
+    -- TermType <----- CedarType
+    --    ^               ^
+    --    |               |
+    --    | typeOf        | InstanceOfType
+    --    |               |
+    --    |               |
+    --  Term ---------> Value
+    --         value?
+    --       <---------
+    --       symbolize?
+
+theorem ofEnv_completeness
+  {Γ : TypeEnv} {env : Env}
+  (hwf : Γ.WellFormed)
+  (hwf_env : env.StronglyWellFormed)
+  (hinst : env ∈ᵢ SymEnv.ofEnv Γ) :
+  InstanceOfWellFormedEnvironment env.request env.entities Γ
+:= by
+  constructor
+  · exact hwf
+  have ⟨I, hwf_I, hsame_I⟩ := hinst
+  constructor
+  · exact ofEnv_request_completeness hwf hwf_env hwf_I hsame_I
+  · sorry
+
+end Cedar.Thm

--- a/cedar-lean/Cedar/Thm/SymCC/Env/Soundness.lean
+++ b/cedar-lean/Cedar/Thm/SymCC/Env/Soundness.lean
@@ -719,6 +719,8 @@ private theorem env_symbolize?_same_entity_data_standard
       simp only [Option.ite_none_right_eq_some, Option.some.injEq] at heq
       simp only [←heq, true_and]
       exact hmem_anc'
+  · intros mems hmems
+    simp at hmems
   · exact env_symbolize?_same_entity_data_standard_same_tag
       hwf_env hinst hinst_data hfind_entry hfind_data
 
@@ -734,7 +736,7 @@ private theorem env_symbolize?_same_entity_data_enum
       (SymEntityData.ofEnumEntityType uid.ty eids))
 := by
   have ⟨hwf_Γ, _, _⟩ := hinst
-  have ⟨entry', hfind_entry', _, hwt_data_attrs, hwt_data_ancs, hwt_data_tags⟩ := hinst_data
+  have ⟨entry', hfind_entry', hvalid_eid, hwt_data_attrs, hwt_data_ancs, hwt_data_tags⟩ := hinst_data
   simp only [hfind_entry, Option.some.injEq] at hfind_entry'
   simp only [←hfind_entry'] at hwt_data_attrs hwt_data_ancs hwt_data_tags
   simp only [
@@ -788,6 +790,11 @@ private theorem env_symbolize?_same_entity_data_enum
     contradiction
   · intros ancTy ancUF
     simp [Map.empty, Map.mapOnValues, List.map, Map.find?, List.find?]
+  · intros mems hmems
+    simp only [Option.some.injEq] at hmems
+    simp only [←hmems]
+    simp only [←hfind_entry'] at hvalid_eid
+    exact hvalid_eid
   · simp only [SameTags, Option.map_none]
     simp only [InstanceOfEntityTags, EntitySchemaEntry.tags?] at hwt_data_tags
     exact hwt_data_tags
@@ -1043,6 +1050,14 @@ private theorem env_symbolize?_same_entities_action
     ] at hanc_term
     simp only [hanc_term.2, true_and, heq_ancs]
     exact hmem_anc
+  · intros mems hmems
+    simp only [Option.some.injEq] at hmems
+    simp only [←hmems]
+    apply (Set.make_mem _ _).mp
+    simp only [SymEntityData.ofActionType.acts]
+    apply List.mem_filterMap.mpr
+    exists (uid, entry)
+    simp [Map.find?_mem_toList hfind_entry]
   · simp only [SameTags, htags_emp]
 
 private theorem env_symbolize?_same_entities

--- a/cedar-lean/Cedar/Thm/SymCC/Symbolizer.lean
+++ b/cedar-lean/Cedar/Thm/SymCC/Symbolizer.lean
@@ -15,6 +15,7 @@
 -/
 
 import Cedar.Thm.SymCC.Env.ofEnv
+import Cedar.Thm.SymCC.Term.ofType
 import Cedar.SymCC.Concretizer
 import Cedar.SymCC.Symbolizer
 
@@ -74,15 +75,7 @@ theorem value_symbolize?_well_typed
     simp only [←hsym, Term.typeOf, TermType.ofType]
     congr
     simp only [List.map_attach₃_snd]
-    -- Rephrase `TermType.ofRecordType` as a map
-    have (rty : List (Attr × QualifiedType)) :
-      TermType.ofRecordType rty
-      = rty.map λ (a, qty) => (a, TermType.ofQualifiedType qty)
-    := by
-      induction rty with
-      | nil => simp [TermType.ofRecordType]
-      | cons => simp [TermType.ofRecordType]; assumption
-    simp only [this]
+    simp only [ofRecordType_as_map]
     have :
       List.Forall₂
         (λ rty_entry sym_attr =>

--- a/cedar-lean/Cedar/Thm/SymCC/Term/ofType.lean
+++ b/cedar-lean/Cedar/Thm/SymCC/Term/ofType.lean
@@ -1,0 +1,33 @@
+/-
+ Copyright Cedar Contributors
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-/
+
+import Cedar.Spec
+import Cedar.SymCC
+
+namespace Cedar.Thm
+
+open Validation SymCC Spec
+
+/-- Rephrases `ofRecordType` with map -/
+theorem ofRecordType_as_map (rty : List (Attr × QualifiedType)) :
+  TermType.ofRecordType rty
+  = rty.map λ (a, qty) => (a, TermType.ofQualifiedType qty)
+:= by
+  induction rty with
+  | nil => simp [TermType.ofRecordType]
+  | cons => simp [TermType.ofRecordType]; assumption
+
+end Cedar.Thm

--- a/cedar-lean/Cedar/Thm/Validation/Typechecker/Types.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Typechecker/Types.lean
@@ -123,6 +123,10 @@ def InstanceOfSchemaEntry (uid : EntityUID) (data : EntityData) (env : TypeEnv) 
   InstanceOfEntitySchemaEntry uid data env ∨
   InstanceOfActionSchemaEntry uid data env
 
+def Entities.HasAllActions (entities : Entities) (env : TypeEnv) : Prop :=
+  ∀ (uid : EntityUID) (entry : ActionSchemaEntry),
+    env.acts.find? uid = some entry → ∃ data, entities.find? uid = some data
+
 /--
 Each entry in the store is valid
 -/
@@ -130,9 +134,7 @@ def InstanceOfSchema (entities : Entities) (env : TypeEnv) : Prop :=
   -- Each entity data is valid
   (∀ (uid : EntityUID) (data : EntityData),
     entities.find? uid = some data → InstanceOfSchemaEntry uid data env) ∧
-  -- Each action in the schema exists
-  (∀ (uid : EntityUID) (entry : ActionSchemaEntry),
-    env.acts.find? uid = some entry → ∃ data, entities.find? uid = some data)
+  Entities.HasAllActions entities env
 
 def InstanceOfWellFormedEnvironment (request : Request) (entities : Entities) (env : TypeEnv) : Prop :=
   env.WellFormed ∧

--- a/cedar-lean/Cedar/Thm/Validation/Typechecker/WF.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Typechecker/WF.lean
@@ -319,6 +319,20 @@ theorem wf_env_implies_wf_request
     simp [Set.contains, hwf_res, Membership.mem]
   · simp [hwf_ctx, hwf_ctx_ty]
 
+/--
+More well-formedness properties of `env.reqty`.
+-/
+theorem wf_env_implies_ctx_lifted
+  {env : TypeEnv}
+  (hwf : env.WellFormed) :
+  (CedarType.record env.reqty.context).IsLifted
+:= by
+  have ⟨_, hwf_acts, ⟨entry, hwf_act, _, _, hwf_ctx⟩⟩ := hwf
+  have ⟨_, hwf_acts, _⟩ := hwf_acts
+  have hwf_act_entry := hwf_acts env.reqty.action entry hwf_act
+  have ⟨_, _, _, _, _, _, hwf_ctx_ty⟩ := hwf_act_entry
+  simp [hwf_ctx, hwf_ctx_ty]
+
 theorem wf_env_implies_wf_acts_map
   {env : TypeEnv}
   (hwf : env.WellFormed) :

--- a/cedar-lean/Cedar/Thm/Validation/Typechecker/WF.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Typechecker/WF.lean
@@ -270,6 +270,25 @@ theorem wf_env_implies_wf_attrs {env : TypeEnv} {ety : EntityType} {attrs : Reco
     . simp [Map.WellFormed, Map.toList, Map.kvs, Map.make, List.canonicalize]
     · simp [Map.find?, List.find?]
 
+theorem wf_env_implies_attrs_lifted {env : TypeEnv} {ety : EntityType} {attrs : RecordType}
+  (hwf : env.WellFormed)
+  (hattrs : env.ets.attrs? ety = .some attrs) :
+  (CedarType.record attrs).IsLifted
+:= by
+  simp only [EntitySchema.attrs?, Option.map_eq_some_iff] at hattrs
+  have ⟨entry, hentry, hattrs⟩ := hattrs
+  have ⟨⟨_, hwf_ets⟩, _⟩ := hwf
+  have hwf_entry := hwf_ets ety entry hentry
+  simp only [EntitySchemaEntry.WellFormed] at hwf_entry
+  split at hwf_entry
+  · have ⟨_, _, _, hlift, _⟩ := hwf_entry
+    simp only [← hattrs]
+    exact hlift
+  · simp only [EntitySchemaEntry.attrs] at hattrs
+    simp only [← hattrs, Map.empty]
+    constructor
+    simp [Map.WellFormed, Map.toList, Map.kvs, Map.make, List.canonicalize]
+
 theorem wf_env_implies_action_wf {env : TypeEnv}
   (hwf : env.WellFormed) :
   EntityUID.WellFormed env env.reqty.action

--- a/cedar-lean/Cedar/Thm/Validation/Typechecker/WF.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Typechecker/WF.lean
@@ -429,6 +429,18 @@ theorem wf_env_implies_wf_ancestor_set
   | enum es =>
     simp only [EntitySchemaEntry.ancestors, Set.empty_wf]
 
+theorem wf_env_implies_wf_action_ancestor_set
+  {env : TypeEnv} {entry : ActionSchemaEntry}
+  {uid : EntityUID}
+  (hwf : env.WellFormed)
+  (hfind : env.acts.find? uid = some entry) :
+  Set.WellFormed entry.ancestors
+:= by
+  have ⟨_, hwf_acts⟩ := hwf
+  replace ⟨⟨_, hwf_acts, _⟩, _⟩ := hwf_acts
+  have ⟨_, _, h, _⟩ := hwf_acts uid entry hfind
+  exact h
+
 theorem wf_env_implies_acyclic_action_hierarchy
   {env : TypeEnv}
   (hwf : env.WellFormed) :

--- a/cedar-lean/Cedar/Thm/Validation/Typechecker/WF.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Typechecker/WF.lean
@@ -250,6 +250,22 @@ theorem wf_env_implies_wf_tag_type {env : TypeEnv} {ety : EntityType} {ty : Ceda
     exact (hwf_tag ty htags).1
   · simp [EntitySchemaEntry.tags?] at htags
 
+theorem wf_env_implies_tag_type_lifted {env : TypeEnv} {ety : EntityType} {ty : CedarType}
+  (hwf : env.WellFormed)
+  (hety : env.ets.tags? ety = .some (.some ty)) :
+  ty.IsLifted
+:= by
+  simp only [EntitySchema.tags?, Option.map_eq_some_iff] at hety
+  have ⟨entry, hentry, htags⟩ := hety
+  have ⟨⟨_, hwf_ets⟩, _⟩ := hwf
+  have hwf_entry := hwf_ets ety entry hentry
+  simp only [EntitySchemaEntry.WellFormed] at hwf_entry
+  split at hwf_entry
+  · have ⟨_, _, _, _, hwf_tag⟩ := hwf_entry
+    simp only [EntitySchemaEntry.tags?] at htags
+    exact (hwf_tag ty htags).2
+  · simp [EntitySchemaEntry.tags?] at htags
+
 theorem wf_env_implies_wf_attrs {env : TypeEnv} {ety : EntityType} {attrs : RecordType}
   (hwf : env.WellFormed)
   (hattrs : env.ets.attrs? ety = .some attrs) :

--- a/cedar-lean/Cedar/Thm/Verification.lean
+++ b/cedar-lean/Cedar/Thm/Verification.lean
@@ -15,7 +15,6 @@
 -/
 
 import Cedar.Thm.SymCC.Verifier
-import Cedar.Thm.SymCC.Env.Soundness
 
 /-!
 This file proves the soundness and completeness of the verification queries in

--- a/cedar-lean/Cedar/Thm/WellTypedVerification.lean
+++ b/cedar-lean/Cedar/Thm/WellTypedVerification.lean
@@ -17,6 +17,8 @@
 import Cedar.Thm.SymCC.Verifier.WellTypedOk
 import Cedar.Thm.SymCC.WellTyped
 import Cedar.Thm.Verification
+import Cedar.Thm.SymCC.Env.Soundness
+import Cedar.Thm.SymCC.Env.Completeness
 
 /-!
 This file connects soundness theorems in `Cedar.Thm.Verification`


### PR DESCRIPTION
new theorem has dropped :)
```
theorem ofEnv_completeness
  {Γ : TypeEnv} {env : Env}
  Γ.WellFormed →
  env.StronglyWellFormed →
  Env.EnumCompleteFor env (SymEnv.ofEnv Γ) →
  env ∈ᵢ SymEnv.ofEnv Γ →
  InstanceOfWellFormedEnvironment env.request env.entities Γ
```

This is the converse of #682.

A few caveats and tweaks:
- It turns out that the new condition `Env.EnumCompleteFor` is necessary, after a dicussion with @emina. This is because `SameEntities` does not enforce that all action entities exist in the concrete entity store, whereas `InstanceOfWellFormedEnvironment` does require that for typechecking soundness. However, while action and enum entities are distinguished at the level of `TypeEnv`, they are have similar representation at the level of `SymEnv`: so `SameEntities` cannot distinguish actions and enums. We decided to settle for this new precondition `Env.EnumCompleteFor` because other options (such as strengthening `InstanceOfWellFormedEnvironment` would break entity validation and potentially DRT).

  In the proof of completeness theorems of verification (e.g., `verifyEquivalent_is_complete`), the concretizer is used for constructing the witness `Env`, which means that it should satisfy `Env.EnumCompleteFor` (but I'll leave the proof for another PR).
- I added a new condition in `SameEntityData` for `members`; otherwise `SameEntities` may allow invalid action UIDs with a valid action entity type.
```
def SameEntityData (uid : EntityUID) (d : EntityData) (δ : SymEntityData) : Prop :=
  SameValues (.record d.attrs) (app δ.attrs uid) ∧
  (∀ anc, anc ∈ d.ancestors → InSymAncestors anc) ∧
  (∀ ancTy ancUF, δ.ancestors.find? ancTy = .some ancUF → InAncestors ancUF ancTy) ∧
  (∀ mems, δ.members = .some mems → uid.eid ∈ mems) ∧ /-- HERE --/
  SameTags uid d δ
```
Other proofs are fixed accordingly; @emina please check if this is ok.
