### PR TITLE
More completeness theorems

### DIFF
--- a/cedar-lean/Cedar/Thm/SymCC/Enforcer.lean
+++ b/cedar-lean/Cedar/Thm/SymCC/Enforcer.lean
@@ -16,6 +16,7 @@
 
 import Cedar.SymCC.Enforcer
 import Cedar.Thm.SymCC.Enforcer.Enforce
+import Cedar.Thm.SymCC.Enforcer.Extractor
 
 /-!
 This file proves key lemmas for the strong well-formedness assumptions for
@@ -65,10 +66,12 @@ theorem enforce_satisfiedBy_implies_exists_swf {ps : Policies} {εnv : SymEnv} {
     I'.WellFormed εnv.entities ∧
     env ∼ εnv.interpret I' ∧
     env.StronglyWellFormedForPolicies ps ∧
+    Env.EnumCompleteFor env εnv ∧
     ∀ p t, p ∈ ps → compile p.toExpr εnv = .ok t → t.interpret I = t.interpret I'
 := by
   intro hsε hI hok hsat
-  have ⟨I', env, _, _, _⟩ := enforce_satisfiedBy_implies_exists_swf_extract? hsε hI hok hsat
+  have ⟨I', env, hext, _, _, _, _⟩ := enforce_satisfiedBy_implies_exists_swf_extract? hsε hI hok hsat
+  have := extract?_implies_enum_complete hext
   exists I', env
 
 end Cedar.Thm

--- a/cedar-lean/Cedar/Thm/SymCC/Env/Completeness.lean
+++ b/cedar-lean/Cedar/Thm/SymCC/Env/Completeness.lean
@@ -239,7 +239,7 @@ private theorem ofType_typeOf_pullback
     any_goals contradiction
     rename_i ty_ts
     injection heq_ty with heq_ty
-    cases hlift_ty with | set_wf hlift_ty_ts =>
+    cases hlift_ty with | set_lifted hlift_ty_ts =>
     cases hwf_ty with | set_wf hwf_ty_ts =>
     cases hwf_t with | set_wf hwf_ts heq_ty_ts =>
     simp only [←hval]
@@ -265,7 +265,7 @@ private theorem ofType_typeOf_pullback
     any_goals contradiction
     simp only [TermType.record.injEq, Map.mk.injEq] at heq_ty
     rename_i ty_rec
-    cases hlift_ty with | record_wf hlift_ty_rec =>
+    cases hlift_ty with | record_lifted hlift_ty_rec =>
     cases hwf_ty with | record_wf hwf_ty_rec_map hwf_ty_rec =>
     cases hwf_t with | record_wf hwf_rec heq_ty_rec =>
     simp only [←hval]

--- a/cedar-lean/Cedar/Thm/SymCC/Verifier/VerifyEvaluate.lean
+++ b/cedar-lean/Cedar/Thm/SymCC/Verifier/VerifyEvaluate.lean
@@ -126,6 +126,7 @@ theorem verifyEvaluate_is_complete {φ : Term → Term} {f : Spec.Result Value �
   ∃ env,
     env ∈ᵢ εnv ∧
     env.StronglyWellFormedForPolicy p ∧
+    Env.EnumCompleteFor env εnv ∧
     f (evaluate p.toExpr env.request env.entities) = false
 := by
   intro ⟨hwφ, hiφ, hφf⟩ hwε hok hsat
@@ -134,7 +135,7 @@ theorem verifyEvaluate_is_complete {φ : Term → Term} {f : Spec.Result Value �
   replace ⟨t₁, ts, hok, ha, hvc⟩ := verifyEvaluate_ok_implies hok
   subst hvc
   replace ⟨hsat, hvc⟩ := asserts_all_true hsat
-  replace ⟨I', env, hwI', heq, hwe, hsat⟩ := enforce_satisfiedBy_implies_exists_swf
+  replace ⟨I', env, hwI', heq, hwe, henum_comp, hsat⟩ := enforce_satisfiedBy_implies_exists_swf
     (swf_εnv_for_policy_iff_swf_for_polices.mp hwε) hwI ha hsat
   exists env
   rw [← swf_env_for_policy_iff_swf_for_polices] at hwe
@@ -148,6 +149,7 @@ theorem verifyEvaluate_is_complete {φ : Term → Term} {f : Spec.Result Value �
     specialize hsat p t₁ (by simp only [List.mem_cons, List.not_mem_nil, or_false]) hok
     rw [interpret_not_wbeq hwI hwt₁ hwφ hiφ, hsat] at hvc
     replace hrb := wbeq_bisimulation hwt₁ hφf hwI' hrb
+    simp only [henum_comp, true_and]
     exact same_bool_not_true_implies_false hrb hvc
 
 end Cedar.Thm

--- a/cedar-lean/Cedar/Thm/SymCC/Verifier/VerifyIsAuthorized.lean
+++ b/cedar-lean/Cedar/Thm/SymCC/Verifier/VerifyIsAuthorized.lean
@@ -141,6 +141,7 @@ theorem verifyIsAuthorized_is_complete {φ : Term → Term → Term} {f : Respon
     env ∈ᵢ εnv ∧
     env.StronglyWellFormedForPolicies ps₁ ∧
     env.StronglyWellFormedForPolicies ps₂ ∧
+    Env.EnumCompleteFor env εnv ∧
     f (Spec.isAuthorized env.request env.entities ps₁) (Spec.isAuthorized env.request env.entities ps₂) = false
 := by
   intro ⟨hwφ, hiφ, hφf⟩ hwε₁ hwε₂ hok hsat
@@ -149,7 +150,7 @@ theorem verifyIsAuthorized_is_complete {φ : Term → Term → Term} {f : Respon
   replace ⟨t₁, t₂, ts, hok₁, hok₂, ha, hok⟩ := verifyIsAuthorized_ok_implies hok
   subst hok
   replace ⟨hsat, hvc⟩ := asserts_all_true hsat
-  replace ⟨I', env, hwI', heq, hwe, hsat⟩ := enforce_satisfiedBy_implies_exists_swf
+  replace ⟨I', env, hwI', heq, hwe, henum_comp, hsat⟩ := enforce_satisfiedBy_implies_exists_swf
     (swf_εnv_for_policies_iff_swf_for_append.mp (And.intro hwε₁ hwε₂)) hwI ha hsat
   exists env
   rw [← swf_env_for_policies_iff_swf_for_append] at hwe
@@ -174,6 +175,7 @@ theorem verifyIsAuthorized_is_complete {φ : Term → Term → Term} {f : Respon
     replace hok₂ := isAuthorized_interpret_eq_when_interpret_eq hwε₂ hwI hwI' hsat₂ hok₂
     rw [interpret_not_wbaq hwI (And.intro hwt₁ hwt₂) hwφ hiφ, hok₁, hok₂] at hvc
     have hrb := wbaq_bisimulation (And.intro hwt₁ hwt₂) hφf hwI' hrb₁ hrb₂
+    simp only [henum_comp, true_and]
     exact same_bool_not_true_implies_false hrb hvc
 
 end Cedar.Thm

--- a/cedar-lean/Cedar/Thm/Validation/Typechecker/WF.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Typechecker/WF.lean
@@ -73,10 +73,10 @@ end
 
 mutual
 inductive QualifiedType.IsLifted : Qualified CedarType → Prop where
-  | optional_wf {ty : CedarType}
+  | optional_lifted {ty : CedarType}
     (h : CedarType.IsLifted ty) :
     QualifiedType.IsLifted (.optional ty)
-  | required_wf {ty : CedarType}
+  | required_lifted {ty : CedarType}
     (h : CedarType.IsLifted ty) :
     QualifiedType.IsLifted (.required ty)
 
@@ -84,17 +84,17 @@ inductive QualifiedType.IsLifted : Qualified CedarType → Prop where
 Defines when a `CedarType` does not have any singleton Bool types.
 -/
 inductive CedarType.IsLifted : CedarType → Prop where
-  | bool_wf : CedarType.IsLifted (.bool .anyBool)
-  | int_wf : CedarType.IsLifted .int
-  | string_wf : CedarType.IsLifted .string
-  | entity_wf {ety : EntityType} : CedarType.IsLifted (.entity ety)
-  | set_wf {ty : CedarType}
+  | bool_lifted : CedarType.IsLifted (.bool .anyBool)
+  | int_lifted : CedarType.IsLifted .int
+  | string_lifted : CedarType.IsLifted .string
+  | entity_lifted {ety : EntityType} : CedarType.IsLifted (.entity ety)
+  | set_lifted {ty : CedarType}
     (h : CedarType.IsLifted ty) :
     CedarType.IsLifted (.set ty)
-  | record_wf {rty : RecordType}
+  | record_lifted {rty : RecordType}
     (h₂ : ∀ attr qty, (attr, qty) ∈ rty.toList → QualifiedType.IsLifted qty) :
     CedarType.IsLifted (.record rty)
-  | ext_wf {xty : ExtType} : CedarType.IsLifted (.ext xty)
+  | ext_lifted {xty : ExtType} : CedarType.IsLifted (.ext xty)
 end
 
 def StandardSchemaEntry.WellFormed (env : TypeEnv) (entry : StandardSchemaEntry) : Prop :=

--- a/cedar-lean/Cedar/Thm/Verification.lean
+++ b/cedar-lean/Cedar/Thm/Verification.lean
@@ -68,6 +68,7 @@ theorem verifyNeverErrors_is_complete {p : Policy} {εnv : SymEnv} {asserts : As
   ∃ env,
     env ∈ᵢ εnv ∧
     env.StronglyWellFormedForPolicy p ∧
+    Env.EnumCompleteFor env εnv ∧
     ¬ (evaluate p.toExpr env.request env.entities).isOk
 := by
   simp only [Bool.not_eq_true]
@@ -112,6 +113,7 @@ theorem verifyEquivalent_is_complete  {ps₁ ps₂ : Policies} {εnv : SymEnv} {
     env ∈ᵢ εnv ∧
     env.StronglyWellFormedForPolicies ps₁ ∧
     env.StronglyWellFormedForPolicies ps₂ ∧
+    Env.EnumCompleteFor env εnv ∧
     ¬ bothAllowOrBothDeny
       (Spec.isAuthorized env.request env.entities ps₁)
       (Spec.isAuthorized env.request env.entities ps₂)
@@ -158,6 +160,7 @@ theorem verifyDisjoint_is_complete  {ps₁ ps₂ : Policies} {εnv : SymEnv} {as
     env ∈ᵢ εnv ∧
     env.StronglyWellFormedForPolicies ps₁ ∧
     env.StronglyWellFormedForPolicies ps₂ ∧
+    Env.EnumCompleteFor env εnv ∧
     ¬ atLeastOneDenies
       (Spec.isAuthorized env.request env.entities ps₁)
       (Spec.isAuthorized env.request env.entities ps₂)
@@ -203,6 +206,7 @@ theorem verifyImplies_is_complete  {ps₁ ps₂ : Policies} {εnv : SymEnv} {ass
     env ∈ᵢ εnv ∧
     env.StronglyWellFormedForPolicies ps₁ ∧
     env.StronglyWellFormedForPolicies ps₂ ∧
+    Env.EnumCompleteFor env εnv ∧
     ¬ ifFirstAllowsSoDoesSecond
       (Spec.isAuthorized env.request env.entities ps₁)
       (Spec.isAuthorized env.request env.entities ps₂)

--- a/cedar-lean/Cedar/Thm/Verification.lean
+++ b/cedar-lean/Cedar/Thm/Verification.lean
@@ -251,6 +251,7 @@ theorem verifyAlwaysDenies_is_complete {ps₁ : Policies} {εnv : SymEnv} {asser
   ∃ env,
     env ∈ᵢ εnv ∧
     env.StronglyWellFormedForPolicies ps₁ ∧
+    Env.EnumCompleteFor env εnv ∧
     ¬ denies (Spec.isAuthorized env.request env.entities ps₁)
 := by
   intro hwε₁ hvc hsat
@@ -299,6 +300,7 @@ theorem verifyAlwaysAllows_is_complete {ps₁ : Policies} {εnv : SymEnv} {asser
   ∃ env,
     env ∈ᵢ εnv ∧
     env.StronglyWellFormedForPolicies ps₁ ∧
+    Env.EnumCompleteFor env εnv ∧
     ¬ allows (Spec.isAuthorized env.request env.entities ps₁)
 := by
   intro hwε₁ hvc hsat

--- a/cedar-lean/Cedar/Thm/WellTypedVerification.lean
+++ b/cedar-lean/Cedar/Thm/WellTypedVerification.lean
@@ -49,11 +49,11 @@ theorem verifyNeverErrors_is_ok_and_sound {p p' : Policy} {Γ : TypeEnv} :
   wellTypedPolicy p Γ = .some p' →
   ∃ asserts,
     verifyNeverErrors p' (SymEnv.ofEnv Γ) = .ok asserts ∧
-    SymEnv.ofEnv Γ ⊭ asserts →
+    (SymEnv.ofEnv Γ ⊭ asserts →
       ∀ env : Env,
         InstanceOfWellFormedEnvironment env.request env.entities Γ →
         env.StronglyWellFormedForPolicy p' →
-        (evaluate p.toExpr env.request env.entities).isOk
+        (evaluate p.toExpr env.request env.entities).isOk)
 := by
   intros hwf hwt
   have hwf_εnv := ofEnv_swf_for_policy hwf hwt
@@ -72,11 +72,11 @@ theorem verifyNeverErrors_is_ok_and_complete {p p' : Policy} {Γ : TypeEnv} :
   wellTypedPolicy p Γ = .some p' →
   ∃ asserts,
     verifyNeverErrors p' (SymEnv.ofEnv Γ) = .ok asserts ∧
-    SymEnv.ofEnv Γ ⊧ asserts →
+    (SymEnv.ofEnv Γ ⊧ asserts →
       ∃ env : Env,
         InstanceOfWellFormedEnvironment env.request env.entities Γ ∧
         env.StronglyWellFormedForPolicy p' ∧
-        ¬ (evaluate p.toExpr env.request env.entities).isOk
+        ¬ (evaluate p.toExpr env.request env.entities).isOk)
 := by
   intros hwf hwt
   have hwf_εnv := ofEnv_swf_for_policy hwf hwt
@@ -97,14 +97,14 @@ theorem verifyEquivalent_is_ok_and_sound {ps₁ ps₁' ps₂ ps₂' : Policies} 
   wellTypedPolicies ps₂ Γ = .some ps₂' →
   ∃ asserts,
     verifyEquivalent ps₁' ps₂' (SymEnv.ofEnv Γ) = .ok asserts ∧
-    SymEnv.ofEnv Γ ⊭ asserts →
-    ∀ env : Env,
-      InstanceOfWellFormedEnvironment env.request env.entities Γ →
-      env.StronglyWellFormedForPolicies ps₁' →
-      env.StronglyWellFormedForPolicies ps₂' →
-      bothAllowOrBothDeny
-        (Spec.isAuthorized env.request env.entities ps₁)
-        (Spec.isAuthorized env.request env.entities ps₂)
+    (SymEnv.ofEnv Γ ⊭ asserts →
+      ∀ env : Env,
+        InstanceOfWellFormedEnvironment env.request env.entities Γ →
+        env.StronglyWellFormedForPolicies ps₁' →
+        env.StronglyWellFormedForPolicies ps₂' →
+        bothAllowOrBothDeny
+          (Spec.isAuthorized env.request env.entities ps₁)
+          (Spec.isAuthorized env.request env.entities ps₂))
 := by
   intros hwf hwt₁ hwt₂
   have hwf_εnv₁ := ofEnv_swf_for_policies hwf hwt₁
@@ -127,14 +127,14 @@ theorem verifyEquivalent_is_ok_and_complete {ps₁ ps₁' ps₂ ps₂' : Policie
   wellTypedPolicies ps₂ Γ = .some ps₂' →
   ∃ asserts,
     verifyEquivalent ps₁' ps₂' (SymEnv.ofEnv Γ) = .ok asserts ∧
-    SymEnv.ofEnv Γ ⊧ asserts →
-    ∃ env : Env,
-      InstanceOfWellFormedEnvironment env.request env.entities Γ ∧
-      env.StronglyWellFormedForPolicies ps₁' ∧
-      env.StronglyWellFormedForPolicies ps₂' ∧
-      ¬ bothAllowOrBothDeny
-        (Spec.isAuthorized env.request env.entities ps₁)
-        (Spec.isAuthorized env.request env.entities ps₂)
+    (SymEnv.ofEnv Γ ⊧ asserts →
+      ∃ env : Env,
+        InstanceOfWellFormedEnvironment env.request env.entities Γ ∧
+        env.StronglyWellFormedForPolicies ps₁' ∧
+        env.StronglyWellFormedForPolicies ps₂' ∧
+        ¬ bothAllowOrBothDeny
+          (Spec.isAuthorized env.request env.entities ps₁)
+          (Spec.isAuthorized env.request env.entities ps₂))
 := by
   intros hwf hwt₁ hwt₂
   have hwf_εnv₁ := ofEnv_swf_for_policies hwf hwt₁
@@ -158,14 +158,14 @@ theorem verifyDisjoint_is_ok_and_sound {ps₁ ps₁' ps₂ ps₂' : Policies} {�
   wellTypedPolicies ps₂ Γ = .some ps₂' →
   ∃ asserts,
     verifyDisjoint ps₁' ps₂' (SymEnv.ofEnv Γ) = .ok asserts ∧
-    SymEnv.ofEnv Γ ⊭ asserts →
-    ∀ env : Env,
-      InstanceOfWellFormedEnvironment env.request env.entities Γ →
-      env.StronglyWellFormedForPolicies ps₁' →
-      env.StronglyWellFormedForPolicies ps₂' →
-      atLeastOneDenies
-        (Spec.isAuthorized env.request env.entities ps₁)
-        (Spec.isAuthorized env.request env.entities ps₂)
+    (SymEnv.ofEnv Γ ⊭ asserts →
+      ∀ env : Env,
+        InstanceOfWellFormedEnvironment env.request env.entities Γ →
+        env.StronglyWellFormedForPolicies ps₁' →
+        env.StronglyWellFormedForPolicies ps₂' →
+        atLeastOneDenies
+          (Spec.isAuthorized env.request env.entities ps₁)
+          (Spec.isAuthorized env.request env.entities ps₂))
 := by
   intros hwf hwt₁ hwt₂
   have hwf_εnv₁ := ofEnv_swf_for_policies hwf hwt₁
@@ -188,14 +188,14 @@ theorem verifyDisjoint_is_ok_and_complete {ps₁ ps₁' ps₂ ps₂' : Policies}
   wellTypedPolicies ps₂ Γ = .some ps₂' →
   ∃ asserts,
     verifyDisjoint ps₁' ps₂' (SymEnv.ofEnv Γ) = .ok asserts ∧
-    SymEnv.ofEnv Γ ⊧ asserts →
-    ∃ env : Env,
-      InstanceOfWellFormedEnvironment env.request env.entities Γ ∧
-      env.StronglyWellFormedForPolicies ps₁' ∧
-      env.StronglyWellFormedForPolicies ps₂' ∧
-      ¬ atLeastOneDenies
-        (Spec.isAuthorized env.request env.entities ps₁)
-        (Spec.isAuthorized env.request env.entities ps₂)
+    (SymEnv.ofEnv Γ ⊧ asserts →
+      ∃ env : Env,
+        InstanceOfWellFormedEnvironment env.request env.entities Γ ∧
+        env.StronglyWellFormedForPolicies ps₁' ∧
+        env.StronglyWellFormedForPolicies ps₂' ∧
+        ¬ atLeastOneDenies
+          (Spec.isAuthorized env.request env.entities ps₁)
+          (Spec.isAuthorized env.request env.entities ps₂))
 := by
   intros hwf hwt₁ hwt₂
   have hwf_εnv₁ := ofEnv_swf_for_policies hwf hwt₁
@@ -219,14 +219,14 @@ theorem verifyImplies_is_ok_and_sound {ps₁ ps₁' ps₂ ps₂' : Policies} {Γ
   wellTypedPolicies ps₂ Γ = .some ps₂' →
   ∃ asserts,
     verifyImplies ps₁' ps₂' (SymEnv.ofEnv Γ) = .ok asserts ∧
-    SymEnv.ofEnv Γ ⊭ asserts →
-    ∀ env : Env,
-      InstanceOfWellFormedEnvironment env.request env.entities Γ →
-      env.StronglyWellFormedForPolicies ps₁' →
-      env.StronglyWellFormedForPolicies ps₂' →
-      ifFirstAllowsSoDoesSecond
-        (Spec.isAuthorized env.request env.entities ps₁)
-        (Spec.isAuthorized env.request env.entities ps₂)
+    (SymEnv.ofEnv Γ ⊭ asserts →
+      ∀ env : Env,
+        InstanceOfWellFormedEnvironment env.request env.entities Γ →
+        env.StronglyWellFormedForPolicies ps₁' →
+        env.StronglyWellFormedForPolicies ps₂' →
+        ifFirstAllowsSoDoesSecond
+          (Spec.isAuthorized env.request env.entities ps₁)
+          (Spec.isAuthorized env.request env.entities ps₂))
 := by
   intros hwf hwt₁ hwt₂
   have hwf_εnv₁ := ofEnv_swf_for_policies hwf hwt₁
@@ -249,14 +249,14 @@ theorem verifyImplies_is_ok_and_complete {ps₁ ps₁' ps₂ ps₂' : Policies} 
   wellTypedPolicies ps₂ Γ = .some ps₂' →
   ∃ asserts,
     verifyImplies ps₁' ps₂' (SymEnv.ofEnv Γ) = .ok asserts ∧
-    SymEnv.ofEnv Γ ⊧ asserts →
-    ∃ env : Env,
-      InstanceOfWellFormedEnvironment env.request env.entities Γ ∧
-      env.StronglyWellFormedForPolicies ps₁' ∧
-      env.StronglyWellFormedForPolicies ps₂' ∧
-      ¬ ifFirstAllowsSoDoesSecond
-        (Spec.isAuthorized env.request env.entities ps₁)
-        (Spec.isAuthorized env.request env.entities ps₂)
+    (SymEnv.ofEnv Γ ⊧ asserts →
+      ∃ env : Env,
+        InstanceOfWellFormedEnvironment env.request env.entities Γ ∧
+        env.StronglyWellFormedForPolicies ps₁' ∧
+        env.StronglyWellFormedForPolicies ps₂' ∧
+        ¬ ifFirstAllowsSoDoesSecond
+          (Spec.isAuthorized env.request env.entities ps₁)
+          (Spec.isAuthorized env.request env.entities ps₂))
 := by
   intros hwf hwt₁ hwt₂
   have hwf_εnv₁ := ofEnv_swf_for_policies hwf hwt₁
@@ -279,11 +279,11 @@ theorem verifyAlwaysDenies_is_ok_and_sound {ps₁ ps₁' : Policies} {Γ : TypeE
   wellTypedPolicies ps₁ Γ = .some ps₁' →
   ∃ asserts,
     verifyAlwaysDenies ps₁' (SymEnv.ofEnv Γ) = .ok asserts ∧
-    SymEnv.ofEnv Γ ⊭ asserts →
-    ∀ env : Env,
-      InstanceOfWellFormedEnvironment env.request env.entities Γ →
-      env.StronglyWellFormedForPolicies ps₁' →
-      denies (Spec.isAuthorized env.request env.entities ps₁)
+    (SymEnv.ofEnv Γ ⊭ asserts →
+      ∀ env : Env,
+        InstanceOfWellFormedEnvironment env.request env.entities Γ →
+        env.StronglyWellFormedForPolicies ps₁' →
+        denies (Spec.isAuthorized env.request env.entities ps₁))
 := by
   intros hwf hwt₁
   have hwf_εnv₁ := ofEnv_swf_for_policies hwf hwt₁
@@ -303,11 +303,11 @@ theorem verifyAlwaysDenies_is_ok_and_complete {ps₁ ps₁' : Policies} {Γ : Ty
   wellTypedPolicies ps₁ Γ = .some ps₁' →
   ∃ asserts,
     verifyAlwaysDenies ps₁' (SymEnv.ofEnv Γ) = .ok asserts ∧
-    SymEnv.ofEnv Γ ⊧ asserts →
-    ∃ env : Env,
-      InstanceOfWellFormedEnvironment env.request env.entities Γ ∧
-      env.StronglyWellFormedForPolicies ps₁' ∧
-      ¬ denies (Spec.isAuthorized env.request env.entities ps₁)
+    (SymEnv.ofEnv Γ ⊧ asserts →
+      ∃ env : Env,
+        InstanceOfWellFormedEnvironment env.request env.entities Γ ∧
+        env.StronglyWellFormedForPolicies ps₁' ∧
+        ¬ denies (Spec.isAuthorized env.request env.entities ps₁))
 := by
   intros hwf hwt₁
   have hwf_εnv₁ := ofEnv_swf_for_policies hwf hwt₁
@@ -328,11 +328,11 @@ theorem verifyAlwaysAllows_is_ok_and_sound {ps₁ ps₁' : Policies} {Γ : TypeE
   wellTypedPolicies ps₁ Γ = .some ps₁' →
   ∃ asserts,
     verifyAlwaysAllows ps₁' (SymEnv.ofEnv Γ) = .ok asserts ∧
-    SymEnv.ofEnv Γ ⊭ asserts →
-    ∀ env : Env,
-      InstanceOfWellFormedEnvironment env.request env.entities Γ →
-      env.StronglyWellFormedForPolicies ps₁' →
-      allows (Spec.isAuthorized env.request env.entities ps₁)
+    (SymEnv.ofEnv Γ ⊭ asserts →
+      ∀ env : Env,
+        InstanceOfWellFormedEnvironment env.request env.entities Γ →
+        env.StronglyWellFormedForPolicies ps₁' →
+        allows (Spec.isAuthorized env.request env.entities ps₁))
 := by
   intros hwf hwt₁
   have hwf_εnv₁ := ofEnv_swf_for_policies hwf hwt₁
@@ -352,11 +352,11 @@ theorem verifyAlwaysAllows_is_ok_and_complete {ps₁ ps₁' : Policies} {Γ : Ty
   wellTypedPolicies ps₁ Γ = .some ps₁' →
   ∃ asserts,
     verifyAlwaysAllows ps₁' (SymEnv.ofEnv Γ) = .ok asserts ∧
-    SymEnv.ofEnv Γ ⊧ asserts →
-    ∃ env : Env,
-      InstanceOfWellFormedEnvironment env.request env.entities Γ ∧
-      env.StronglyWellFormedForPolicies ps₁' ∧
-      ¬ allows (Spec.isAuthorized env.request env.entities ps₁)
+    (SymEnv.ofEnv Γ ⊧ asserts →
+      ∃ env : Env,
+        InstanceOfWellFormedEnvironment env.request env.entities Γ ∧
+        env.StronglyWellFormedForPolicies ps₁' ∧
+        ¬ allows (Spec.isAuthorized env.request env.entities ps₁))
 := by
   intros hwf hwt₁
   have hwf_εnv₁ := ofEnv_swf_for_policies hwf hwt₁

--- a/cedar-lean/Cedar/Thm/WellTypedVerification.lean
+++ b/cedar-lean/Cedar/Thm/WellTypedVerification.lean
@@ -66,6 +66,30 @@ theorem verifyNeverErrors_is_ok_and_sound {p p' : Policy} {Γ : TypeEnv} :
   · exact ofEnv_soundness hwf_env.1 hinst
   · exact hwf_env
 
+/-- Concrete version of `verifyNeverErrors_is_complete`. -/
+theorem verifyNeverErrors_is_ok_and_complete {p p' : Policy} {Γ : TypeEnv} :
+  Γ.WellFormed →
+  wellTypedPolicy p Γ = .some p' →
+  ∃ asserts,
+    verifyNeverErrors p' (SymEnv.ofEnv Γ) = .ok asserts ∧
+    SymEnv.ofEnv Γ ⊧ asserts →
+      ∃ env : Env,
+        InstanceOfWellFormedEnvironment env.request env.entities Γ ∧
+        env.StronglyWellFormedForPolicy p' ∧
+        ¬ (evaluate p.toExpr env.request env.entities).isOk
+:= by
+  intros hwf hwt
+  have hwf_εnv := ofEnv_swf_for_policy hwf hwt
+  have ⟨asserts, hok⟩ := verifyNeverErrors_is_ok hwf hwt
+  exists asserts
+  simp only [hok, true_and]
+  intros hsat
+  have ⟨env, hmodel, hswf_env, henum_comp, hres⟩ := verifyNeverErrors_is_complete hwf_εnv hok hsat
+  have hinst := ofEnv_completeness hwf hswf_env.1 henum_comp hmodel
+  have := wellTypedPolicy_preserves_evaluation hinst hwt
+  simp only [←wellTypedPolicy_preserves_evaluation hinst hwt] at hres
+  exists env
+
 /-- Concrete version of `verifyEquivalent_is_sound`. -/
 theorem verifyEquivalent_is_ok_and_sound {ps₁ ps₁' ps₂ ps₂' : Policies} {Γ : TypeEnv} :
   Γ.WellFormed →
@@ -95,6 +119,37 @@ theorem verifyEquivalent_is_ok_and_sound {ps₁ ps₁' ps₂ ps₂' : Policies} 
   ]
   apply verifyEquivalent_is_sound hwf_εnv₁ hwf_εnv₂ hok hunsat env _ hwf_ps₁ hwf_ps₂
   exact ofEnv_soundness hwf_ps₁.1 hinst
+
+/-- Concrete version of `verifyEquivalent_is_complete`. -/
+theorem verifyEquivalent_is_ok_and_complete {ps₁ ps₁' ps₂ ps₂' : Policies} {Γ : TypeEnv} :
+  Γ.WellFormed →
+  wellTypedPolicies ps₁ Γ = .some ps₁' →
+  wellTypedPolicies ps₂ Γ = .some ps₂' →
+  ∃ asserts,
+    verifyEquivalent ps₁' ps₂' (SymEnv.ofEnv Γ) = .ok asserts ∧
+    SymEnv.ofEnv Γ ⊧ asserts →
+    ∃ env : Env,
+      InstanceOfWellFormedEnvironment env.request env.entities Γ ∧
+      env.StronglyWellFormedForPolicies ps₁' ∧
+      env.StronglyWellFormedForPolicies ps₂' ∧
+      ¬ bothAllowOrBothDeny
+        (Spec.isAuthorized env.request env.entities ps₁)
+        (Spec.isAuthorized env.request env.entities ps₂)
+:= by
+  intros hwf hwt₁ hwt₂
+  have hwf_εnv₁ := ofEnv_swf_for_policies hwf hwt₁
+  have hwf_εnv₂ := ofEnv_swf_for_policies hwf hwt₂
+  have ⟨asserts, hok⟩ := verifyEquivalent_is_ok hwf hwt₁ hwt₂
+  exists asserts
+  simp only [hok, true_and]
+  intros hsat
+  have ⟨env, hmodel, hswf_env₁, hswf_env₂, henum_comp, hres⟩ := verifyEquivalent_is_complete hwf_εnv₁ hwf_εnv₂ hok hsat
+  have hinst := ofEnv_completeness hwf hswf_env₁.1 henum_comp hmodel
+  simp only [
+    ←wellTypedPolicies_preserves_isAuthorized hinst hwt₁,
+    ←wellTypedPolicies_preserves_isAuthorized hinst hwt₂,
+  ] at hres
+  exists env
 
 /-- Concrete version of `verifyDisjoint_is_sound`. -/
 theorem verifyDisjoint_is_ok_and_sound {ps₁ ps₁' ps₂ ps₂' : Policies} {Γ : TypeEnv} :
@@ -126,6 +181,37 @@ theorem verifyDisjoint_is_ok_and_sound {ps₁ ps₁' ps₂ ps₂' : Policies} {�
   apply verifyDisjoint_is_sound hwf_εnv₁ hwf_εnv₂ hok hunsat env _ hwf_ps₁ hwf_ps₂
   exact ofEnv_soundness hwf_ps₁.1 hinst
 
+/-- Concrete version of `verifyDisjoint_is_complete`. -/
+theorem verifyDisjoint_is_ok_and_complete {ps₁ ps₁' ps₂ ps₂' : Policies} {Γ : TypeEnv} :
+  Γ.WellFormed →
+  wellTypedPolicies ps₁ Γ = .some ps₁' →
+  wellTypedPolicies ps₂ Γ = .some ps₂' →
+  ∃ asserts,
+    verifyDisjoint ps₁' ps₂' (SymEnv.ofEnv Γ) = .ok asserts ∧
+    SymEnv.ofEnv Γ ⊧ asserts →
+    ∃ env : Env,
+      InstanceOfWellFormedEnvironment env.request env.entities Γ ∧
+      env.StronglyWellFormedForPolicies ps₁' ∧
+      env.StronglyWellFormedForPolicies ps₂' ∧
+      ¬ atLeastOneDenies
+        (Spec.isAuthorized env.request env.entities ps₁)
+        (Spec.isAuthorized env.request env.entities ps₂)
+:= by
+  intros hwf hwt₁ hwt₂
+  have hwf_εnv₁ := ofEnv_swf_for_policies hwf hwt₁
+  have hwf_εnv₂ := ofEnv_swf_for_policies hwf hwt₂
+  have ⟨asserts, hok⟩ := verifyDisjoint_is_ok hwf hwt₁ hwt₂
+  exists asserts
+  simp only [hok, true_and]
+  intros hsat
+  have ⟨env, hmodel, hswf_env₁, hswf_env₂, henum_comp, hres⟩ := verifyDisjoint_is_complete hwf_εnv₁ hwf_εnv₂ hok hsat
+  have hinst := ofEnv_completeness hwf hswf_env₁.1 henum_comp hmodel
+  simp only [
+    ←wellTypedPolicies_preserves_isAuthorized hinst hwt₁,
+    ←wellTypedPolicies_preserves_isAuthorized hinst hwt₂,
+  ] at hres
+  exists env
+
 /-- Concrete version of `verifyImplies_is_sound`. -/
 theorem verifyImplies_is_ok_and_sound {ps₁ ps₁' ps₂ ps₂' : Policies} {Γ : TypeEnv} :
   Γ.WellFormed →
@@ -156,6 +242,37 @@ theorem verifyImplies_is_ok_and_sound {ps₁ ps₁' ps₂ ps₂' : Policies} {Γ
   apply verifyImplies_is_sound hwf_εnv₁ hwf_εnv₂ hok hunsat env _ hwf_ps₁ hwf_ps₂
   exact ofEnv_soundness hwf_ps₁.1 hinst
 
+/-- Concrete version of `verifyImplies_is_complete`. -/
+theorem verifyImplies_is_ok_and_complete {ps₁ ps₁' ps₂ ps₂' : Policies} {Γ : TypeEnv} :
+  Γ.WellFormed →
+  wellTypedPolicies ps₁ Γ = .some ps₁' →
+  wellTypedPolicies ps₂ Γ = .some ps₂' →
+  ∃ asserts,
+    verifyImplies ps₁' ps₂' (SymEnv.ofEnv Γ) = .ok asserts ∧
+    SymEnv.ofEnv Γ ⊧ asserts →
+    ∃ env : Env,
+      InstanceOfWellFormedEnvironment env.request env.entities Γ ∧
+      env.StronglyWellFormedForPolicies ps₁' ∧
+      env.StronglyWellFormedForPolicies ps₂' ∧
+      ¬ ifFirstAllowsSoDoesSecond
+        (Spec.isAuthorized env.request env.entities ps₁)
+        (Spec.isAuthorized env.request env.entities ps₂)
+:= by
+  intros hwf hwt₁ hwt₂
+  have hwf_εnv₁ := ofEnv_swf_for_policies hwf hwt₁
+  have hwf_εnv₂ := ofEnv_swf_for_policies hwf hwt₂
+  have ⟨asserts, hok⟩ := verifyImplies_is_ok hwf hwt₁ hwt₂
+  exists asserts
+  simp only [hok, true_and]
+  intros hsat
+  have ⟨env, hmodel, hswf_env₁, hswf_env₂, henum_comp, hres⟩ := verifyImplies_is_complete hwf_εnv₁ hwf_εnv₂ hok hsat
+  have hinst := ofEnv_completeness hwf hswf_env₁.1 henum_comp hmodel
+  simp only [
+    ←wellTypedPolicies_preserves_isAuthorized hinst hwt₁,
+    ←wellTypedPolicies_preserves_isAuthorized hinst hwt₂,
+  ] at hres
+  exists env
+
 /-- Concrete version of `verifyAlwaysDenies_is_sound`. -/
 theorem verifyAlwaysDenies_is_ok_and_sound {ps₁ ps₁' : Policies} {Γ : TypeEnv} :
   Γ.WellFormed →
@@ -180,6 +297,31 @@ theorem verifyAlwaysDenies_is_ok_and_sound {ps₁ ps₁' : Policies} {Γ : TypeE
   apply verifyAlwaysDenies_is_sound hwf_εnv₁ hok hunsat env _ hwf_ps₁
   exact ofEnv_soundness hwf_ps₁.1 hinst
 
+/-- Concrete version of `verifyAlwaysDenies_is_complete`. -/
+theorem verifyAlwaysDenies_is_ok_and_complete {ps₁ ps₁' : Policies} {Γ : TypeEnv} :
+  Γ.WellFormed →
+  wellTypedPolicies ps₁ Γ = .some ps₁' →
+  ∃ asserts,
+    verifyAlwaysDenies ps₁' (SymEnv.ofEnv Γ) = .ok asserts ∧
+    SymEnv.ofEnv Γ ⊧ asserts →
+    ∃ env : Env,
+      InstanceOfWellFormedEnvironment env.request env.entities Γ ∧
+      env.StronglyWellFormedForPolicies ps₁' ∧
+      ¬ denies (Spec.isAuthorized env.request env.entities ps₁)
+:= by
+  intros hwf hwt₁
+  have hwf_εnv₁ := ofEnv_swf_for_policies hwf hwt₁
+  have ⟨asserts, hok⟩ := verifyAlwaysDenies_is_ok hwf hwt₁
+  exists asserts
+  simp only [hok, true_and]
+  intros hsat
+  have ⟨env, hmodel, hswf_env₁, henum_comp, hres⟩ := verifyAlwaysDenies_is_complete hwf_εnv₁ hok hsat
+  have hinst := ofEnv_completeness hwf hswf_env₁.1 henum_comp hmodel
+  simp only [
+    ←wellTypedPolicies_preserves_isAuthorized hinst hwt₁,
+  ] at hres
+  exists env
+
 /-- Concrete version of `verifyAlwaysAllows_is_sound`. -/
 theorem verifyAlwaysAllows_is_ok_and_sound {ps₁ ps₁' : Policies} {Γ : TypeEnv} :
   Γ.WellFormed →
@@ -203,5 +345,30 @@ theorem verifyAlwaysAllows_is_ok_and_sound {ps₁ ps₁' : Policies} {Γ : TypeE
   ]
   apply verifyAlwaysAllows_is_sound hwf_εnv₁ hok hunsat env _ hwf_ps₁
   exact ofEnv_soundness hwf_ps₁.1 hinst
+
+/-- Concrete version of `verifyAlwaysAllows_is_complete`. -/
+theorem verifyAlwaysAllows_is_ok_and_complete {ps₁ ps₁' : Policies} {Γ : TypeEnv} :
+  Γ.WellFormed →
+  wellTypedPolicies ps₁ Γ = .some ps₁' →
+  ∃ asserts,
+    verifyAlwaysAllows ps₁' (SymEnv.ofEnv Γ) = .ok asserts ∧
+    SymEnv.ofEnv Γ ⊧ asserts →
+    ∃ env : Env,
+      InstanceOfWellFormedEnvironment env.request env.entities Γ ∧
+      env.StronglyWellFormedForPolicies ps₁' ∧
+      ¬ allows (Spec.isAuthorized env.request env.entities ps₁)
+:= by
+  intros hwf hwt₁
+  have hwf_εnv₁ := ofEnv_swf_for_policies hwf hwt₁
+  have ⟨asserts, hok⟩ := verifyAlwaysAllows_is_ok hwf hwt₁
+  exists asserts
+  simp only [hok, true_and]
+  intros hsat
+  have ⟨env, hmodel, hswf_env₁, henum_comp, hres⟩ := verifyAlwaysAllows_is_complete hwf_εnv₁ hok hsat
+  have hinst := ofEnv_completeness hwf hswf_env₁.1 henum_comp hmodel
+  simp only [
+    ←wellTypedPolicies_preserves_isAuthorized hinst hwt₁,
+  ] at hres
+  exists env
 
 end Cedar.Thm


### PR DESCRIPTION
This PR adds more concrete completeness theorems for various verification taks specialized to `SymEnv.ofEnv` (i.e., converses of theorems in #688).

For example:
```
theorem verifyNeverErrors_is_ok_and_complete {p p' : Policy} {Γ : TypeEnv} :
  Γ.WellFormed →
  wellTypedPolicy p Γ = .some p' →
  ∃ asserts,
    verifyNeverErrors p' (SymEnv.ofEnv Γ) = .ok asserts ∧
    (SymEnv.ofEnv Γ ⊧ asserts →
      ∃ env : Env,
        InstanceOfWellFormedEnvironment env.request env.entities Γ ∧
        env.StronglyWellFormedForPolicy p' ∧
        ¬ (evaluate p.toExpr env.request env.entities).isOk)
```