### PR TITLE
Use `deep_eq` for equality in entity roundtrip targets

### DIFF
--- a/cedar-drt/fuzz/fuzz_targets/roundtrip-entities.rs
+++ b/cedar-drt/fuzz/fuzz_targets/roundtrip-entities.rs
@@ -16,17 +16,12 @@
 
 #![no_main]
 
-use cedar_drt_inner::fuzz_target;
+use cedar_drt_inner::{fuzz_target, roundtrip_entities};
 
 use cedar_policy::{Entities, Schema};
 
-use cedar_policy::{
-    conformance_errors::EntitySchemaConformanceError, entities_errors::EntitiesError,
-    entities_json_errors::JsonSerializationError,
-};
 use cedar_policy_generators::{hierarchy::HierarchyGenerator, schema, settings::ABACSettings};
 use libfuzzer_sys::arbitrary::{self, Arbitrary, MaxRecursionReached, Unstructured};
-use similar_asserts::assert_eq;
 
 #[derive(Debug)]
 struct FuzzTargetInput {
@@ -70,51 +65,5 @@ impl<'a> Arbitrary<'a> for FuzzTargetInput {
 }
 
 fuzz_target!(|input: FuzzTargetInput| {
-    let json = match input.entities.as_ref().to_json_value() {
-        Ok(json) => json,
-        Err(EntitiesError::Serialization(JsonSerializationError::ReservedKey(_))) => {
-            // Serializing to JSON is expected to fail when there's a record
-            // attribute `__entity`, `__expr`, or `__extn`
-            return;
-        }
-        Err(EntitiesError::Serialization(JsonSerializationError::ExtnCall2OrMoreArguments(
-            err,
-        ))) if err.to_string().contains("offset") => {
-            // Serializing to JSON is expected to fail when there's a record
-            // attribute of type `datetime`, which involves calls to `offset`.
-            // This is because years before AD 1 cannot be constructed using the
-            // `datetime` function, of which the valid inputs span from AD 1 to
-            // year 9999.
-            return;
-        }
-        Err(err) => {
-            panic!("Should be able to serialize entities to JSON, instead got error: {err}")
-        }
-    };
-
-    let roundtripped_entities = Entities::from_json_value(json.clone(), None)
-        .expect("Should be able to parse serialized entity JSON");
-
-    assert_eq!(input.entities, roundtripped_entities);
-
-    // The entity store generator currently produces entities of enumerated entity types but with invalid EIDs,
-    // which are rejected by entity validation
-    match Entities::from_json_value(json.clone(), Some(&input.schema)) {
-        Ok(roundtripped_entities) => {
-            // Weaker assertion for schema based parsing because it adds actions from the schema into entities.
-            for e in input.entities {
-                let roundtripped_e = roundtripped_entities
-                    .get(&e.uid())
-                    .expect("Schema-based roundtrip dropped entity");
-                assert_eq!(&e, roundtripped_e);
-            }
-        }
-        Err(err) => {
-            // The error should only be `InvalidEnumEntity`
-            assert!(matches!(
-                err,
-                EntitiesError::InvalidEntity(EntitySchemaConformanceError::InvalidEnumEntity(_))
-            ));
-        }
-    }
+    roundtrip_entities::fuzz_target(input.entities, Some(input.schema));
 });

--- a/cedar-drt/fuzz/src/lib.rs
+++ b/cedar-drt/fuzz/src/lib.rs
@@ -2,5 +2,6 @@ mod prt;
 #[cfg(not(feature = "prt"))]
 pub use libfuzzer_sys::fuzz_target;
 
+pub mod roundtrip_entities;
 pub mod schemas;
 pub mod validation_drt;

--- a/cedar-drt/fuzz/src/roundtrip_entities.rs
+++ b/cedar-drt/fuzz/src/roundtrip_entities.rs
@@ -1,0 +1,104 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use cedar_policy::{Entities, Schema};
+
+use cedar_policy::{
+    conformance_errors::EntitySchemaConformanceError, entities_errors::EntitiesError,
+    entities_json_errors::JsonSerializationError,
+};
+use itertools::Itertools;
+
+pub fn fuzz_target(entities: Entities, schema: Option<Schema>) {
+    let json = match entities.as_ref().to_json_value() {
+        Ok(json) => json,
+        Err(EntitiesError::Serialization(JsonSerializationError::ReservedKey(_))) => {
+            // Serializing to JSON is expected to fail when there's a record
+            // attribute `__entity`, `__expr`, or `__extn`
+            return;
+        }
+        Err(EntitiesError::Serialization(JsonSerializationError::ExtnCall2OrMoreArguments(
+            err,
+        ))) if err.to_string().contains("offset") => {
+            // Serializing to JSON is expected to fail when there's a record
+            // attribute of type `datetime`, which involves calls to `offset`.
+            // This is because years before AD 1 cannot be constructed using the
+            // `datetime` function, of which the valid inputs span from AD 1 to
+            // year 9999.
+            return;
+        }
+        Err(err) => {
+            panic!("Should be able to serialize entities to JSON, instead got error: {err}")
+        }
+    };
+
+    let roundtripped_entities = Entities::from_json_value(json.clone(), None)
+        .expect("Should be able to parse serialized entity JSON");
+
+    if !entities.deep_eq(&roundtripped_entities) {
+        // Sort for usefull diff. `Entities` is backed by a `HashMap`
+        let entities = entities.iter().sorted_by_key(|e| e.uid()).collect_vec();
+        let roundtripped = roundtripped_entities
+            .iter()
+            .sorted_by_key(|e| e.uid())
+            .collect_vec();
+        panic!(
+            "{}",
+            similar_asserts::SimpleDiff::from_str(
+                &format!("{entities:#?}"),
+                &format!("{roundtripped:#?}"),
+                "original",
+                "roundtripped",
+            )
+        );
+    }
+
+    // Also check schema-based roundtirp
+    if let Some(schema) = schema {
+        // The entity store generator currently produces entities of enumerated entity types but with invalid EIDs,
+        // which are rejected by entity validation
+        match Entities::from_json_value(json.clone(), Some(&schema)) {
+            Ok(roundtripped_entities) => {
+                // Weaker assertion for schema based parsing because it adds actions from the schema into entities.
+                for e in entities {
+                    let roundtripped_e = roundtripped_entities
+                        .get(&e.uid())
+                        .expect("Schema-based roundtrip dropped entity");
+                    if !e.deep_eq(&roundtripped_e) {
+                        panic!(
+                            "{}",
+                            similar_asserts::SimpleDiff::from_str(
+                                &format!("{e:#?}"),
+                                &format!("{roundtripped_e:#?}"),
+                                "original",
+                                "roundtripped",
+                            )
+                        );
+                    }
+                }
+            }
+            Err(err) => {
+                // The error should only be `InvalidEnumEntity`
+                assert!(matches!(
+                    err,
+                    EntitiesError::InvalidEntity(EntitySchemaConformanceError::InvalidEnumEntity(
+                        _
+                    ))
+                ));
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fix #694, requires https://github.com/cedar-policy/cedar/pull/1723

a short local run of both targets doesn't find any bugs
