### PR TITLE
Change `Conditions.toExpr` to match the Rust version

### DIFF
--- a/cedar-lean/Cedar/Spec/Policy.lean
+++ b/cedar-lean/Cedar/Spec/Policy.lean
@@ -117,7 +117,9 @@ def Condition.toExpr (c : Condition) : Expr :=
 
 -- Conditions are evaluated top to bottom, and short circuit
 def Conditions.toExpr (cs : Conditions) : Expr :=
-  cs.foldr (λ c expr => .and (c.toExpr) expr) (Expr.lit (Prim.bool true))
+  match cs with
+  | [] => Expr.lit (Prim.bool true)
+  | c :: cs => cs.foldl (λ expr c => .and expr (c.toExpr)) c.toExpr
 
 def Policy.toExpr (p : Policy) : Expr :=
   .and

--- a/cedar-lean/Cedar/Thm/SymCC/Env/ofEnv.lean
+++ b/cedar-lean/Cedar/Thm/SymCC/Env/ofEnv.lean
@@ -1389,8 +1389,7 @@ theorem wellTypedPolicy_some_implies_valid_refs
   contradiction
   rename_i tx hwt
   simp only [Option.some.injEq] at hsome
-  simp only [←hsome, Policy.toExpr]
-  any_goals repeat constructor
+  simp only [←hsome, Policy.toExpr, Conditions.toExpr, List.foldr, List.foldl]
   any_goals repeat constructor
   simp only [Condition.toExpr]
   simp only [typecheckPolicy] at hwt

--- a/cedar-lean/Cedar/Thm/SymCC/WellTyped.lean
+++ b/cedar-lean/Cedar/Thm/SymCC/WellTyped.lean
@@ -44,10 +44,7 @@ theorem wellTypedPolicy_some_implies_exists_typed_exprs
       (TypedExpr.and (TypedExpr.lit (Prim.bool true) (.bool .anyBool))
       (TypedExpr.and (TypedExpr.lit (Prim.bool true) (.bool .anyBool))
       (TypedExpr.and (TypedExpr.lit (Prim.bool true) (.bool .anyBool))
-        (TypedExpr.and
-          tx.liftBoolTypes
-          (TypedExpr.lit (Prim.bool true) (.bool .anyBool))
-          (.bool .anyBool))
+        tx.liftBoolTypes
       (.bool .anyBool))
       (.bool .anyBool))
       (.bool .anyBool)) ∧
@@ -83,10 +80,7 @@ theorem wellTypedPolicy_some_implies_exists_typed_exprs
         (TypedExpr.and (TypedExpr.lit (Prim.bool true) (.bool .anyBool))
         (TypedExpr.and (TypedExpr.lit (Prim.bool true) (.bool .anyBool))
         (TypedExpr.and (TypedExpr.lit (Prim.bool true) (.bool .anyBool))
-          (TypedExpr.and
-            tx.liftBoolTypes
-            (TypedExpr.lit (Prim.bool true) (.bool .anyBool))
-            (.bool .anyBool))
+          tx.liftBoolTypes
         (.bool .anyBool))
         (.bool .anyBool))
         (.bool .anyBool)) = tx''
@@ -98,13 +92,9 @@ theorem wellTypedPolicy_some_implies_exists_typed_exprs
           · repeat constructor
           · constructor
             · repeat constructor
-            · constructor
-              · exact hwf_lift
-              · repeat constructor
-              · exact this
-              · rfl
-            · rfl
-            · rfl
+            · exact hwf_lift
+            · repeat constructor
+            · exact this
           · rfl
           · rfl
         · rfl
@@ -123,6 +113,7 @@ theorem wellTypedPolicy_some_implies_exists_typed_exprs
         Conditions.toExpr,
         Condition.toExpr,
         List.foldr,
+        List.foldl,
         TypedExpr.toExpr,
         ←htx'',
         type_lifting_preserves_expr tx,


### PR DESCRIPTION
This PR tweaks the definition of `Conditions.toExpr` to match the behavior of the Rust version.
Previously, this causes some issues with DRT.
