### PR TITLE
Fix Term deserialization

### DIFF
--- a/cedar-lean-ffi/src/datatypes.rs
+++ b/cedar-lean-ffi/src/datatypes.rs
@@ -92,15 +92,6 @@ pub(crate) struct EntityUidDef {
 }
 
 /********************************** Deserialization Helpers **********************************/
-// Helper function to deserialize OptionDef into Option
-fn deserialize_option_def<'de, D, T>(deserializer: D) -> Result<Option<T>, D::Error>
-where
-    D: Deserializer<'de>,
-    T: Deserialize<'de>,
-    OptionDef<T>: Deserialize<'de>,
-{
-    Ok(OptionDef::deserialize(deserializer)?.into())
-}
 
 // Helper function to deserialize NameDef into an EntityTypeName
 fn deserialize_entity_type_name<'de, D>(deserializer: D) -> Result<EntityTypeName, D::Error>
@@ -325,7 +316,7 @@ pub struct Decimal(pub i64);
 #[derive(Debug, Deserialize)]
 pub struct Cidr {
     pub addr: Bitvec,
-    #[serde(rename = "pre", deserialize_with = "deserialize_option_def")]
+    #[serde(rename = "pre")]
     pub prefix: Option<Bitvec>,
 }
 
@@ -392,7 +383,7 @@ pub enum Ext {
     Decimal { d: Decimal },
     Ipaddr { ip: IpAddr },
     Datetime { dt: Datetime },
-    Duration { d: Duration },
+    Duration { dur: Duration },
 }
 
 #[derive(Debug, Deserialize)]
@@ -545,7 +536,7 @@ impl TryFrom<Ext> for cedar_policy_symcc::ext::Ext {
     fn try_from(value: Ext) -> Result<Self, Self::Error> {
         Ok(match value {
             Ext::Datetime { dt } => Self::Datetime { dt: dt.val.into() },
-            Ext::Duration { d } => Self::Duration { d: d.val.into() },
+            Ext::Duration { dur } => Self::Duration { d: dur.val.into() },
             Ext::Decimal { d } => Self::Decimal {
                 d: cedar_policy_symcc::extension_types::decimal::Decimal(d.0),
             },

--- a/cedar-lean-ffi/src/datatypes.rs
+++ b/cedar-lean-ffi/src/datatypes.rs
@@ -239,7 +239,7 @@ pub struct Uuf {
 pub enum ExtOp {
     #[serde(rename = "decimal.val")]
     DecimalVal,
-    #[serde(rename = "ipaddr.isv4")]
+    #[serde(rename = "ipaddr.isV4")]
     IPaddrIsV4,
     #[serde(rename = "ipaddr.addrV4")]
     IPaddrAddrV4,
@@ -687,5 +687,28 @@ mod deserialization {
             cedar_policy_symcc::bitvec::BitVec::try_from(bv).expect("conversion should succeed");
         assert_eq!(bv.width(), 64);
         assert_eq!(bv.to_nat().to_string(), "9223372036854775808");
+    }
+
+    #[test]
+    fn term() {
+        let json = serde_json::json!(
+                [{"prim": {"bool": true}},
+        {"app":
+         {"retTy": {"prim": {"pty": "bool"}},
+          "op": "not",
+          "args":
+          [{"app":
+            {"retTy": {"prim": {"pty": "bool"}},
+             "op": "eq",
+             "args":
+             [{"var":
+               {"ty":
+                {"prim": {"pty": {"entity": {"ety": {"path": [], "id": "a"}}}}},
+                "id": "resource"}},
+              {"prim":
+               {"entity": {"ty": {"path": [], "id": "a"}, "eid": ""}}}]}}]}}]
+            );
+        let _: Vec<crate::Term> =
+            serde_json::from_value(json).expect("deserialization should succeed");
     }
 }

--- a/cedar-lean-ffi/src/lean_ffi.rs
+++ b/cedar-lean-ffi/src/lean_ffi.rs
@@ -155,7 +155,7 @@ macro_rules! checkPolicy_func {
             match serde_json::from_str(&response) {
                 Ok(ResultDef::Ok(t)) => Ok(TimedResult::from_def(t).transform($transform)),
                 Ok(ResultDef::Error(s)) => Err(FfiError::LeanBackendError(s)),
-                Err(_) => Err(FfiError::LeanDeserializationError(response)),
+                Err(err) => Err(FfiError::LeanDeserializationError(format!("error: {err}\n{response}"))),
             }
         }
         pub fn $untimed_func_name(
@@ -197,7 +197,7 @@ macro_rules! checkPolicySet_func {
             match serde_json::from_str(&response) {
                 Ok(ResultDef::Ok(t)) => Ok(TimedResult::from_def(t).transform($transform)),
                 Ok(ResultDef::Error(s)) => Err(FfiError::LeanBackendError(s)),
-                Err(_) => Err(FfiError::LeanDeserializationError(response)),
+                Err(err) => Err(FfiError::LeanDeserializationError(format!("error: {err}\n{response}"))),
             }
         }
         pub fn $untimed_func_name(
@@ -245,7 +245,7 @@ macro_rules! comparePolicySet_func {
             match serde_json::from_str(&response) {
                 Ok(ResultDef::Ok(t)) => Ok(TimedResult::from_def(t).transform($transform)),
                 Ok(ResultDef::Error(s)) => Err(FfiError::LeanBackendError(s)),
-                Err(_) => Err(FfiError::LeanDeserializationError(response)),
+                Err(err) => Err(FfiError::LeanDeserializationError(format!("error: {err}\n{response}"))),
             }
         }
         pub fn $untimed_func_name(

--- a/cedar-lean-ffi/src/messages.rs
+++ b/cedar-lean-ffi/src/messages.rs
@@ -473,7 +473,9 @@ impl proto::Ext {
             datatypes::Ext::Decimal { d } => proto::ext::Ext::Decimal(proto::Decimal::new(d)),
             datatypes::Ext::Ipaddr { ip } => proto::ext::Ext::Ipaddr(proto::IpAddr::new(ip)),
             datatypes::Ext::Datetime { dt } => proto::ext::Ext::Datetime(proto::Datetime::new(dt)),
-            datatypes::Ext::Duration { d } => proto::ext::Ext::Duration(proto::Duration::new(d)),
+            datatypes::Ext::Duration { dur } => {
+                proto::ext::Ext::Duration(proto::Duration::new(dur))
+            }
         };
         Self { ext: Some(ext) }
     }

--- a/cedar-lean/CedarFFI/ToJson.lean
+++ b/cedar-lean/CedarFFI/ToJson.lean
@@ -134,7 +134,7 @@ partial def termToJson : Term → Lean.Json
     Lean.Json.mkObj [
         ("set", Lean.Json.mkObj [
           ("elts", Lean.Json.arr (elts.elts.map termToJson).toArray),
-          ("elts_ty", Lean.toJson eltsTy)
+          ("eltsTy", Lean.toJson eltsTy)
         ])
       ]
   | .record m => Lean.Json.mkObj [("record", Lean.Json.mkObj (m.toList.map (fun (k, v) => (k, termToJson v))))]
@@ -142,7 +142,7 @@ partial def termToJson : Term → Lean.Json
     [("app",
       Lean.Json.mkObj [
         ("op", Lean.toJson op),
-        ("args", Lean.Json.arr (List.toArray (args.map termToJson))), ("ret_ty", Lean.toJson retTy)])]
+        ("args", Lean.Json.arr (List.toArray (args.map termToJson))), ("retTy", Lean.toJson retTy)])]
 
 partial instance : Lean.ToJson Term where
   toJson := termToJson

--- a/cedar-lean/CedarFFI/ToJson.lean
+++ b/cedar-lean/CedarFFI/ToJson.lean
@@ -2,11 +2,13 @@ import Lean.Data.Json.FromToJson
 
 import Cedar.Spec
 import Cedar.SymCC
+import Cedar.Data
 
 namespace CedarFFI
 
 open Cedar.Spec
 open Cedar.SymCC
+open Cedar.Data
 
 abbrev x := Term
 
@@ -125,26 +127,51 @@ instance : Lean.ToJson TermPrim where
 
 deriving instance Lean.ToJson for TermVar
 
-partial def termToJson : Term → Lean.Json
+def termToJson : Term → Lean.Json
   | .prim p => Lean.Json.mkObj [("prim", Lean.toJson p)]
-  | .var v => Lean.Json.mkObj [("var", Lean.toJson v)]
+  | .var v  => Lean.Json.mkObj [("var",  Lean.toJson v)]
   | .none t => Lean.Json.mkObj [("none", Lean.toJson t)]
   | .some t => Lean.Json.mkObj [("some", termToJson t)]
   | .set elts eltsTy =>
     Lean.Json.mkObj [
-        ("set", Lean.Json.mkObj [
-          ("elts", Lean.Json.arr (elts.elts.map termToJson).toArray),
+      ("set",
+        Lean.Json.mkObj [
+          ("elts",
+            Lean.Json.arr (List.map₁ elts.elts (fun ⟨t,_⟩ => termToJson t) |>.toArray)),
           ("eltsTy", Lean.toJson eltsTy)
         ])
-      ]
-  | .record m => Lean.Json.mkObj [("record", Lean.Json.mkObj (m.toList.map (fun (k, v) => (k, termToJson v))))]
-  | .app op args retTy => Lean.Json.mkObj
-    [("app",
-      Lean.Json.mkObj [
-        ("op", Lean.toJson op),
-        ("args", Lean.Json.arr (List.toArray (args.map termToJson))), ("retTy", Lean.toJson retTy)])]
+    ]
+  | .record m =>
+    Lean.Json.mkObj [
+      ("record",
+        Lean.Json.arr (m.kvs.attach₂.map (fun ⟨(k,v), _⟩ =>
+          Lean.Json.arr [Lean.Json.str k, termToJson v].toArray)).toArray)
+    ]
+  | .app op args retTy =>
+    Lean.Json.mkObj [
+      ("app",
+        Lean.Json.mkObj [
+          ("op",   Lean.toJson op),
+          ("args", Lean.Json.arr (List.map₁ args (fun ⟨t,_⟩ => termToJson t) |>.toArray)),
+          ("retTy", Lean.toJson retTy)
+        ])
+    ]
+decreasing_by
+  all_goals simp_wf
+  case _ h₁ =>
+    have := Set.sizeOf_lt_of_mem h₁
+    omega
+  case _ h₁ =>
+    cases m
+    simp only [Map.kvs] at h₁
+    simp only [Map.mk.sizeOf_spec]
+    omega
+  case _ h₁ =>
+    have := List.sizeOf_lt_of_mem h₁
+    omega
 
-partial instance : Lean.ToJson Term where
+
+instance : Lean.ToJson Term where
   toJson := termToJson
 
 deriving instance Lean.ToJson for Cedar.SymCC.Error

--- a/cedar-lean/CedarFFI/ToJson.lean
+++ b/cedar-lean/CedarFFI/ToJson.lean
@@ -138,7 +138,11 @@ partial def termToJson : Term → Lean.Json
         ])
       ]
   | .record m => Lean.Json.mkObj [("record", Lean.Json.mkObj (m.toList.map (fun (k, v) => (k, termToJson v))))]
-  | .app op args retTy => Lean.Json.mkObj [("app", Lean.toJson op), ("args", Lean.Json.arr (List.toArray (args.map termToJson))), ("ret_ty", Lean.toJson retTy)]
+  | .app op args retTy => Lean.Json.mkObj
+    [("app",
+      Lean.Json.mkObj [
+        ("op", Lean.toJson op),
+        ("args", Lean.Json.arr (List.toArray (args.map termToJson))), ("ret_ty", Lean.toJson retTy)])]
 
 partial instance : Lean.ToJson Term where
   toJson := termToJson


### PR DESCRIPTION
*Description of changes:*
* Fix a typo in renaming of `ExtOp::IPaddrIsV4`
* Fix the serialization of `Cidr`: Lean and Rust handle `Option` type consistently so we don't need custom deserializing function
* Fix a typo in `Ext::Duration`
* Forward deserialization errors to the FFI error
* Fix term serialization in Lean

