### PR TITLE
Add check with cex functions to FFI

### DIFF
--- a/cedar-lean-ffi/Cargo.toml
+++ b/cedar-lean-ffi/Cargo.toml
@@ -22,4 +22,7 @@ num-bigint = "0.4.6"
 prost-build = "0.14"
 cargo_metadata = "0.20.0"
 
+[dev-dependencies]
+cool_asserts = "2.0.3"
+
 [profile.release]

--- a/cedar-lean-ffi/src/datatypes.rs
+++ b/cedar-lean-ffi/src/datatypes.rs
@@ -877,6 +877,15 @@ impl From<cedar_policy_symcc::term::Term> for Term {
     }
 }
 
+/// Represent a counterexample
+#[derive(Debug, Deserialize)]
+pub struct Env {
+    /// The request
+    pub request: serde_json::Value,
+    /// The entities
+    pub entities: serde_json::Value,
+}
+
 #[cfg(test)]
 mod deserialization {
     use crate::Bitvec;

--- a/cedar-lean-ffi/src/lean_ffi.rs
+++ b/cedar-lean-ffi/src/lean_ffi.rs
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 use crate::datatypes::{
-    AuthorizationResponse, AuthorizationResponseInner, ResultDef, Term, TimedDef, TimedResult,
+    AuthorizationResponse, AuthorizationResponseInner, Env, ResultDef, Term, TimedDef, TimedResult,
     ValidationResponse,
 };
 use crate::err::FfiError;
@@ -347,7 +347,7 @@ impl CedarLeanFfi {
         run_check_never_errors_with_cex,
         runCheckNeverErrorsWithCex,
         |x| x,
-        Option<serde_json::Value>
+        Option<Env>
     );
 
     checkPolicySet_func!(
@@ -363,7 +363,7 @@ impl CedarLeanFfi {
         run_check_always_allows_with_cex,
         runCheckAlwaysAllowsWithCex,
         |x| x,
-        Option<serde_json::Value>
+        Option<Env>
     );
 
     checkPolicySet_func!(
@@ -379,7 +379,7 @@ impl CedarLeanFfi {
         run_check_always_denies_with_cex,
         runCheckAlwaysDeniesWithCex,
         |x| x,
-        Option<serde_json::Value>
+        Option<Env>
     );
 
     comparePolicySet_func!(
@@ -395,7 +395,7 @@ impl CedarLeanFfi {
         run_check_equivalent_with_cex,
         runCheckEquivalentWithCex,
         |x| x,
-        Option<serde_json::Value>
+        Option<Env>
     );
 
     comparePolicySet_func!(
@@ -411,7 +411,7 @@ impl CedarLeanFfi {
         run_check_implies_with_cex,
         runCheckImpliesWithCex,
         |x| x,
-        Option<serde_json::Value>
+        Option<Env>
     );
 
     comparePolicySet_func!(
@@ -427,7 +427,7 @@ impl CedarLeanFfi {
         run_check_disjoint_with_cex,
         runCheckDisjointWithCex,
         |x| x,
-        Option<serde_json::Value>
+        Option<Env>
     );
 
     // Adds each of the print_(symcc-command) to call the corresponding lean function

--- a/cedar-lean-ffi/src/lean_ffi.rs
+++ b/cedar-lean-ffi/src/lean_ffi.rs
@@ -47,11 +47,17 @@ use std::sync::Once;
 #[link(name = "CedarFFI", kind = "static")]
 extern "C" {
     fn runCheckNeverErrors(req: *mut lean_object) -> *mut lean_object;
+    fn runCheckNeverErrorsWithCex(req: *mut lean_object) -> *mut lean_object;
     fn runCheckAlwaysAllows(req: *mut lean_object) -> *mut lean_object;
+    fn runCheckAlwaysAllowsWithCex(req: *mut lean_object) -> *mut lean_object;
     fn runCheckAlwaysDenies(req: *mut lean_object) -> *mut lean_object;
+    fn runCheckAlwaysDeniesWithCex(req: *mut lean_object) -> *mut lean_object;
     fn runCheckEquivalent(req: *mut lean_object) -> *mut lean_object;
+    fn runCheckEquivalentWithCex(req: *mut lean_object) -> *mut lean_object;
     fn runCheckImplies(req: *mut lean_object) -> *mut lean_object;
+    fn runCheckImpliesWithCex(req: *mut lean_object) -> *mut lean_object;
     fn runCheckDisjoint(req: *mut lean_object) -> *mut lean_object;
+    fn runCheckDisjointWithCex(req: *mut lean_object) -> *mut lean_object;
 
     fn printCheckNeverErrors(req: *mut lean_object) -> *mut lean_object;
     fn printCheckAlwaysAllows(req: *mut lean_object) -> *mut lean_object;
@@ -336,6 +342,14 @@ impl CedarLeanFfi {
         bool
     );
 
+    checkPolicy_func!(
+        run_check_never_errors_with_cex_timed,
+        run_check_never_errors_with_cex,
+        runCheckNeverErrorsWithCex,
+        |x| x,
+        Option<serde_json::Value>
+    );
+
     checkPolicySet_func!(
         run_check_always_allows_timed,
         run_check_always_allows,
@@ -345,11 +359,27 @@ impl CedarLeanFfi {
     );
 
     checkPolicySet_func!(
+        run_check_always_allows_with_cex_timed,
+        run_check_always_allows_with_cex,
+        runCheckAlwaysAllowsWithCex,
+        |x| x,
+        Option<serde_json::Value>
+    );
+
+    checkPolicySet_func!(
         run_check_always_denies_timed,
         run_check_always_denies,
         runCheckAlwaysDenies,
         |x| x,
         bool
+    );
+
+    checkPolicySet_func!(
+        run_check_always_denies_with_cex_timed,
+        run_check_always_denies_with_cex,
+        runCheckAlwaysDeniesWithCex,
+        |x| x,
+        Option<serde_json::Value>
     );
 
     comparePolicySet_func!(
@@ -361,6 +391,14 @@ impl CedarLeanFfi {
     );
 
     comparePolicySet_func!(
+        run_check_equivalent_with_cex_timed,
+        run_check_equivalent_with_cex,
+        runCheckEquivalentWithCex,
+        |x| x,
+        Option<serde_json::Value>
+    );
+
+    comparePolicySet_func!(
         run_check_implies_timed,
         run_check_implies,
         runCheckImplies,
@@ -369,11 +407,27 @@ impl CedarLeanFfi {
     );
 
     comparePolicySet_func!(
+        run_check_implies_with_cex_timed,
+        run_check_implies_with_cex,
+        runCheckImpliesWithCex,
+        |x| x,
+        Option<serde_json::Value>
+    );
+
+    comparePolicySet_func!(
         run_check_disjoint_timed,
         run_check_disjoint,
         runCheckDisjoint,
         |x| x,
         bool
+    );
+
+    comparePolicySet_func!(
+        run_check_disjoint_with_cex_timed,
+        run_check_disjoint_with_cex,
+        runCheckDisjointWithCex,
+        |x| x,
+        Option<serde_json::Value>
     );
 
     // Adds each of the print_(symcc-command) to call the corresponding lean function
@@ -829,6 +883,7 @@ mod test {
         Context, Entities, Entity, EntityTypeName, EntityUid, Expression, Policy, PolicyId,
         PolicySet, Request, RequestEnv, Schema, ValidationMode,
     };
+    use cool_asserts::assert_matches;
 
     use std::collections::HashSet;
     use std::str::FromStr;
@@ -1364,5 +1419,119 @@ mod test {
             .validate_request(&schema, &req)
             .expect("Lean call unexpectedly failed for validate_request");
         assert_eq!(res, ValidationResponse::Ok(()));
+    }
+
+    #[test]
+    fn test_cex() {
+        let schema = Schema::from_str(
+            r#"
+        entity a {
+          r : Bool,
+        };
+        action "action" appliesTo {
+          principal: a,
+          resource: a,
+        };
+        "#,
+        )
+        .unwrap();
+        let ps = PolicySet::from_str(
+            r#"
+        permit(
+      principal,
+      action in [Action::"action"],
+      resource
+    ) when {
+      ((true && (a::"*"["r"])) && true) && true
+    };"#,
+        )
+        .unwrap();
+        let ffi = CedarLeanFfi::new();
+        let req_env = request_env("a", "Action::\"action\"", "a");
+
+        assert_matches!(
+            ffi.run_check_always_denies_with_cex_timed(&ps, &schema, &req_env),
+            Ok(TimedResult {
+                result: Some(_),
+                ..
+            })
+        );
+        assert_matches!(
+            ffi.run_check_always_denies_timed(&ps, &schema, &req_env),
+            Ok(TimedResult { result: false, .. })
+        );
+
+        assert_matches!(
+            ffi.run_check_always_allows_with_cex_timed(&ps, &schema, &req_env),
+            Ok(TimedResult {
+                result: Some(_),
+                ..
+            })
+        );
+        assert_matches!(
+            ffi.run_check_always_allows_timed(&ps, &schema, &req_env),
+            Ok(TimedResult { result: false, .. })
+        );
+
+        assert_matches!(
+            ffi.run_check_never_errors_with_cex_timed(
+                ps.policies().next().unwrap(),
+                &schema,
+                &req_env,
+            ),
+            Ok(TimedResult { result: None, .. })
+        );
+        assert_matches!(
+            ffi.run_check_never_errors_timed(ps.policies().next().unwrap(), &schema, &req_env,),
+            Ok(TimedResult { result: true, .. })
+        );
+
+        let ps_new = PolicySet::from_str(
+            r#"
+        permit(
+      principal,
+      action in [Action::"action"],
+      resource
+    ) when {
+      ((true && (a::"..."["r"])) && true) && true
+    };"#,
+        )
+        .unwrap();
+
+        assert_matches!(
+            ffi.run_check_equivalent_with_cex_timed(&ps, &ps_new, &schema, &req_env),
+            Ok(TimedResult {
+                result: Some(_),
+                ..
+            })
+        );
+        assert_matches!(
+            ffi.run_check_equivalent_timed(&ps, &ps_new, &schema, &req_env),
+            Ok(TimedResult { result: false, .. })
+        );
+
+        assert_matches!(
+            ffi.run_check_implies_with_cex_timed(&ps, &ps_new, &schema, &req_env),
+            Ok(TimedResult {
+                result: Some(_),
+                ..
+            })
+        );
+        assert_matches!(
+            ffi.run_check_implies_timed(&ps, &ps_new, &schema, &req_env),
+            Ok(TimedResult { result: false, .. })
+        );
+
+        assert_matches!(
+            ffi.run_check_disjoint_with_cex_timed(&ps, &ps_new, &schema, &req_env),
+            Ok(TimedResult {
+                result: Some(_),
+                ..
+            })
+        );
+        assert_matches!(
+            ffi.run_check_disjoint_timed(&ps, &ps_new, &schema, &req_env),
+            Ok(TimedResult { result: false, .. })
+        );
     }
 }

--- a/cedar-lean/CedarFFI/Main.lean
+++ b/cedar-lean/CedarFFI/Main.lean
@@ -261,7 +261,7 @@ opaque timedSolve {α} (solver : IO Solver) (vcs : SolverM α) : IO (Except Stri
   returns JSON encoded string that encodes
   1.) .error err_message if there was in error in parsing or running the solver
   2.) .ok { data := true, duration := <encode+solve_time> } if the solver could prove `req` holds
-  3.) .ok { data := true, duration := <encode+solve_time> } if the solver could prove `req` does not hold
+  3.) .ok { data := false, duration := <encode+solve_time> } if the solver could prove `req` does not hold
 -/
 @[export runCheckNeverErrors] unsafe def runCheckNeverErrors (req : ByteArray) : String :=
   runFfiM do
@@ -273,8 +273,8 @@ opaque timedSolve {α} (solver : IO Solver) (vcs : SolverM α) : IO (Except Stri
 
   returns JSON encoded string that encodes
   1.) .error err_message if there was in error in parsing or running the solver
-  2.) .ok { data := true, duration := <encode+solve_time> } if the solver could prove `req` holds
-  3.) .ok { data := true, duration := <encode+solve_time> } if the solver could prove `req` does not hold
+  2.) .ok { data := null, duration := <encode+solve_time> } if the solver could prove `req` holds
+  3.) .ok { data := {request: ..., entities: ...}, duration := <encode+solve_time> } if the solver could prove `req` does not hold
 -/
 @[export runCheckNeverErrorsWithCex] unsafe def runCheckNeverErrorsWithCex (req : ByteArray) : String :=
   runFfiM do
@@ -287,7 +287,7 @@ opaque timedSolve {α} (solver : IO Solver) (vcs : SolverM α) : IO (Except Stri
   returns JSON encoded string that encodes
   1.) .error err_message if there was in error in parsing or running the solver
   2.) .ok { data := true, duration := <encode+solve_time> } if the solver could prove `req` holds
-  3.) .ok { data := true, duration := <encode+solve_time> } if the solver could prove `req` does not hold
+  3.) .ok { data := false, duration := <encode+solve_time> } if the solver could prove `req` does not hold
 -/
 @[export runCheckAlwaysAllows] unsafe def runCheckAlwaysAllows (req : ByteArray) : String :=
   runFfiM do
@@ -299,8 +299,8 @@ opaque timedSolve {α} (solver : IO Solver) (vcs : SolverM α) : IO (Except Stri
 
   returns JSON encoded string that encodes
   1.) .error err_message if there was in error in parsing or running the solver
-  2.) .ok { data := true, duration := <encode+solve_time> } if the solver could prove `req` holds
-  3.) .ok { data := true, duration := <encode+solve_time> } if the solver could prove `req` does not hold
+  2.) .ok { data := null, duration := <encode+solve_time> } if the solver could prove `req` holds
+  3.) .ok { data := {request: ..., entities: ...}, duration := <encode+solve_time> } if the solver could prove `req` does not hold
 -/
 @[export runCheckAlwaysAllowsWithCex] unsafe def runCheckAlwaysAllowsWithCex (req : ByteArray) : String :=
   runFfiM do
@@ -313,7 +313,7 @@ opaque timedSolve {α} (solver : IO Solver) (vcs : SolverM α) : IO (Except Stri
   returns JSON encoded string that encodes
   1.) .error err_message if there was in error in parsing or running the solver
   2.) .ok { data := true, duration := <encode+solve_time> } if the solver could prove `req` holds
-  3.) .ok { data := true, duration := <encode+solve_time> } if the solver could prove `req` does not hold
+  3.) .ok { data := false, duration := <encode+solve_time> } if the solver could prove `req` does not hold
 -/
 @[export runCheckAlwaysDenies] unsafe def runCheckAlwaysDenies (req : ByteArray) : String :=
   runFfiM do
@@ -325,8 +325,8 @@ opaque timedSolve {α} (solver : IO Solver) (vcs : SolverM α) : IO (Except Stri
 
   returns JSON encoded string that encodes
   1.) .error err_message if there was in error in parsing or running the solver
-  2.) .ok { data := true, duration := <encode+solve_time> } if the solver could prove `req` holds
-  3.) .ok { data := true, duration := <encode+solve_time> } if the solver could prove `req` does not hold
+  2.) .ok { data := null, duration := <encode+solve_time> } if the solver could prove `req` holds
+  3.) .ok { data := {request: ..., entities: ...}, duration := <encode+solve_time> } if the solver could prove `req` does not hold
 -/
 @[export runCheckAlwaysDeniesWithCex] unsafe def runCheckAlwaysDeniesWithCex (req : ByteArray) : String :=
   runFfiM do
@@ -339,7 +339,7 @@ opaque timedSolve {α} (solver : IO Solver) (vcs : SolverM α) : IO (Except Stri
   returns JSON encoded string that encodes
   1.) .error err_message if there was in error in parsing or running the solver
   2.) .ok { data := true, duration := <encode+solve_time> } if the solver could prove `req` holds
-  3.) .ok { data := true, duration := <encode+solve_time> } if the solver could prove `req` does not hold
+  3.) .ok { data := false, duration := <encode+solve_time> } if the solver could prove `req` does not hold
 -/
 @[export runCheckEquivalent] unsafe def runCheckEquivalent (req : ByteArray) : String :=
   runFfiM do
@@ -351,8 +351,8 @@ opaque timedSolve {α} (solver : IO Solver) (vcs : SolverM α) : IO (Except Stri
 
   returns JSON encoded string that encodes
   1.) .error err_message if there was in error in parsing or running the solver
-  2.) .ok { data := true, duration := <encode+solve_time> } if the solver could prove `req` holds
-  3.) .ok { data := true, duration := <encode+solve_time> } if the solver could prove `req` does not hold
+  2.) .ok { data := null, duration := <encode+solve_time> } if the solver could prove `req` holds
+  3.) .ok { data := {request: ..., entities: ...}, duration := <encode+solve_time> } if the solver could prove `req` does not hold
 -/
 @[export runCheckEquivalentWithCex] unsafe def runCheckEquivalentWithCex (req : ByteArray) : String :=
   runFfiM do
@@ -365,7 +365,7 @@ opaque timedSolve {α} (solver : IO Solver) (vcs : SolverM α) : IO (Except Stri
   returns JSON encoded string that encodes
   1.) .error err_message if there was in error in parsing or running the solver
   2.) .ok { data := true, duration := <encode+solve_time> } if the solver could prove `req` holds
-  3.) .ok { data := true, duration := <encode+solve_time> } if the solver could prove `req` does not hold
+  3.) .ok { data := false, duration := <encode+solve_time> } if the solver could prove `req` does not hold
 -/
 @[export runCheckImplies] unsafe def runCheckImplies (req : ByteArray) : String :=
   runFfiM do
@@ -377,8 +377,8 @@ opaque timedSolve {α} (solver : IO Solver) (vcs : SolverM α) : IO (Except Stri
 
   returns JSON encoded string that encodes
   1.) .error err_message if there was in error in parsing or running the solver
-  2.) .ok { data := true, duration := <encode+solve_time> } if the solver could prove `req` holds
-  3.) .ok { data := true, duration := <encode+solve_time> } if the solver could prove `req` does not hold
+  2.) .ok { data := null, duration := <encode+solve_time> } if the solver could prove `req` holds
+  3.) .ok { data := {request: ..., entities: ...}, duration := <encode+solve_time> } if the solver could prove `req` does not hold
 -/
 @[export runCheckImpliesWithCex] unsafe def runCheckImpliesWithCex (req : ByteArray) : String :=
   runFfiM do
@@ -391,7 +391,7 @@ opaque timedSolve {α} (solver : IO Solver) (vcs : SolverM α) : IO (Except Stri
   returns JSON encoded string that encodes
   1.) .error err_message if there was in error in parsing or running the solver
   2.) .ok { data := true, duration := <encode+solve_time> } if the solver could prove `req` holds
-  3.) .ok { data := true, duration := <encode+solve_time> } if the solver could prove `req` does not hold
+  3.) .ok { data := false, duration := <encode+solve_time> } if the solver could prove `req` does not hold
 -/
 @[export runCheckDisjoint] unsafe def runCheckDisjoint (req : ByteArray) : String :=
   runFfiM do
@@ -403,8 +403,8 @@ opaque timedSolve {α} (solver : IO Solver) (vcs : SolverM α) : IO (Except Stri
 
   returns JSON encoded string that encodes
   1.) .error err_message if there was in error in parsing or running the solver
-  2.) .ok { data := true, duration := <encode+solve_time> } if the solver could prove `req` holds
-  3.) .ok { data := true, duration := <encode+solve_time> } if the solver could prove `req` does not hold
+  2.) .ok { data := null, duration := <encode+solve_time> } if the solver could prove `req` holds
+  3.) .ok { data := {request: ..., entities: ...}, duration := <encode+solve_time> } if the solver could prove `req` does not hold
 -/
 @[export runCheckDisjointWithCex] unsafe def runCheckDisjointWithCex (req : ByteArray) : String :=
   runFfiM do
@@ -527,7 +527,7 @@ private def ignoreOutput (vc : SymEnv → Cedar.SymCC.Result Cedar.SymCC.Asserts
   returns JSON encoded string that encodes
   1.) .error err_message if there was in error in parsing or running the solver
   2.) .ok { data := true, duration := <solve_time> } if the solver could prove `asserts` hold
-  3.) .ok { data := true, duration := <solve_time> } if the solver could prove `asserts` do not hold
+  3.) .ok { data := false, duration := <solve_time> } if the solver could prove `asserts` do not hold
 -/
 @[export runCheckAsserts] unsafe def runCheckAsserts (req: ByteArray) : String :=
   runFfiM do

--- a/cedar-lean/CedarFFI/Main.lean
+++ b/cedar-lean/CedarFFI/Main.lean
@@ -269,6 +269,19 @@ opaque timedSolve {α} (solver : IO Solver) (vcs : SolverM α) : IO (Except Stri
     timedSolve Solver.cvc5 (checkNeverErrors policy εnv)
 
 /--
+  `req`: binary protobuf for an `CheckPolicyRequest`
+
+  returns JSON encoded string that encodes
+  1.) .error err_message if there was in error in parsing or running the solver
+  2.) .ok { data := true, duration := <encode+solve_time> } if the solver could prove `req` holds
+  3.) .ok { data := true, duration := <encode+solve_time> } if the solver could prove `req` does not hold
+-/
+@[export runCheckNeverErrorsWithCex] unsafe def runCheckNeverErrorsWithCex (req : ByteArray) : String :=
+  runFfiM do
+    let (policy, εnv) ← parseCheckPolicyReq req false
+    timedSolve Solver.cvc5 (neverErrors? policy εnv)
+
+/--
   `req`: binary protobuf for an `CheckPolicySetRequest`
 
   returns JSON encoded string that encodes
@@ -289,10 +302,36 @@ opaque timedSolve {α} (solver : IO Solver) (vcs : SolverM α) : IO (Except Stri
   2.) .ok { data := true, duration := <encode+solve_time> } if the solver could prove `req` holds
   3.) .ok { data := true, duration := <encode+solve_time> } if the solver could prove `req` does not hold
 -/
+@[export runCheckAlwaysAllowsWithCex] unsafe def runCheckAlwaysAllowsWithCex (req : ByteArray) : String :=
+  runFfiM do
+    let (policies, εnv) ← parseCheckPoliciesReq req false
+    timedSolve Solver.cvc5 (alwaysAllows? policies εnv)
+
+/--
+  `req`: binary protobuf for an `CheckPolicySetRequest`
+
+  returns JSON encoded string that encodes
+  1.) .error err_message if there was in error in parsing or running the solver
+  2.) .ok { data := true, duration := <encode+solve_time> } if the solver could prove `req` holds
+  3.) .ok { data := true, duration := <encode+solve_time> } if the solver could prove `req` does not hold
+-/
 @[export runCheckAlwaysDenies] unsafe def runCheckAlwaysDenies (req : ByteArray) : String :=
   runFfiM do
     let (policies, εnv) ← parseCheckPoliciesReq req false
     timedSolve Solver.cvc5 (checkAlwaysDenies policies εnv)
+
+/--
+  `req`: binary protobuf for an `CheckPolicySetRequest`
+
+  returns JSON encoded string that encodes
+  1.) .error err_message if there was in error in parsing or running the solver
+  2.) .ok { data := true, duration := <encode+solve_time> } if the solver could prove `req` holds
+  3.) .ok { data := true, duration := <encode+solve_time> } if the solver could prove `req` does not hold
+-/
+@[export runCheckAlwaysDeniesWithCex] unsafe def runCheckAlwaysDeniesWithCex (req : ByteArray) : String :=
+  runFfiM do
+    let (policies, εnv) ← parseCheckPoliciesReq req false
+    timedSolve Solver.cvc5 (alwaysDenies? policies εnv)
 
 /--
   `req`: binary protobuf for an `ComparePolicySetsRequest`
@@ -315,6 +354,19 @@ opaque timedSolve {α} (solver : IO Solver) (vcs : SolverM α) : IO (Except Stri
   2.) .ok { data := true, duration := <encode+solve_time> } if the solver could prove `req` holds
   3.) .ok { data := true, duration := <encode+solve_time> } if the solver could prove `req` does not hold
 -/
+@[export runCheckEquivalentWithCex] unsafe def runCheckEquivalentWithCex (req : ByteArray) : String :=
+  runFfiM do
+    let (srcPolicies, tgtPolicies, εnv) ← parseComparePolicySetsReq req false
+    timedSolve Solver.cvc5 (equivalent? srcPolicies tgtPolicies εnv)
+
+/--
+  `req`: binary protobuf for an `ComparePolicySetsRequest`
+
+  returns JSON encoded string that encodes
+  1.) .error err_message if there was in error in parsing or running the solver
+  2.) .ok { data := true, duration := <encode+solve_time> } if the solver could prove `req` holds
+  3.) .ok { data := true, duration := <encode+solve_time> } if the solver could prove `req` does not hold
+-/
 @[export runCheckImplies] unsafe def runCheckImplies (req : ByteArray) : String :=
   runFfiM do
     let (srcPolicies, tgtPolicies, εnv) ← parseComparePolicySetsReq req false
@@ -328,10 +380,36 @@ opaque timedSolve {α} (solver : IO Solver) (vcs : SolverM α) : IO (Except Stri
   2.) .ok { data := true, duration := <encode+solve_time> } if the solver could prove `req` holds
   3.) .ok { data := true, duration := <encode+solve_time> } if the solver could prove `req` does not hold
 -/
+@[export runCheckImpliesWithCex] unsafe def runCheckImpliesWithCex (req : ByteArray) : String :=
+  runFfiM do
+    let (srcPolicies, tgtPolicies, εnv) ← parseComparePolicySetsReq req false
+    timedSolve Solver.cvc5 (implies? srcPolicies tgtPolicies εnv)
+
+/--
+  `req`: binary protobuf for an `ComparePolicySetsRequest`
+
+  returns JSON encoded string that encodes
+  1.) .error err_message if there was in error in parsing or running the solver
+  2.) .ok { data := true, duration := <encode+solve_time> } if the solver could prove `req` holds
+  3.) .ok { data := true, duration := <encode+solve_time> } if the solver could prove `req` does not hold
+-/
 @[export runCheckDisjoint] unsafe def runCheckDisjoint (req : ByteArray) : String :=
   runFfiM do
     let (srcPolicies, tgtPolicies, εnv) ← parseComparePolicySetsReq req false
     timedSolve Solver.cvc5 (checkDisjoint srcPolicies tgtPolicies εnv)
+
+/--
+  `req`: binary protobuf for an `ComparePolicySetsRequest`
+
+  returns JSON encoded string that encodes
+  1.) .error err_message if there was in error in parsing or running the solver
+  2.) .ok { data := true, duration := <encode+solve_time> } if the solver could prove `req` holds
+  3.) .ok { data := true, duration := <encode+solve_time> } if the solver could prove `req` does not hold
+-/
+@[export runCheckDisjointWithCex] unsafe def runCheckDisjointWithCex (req : ByteArray) : String :=
+  runFfiM do
+    let (srcPolicies, tgtPolicies, εnv) ← parseComparePolicySetsReq req false
+    timedSolve Solver.cvc5 (disjoint? srcPolicies tgtPolicies εnv)
 
 /--
   Auxillary function that encodes and runs the solver on the generated VCs. Useful for

--- a/cedar-lean/CedarFFI/ToJson.lean
+++ b/cedar-lean/CedarFFI/ToJson.lean
@@ -127,6 +127,14 @@ instance : Lean.ToJson TermPrim where
 
 deriving instance Lean.ToJson for TermVar
 
+/- Add ToJson instance for Cedar Value -/
+instance : Lean.ToJson Cedar.Spec.Prim where
+  toJson
+  | .bool b => Lean.Json.mkObj [("bool", Lean.toJson b)]
+  | .int i => Lean.Json.mkObj [("int", Lean.toJson i.toInt)]
+  | .string s => Lean.Json.mkObj [("string", Lean.toJson s)]
+  | .entityUID uid => Lean.Json.mkObj [("entityUID", Lean.toJson uid)]
+
 def termToJson : Term → Lean.Json
   | .prim p => Lean.Json.mkObj [("prim", Lean.toJson p)]
   | .var v  => Lean.Json.mkObj [("var",  Lean.toJson v)]
@@ -175,5 +183,14 @@ instance : Lean.ToJson Term where
   toJson := termToJson
 
 deriving instance Lean.ToJson for Cedar.SymCC.Error
+
+/- Serializing `Request` and `Entities` -/
+deriving instance Lean.ToJson for Value
+deriving instance Lean.ToJson for Request
+deriving instance Lean.ToJson for EntityData
+deriving instance Lean.ToJson for Entities
+
+/- Serializing `Env` -/
+deriving instance Lean.ToJson for Env
 
 end CedarFFI


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
We currently do not perform deserialization of `Env` because we will need to serialize `Env` properly, e.g., according to the entity format.


