### PR TITLE
Fix decoder issue on empty records

### DIFF
--- a/cedar-lean/Cedar/SymCC/Decoder.lean
+++ b/cedar-lean/Cedar/SymCC/Decoder.lean
@@ -233,7 +233,7 @@ where
     | .none     => constructEntityOrRecord s []
   constructEntityOrRecord tyId args : Result Term := do
     match ids.types.find? tyId, args with
-    | .some (.entity ety), [.string eid] =>
+    | .some (.entity ety), [SExpr.string eid] =>
       Term.entity ⟨ety, eid⟩
     | .some (.record (Map.mk rty)), _ =>
       let ts ← args.mapM (SExpr.decodeLit ids)

--- a/cedar-lean/Cedar/SymCC/Decoder.lean
+++ b/cedar-lean/Cedar/SymCC/Decoder.lean
@@ -223,14 +223,14 @@ partial def SExpr.decodeLit (ids : IdMaps) : SExpr → Result Term
   | .string s       => Term.string s
   | .symbol "true"  => Term.bool true
   | .symbol "false" => Term.bool false
-  | .symbol e       => enum e
+  | .symbol e       => enumOrEmptyRecord e
   | .sexpr xs       => construct xs
   | other           => fail "literal expr" other
 where
-  enum (s : String) : Result Term :=
+  enumOrEmptyRecord (s : String) : Result Term :=
     match ids.enums.find? s with
     | .some uid => Term.entity uid
-    | .none     =>  fail "enum id" s
+    | .none     => constructEntityOrRecord s []
   constructEntityOrRecord tyId args : Result Term := do
     match ids.types.find? tyId, args with
     | .some (.entity ety), [.string eid] =>

--- a/cedar-lean/SymTest/Decoder.lean
+++ b/cedar-lean/SymTest/Decoder.lean
@@ -301,6 +301,7 @@ def testsDecodeValidLitStrings :=
     testDecodeLitOk "(V6 #b00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000 ((as some (Option (_ BitVec 7))) #b0000001))" (.ext (.ipaddr (.V6 ⟨0#128, 1#7⟩))),
     testDecodeLitOk "(E1 \"Alice\")" (.entity ⟨userType, "Alice"⟩),
     testDecodeLitOk "(R3)" (.record Map.empty),
+    testDecodeLitOk "R3" (.record Map.empty),
     testDecodeLitOk "(R4 (as none (Option Bool)) #b0000000000000000000000000000000000000000000000000000000000001010 E0_m2)"
       (.record (Map.make [("a", .none .bool), ("b", 10#64), ("c", .entity ⟨colorType, "red"⟩)])),
     testDecodeLitOk "(R6 (R5 true))" (.record (Map.make [("d", .record (Map.make [("e", .bool true)]))])),


### PR DESCRIPTION
Fixes an issue in the decoder when reading empty record values.
Related Rust fix: https://github.com/cedar-policy/cedar/pull/1801

