### PR TITLE
rename RequestType to ActionSignature

### DIFF
--- a/cedar-lean/Cedar/SymCC/Env.lean
+++ b/cedar-lean/Cedar/SymCC/Env.lean
@@ -215,14 +215,14 @@ def SymEntities.ofSchema (ets : EntitySchema) (acts : ActionSchema) : SymEntitie
   Map.make (eData ++ aData)
 
 /--
-Creates a symbolic request for the given request type.
+Creates a symbolic request for the given action signature.
 -/
-def SymRequest.ofRequestType (reqTy : RequestType) : SymRequest :=
+def SymRequest.ofActionSignature (sig : ActionSignature) : SymRequest :=
   {
-    principal := .var ⟨"principal", TermType.ofType (.entity reqTy.principal)⟩,
-    action    := .prim (.entity reqTy.action),
-    resource  := .var ⟨"resource", TermType.ofType (.entity reqTy.resource)⟩,
-    context   := .var ⟨"context", TermType.ofType (.record reqTy.context)⟩
+    principal := .var ⟨"principal", TermType.ofType (.entity sig.principal)⟩,
+    action    := .prim (.entity sig.action),
+    resource  := .var ⟨"resource", TermType.ofType (.entity sig.resource)⟩,
+    context   := .var ⟨"context", TermType.ofType (.record sig.context)⟩
   }
 
 /--
@@ -231,7 +231,7 @@ type environment.
 -/
 def SymEnv.ofEnv (tyEnv : TypeEnv) : SymEnv :=
   {
-    request  := SymRequest.ofRequestType tyEnv.reqty,
+    request  := SymRequest.ofActionSignature tyEnv.sig,
     entities := SymEntities.ofSchema tyEnv.ets tyEnv.acts
   }
 

--- a/cedar-lean/Cedar/SymCC/Symbolizer.lean
+++ b/cedar-lean/Cedar/SymCC/Symbolizer.lean
@@ -74,17 +74,17 @@ where
       omega
 
 /--
-The variable ids here should match the variables in `SymRequest.ofRequestType`.
+The variable ids here should match the variables in `SymRequest.ofActionSignature`.
 -/
 def Request.symbolize? (req : Request) (Γ : TypeEnv) (var : TermVar) : Option Term :=
-  if var == { id := "principal", ty := TermType.ofType (.entity Γ.reqty.principal) } then
-    Value.symbolize? ↑req.principal (.entity Γ.reqty.principal)
-  else if var == { id := "action", ty := TermType.ofType (.entity Γ.reqty.action.ty) } then
-    Value.symbolize? ↑req.action (.entity Γ.reqty.action.ty)
-  else if var == { id := "resource", ty := TermType.ofType (.entity Γ.reqty.resource) } then
-    Value.symbolize? ↑req.resource (.entity Γ.reqty.resource)
-  else if var == { id := "context", ty := TermType.ofType (.record Γ.reqty.context) } then
-    Value.symbolize? ↑req.context (.record Γ.reqty.context)
+  if var == { id := "principal", ty := TermType.ofType (.entity Γ.sig.principal) } then
+    Value.symbolize? ↑req.principal (.entity Γ.sig.principal)
+  else if var == { id := "action", ty := TermType.ofType (.entity Γ.sig.action.ty) } then
+    Value.symbolize? ↑req.action (.entity Γ.sig.action.ty)
+  else if var == { id := "resource", ty := TermType.ofType (.entity Γ.sig.resource) } then
+    Value.symbolize? ↑req.resource (.entity Γ.sig.resource)
+  else if var == { id := "context", ty := TermType.ofType (.record Γ.sig.context) } then
+    Value.symbolize? ↑req.context (.record Γ.sig.context)
   else
     .none
 

--- a/cedar-lean/Cedar/TPE/Evaluator.lean
+++ b/cedar-lean/Cedar/TPE/Evaluator.lean
@@ -266,7 +266,7 @@ def evaluatePolicy (schema : Schema)
       if requestAndEntitiesIsValid env req es
       then
         do
-          let expr := substituteAction env.reqty.action p.toExpr
+          let expr := substituteAction env.sig.action p.toExpr
           let (te, _) ← (typeOf expr ∅ env).mapError Error.invalidPolicy
           .ok (evaluate (TypedExpr.toResidual te.liftBoolTypes) req es)
       else .error .invalidRequestOrEntities

--- a/cedar-lean/Cedar/TPE/Input.lean
+++ b/cedar-lean/Cedar/TPE/Input.lean
@@ -65,12 +65,12 @@ def partialIsValid {α} (o : Option α) (f : α → Bool) : Bool :=
 
 def requestIsValid (env : TypeEnv) (req : PartialRequest) : Bool :=
   (partialIsValid req.principal.asEntityUID λ principal =>
-    instanceOfEntityType principal env.reqty.principal env) &&
-  req.action == env.reqty.action &&
+    instanceOfEntityType principal env.sig.principal env) &&
+  req.action == env.sig.action &&
   (partialIsValid req.resource.asEntityUID λ resource =>
-    instanceOfEntityType resource env.reqty.resource env) &&
+    instanceOfEntityType resource env.sig.resource env) &&
   (partialIsValid req.context λ m =>
-    instanceOfType (.record m) (.record env.reqty.context) env)
+    instanceOfType (.record m) (.record env.sig.context) env)
 
 def entitiesIsValid (env : TypeEnv) (es : PartialEntities) : Bool :=
   (es.toList.all entityIsValid) && (env.acts.toList.all instanceOfActionSchema)

--- a/cedar-lean/Cedar/Thm/SymCC/Compiler/WellTyped.lean
+++ b/cedar-lean/Cedar/Thm/SymCC/Compiler/WellTyped.lean
@@ -435,7 +435,7 @@ theorem compile_well_typed_var {v : Var} {ty : CedarType} {Γ : TypeEnv} {εnv :
     CompileWellTyped,
     TypedExpr.toExpr,
     SymEnv.ofEnv,
-    SymRequest.ofRequestType,
+    SymRequest.ofActionSignature,
     TermType.ofType,
     compile,
     compileVar,

--- a/cedar-lean/Cedar/Thm/SymCC/Env/Completeness.lean
+++ b/cedar-lean/Cedar/Thm/SymCC/Env/Completeness.lean
@@ -504,7 +504,7 @@ private theorem ofEnv_request_completeness
   (hwf_Γ : Γ.WellFormed)
   (hwf_I : I.WellFormed (SymEnv.ofEnv Γ).entities)
   (hsame_I : env ∼ SymEnv.interpret I (SymEnv.ofEnv Γ)) :
-  InstanceOfRequestType env.request Γ
+  InstanceOfTypeEnv env.request Γ
 := by
   have ⟨hwf_I_vars, _⟩ := hwf_I
   have ⟨⟨hsame_I_princ, hsame_I_act, hsame_I_res, hsame_I_ctx⟩, _⟩ := hsame_I
@@ -520,7 +520,7 @@ private theorem ofEnv_request_completeness
     simp only [hsame_I_princ, Term.typeOf, TermPrim.typeOf] at hwt_I_princ
     simp only [
       SymEnv.ofEnv,
-      SymRequest.ofRequestType,
+      SymRequest.ofActionSignature,
       Term.typeOf,
       TermType.ofType,
     ] at hwt_I_princ
@@ -535,7 +535,7 @@ private theorem ofEnv_request_completeness
   · simp only [
       Term.interpret,
       SymEnv.ofEnv,
-      SymRequest.ofRequestType,
+      SymRequest.ofActionSignature,
     ] at hsame_I_act
     simp only [Term.prim.injEq, TermPrim.entity.injEq] at hsame_I_act
     simp [hsame_I_act]
@@ -544,7 +544,7 @@ private theorem ofEnv_request_completeness
     simp only [hsame_I_res, Term.typeOf, TermPrim.typeOf] at hwt_I_res
     simp only [
       SymEnv.ofEnv,
-      SymRequest.ofRequestType,
+      SymRequest.ofActionSignature,
       Term.typeOf,
       TermType.ofType,
     ] at hwt_I_res
@@ -558,13 +558,13 @@ private theorem ofEnv_request_completeness
   · have ⟨hwf_I_ctx, hwt_I_ctx⟩ := interpret_term_wf hwf_I hwf_sym_ctx
     simp only [
       SymEnv.ofEnv,
-      SymRequest.ofRequestType,
+      SymRequest.ofActionSignature,
       Term.typeOf,
     ] at hwt_I_ctx
     simp only [
       SameValues,
       SymEnv.ofEnv,
-      SymRequest.ofRequestType,
+      SymRequest.ofActionSignature,
     ] at hsame_I_ctx
     have ⟨_, _, _, hwt_ctx⟩ := wf_env_implies_wf_request hwf_Γ
     have hlifted_ctx := wf_env_implies_ctx_lifted hwf_Γ

--- a/cedar-lean/Cedar/Thm/SymCC/Env/Soundness.lean
+++ b/cedar-lean/Cedar/Thm/SymCC/Env/Soundness.lean
@@ -49,7 +49,7 @@ private theorem env_symbolize?_same_request
     SymEnv.interpret,
     Env.symbolize?,
     SymEnv.ofEnv,
-    SymRequest.ofRequestType,
+    SymRequest.ofActionSignature,
     SymRequest.interpret,
     Request.symbolize?,
     Value.symbolize?,
@@ -67,10 +67,10 @@ private theorem env_symbolize?_same_request
   · have ⟨_, ⟨_, h, _, _⟩, _⟩ := hinst
     simp [h]
   -- Same context after interpretation
-  · have hwf_ctx_ty : (CedarType.record Γ.reqty.context).WellFormed Γ := by
+  · have hwf_ctx_ty : (CedarType.record Γ.sig.context).WellFormed Γ := by
       have ⟨_, _, _, h⟩ := wf_env_implies_wf_request hwf
       exact h
-    have hwt_ctx : InstanceOfType Γ env.request.context (.record Γ.reqty.context) := by
+    have hwt_ctx : InstanceOfType Γ env.request.context (.record Γ.sig.context) := by
       have ⟨_, ⟨_, _, _, h⟩, _⟩ := hinst
       exact h
     have hwf_ctx : (Value.record env.request.context).WellFormed env.entities := by
@@ -1162,27 +1162,27 @@ private theorem env_symbolize?_wf_vars
   have ⟨hwf_Γ, _, _⟩ := hinst
   have ⟨hwf_princ_ty, hcontains_action, hwf_resource_ty, hwf_context_ty⟩ := wf_env_implies_wf_request hwf_Γ
   replace hwf_princ_ty :
-    (CedarType.entity Γ.reqty.principal).WellFormed Γ
+    (CedarType.entity Γ.sig.principal).WellFormed Γ
   := by constructor; exact hwf_princ_ty
   replace hwf_resource_ty :
-    (CedarType.entity Γ.reqty.resource).WellFormed Γ
+    (CedarType.entity Γ.sig.resource).WellFormed Γ
   := by constructor; exact hwf_resource_ty
   have hwf_action_ty :
-    (CedarType.entity Γ.reqty.action.ty).WellFormed Γ
+    (CedarType.entity Γ.sig.action.ty).WellFormed Γ
   := by
     constructor
     apply Or.inr
     simp only [ActionSchema.IsActionEntityType]
-    exists Γ.reqty.action
+    exists Γ.sig.action
   have ⟨_, ⟨hinst_princ, hinst_action, hinst_resource, hinst_context⟩, _⟩ := hinst
   replace hinst_princ :
-    InstanceOfType Γ (Value.prim (Prim.entityUID env.request.principal)) (CedarType.entity Γ.reqty.principal)
+    InstanceOfType Γ (Value.prim (Prim.entityUID env.request.principal)) (CedarType.entity Γ.sig.principal)
   := by constructor; exact hinst_princ
   replace hinst_resource :
-    InstanceOfType Γ (Value.prim (Prim.entityUID env.request.resource)) (CedarType.entity Γ.reqty.resource)
+    InstanceOfType Γ (Value.prim (Prim.entityUID env.request.resource)) (CedarType.entity Γ.sig.resource)
   := by constructor; exact hinst_resource
   replace hinst_action :
-    InstanceOfType Γ (Value.prim (Prim.entityUID env.request.action)) (CedarType.entity Γ.reqty.action.ty)
+    InstanceOfType Γ (Value.prim (Prim.entityUID env.request.action)) (CedarType.entity Γ.sig.action.ty)
   := by
     constructor
     simp only [InstanceOfEntityType, hinst_action, true_and]

--- a/cedar-lean/Cedar/Thm/SymCC/Env/ofEnv.lean
+++ b/cedar-lean/Cedar/Thm/SymCC/Env/ofEnv.lean
@@ -567,7 +567,7 @@ theorem ofEnv_request_is_wf
 := by
   simp only [
     SymEnv.ofEnv,
-    SymRequest.ofRequestType,
+    SymRequest.ofActionSignature,
     SymRequest.WellFormed,
     TermType.ofType,
   ]
@@ -610,7 +610,7 @@ theorem ofEnv_request_is_basic
 := by
   simp [
     SymEnv.ofEnv,
-    SymRequest.ofRequestType,
+    SymRequest.ofActionSignature,
     SymRequest.IsBasic,
     Term.isBasic,
     Term.isLiteral,

--- a/cedar-lean/Cedar/Thm/SymCC/WellTyped.lean
+++ b/cedar-lean/Cedar/Thm/SymCC/WellTyped.lean
@@ -38,7 +38,7 @@ theorem wellTypedPolicy_some_implies_exists_typed_exprs
   ∃ tx tx' : TypedExpr, ∃ c,
     TypedExpr.WellTyped Γ tx.liftBoolTypes ∧
     TypedExpr.WellTyped Γ tx' ∧
-    typeOf (substituteAction Γ.reqty.action p.toExpr) ∅ Γ = Except.ok (tx, c) ∧
+    typeOf (substituteAction Γ.sig.action p.toExpr) ∅ Γ = Except.ok (tx, c) ∧
     p'.toExpr = tx'.toExpr ∧
     tx' =
       (TypedExpr.and (TypedExpr.lit (Prim.bool true) (.bool .anyBool))
@@ -147,7 +147,7 @@ theorem substitute_action_preserves_valid_refs
 := by
   have ⟨hwf_Γ, _, ⟨_, hinst_sch⟩⟩ := hinst
   have ⟨_, _, ⟨act_entry, hfind_act, _⟩⟩ := hwf_Γ
-  have heq_act : Γ.reqty.action = request.action := by
+  have heq_act : Γ.sig.action = request.action := by
     have ⟨_, ⟨_, h, _⟩, _⟩ := hinst
     simp [h]
   cases expr with
@@ -292,7 +292,7 @@ theorem wellTypedPolicy_preserves_valid_refs
   rotate_left
   repeat constructor
   apply typeOf_preserves_valid_refs entities hty
-  have : Γ.reqty.action = request.action := by
+  have : Γ.sig.action = request.action := by
     have ⟨_, ⟨_, h, _⟩, _⟩ := hinst
     simp [h]
   simp only [this]
@@ -341,18 +341,18 @@ theorem wellTypedPolicy_preserves_evaluation
   = evaluate p'.toExpr request entities
 := by
   have ⟨tx, tx', _, hwt_tx_lift, hwt_tx', hty, heq_p'_tx', heq_tx', hbool⟩ := wellTypedPolicy_some_implies_exists_typed_exprs hwt
-  have heq_action : Γ.reqty.action = request.action := by
+  have heq_action : Γ.sig.action = request.action := by
     have ⟨_, ⟨_, h, _⟩, _⟩ := hinst
     simp [h]
   have :
     evaluate p.toExpr request entities
-    = evaluate (substituteAction Γ.reqty.action p.toExpr) request entities
+    = evaluate (substituteAction Γ.sig.action p.toExpr) request entities
   := by
     simp only [heq_action]
     exact Eq.symm (substitute_action_preserves_evaluation _ _ _)
   rw [this]
   have heq :
-    evaluate (substituteAction Γ.reqty.action p.toExpr) request entities
+    evaluate (substituteAction Γ.sig.action p.toExpr) request entities
     = evaluate tx.toExpr request entities
   := type_of_preserves_evaluation_results (empty_capabilities_invariant _ _) hinst hty
   rw [heq]

--- a/cedar-lean/Cedar/Thm/TPE.lean
+++ b/cedar-lean/Cedar/Thm/TPE.lean
@@ -154,10 +154,10 @@ theorem partial_evaluate_policy_is_sound
   have h₆ := partial_evaluate_is_sound h₉ h₄ h₃
   subst h₁₂
   have h₇ := type_of_preserves_evaluation_results (empty_capabilities_invariant req es) h₄ heq₂
-  have h₈ : Spec.evaluate (substituteAction env.reqty.action policy.toExpr) req es = Spec.evaluate policy.toExpr req es := by
+  have h₈ : Spec.evaluate (substituteAction env.sig.action policy.toExpr) req es = Spec.evaluate policy.toExpr req es := by
     simp [InstanceOfWellFormedEnvironment] at h₄
     rcases h₄ with ⟨_, h₄, _⟩
-    simp [InstanceOfRequestType] at h₄
+    simp [InstanceOfTypeEnv] at h₄
     rcases h₄ with ⟨_, h₄, _⟩
     rw [←h₄]
     exact substitute_action_preserves_evaluation policy.toExpr req es

--- a/cedar-lean/Cedar/Thm/Validation/EnvironmentValidation.lean
+++ b/cedar-lean/Cedar/Thm/Validation/EnvironmentValidation.lean
@@ -465,12 +465,12 @@ theorem action_schema_validate_well_formed_is_sound
   exact action_schema_validate_transitive_action_hierarchy_is_sound hok
 
 theorem request_type_validate_well_formed_is_sound
-  {env : TypeEnv} {reqty : RequestType}
-  (hok : reqty.validateWellFormed env = .ok ()) :
-  RequestType.WellFormed env reqty
+  {env : TypeEnv} {sig : ActionSignature}
+  (hok : sig.validateWellFormed env = .ok ()) :
+  sig.WellFormed env
 := by
-  simp only [RequestType.WellFormed]
-  simp only [RequestType.validateWellFormed] at hok
+  simp only [ActionSignature.WellFormed]
+  simp only [ActionSignature.validateWellFormed] at hok
   split at hok
   rotate_left
   · contradiction
@@ -519,8 +519,8 @@ theorem env_validate_well_formed_is_sound
     action_schema_validate_well_formed_is_sound hwf_acts,
     true_and,
   ]
-  -- Check that the request types are well-formed
-  cases hwf_reqs : RequestType.validateWellFormed env env.reqty
+  -- Check that the action signature is well-formed
+  cases hwf_reqs : env.sig.validateWellFormed env
   · simp [hwf_reqs] at hok
   simp only [hwf_reqs] at hok
   exact request_type_validate_well_formed_is_sound hwf_reqs

--- a/cedar-lean/Cedar/Thm/Validation/Levels/CheckLevel.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Levels/CheckLevel.lean
@@ -46,7 +46,7 @@ inductive TypedExpr.EntityAccessAtLevel (env : TypeEnv) : TypedExpr → Nat → 
   | var (v : Var) (ty : CedarType) (n nmax : Nat) (path : List Attr) :
     EntityAccessAtLevel env (.var v ty) n nmax path
   | action (ty : CedarType) (n nmax : Nat) (path : List Attr) :
-    EntityAccessAtLevel env (.lit (.entityUID env.reqty.action) ty) n nmax path
+    EntityAccessAtLevel env (.lit (.entityUID env.sig.action) ty) n nmax path
   | ite (tx₁ tx₂ tx₃ : TypedExpr) (ty : CedarType)  (n nmax : Nat) (path : List Attr)
     (hl₁ : AtLevel env tx₁ nmax)
     (hl₂ : tx₂.EntityAccessAtLevel env n nmax path)

--- a/cedar-lean/Cedar/Thm/Validation/RequestEntityValidation.lean
+++ b/cedar-lean/Cedar/Thm/Validation/RequestEntityValidation.lean
@@ -147,11 +147,11 @@ decreasing_by
     omega
 
 theorem instance_of_request_type_refl {request : Request} {env : TypeEnv}:
-  instanceOfRequestType request env = true → InstanceOfRequestType request env
+  instanceOfTypeEnv request env = true → InstanceOfTypeEnv request env
 := by
   intro h₀
-  simp only [InstanceOfRequestType]
-  simp only [instanceOfRequestType, Bool.and_eq_true, beq_iff_eq] at h₀
+  simp only [InstanceOfTypeEnv]
+  simp only [instanceOfTypeEnv, Bool.and_eq_true, beq_iff_eq] at h₀
   have ⟨⟨⟨h₁,h₂⟩,h₃⟩, h₄⟩ := h₀
   and_intros
   · exact (instance_of_entity_type_refl h₁).1

--- a/cedar-lean/Cedar/Thm/Validation/Slice/Reachable.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Slice/Reachable.lean
@@ -47,7 +47,7 @@ theorem checked_eval_entity_lit_is_action {p : Prim} {n nmax : Nat} {c c' : Capa
 := by
   cases p
   case entityUID =>
-    replace he : euid = env.reqty.action := by
+    replace he : euid = env.sig.action := by
       replace ⟨ _, ht ⟩ := type_of_lit_inversion ht
       rw [ht] at hel
       cases hel

--- a/cedar-lean/Cedar/Thm/Validation/Typechecker/LitVar.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Typechecker/LitVar.lean
@@ -65,7 +65,7 @@ theorem type_of_var_is_sound {var : Var} {c₁ c₂ : Capabilities} {env : TypeE
   simp only [typeOf, typeOfVar, List.empty_eq, Function.comp_apply] at h₃
   have hwf := h₂.wf_env
   have ⟨_, h₂, _⟩ := h₂
-  simp [InstanceOfRequestType] at h₂
+  simp [InstanceOfTypeEnv] at h₂
   cases var
   <;> simp [ok] at h₃
   <;> have ⟨h₃, h₄⟩ := h₃

--- a/cedar-lean/Cedar/Thm/Validation/Typechecker/Types.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Typechecker/Types.lean
@@ -76,11 +76,11 @@ inductive InstanceOfType (env : TypeEnv) : Value → CedarType → Prop where
       (h₁ : InstanceOfExtType x xty) :
       InstanceOfType env (.ext x) (.ext xty)
 
-def InstanceOfRequestType (request : Request) (env : TypeEnv) : Prop :=
-  InstanceOfEntityType request.principal env.reqty.principal env ∧
-  request.action = env.reqty.action ∧
-  InstanceOfEntityType request.resource env.reqty.resource env ∧
-  InstanceOfType env request.context (.record env.reqty.context)
+def InstanceOfTypeEnv (request : Request) (env : TypeEnv) : Prop :=
+  InstanceOfEntityType request.principal env.sig.principal env ∧
+  request.action = env.sig.action ∧
+  InstanceOfEntityType request.resource env.sig.resource env ∧
+  InstanceOfType env request.context (.record env.sig.context)
 
 def InstanceOfEntityTags (data : EntityData) (entry : EntitySchemaEntry) (env : TypeEnv) : Prop :=
   match entry.tags? with
@@ -138,7 +138,7 @@ def InstanceOfSchema (entities : Entities) (env : TypeEnv) : Prop :=
 
 def InstanceOfWellFormedEnvironment (request : Request) (entities : Entities) (env : TypeEnv) : Prop :=
   env.WellFormed ∧
-  InstanceOfRequestType request env ∧
+  InstanceOfTypeEnv request env ∧
   InstanceOfSchema entities env
 
 ----- Theorems -----

--- a/cedar-lean/Cedar/Thm/Validation/Typechecker/WF.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Typechecker/WF.lean
@@ -154,19 +154,19 @@ def ActionSchema.WellFormed (env : TypeEnv) (acts : ActionSchema) : Prop :=
   acts.AcyclicActionHierarchy ∧
   acts.TransitiveActionHierarchy
 
-def RequestType.WellFormed (env : TypeEnv) (reqty : RequestType) : Prop :=
-  ∃ entry, env.acts.find? reqty.action = some entry ∧
+def ActionSignature.WellFormed (env : TypeEnv) (sig : ActionSignature) : Prop :=
+  ∃ entry, env.acts.find? sig.action = some entry ∧
     -- Enforce that principal/resource/context are valid for the action
-    reqty.principal ∈ entry.appliesToPrincipal ∧
-    reqty.resource ∈ entry.appliesToResource ∧
-    reqty.context = entry.context
+    sig.principal ∈ entry.appliesToPrincipal ∧
+    sig.resource ∈ entry.appliesToResource ∧
+    sig.context = entry.context
   -- Other properties, such as the well-formedness of principal/resource/context
   -- follows from the above and the well-formedness of `env.ets` and `env.acts`.
 
 def TypeEnv.WellFormed (env : TypeEnv) : Prop :=
   env.ets.WellFormed env ∧
   env.acts.WellFormed env ∧
-  env.reqty.WellFormed env
+  env.sig.WellFormed env
 
 ----- Some lemmas -----
 
@@ -307,7 +307,7 @@ theorem wf_env_implies_attrs_lifted {env : TypeEnv} {ety : EntityType} {attrs : 
 
 theorem wf_env_implies_action_wf {env : TypeEnv}
   (hwf : env.WellFormed) :
-  EntityUID.WellFormed env env.reqty.action
+  EntityUID.WellFormed env env.sig.action
 := by
   have ⟨_, _, hwf_req⟩ := hwf
   have ⟨_, hact, _⟩ := hwf_req
@@ -330,19 +330,19 @@ theorem wf_env_disjoint_ets_acts
   · simp [EntitySchema.contains, hets]
 
 /--
-More well-formedness properties of `env.reqty`.
+More well-formedness properties of `env.sig`.
 -/
 theorem wf_env_implies_wf_request
   {env : TypeEnv}
   (hwf : env.WellFormed) :
-  EntityType.WellFormed env env.reqty.principal ∧
-  env.acts.contains env.reqty.action ∧
-  EntityType.WellFormed env env.reqty.resource ∧
-  (CedarType.record env.reqty.context).WellFormed env
+  EntityType.WellFormed env env.sig.principal ∧
+  env.acts.contains env.sig.action ∧
+  EntityType.WellFormed env env.sig.resource ∧
+  (CedarType.record env.sig.context).WellFormed env
 := by
   have ⟨_, hwf_acts, ⟨entry, hwf_act, hwf_princ, hwf_res, hwf_ctx⟩⟩ := hwf
   have ⟨_, hwf_acts, _⟩ := hwf_acts
-  have hwf_act_entry := hwf_acts env.reqty.action entry hwf_act
+  have hwf_act_entry := hwf_acts env.sig.action entry hwf_act
   have ⟨_, _, _, hwf_app_to_princ, hwf_app_to_res, _, hwf_ctx_ty⟩ := hwf_act_entry
   and_intros
   · apply hwf_app_to_princ
@@ -355,16 +355,16 @@ theorem wf_env_implies_wf_request
   · simp [hwf_ctx, hwf_ctx_ty]
 
 /--
-More well-formedness properties of `env.reqty`.
+More well-formedness properties of `env.sig`.
 -/
 theorem wf_env_implies_ctx_lifted
   {env : TypeEnv}
   (hwf : env.WellFormed) :
-  (CedarType.record env.reqty.context).IsLifted
+  (CedarType.record env.sig.context).IsLifted
 := by
   have ⟨_, hwf_acts, ⟨entry, hwf_act, _, _, hwf_ctx⟩⟩ := hwf
   have ⟨_, hwf_acts, _⟩ := hwf_acts
-  have hwf_act_entry := hwf_acts env.reqty.action entry hwf_act
+  have hwf_act_entry := hwf_acts env.sig.action entry hwf_act
   have ⟨_, _, _, _, _, _, hwf_ctx_ty⟩ := hwf_act_entry
   simp [hwf_ctx, hwf_ctx_ty]
 

--- a/cedar-lean/Cedar/Thm/Validation/Validator.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Validator.lean
@@ -41,10 +41,10 @@ def InstanceOfWellFormedSchema (schema : Schema) (request : Request) (entities :
 
 theorem action_matches_env {env : TypeEnv} {request : Request} {entities : Entities} :
   InstanceOfWellFormedEnvironment request entities env →
-  request.action = env.reqty.action
+  request.action = env.sig.action
 := by
   intro h₀
-  simp only [InstanceOfWellFormedEnvironment, InstanceOfRequestType] at h₀
+  simp only [InstanceOfWellFormedEnvironment, InstanceOfTypeEnv] at h₀
   obtain ⟨_, ⟨ _, h₁, _, _ ⟩, _⟩ := h₀
   exact h₁
 
@@ -55,7 +55,7 @@ theorem typecheck_policy_is_sound (policy : Policy) (env : TypeEnv) (tx : TypedE
 := by
   intro h₁ h₂
   simp only [typecheckPolicy] at h₂
-  cases h₃ : typeOf (substituteAction env.reqty.action policy.toExpr) [] env <;>
+  cases h₃ : typeOf (substituteAction env.sig.action policy.toExpr) [] env <;>
   simp only [List.empty_eq, h₃, reduceCtorEq] at h₂
   split at h₂ <;> simp only [Except.ok.injEq, reduceCtorEq] at h₂
   rename_i cp ht

--- a/cedar-lean/Cedar/Thm/Validation/WellTyped/Definition.lean
+++ b/cedar-lean/Cedar/Thm/Validation/WellTyped/Definition.lean
@@ -39,13 +39,13 @@ inductive Prim.WellTyped (env : TypeEnv) : Prim → CedarType → Prop
 
 inductive Var.WellTyped (env : TypeEnv) : Var → CedarType → Prop
   | principal :
-    WellTyped env .principal (.entity env.reqty.principal)
+    WellTyped env .principal (.entity env.sig.principal)
   | resource :
-    WellTyped env .resource (.entity env.reqty.resource)
+    WellTyped env .resource (.entity env.sig.resource)
   | action :
-    WellTyped env .action (.entity env.reqty.action.ty)
+    WellTyped env .action (.entity env.sig.action.ty)
   | context:
-    WellTyped env .context (CedarType.liftBoolTypes (.record env.reqty.context))
+    WellTyped env .context (CedarType.liftBoolTypes (.record env.sig.context))
 
 inductive UnaryOp.WellTyped : UnaryOp → TypedExpr → CedarType → Prop
   | not {x₁ : TypedExpr}

--- a/cedar-lean/Cedar/Thm/Validation/WellTyped/ResidualSoundness.lean
+++ b/cedar-lean/Cedar/Thm/Validation/WellTyped/ResidualSoundness.lean
@@ -65,23 +65,23 @@ InstanceOfType env v (Residual.var var ty).typeOf
   cases h₂ <;>
   simp only [Residual.evaluate, Except.ok.injEq] at h₃ <;>
   rw [←h₃] <;>
-  simp only [InstanceOfWellFormedEnvironment, InstanceOfRequestType] at h₁
+  simp only [InstanceOfWellFormedEnvironment, InstanceOfTypeEnv] at h₁
   case principal =>
     rcases h₁ with ⟨_, ⟨h₁, _, _, _⟩, _⟩
-    exact InstanceOfType.instance_of_entity request.principal env.reqty.principal h₁
+    exact InstanceOfType.instance_of_entity request.principal env.sig.principal h₁
   case resource =>
     rcases h₁ with ⟨_, ⟨_, _, h₁, _⟩, _⟩
-    exact InstanceOfType.instance_of_entity request.resource env.reqty.resource h₁
+    exact InstanceOfType.instance_of_entity request.resource env.sig.resource h₁
   case action =>
     rcases h₁ with ⟨hwf, ⟨_, h₁, _, _⟩, _⟩
     rw [h₁]
-    have : InstanceOfEntityType env.reqty.action env.reqty.action.ty env := by
+    have : InstanceOfEntityType env.sig.action env.sig.action.ty env := by
       have ⟨_, _, ⟨_, hwf_act, _⟩⟩ := hwf
       simp [
         InstanceOfEntityType, EntityUID.WellFormed,
         ActionSchema.contains, hwf_act,
       ]
-    exact InstanceOfType.instance_of_entity env.reqty.action env.reqty.action.ty this
+    exact InstanceOfType.instance_of_entity env.sig.action env.sig.action.ty this
   case context =>
     rcases h₁ with ⟨_, ⟨_, _, _, h₁⟩, _⟩
     exact type_lifting_preserves_instance_of_type h₁

--- a/cedar-lean/Cedar/Thm/Validation/WellTyped/Soundness.lean
+++ b/cedar-lean/Cedar/Thm/Validation/WellTyped/Soundness.lean
@@ -69,23 +69,23 @@ InstanceOfType env v (TypedExpr.var var ty).typeOf
   simp only [TypedExpr.typeOf] <;>
   simp only [evaluate, Except.ok.injEq] at h₃ <;>
   rw [←h₃] <;>
-  simp only [InstanceOfWellFormedEnvironment, InstanceOfRequestType] at h₁
+  simp only [InstanceOfWellFormedEnvironment, InstanceOfTypeEnv] at h₁
   case principal =>
     rcases h₁ with ⟨_, ⟨h₁, _, _, _⟩, _⟩
-    exact InstanceOfType.instance_of_entity request.principal env.reqty.principal h₁
+    exact InstanceOfType.instance_of_entity request.principal env.sig.principal h₁
   case resource =>
     rcases h₁ with ⟨_, ⟨_, _, h₁, _⟩, _⟩
-    exact InstanceOfType.instance_of_entity request.resource env.reqty.resource h₁
+    exact InstanceOfType.instance_of_entity request.resource env.sig.resource h₁
   case action =>
     rcases h₁ with ⟨_, ⟨_, h₁, _, _⟩, _⟩
     simp only [h₁]
-    have : InstanceOfEntityType env.reqty.action env.reqty.action.ty env := by
+    have : InstanceOfEntityType env.sig.action env.sig.action.ty env := by
       have ⟨_, _, ⟨_, hwf_act, _⟩⟩ := hwf
       simp [
         InstanceOfEntityType, EntityUID.WellFormed,
         ActionSchema.contains, hwf_act,
       ]
-    exact InstanceOfType.instance_of_entity env.reqty.action env.reqty.action.ty this
+    exact InstanceOfType.instance_of_entity env.sig.action env.sig.action.ty this
   case context =>
     rcases h₁ with ⟨_, ⟨_, _, _, h₁⟩, _⟩
     exact type_lifting_preserves_instance_of_type h₁

--- a/cedar-lean/Cedar/Thm/Validation/WellTyped/WF.lean
+++ b/cedar-lean/Cedar/Thm/Validation/WellTyped/WF.lean
@@ -67,7 +67,7 @@ theorem well_typed_implies_wf_type
       constructor
       simp only [EntityType.WellFormed, ActionSchema.IsActionEntityType]
       apply Or.inr
-      exists env.reqty.action
+      exists env.sig.action
     case resource =>
       constructor
       assumption

--- a/cedar-lean/Cedar/Validation/EnvironmentValidator.lean
+++ b/cedar-lean/Cedar/Validation/EnvironmentValidator.lean
@@ -181,24 +181,24 @@ def ActionSchema.validateWellFormed (env : TypeEnv) (acts : ActionSchema) : Envi
     acts.validateAcyclicActionHierarchy
     acts.validateTransitiveActionHierarchy
 
-def RequestType.validateWellFormed (env : TypeEnv) (reqty : RequestType) : EnvironmentValidationResult :=
-  match env.acts.find? reqty.action with
+def ActionSignature.validateWellFormed (env : TypeEnv) (sig : ActionSignature) : EnvironmentValidationResult :=
+  match env.acts.find? sig.action with
   | some entry => do
-    if entry.appliesToPrincipal.contains reqty.principal then .ok ()
+    if entry.appliesToPrincipal.contains sig.principal then .ok ()
     else
-      .error (.typeError s!"action {reqty.action} does not apply to principal {reqty.principal}")
-    if entry.appliesToResource.contains reqty.resource then .ok ()
+      .error (.typeError s!"action {sig.action} does not apply to principal {sig.principal}")
+    if entry.appliesToResource.contains sig.resource then .ok ()
     else
-      .error (.typeError s!"action {reqty.action} does not apply to resource {reqty.resource}")
-    if reqty.context == entry.context then .ok ()
+      .error (.typeError s!"action {sig.action} does not apply to resource {sig.resource}")
+    if sig.context == entry.context then .ok ()
     else
-      .error (.typeError s!"action {reqty.action} context type does not match schema")
-  | none => .error (.typeError s!"action {reqty.action} does not exist in schema")
+      .error (.typeError s!"action {sig.action} context type does not match schema")
+  | none => .error (.typeError s!"action {sig.action} does not exist in schema")
 
 def TypeEnv.validateWellFormed (env : TypeEnv) : EnvironmentValidationResult := do
   env.ets.validateWellFormed env
   env.acts.validateWellFormed env
-  env.reqty.validateWellFormed env
+  env.sig.validateWellFormed env
 
 -- TODO: Can be optimized, as `TypeEnv.validateWellFormed`
 --       mostly only depends on the schema part of the environment.

--- a/cedar-lean/Cedar/Validation/Levels.lean
+++ b/cedar-lean/Cedar/Validation/Levels.lean
@@ -56,7 +56,7 @@ def TypedExpr.checkEntityAccessLevel (tx : TypedExpr) (env : TypeEnv) (n nmax : 
   match tx, path with
   | .var _ _, _ => true
   | .lit (.entityUID euid) _, _ =>
-    euid == env.reqty.action
+    euid == env.sig.action
   | .ite tx₁ tx₂ tx₃ _, _ =>
     tx₁.checkLevel env nmax &&
     tx₂.checkEntityAccessLevel env n nmax path &&

--- a/cedar-lean/Cedar/Validation/RequestEntityValidator.lean
+++ b/cedar-lean/Cedar/Validation/RequestEntityValidator.lean
@@ -83,11 +83,11 @@ def instanceOfType (v : Value) (ty : CedarType) (env : TypeEnv) : Bool :=
         simp only [Map.mk.sizeOf_spec]
         omega
 
-def instanceOfRequestType (request : Request) (env : TypeEnv) : Bool :=
-  instanceOfEntityType request.principal env.reqty.principal env &&
-  request.action == env.reqty.action &&
-  instanceOfEntityType request.resource env.reqty.resource env &&
-  instanceOfType request.context (.record env.reqty.context) env
+def instanceOfTypeEnv (request : Request) (env : TypeEnv) : Bool :=
+  instanceOfEntityType request.principal env.sig.principal env &&
+  request.action == env.sig.action &&
+  instanceOfEntityType request.resource env.sig.resource env &&
+  instanceOfType request.context (.record env.sig.context) env
 
 /--
 For every entity in the store,
@@ -138,7 +138,7 @@ where
     if entities.contains uid then .ok ()
     else .error (.typeError s!"action entity {uid} does not exist")
 
-def requestMatchesEnvironment (env : TypeEnv) (request : Request) : Bool := instanceOfRequestType request env
+def requestMatchesEnvironment (env : TypeEnv) (request : Request) : Bool := instanceOfTypeEnv request env
 
 def validateRequest (schema : Schema) (request : Request) : RequestValidationResult :=
   if ((schema.environments.any (requestMatchesEnvironment · request)))

--- a/cedar-lean/Cedar/Validation/Typechecker.lean
+++ b/cedar-lean/Cedar/Validation/Typechecker.lean
@@ -66,10 +66,10 @@ def typeOfLit (p : Prim) (env : TypeEnv) : ResultType :=
 def typeOfVar (v : Var) (env : TypeEnv) : ResultType :=
   let ok := ok ∘ TypedExpr.var v
   match v with
-  | .principal => ok (.entity env.reqty.principal)
-  | .action    => ok (.entity env.reqty.action.ty)
-  | .resource  => ok (.entity env.reqty.resource)
-  | .context   => ok (.record env.reqty.context)
+  | .principal => ok (.entity env.sig.principal)
+  | .action    => ok (.entity env.sig.action.ty)
+  | .resource  => ok (.entity env.sig.resource)
+  | .context   => ok (.record env.sig.context)
 
 def typeOfIf (r₁ : TypedExpr × Capabilities) (r₂ r₃ : ResultType) : ResultType :=
   let c₁ := r₁.snd
@@ -376,7 +376,7 @@ def typeOf (x : Expr) (c : Capabilities) (env : TypeEnv) : ResultType :=
 
 ---- Derivations -----
 
-deriving instance Repr for RequestType
+deriving instance Repr for ActionSignature
 deriving instance Repr for TypeEnv
 
 end Cedar.Validation

--- a/cedar-lean/Cedar/Validation/Types.lean
+++ b/cedar-lean/Cedar/Validation/Types.lean
@@ -188,7 +188,7 @@ structure Schema where
   ets : EntitySchema
   acts : ActionSchema
 
-structure RequestType where
+structure ActionSignature where
   principal : EntityType
   action : EntityUID
   resource : EntityType
@@ -197,7 +197,7 @@ structure RequestType where
 structure TypeEnv where
   ets : EntitySchema
   acts : ActionSchema
-  reqty : RequestType
+  sig : ActionSignature
 
 def ActionSchema.maybeDescendentOf (as : ActionSchema) (ety₁ ety₂ : EntityType) : Bool :=
   as.kvs.any λ (act, entry) => act.ty = ety₁ && entry.ancestors.any (EntityUID.ty · == ety₂)

--- a/cedar-lean/SymTest/Util.lean
+++ b/cedar-lean/SymTest/Util.lean
@@ -85,7 +85,7 @@ def actionSchema (context : RecordType) : ActionSchema :=
   }
   Map.make [(action, entry)]
 
-def requestType (context : RecordType) : RequestType :=
+def actionSignature (context : RecordType) : ActionSignature :=
   {
     principal := principalType,
     action := action,
@@ -101,9 +101,9 @@ def entitySchema (principalAttrs resourceAttrs : RecordType) (principalTags reso
 
 def env (principalAttrs resourceAttrs context : RecordType) (principalTags resourceTags : Option CedarType := none) : TypeEnv :=
   {
-    ets   := entitySchema principalAttrs resourceAttrs principalTags resourceTags,
-    acts  := actionSchema context,
-    reqty := requestType context
+    ets  := entitySchema principalAttrs resourceAttrs principalTags resourceTags,
+    acts := actionSchema context,
+    sig  := actionSignature context
   }
 
 end BasicTypes
@@ -178,7 +178,7 @@ where
     .standard ⟨Set.make ancs, Map.make attrs, none⟩
 
 
-def requestType (action : EntityUID) (resourceType : EntityType) (context : RecordType) : RequestType :=
+def actionSignature (action : EntityUID) (resourceType : EntityType) (context : RecordType) : ActionSignature :=
   {
     principal := userType,
     action := action,
@@ -192,9 +192,9 @@ def env (action : EntityUID) (context : RecordType) : TypeEnv :=
   let acts := actionSchema context
   let resourceType := (acts.find? action).get!.appliesToPrincipal.toList.head!
   {
-    ets   := entitySchema,
-    acts  := acts,
-    reqty := requestType action resourceType context
+    ets  := entitySchema,
+    acts := acts,
+    sig  := actionSignature action resourceType context
   }
 
 end Photoflash


### PR DESCRIPTION
Renames `RequestType` to `ActionSignature`, to align some names better between our Rust and Lean code.  Also renames related variables and field names (e.g. `reqty` to `sig`). 


