### PR TITLE
Set lower limits for the symcc term roundtrip target

### DIFF
--- a/cedar-drt/fuzz/fuzz_targets/symcc-term-roundtrip-abac-type-directed.rs
+++ b/cedar-drt/fuzz/fuzz_targets/symcc-term-roundtrip-abac-type-directed.rs
@@ -39,6 +39,9 @@ pub struct FuzzTargetInput {
     pub policy: ABACPolicy,
 }
 
+const SYMCC_TERM_ROUNDTRIP_PER_ACTION_REQUEST_ENV_LIMIT: usize = 4;
+const SYMCC_TERM_ROUNDTRIP_TOTAL_ACTION_REQUEST_ENV_LIMIT: usize = 24;
+
 /// settings for this fuzz target
 const SETTINGS: ABACSettings = ABACSettings {
     match_types: true,
@@ -51,8 +54,8 @@ const SETTINGS: ABACSettings = ABACSettings {
     enable_arbitrary_func_call: true,
     enable_unknowns: false,
     enable_action_in_constraints: true,
-    per_action_request_env_limit: ABACSettings::default_per_action_request_env_limit(),
-    total_action_request_env_limit: total_action_request_env_limit(),
+    per_action_request_env_limit: SYMCC_TERM_ROUNDTRIP_PER_ACTION_REQUEST_ENV_LIMIT,
+    total_action_request_env_limit: SYMCC_TERM_ROUNDTRIP_TOTAL_ACTION_REQUEST_ENV_LIMIT,
 };
 
 impl<'a> Arbitrary<'a> for FuzzTargetInput {


### PR DESCRIPTION
In #719 we set lower limits specific to symcc targets. However, the `symcc-term-roundtrip-abac-type-directed` target has resulted in multiple slow units over the last few days. My investigation has revealed that the time we spend on this target for each request environment is close to 350ms. This PR sets lower limits for total action/request environment pairs so that it's easier to stay within bounds. We could also update the symcc limits if we don't want to have too many ad-hoc limits.