### PR TITLE
Adjust level based entity slicing to be infallible

### DIFF
--- a/cedar-lean/Cedar/Thm/Validation.lean
+++ b/cedar-lean/Cedar/Thm/Validation.lean
@@ -82,19 +82,12 @@ authorization request made using a slice of entities obtained by slicing at
 level `n` will return the same response as authorizing using the original
 entities.
 -/
-theorem validate_with_level_is_sound {ps : Policies} {schema : Schema} {n : Nat} {request : Request} {entities slice : Entities}
+theorem validate_with_level_is_sound {ps : Policies} {schema : Schema} {n : Nat} {request : Request} {entities : Entities}
   (hwf : schema.validateWellFormed = .ok ())
   (hr : validateRequest schema request = .ok ())
   (he : validateEntities schema entities = .ok ())
-  (hs : slice = entities.sliceAtLevel request n)
   (htl : validateWithLevel ps schema n = .ok ()) :
-  isAuthorized request entities ps = isAuthorized request slice ps
-:= by
-  have hsound : ∀ p ∈ ps, evaluate p.toExpr request entities = evaluate p.toExpr request slice := by
-    have hre := request_and_entities_validate_implies_instance_of_wf_schema _ _ _ hwf hr he
-    replace htl := List.forM_ok_implies_all_ok _ _ htl
-    intro p hp
-    exact typecheck_policy_at_level_with_environments_is_sound hs hre (htl p hp)
-  exact is_authorized_congr_evaluate hsound
+  isAuthorized request entities ps = isAuthorized request (entities.sliceAtLevel request n) ps
+:= validate_with_level_is_sound_wf (request_and_entities_validate_implies_instance_of_wf_schema _ _ _ hwf hr he) htl
 
 end Cedar.Thm

--- a/cedar-lean/Cedar/Thm/Validation/Levels/And.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Levels/And.lean
@@ -34,15 +34,14 @@ open Cedar.Data
 open Cedar.Spec
 open Cedar.Validation
 
-theorem level_based_slicing_is_sound_and {e₁ e₂ : Expr} {n : Nat} {c₀ c₁: Capabilities} {env : TypeEnv} {request : Request} {entities slice : Entities}
-  (hs : slice = entities.sliceAtLevel request n)
+theorem level_based_slicing_is_sound_and {e₁ e₂ : Expr} {n : Nat} {c₀ c₁: Capabilities} {env : TypeEnv} {request : Request} {entities : Entities}
   (hc : CapabilitiesInvariant c₀ request entities)
   (hr : InstanceOfWellFormedEnvironment request entities env)
   (ht : typeOf (.and e₁ e₂) c₀ env = Except.ok (tx, c₁))
   (hl : tx.AtLevel env n)
   (ih₁ : TypedAtLevelIsSound e₁)
   (ih₂ : TypedAtLevelIsSound e₂)
-  : evaluate (.and e₁ e₂) request entities = evaluate (.and e₁ e₂) request slice
+  : evaluate (.and e₁ e₂) request entities = evaluate (.and e₁ e₂) request (entities.sliceAtLevel request n)
 := by
   replace ⟨ tx₁, bty, c', htx₁, hty₁, ht ⟩ := type_of_and_inversion ht
   have ⟨ hgc, v₁, he₁, hv₁⟩  := type_of_is_sound hc hr htx₁
@@ -53,7 +52,7 @@ theorem level_based_slicing_is_sound_and {e₁ e₂ : Expr} {n : Nat} {c₀ c₁
     subst tx bty
     replace hv₁ := instance_of_ff_is_false hv₁
     subst v₁
-    specialize ih₁ hs hc hr htx₁ hl
+    specialize ih₁ hc hr htx₁ hl
     simp only [evaluate, ←ih₁]
     rcases he₁ with he₁ | he₁ | he₁ | he₁ <;>
     simp [he₁, Result.as, Coe.coe, Value.asBool]
@@ -62,11 +61,11 @@ theorem level_based_slicing_is_sound_and {e₁ e₂ : Expr} {n : Nat} {c₀ c₁
     replace ⟨ b₁ , hv₁⟩ := instance_of_bool_is_bool hv₁
     subst v₁ tx
     cases hl ; rename_i hl₁ hl₂
-    specialize ih₁ hs hc hr htx₁ hl₁
+    specialize ih₁ hc hr htx₁ hl₁
     simp only [evaluate, ←ih₁]
     rcases he₁ with he₁ | he₁ | he₁ | he₁ <;>
     simp only [he₁, Result.as, Bool.not_eq_eq_eq_not, Bool.not_true, Coe.coe, Value.asBool, Except.bind_err]
     cases b₁ <;> simp only [Except.bind_ok, ↓reduceIte]
     specialize hgc he₁
-    specialize ih₂ hs (capability_union_invariant hc hgc) hr htx₂ hl₂
+    specialize ih₂ (capability_union_invariant hc hgc) hr htx₂ hl₂
     simp [ih₂]

--- a/cedar-lean/Cedar/Thm/Validation/Levels/Basic.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Levels/Basic.lean
@@ -26,10 +26,9 @@ Basic definitions for levels proof
 open Cedar.Spec
 open Cedar.Validation
 
-def TypedAtLevelIsSound (e : Expr) : Prop := ∀ {n : Nat} {tx : TypedExpr} {c c₁ : Capabilities} {env : TypeEnv} {request : Request} {entities slice : Entities},
-  slice = entities.sliceAtLevel request n →
+def TypedAtLevelIsSound (e : Expr) : Prop := ∀ {n : Nat} {tx : TypedExpr} {c c₁ : Capabilities} {env : TypeEnv} {request : Request} {entities : Entities},
   CapabilitiesInvariant c request entities →
   InstanceOfWellFormedEnvironment request entities env →
   typeOf e c env = Except.ok (tx, c₁) →
   tx.AtLevel env n →
-  evaluate e request entities = evaluate e request slice
+  evaluate e request entities = evaluate e request (entities.sliceAtLevel request n)

--- a/cedar-lean/Cedar/Thm/Validation/Levels/BinaryApp.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Levels/BinaryApp.lean
@@ -47,39 +47,37 @@ theorem not_dereferencing_apply₂_invariant_entities {op : BinaryOp} {entities 
     ) <;>
     simp only
 
-theorem level_based_slicing_is_sound_inₑ {e₁ : Expr} {euid₁ euid₂ : EntityUID} {n : Nat} {c₀ c₁ : Capabilities} {entities slice : Entities}
+theorem level_based_slicing_is_sound_inₑ {e₁ : Expr} {euid₁ euid₂ : EntityUID} {n : Nat} {c₀ c₁ : Capabilities} {entities : Entities}
   (hc : CapabilitiesInvariant c₀ request entities)
   (hr : InstanceOfWellFormedEnvironment request entities env)
   (ht : typeOf e₁ c₀ env = Except.ok (tx₁, c₁))
   (hl : tx₁.EntityAccessAtLevel env n (n + 1) [])
   (he : evaluate e₁ request entities = .ok (Value.prim (Prim.entityUID euid₁)))
-  (hs : some slice = entities.sliceAtLevel request (n + 1))
-  : inₑ euid₁ euid₂ entities = inₑ euid₁ euid₂ slice
+  : inₑ euid₁ euid₂ entities = inₑ euid₁ euid₂ (entities.sliceAtLevel request (n + 1))
 := by
   simp only [inₑ]
   cases heq : euid₁ == euid₂ <;> simp only [Bool.false_or, Bool.true_or]
-  have hfeq := checked_eval_entity_find_entities_eq_find_slice hc hr ht hl he hs
+  have hfeq := checked_eval_entity_find_entities_eq_find_slice hc hr ht hl he
   simp [hfeq, Entities.ancestorsOrEmpty]
 
-theorem level_based_slicing_is_sound_binary_app {op : BinaryOp} {e₁ e₂ : Expr} {n : Nat} {c₀ c₁: Capabilities} {env : TypeEnv} {request : Request} {entities slice : Entities}
-  (hs : slice = entities.sliceAtLevel request n)
+theorem level_based_slicing_is_sound_binary_app {op : BinaryOp} {e₁ e₂ : Expr} {n : Nat} {c₀ c₁: Capabilities} {env : TypeEnv} {request : Request} {entities : Entities}
   (hc : CapabilitiesInvariant c₀ request entities)
   (hr : InstanceOfWellFormedEnvironment request entities env)
   (ht : typeOf (.binaryApp op e₁ e₂) c₀ env = Except.ok (tx, c₁))
   (hl : tx.AtLevel env n)
   (ihe₁ : TypedAtLevelIsSound e₁)
   (ihe₂ : TypedAtLevelIsSound e₂)
-  : evaluate (.binaryApp op e₁ e₂) request entities = evaluate (.binaryApp op e₁ e₂) request slice
+  : evaluate (.binaryApp op e₁ e₂) request entities = evaluate (.binaryApp op e₁ e₂) request (entities.sliceAtLevel request n)
 := by
   replace ⟨tx₁, c₁, tx₂, c₂, htx₁, htx₂, ty, htx⟩ := type_of_binaryApp_inversion ht
   subst tx
   simp only [evaluate]
   cases hl
   case getTag hel hl₁ hl₂ | hasTag hel hl₁ hl₂ =>
-    specialize ihe₂ hs hc hr htx₂ hl₂
+    specialize ihe₂ hc hr htx₂ hl₂
     rw [←ihe₂]
     have hl₁' := entity_access_at_level_then_at_level hl₁
-    specialize ihe₁ hs hc hr htx₁ hl₁'
+    specialize ihe₁ hc hr htx₁ hl₁'
     rw [←ihe₁]
     cases he₁ : evaluate e₁ request entities <;> simp only [Except.bind_ok, Except.bind_err]
     cases he₂ : evaluate e₂ request entities <;> simp only [Except.bind_ok, Except.bind_err]
@@ -88,13 +86,13 @@ theorem level_based_slicing_is_sound_binary_app {op : BinaryOp} {e₁ e₂ : Exp
     rename_i p₁ p₂
     cases p₁ <;> cases p₂ <;> simp only
     rename_i euid _
-    have hfeq := checked_eval_entity_find_entities_eq_find_slice hc hr htx₁ hl₁ he₁ hs
+    have hfeq := checked_eval_entity_find_entities_eq_find_slice hc hr htx₁ hl₁ he₁
     simp only [hfeq, hasTag, getTag, Entities.tagsOrEmpty, Entities.tags, Map.findOrErr]
   case mem hel hl₁ hl₂ =>
-    specialize ihe₂ hs hc hr htx₂ hl₂
+    specialize ihe₂ hc hr htx₂ hl₂
     rw [←ihe₂]
     have hl₁' := entity_access_at_level_then_at_level hl₁
-    specialize ihe₁ hs hc hr htx₁ hl₁'
+    specialize ihe₁ hc hr htx₁ hl₁'
     rw [←ihe₁]
     cases he₁ : evaluate e₁ request entities <;> simp only [Except.bind_ok, Except.bind_err]
     cases he₂ : evaluate e₂ request entities <;> simp only [Except.bind_ok, Except.bind_err]
@@ -103,13 +101,13 @@ theorem level_based_slicing_is_sound_binary_app {op : BinaryOp} {e₁ e₂ : Exp
     case prim =>
       rename_i p₁ p₂
       cases p₁ <;> cases p₂ <;> simp only
-      simp [level_based_slicing_is_sound_inₑ hc hr htx₁ hl₁ he₁ hs]
+      simp [level_based_slicing_is_sound_inₑ hc hr htx₁ hl₁ he₁]
     case set =>
       rename_i p₁ sv
       cases p₁ <;> simp only
-      simp [inₛ, level_based_slicing_is_sound_inₑ hc hr htx₁ hl₁ he₁ hs]
+      simp [inₛ, level_based_slicing_is_sound_inₑ hc hr htx₁ hl₁ he₁]
   case binaryApp hop hl₁ hl₂ =>
-    specialize ihe₁ hs hc hr htx₁ hl₁
-    specialize ihe₂ hs hc hr htx₂ hl₂
+    specialize ihe₁ hc hr htx₁ hl₁
+    specialize ihe₂ hc hr htx₂ hl₂
     rw [ihe₁, ihe₂]
-    simp [(@not_dereferencing_apply₂_invariant_entities op entities slice · · hop)]
+    simp [(@not_dereferencing_apply₂_invariant_entities op entities (entities.sliceAtLevel request n) · · hop)]

--- a/cedar-lean/Cedar/Thm/Validation/Levels/Call.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Levels/Call.lean
@@ -27,26 +27,25 @@ open Cedar.Data
 open Cedar.Spec
 open Cedar.Validation
 
-theorem level_based_slicing_is_sound_call {xs : List Expr} {n : Nat} {c₀ c₁: Capabilities} {env : TypeEnv} {request : Request} {entities slice : Entities}
-  (hs : slice = entities.sliceAtLevel request n)
+theorem level_based_slicing_is_sound_call {xs : List Expr} {n : Nat} {c₀ c₁: Capabilities} {env : TypeEnv} {request : Request} {entities : Entities}
   (hc : CapabilitiesInvariant c₀ request entities)
   (hr : InstanceOfWellFormedEnvironment request entities env)
   (ht : typeOf (.call xfn xs) c₀ env = Except.ok (tx, c₁))
   (hl : tx.AtLevel env n)
   (ih : ∀ x ∈ xs, TypedAtLevelIsSound x) :
-  evaluate (.call xfn xs) request entities = evaluate (.call xfn xs) request slice
+  evaluate (.call xfn xs) request entities = evaluate (.call xfn xs) request (entities.sliceAtLevel request n)
 := by
   replace ⟨ txs, ⟨ty, hty⟩, ht ⟩ := type_of_call_inversion ht
   subst tx
   cases hl ; rename_i hl
 
-  have he : ∀ x ∈ xs, evaluate x request entities = evaluate x request slice := by
+  have he : ∀ x ∈ xs, evaluate x request entities = evaluate x request (entities.sliceAtLevel request n) := by
     intros x hx
     replace ⟨ tx, htxs, c', htx ⟩ := List.forall₂_implies_all_left ht x hx
     specialize hl tx htxs
-    exact ih x hx hs hc hr htx hl
+    exact ih x hx hc hr htx hl
 
   simp only [evaluate, List.mapM₁, List.attach, List.attachWith]
   simp only [List.mapM_pmap_subtype (λ x : Expr => evaluate x request entities) xs]
-  simp only [List.mapM_pmap_subtype (λ x : Expr => evaluate x request slice) xs]
+  simp only [List.mapM_pmap_subtype (λ x : Expr => evaluate x request (entities.sliceAtLevel request n)) xs]
   rw [List.mapM_congr he]

--- a/cedar-lean/Cedar/Thm/Validation/Levels/HasAttr.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Levels/HasAttr.lean
@@ -19,15 +19,14 @@ open Cedar.Data
 open Cedar.Spec
 open Cedar.Validation
 
-theorem level_based_slicing_is_sound_has_attr_entity {e : Expr} {tx₁: TypedExpr} {ty : CedarType} {a : Attr} {n : Nat} {c₀ c₁: Capabilities} {env : TypeEnv} {request : Request} {entities slice : Entities}
-  (hs : slice = entities.sliceAtLevel request n)
+theorem level_based_slicing_is_sound_has_attr_entity {e : Expr} {tx₁: TypedExpr} {ty : CedarType} {a : Attr} {n : Nat} {c₀ c₁: Capabilities} {env : TypeEnv} {request : Request} {entities : Entities}
   (hc : CapabilitiesInvariant c₀ request entities)
   (hr : InstanceOfWellFormedEnvironment request entities env)
   (hl : (tx₁.hasAttr a ty).AtLevel env n)
   (ht : typeOf e c₀ env = Except.ok (tx₁, c₁))
   (hety : tx₁.typeOf = CedarType.entity ety)
   (ihe : TypedAtLevelIsSound e)
-  : evaluate (.hasAttr e a) request entities = evaluate (.hasAttr e a) request slice
+  : evaluate (.hasAttr e a) request entities = evaluate (.hasAttr e a) request (entities.sliceAtLevel request n)
 := by
   have ⟨ hgc, v, he, hv ⟩ := type_of_is_sound hc hr ht
   rw [hety] at hv
@@ -40,28 +39,27 @@ theorem level_based_slicing_is_sound_has_attr_entity {e : Expr} {tx₁: TypedExp
   rename_i n hel₁ hl₁ _
   simp only [evaluate]
   have hl₁' := entity_access_at_level_then_at_level hl₁
-  specialize ihe hs hc hr ht hl₁'
+  specialize ihe hc hr ht hl₁'
   rw [←ihe]
   unfold EvaluatesTo at he
   rcases he with he | he | he | he <;> simp only [he, Except.bind_err]
-  have hfeq := checked_eval_entity_find_entities_eq_find_slice hc hr ht hl₁ he hs
+  have hfeq := checked_eval_entity_find_entities_eq_find_slice hc hr ht hl₁ he
   simp [hfeq, hasAttr, attrsOf, Entities.attrsOrEmpty]
 
-theorem level_based_slicing_is_sound_has_attr_record {e : Expr} {tx : TypedExpr} {a : Attr} {n : Nat} {c₀: Capabilities} {env : TypeEnv} {request : Request} {entities slice : Entities}
-  (hs : slice = entities.sliceAtLevel request n)
+theorem level_based_slicing_is_sound_has_attr_record {e : Expr} {tx : TypedExpr} {a : Attr} {n : Nat} {c₀: Capabilities} {env : TypeEnv} {request : Request} {entities : Entities}
   (hc : CapabilitiesInvariant c₀ request entities)
   (hr : InstanceOfWellFormedEnvironment request entities env)
   (hl : (tx.hasAttr a ty).AtLevel env n)
   (htx : typeOf e c₀ env = Except.ok (tx, c₁'))
   (hrty : tx.typeOf = CedarType.record rty)
   (ihe : TypedAtLevelIsSound e)
-  : evaluate (.hasAttr e a) request entities = evaluate (.hasAttr e a) request slice
+  : evaluate (.hasAttr e a) request entities = evaluate (.hasAttr e a) request (entities.sliceAtLevel request n)
 := by
   cases hl
   case hasAttr hety =>
     simp [hety] at hrty
   rename_i hl
-  have ih := ihe hs hc hr htx hl
+  have ih := ihe hc hr htx hl
   simp only [evaluate, ←ih]
   cases he₁ : evaluate e request entities <;> simp only [Except.bind_err, Except.bind_ok]
   rename_i v
@@ -73,21 +71,20 @@ theorem level_based_slicing_is_sound_has_attr_record {e : Expr} {tx : TypedExpr}
     simpa [EvaluatesTo, hv, he₁] using he
   simp [he, hasAttr, attrsOf]
 
-theorem level_based_slicing_is_sound_has_attr {e : Expr} {tx : TypedExpr} {a : Attr} {n : Nat} {c₀ c₁: Capabilities} {env : TypeEnv} {request : Request} {entities slice : Entities}
-  (hs : slice = entities.sliceAtLevel request n)
+theorem level_based_slicing_is_sound_has_attr {e : Expr} {tx : TypedExpr} {a : Attr} {n : Nat} {c₀ c₁: Capabilities} {env : TypeEnv} {request : Request} {entities : Entities}
   (hc : CapabilitiesInvariant c₀ request entities)
   (hr : InstanceOfWellFormedEnvironment request entities env)
   (ht : typeOf (e.hasAttr a) c₀ env = Except.ok (tx, c₁))
   (hl : tx.AtLevel env n)
   (ihe : TypedAtLevelIsSound e)
-  : evaluate (.hasAttr e a) request entities = evaluate (.hasAttr e a) request slice
+  : evaluate (.hasAttr e a) request entities = evaluate (.hasAttr e a) request (entities.sliceAtLevel request n)
 := by
   have ⟨ h₇, ty₁, _, ht, h₅, h₆ ⟩ := type_of_hasAttr_inversion ht
   rw [h₅] at hl
   cases h₆
   case _ hety =>
     replace ⟨ ety, hety ⟩ := hety
-    exact level_based_slicing_is_sound_has_attr_entity hs hc hr hl ht hety ihe
+    exact level_based_slicing_is_sound_has_attr_entity hc hr hl ht hety ihe
   case _ hrty =>
     replace ⟨ rty, hrty ⟩ := hrty
-    exact level_based_slicing_is_sound_has_attr_record hs hc hr hl ht hrty ihe
+    exact level_based_slicing_is_sound_has_attr_record hc hr hl ht hrty ihe

--- a/cedar-lean/Cedar/Thm/Validation/Levels/Or.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Levels/Or.lean
@@ -34,15 +34,14 @@ open Cedar.Data
 open Cedar.Spec
 open Cedar.Validation
 
-theorem level_based_slicing_is_sound_or {e₁ e₂ : Expr} {n : Nat} {c₀ c₁: Capabilities} {env : TypeEnv} {request : Request} {entities slice : Entities}
-  (hs : slice = entities.sliceAtLevel request n)
+theorem level_based_slicing_is_sound_or {e₁ e₂ : Expr} {n : Nat} {c₀ c₁: Capabilities} {env : TypeEnv} {request : Request} {entities : Entities}
   (hc : CapabilitiesInvariant c₀ request entities)
   (hr : InstanceOfWellFormedEnvironment request entities env)
   (ht : typeOf (.or e₁ e₂) c₀ env = Except.ok (tx, c₁))
   (hl : tx.AtLevel env n)
   (ih₁ : TypedAtLevelIsSound e₁)
   (ih₂ : TypedAtLevelIsSound e₂)
-  : evaluate (.or e₁ e₂) request entities = evaluate (.or e₁ e₂) request slice
+  : evaluate (.or e₁ e₂) request entities = evaluate (.or e₁ e₂) request (entities.sliceAtLevel request n)
 := by
   replace ⟨ tx₁, bty, c', htx₁, hty₁, ht ⟩ := type_of_or_inversion ht
   have ⟨ hgc, v₁, he₁, hv₁⟩  := type_of_is_sound hc hr htx₁
@@ -55,7 +54,7 @@ theorem level_based_slicing_is_sound_or {e₁ e₂ : Expr} {n : Nat} {c₀ c₁:
     subst v₁
     unfold EvaluatesTo at he₁
     simp only [evaluate]
-    specialize ih₁ hs hc hr htx₁ hl
+    specialize ih₁ hc hr htx₁ hl
     rw [←ih₁]
     rcases he₁ with he₁ | he₁ | he₁ | he₁ <;>
     simp [he₁, Result.as, Coe.coe, Value.asBool]
@@ -64,7 +63,7 @@ theorem level_based_slicing_is_sound_or {e₁ e₂ : Expr} {n : Nat} {c₀ c₁:
     subst tx
     cases hl
     rename_i hl₁ hl₂
-    specialize ih₁ hs hc hr htx₁ hl₁
-    specialize ih₂ hs hc hr htx₂ hl₂
+    specialize ih₁ hc hr htx₁ hl₁
+    specialize ih₂ hc hr htx₂ hl₂
     simp only [evaluate]
     rw [ih₁, ih₂]

--- a/cedar-lean/Cedar/Thm/Validation/Levels/Set.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Levels/Set.lean
@@ -27,26 +27,25 @@ open Cedar.Data
 open Cedar.Spec
 open Cedar.Validation
 
-theorem level_based_slicing_is_sound_set {xs : List Expr} {n : Nat} {c₀ c₁: Capabilities} {env : TypeEnv} {request : Request} {entities slice : Entities}
-  (hs : slice = entities.sliceAtLevel request n)
+theorem level_based_slicing_is_sound_set {xs : List Expr} {n : Nat} {c₀ c₁: Capabilities} {env : TypeEnv} {request : Request} {entities : Entities}
   (hc : CapabilitiesInvariant c₀ request entities)
   (hr : InstanceOfWellFormedEnvironment request entities env)
   (ht : typeOf (.set xs) c₀ env = Except.ok (tx, c₁))
   (hl : tx.AtLevel env n)
   (ih : ∀ x ∈ xs, TypedAtLevelIsSound x) :
-  evaluate (.set xs) request entities = evaluate (.set xs) request slice
+  evaluate (.set xs) request entities = evaluate (.set xs) request (entities.sliceAtLevel request n)
 := by
   replace ⟨ _, txs, ty,  htx, ht ⟩ := type_of_set_inversion ht
   subst tx
   cases hl ; rename_i hl
 
-  have he : ∀ x ∈ xs, evaluate x request entities = evaluate x request slice := by
+  have he : ∀ x ∈ xs, evaluate x request entities = evaluate x request (entities.sliceAtLevel request n) := by
     intros x hx
     replace ⟨ tx, _, htxs, htx, _ ⟩ := ht x hx
     specialize hl tx htxs
-    exact ih x hx hs hc hr htx hl
+    exact ih x hx hc hr htx hl
 
   simp only [evaluate, List.mapM₁, List.attach, List.attachWith]
   simp only [List.mapM_pmap_subtype (λ x : Expr => evaluate x request entities) xs]
-  simp only [List.mapM_pmap_subtype (λ x : Expr => evaluate x request slice) xs]
+  simp only [List.mapM_pmap_subtype (λ x : Expr => evaluate x request (entities.sliceAtLevel request n)) xs]
   rw [List.mapM_congr he]

--- a/cedar-lean/Cedar/Thm/Validation/Levels/UnaryApp.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Levels/UnaryApp.lean
@@ -32,18 +32,17 @@ open Cedar.Data
 open Cedar.Spec
 open Cedar.Validation
 
-theorem level_based_slicing_is_sound_unary_app {op : UnaryOp} {e : Expr} {n : Nat} {c₀ c₁: Capabilities} {env : TypeEnv} {request : Request} {entities slice : Entities}
-  (hs : slice = entities.sliceAtLevel request n)
+theorem level_based_slicing_is_sound_unary_app {op : UnaryOp} {e : Expr} {n : Nat} {c₀ c₁: Capabilities} {env : TypeEnv} {request : Request} {entities : Entities}
   (hc : CapabilitiesInvariant c₀ request entities)
   (hr : InstanceOfWellFormedEnvironment request entities env)
   (ht : typeOf (.unaryApp op e) c₀ env = Except.ok (tx, c₁))
   (hl : tx.AtLevel env n)
   (ihe : TypedAtLevelIsSound e)
-  : evaluate (.unaryApp op e) request entities = evaluate (.unaryApp op e) request slice
+  : evaluate (.unaryApp op e) request entities = evaluate (.unaryApp op e) request (entities.sliceAtLevel request n)
 := by
   replace ⟨hc₁, tx₁, ty, c₁', htx, htx₁, ht⟩ := type_of_unary_inversion ht
   subst tx
   cases hl
   rename_i hl₁
-  specialize ihe hs hc hr htx₁ hl₁
+  specialize ihe hc hr htx₁ hl₁
   simp [evaluate, ihe]

--- a/cedar-lean/Cedar/Thm/Validation/Slice.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Slice.lean
@@ -31,87 +31,61 @@ open Cedar.Data
 open Cedar.Spec
 open Cedar.Validation
 
-theorem slice_at_level_inner_well_formed {entities : Entities} {work slice : Set EntityUID} {n : Nat}
-  (hs : Entities.sliceAtLevel.sliceAtLevel entities work n = some slice) :
-  slice.WellFormed
+theorem slice_at_level_inner_well_formed {entities : Entities} {work : Set EntityUID} {n : Nat} :
+  (Entities.sliceAtLevel.sliceAtLevel entities work n).WellFormed
 := by
-  unfold Entities.sliceAtLevel.sliceAtLevel at hs
-  split at hs
-  · injections hs
-    subst hs
-    exact Set.empty_wf
-  · replace ⟨ _, _, hs⟩ : ∃ s₀ s₁, s₀ ∪ s₁ = slice := by
-      cases hs₁ : work.elts.mapM (Map.find? entities) <;>
-        simp only [hs₁, Option.map_eq_map, Option.bind_eq_bind, Option.bind_none_fun, Option.bind_some_fun, reduceCtorEq] at hs
-      rename_i n eds
-      cases hs₂ : eds.mapM (Entities.sliceAtLevel.sliceAtLevel entities ·.sliceEUIDs n) <;>
-        simp only [hs₂, Option.map_none, Option.map_some, Option.bind_none, Option.bind_some, reduceCtorEq, Option.some.injEq] at hs
-      rename_i slice'
-      exists work, (slice'.mapUnion id)
-    subst hs
-    simp only [Set.union_wf]
+  unfold Entities.sliceAtLevel.sliceAtLevel
+  split
+  · exact Set.empty_wf
+  · simp only [Set.union_wf]
 
-theorem checked_eval_entity_in_slice  {n : Nat} {c c' : Capabilities} {tx : TypedExpr} {env : TypeEnv} {slice entities : Entities} {ed : EntityData}
+theorem checked_eval_entity_in_slice  {n : Nat} {c c' : Capabilities} {tx : TypedExpr} {env : TypeEnv} {entities : Entities} {ed : EntityData}
   (hc : CapabilitiesInvariant c request entities)
   (hr : InstanceOfWellFormedEnvironment request entities env)
   (ht : typeOf e c env = .ok (tx, c'))
   (hl : tx.EntityAccessAtLevel env n nmax [])
   (he : evaluate e request entities = .ok (Value.prim (Prim.entityUID euid)))
-  (hf : entities.find? euid = some ed)
-  (hs : slice = Entities.sliceAtLevel entities request (n + 1)) :
-  slice.find? euid = some ed
+  (hf : entities.find? euid = some ed) :
+  (Entities.sliceAtLevel entities request (n + 1)).find? euid = some ed
 := by
-  simp only [Entities.sliceAtLevel] at hs
-  cases hs₁ : Entities.sliceAtLevel.sliceAtLevel entities request.sliceEUIDs (n + 1)  <;>
-    simp only [hs₁, Option.bind_none_fun, reduceCtorEq] at hs
-  rename_i eids
-  cases hs₂ : (eids.elts.mapM (λ e => (Map.find? entities e).bind λ ed => some (e, ed))) <;>
-    simp only [hs₂, Option.bind_eq_bind, Option.bind_some_fun, Option.bind_none, reduceCtorEq, Option.bind_some, Option.some.injEq] at hs
-  subst hs
+  simp only [Entities.sliceAtLevel]
   have hf₁ : Map.contains entities euid := by simp [Map.contains, hf]
   have hw : ReachableIn entities request.sliceEUIDs euid (n + 1) :=
     checked_eval_entity_reachable hc hr ht hl he (.euid euid) hf₁
-  have hi := slice_contains_reachable hw hs₁
+  have hi := slice_contains_reachable hw
   rw [←hf]
-  rename_i eds
+  let eids := Entities.sliceAtLevel.sliceAtLevel entities request.sliceEUIDs (n + 1)
+  let eds := eids.elts.filterMap (λ e => do some (e, ← Map.find? entities e))
   replace hmake : Map.mk eds = Map.make eds := by
-    have hsorted := eids.wf_iff_sorted.mp (slice_at_level_inner_well_formed hs₁)
-    have hsbfst := List.mapM_key_id_sortedBy_key hs₂ hsorted
+    have hsorted := eids.wf_iff_sorted.mp slice_at_level_inner_well_formed
+    have hsbfst : eds.SortedBy Prod.fst := List.filterMap_key_id_sortedBy_key hsorted
     have hwf : (Map.mk eds).WellFormed := by
       simpa [Map.wf_iff_sorted] using hsbfst
     simpa [Map.WellFormed] using hwf
-  have hmk := Map.find?_mapM_key_id hs₂ hi
-  simpa [hmake] using hmk
+  rw [←hmake]
+  exact Map.find?_filterMap_key_id hi
 
-theorem not_entities_then_not_slice {n: Nat} {request : Request} {uid : EntityUID} {entities slice : Entities}
-  (hs : some slice = Entities.sliceAtLevel entities request n)
-  (hse : entities.find? uid = none)
-  : slice.find? uid = none
+theorem not_entities_then_not_slice {n: Nat} {request : Request} {uid : EntityUID} {entities : Entities}
+  (hse : entities.find? uid = none) :
+  (Entities.sliceAtLevel entities request n).find? uid = none
 := by
-  simp only [Entities.sliceAtLevel] at hs
-  cases hs₁ : Entities.sliceAtLevel.sliceAtLevel entities request.sliceEUIDs n <;>
-    simp only [hs₁, Option.bind_none_fun, reduceCtorEq] at hs
-  rename_i eids
-  cases hs₂ : (eids.elts.mapM (λ e => (entities.find? e).bind λ ed => some (e, ed))) <;>
-    simp only [hs₂, Option.bind_eq_bind, Option.bind_some_fun, Option.bind_none, reduceCtorEq, Option.bind_some, Option.some.injEq] at hs
-  subst hs
-  exact Map.mapM_key_id_key_none_implies_find?_none hs₂ hse
+  simp only [Entities.sliceAtLevel]
+  exact Map.filterMap_key_id_key_none_implies_find?_none hse
 
 /--
 If an expression checks at level `n` and then evaluates to an entity, then the
-data for that entity in the slice will be hte same as in the original entities.
+data for that entity in the slice will be the same as in the original entities.
 -/
-theorem checked_eval_entity_find_entities_eq_find_slice  {n nmax : Nat} {c c' : Capabilities} {tx : TypedExpr} {env : TypeEnv} {slice entities : Entities}
+theorem checked_eval_entity_find_entities_eq_find_slice  {n nmax : Nat} {c c' : Capabilities} {tx : TypedExpr} {env : TypeEnv} {entities : Entities}
   (hc : CapabilitiesInvariant c request entities)
   (hr : InstanceOfWellFormedEnvironment request entities env)
   (ht : typeOf e c env = .ok (tx, c'))
   (hl : tx.EntityAccessAtLevel env n nmax [])
-  (he : evaluate e request entities = .ok (Value.prim (Prim.entityUID euid)))
-  (hs : slice = Entities.sliceAtLevel entities request (n + 1)) :
-  slice.find? euid = entities.find? euid
+  (he : evaluate e request entities = .ok (Value.prim (Prim.entityUID euid))) :
+  (Entities.sliceAtLevel entities request (n + 1)).find? euid = entities.find? euid
 := by
   cases hfe : Map.find? entities euid
   case none =>
-    exact not_entities_then_not_slice hs hfe
+    exact not_entities_then_not_slice hfe
   case some =>
-    exact checked_eval_entity_in_slice hc hr ht hl he hfe hs
+    exact checked_eval_entity_in_slice hc hr ht hl he hfe


### PR DESCRIPTION
This procedure would previously return `none` if it dereferenced an entity which did not exist in the original entities. This PR adjust it to instead return an entity slice without the missing entity.

This change means that evaluating a request with the slice may result in an unknown entity error, but the soundness proofs shows that that this only happens when the error also occurred using the unsliced entities.

The top level theorem drops the precondition `(hs : .some slice = entities.sliceAtLevel request n)` leaving us with

```
theorem validate_with_level_is_sound {ps : Policies} {schema : Schema} {n : Nat} {request : Request} {entities : Entities}
  (hwf : schema.validateWellFormed = .ok ())
  (hr : validateRequest schema request = .ok ())
  (he : validateEntities schema entities = .ok ())
  (htl : validateWithLevel ps schema n = .ok ()) :
  isAuthorized request entities ps = isAuthorized request (entities.sliceAtLevel request n) ps
```

