### PR TITLE
Use `assert_cmd` to find cli binary when not on path

### DIFF
--- a/cedar-lean-cli/Cargo.toml
+++ b/cedar-lean-cli/Cargo.toml
@@ -14,3 +14,6 @@ thiserror = "2.0"
 itertools = "0.14.0"
 miette = "7.6.0"
 prettytable-rs = "0.10"
+
+[dev-dependencies]
+assert_cmd = "2.0.17"

--- a/cedar-lean-cli/tests/integration_tests.rs
+++ b/cedar-lean-cli/tests/integration_tests.rs
@@ -1,10 +1,10 @@
+use assert_cmd::Command;
 use std::path::{Path, PathBuf};
-use std::process::{Command, Output};
 
-fn check_output<P: AsRef<Path>>(output: Output, expected_output_file: P, should_error: bool) {
-    let cli_output = std::str::from_utf8(&output.stdout)
-        .expect("Failed to convert output to string")
-        .to_string();
+fn check_output<P: AsRef<Path>>(cmd: &mut Command, expected_output_file: P, should_error: bool) {
+    let output = cmd.output().expect("Failed to execute command");
+    let cli_output =
+        std::str::from_utf8(&output.stdout).expect("Failed to convert output to string");
     let expected_output = std::fs::read_to_string(expected_output_file.as_ref())
         .expect("Failed to read expected output file");
 
@@ -25,16 +25,15 @@ fn check_output<P: AsRef<Path>>(output: Output, expected_output_file: P, should_
 fn test_analyze_policies_tabular_view_box_p1() {
     let base_path = PathBuf::from("examples/analyze/view_box");
 
-    let output = Command::new("cedar-lean-cli")
+    let mut cmd = Command::cargo_bin("cedar-lean-cli").unwrap();
+    cmd.current_dir(&base_path)
         .arg("analyze")
         .arg("policies")
-        .arg(base_path.join("policies1.cedar"))
-        .arg(base_path.join("policies.cedarschema"))
-        .output()
-        .expect("Failed to run cedar-lean-cli");
+        .arg("policies1.cedar")
+        .arg("policies.cedarschema");
 
     check_output(
-        output,
+        &mut cmd,
         base_path.join("outputs/tabular/policies1.out"),
         false,
     )
@@ -44,16 +43,15 @@ fn test_analyze_policies_tabular_view_box_p1() {
 fn test_analyze_policies_tabular_view_box_p2() {
     let base_path = PathBuf::from("examples/analyze/view_box");
 
-    let output = Command::new("cedar-lean-cli")
+    let mut cmd = Command::cargo_bin("cedar-lean-cli").unwrap();
+    cmd.current_dir(&base_path)
         .arg("analyze")
         .arg("policies")
-        .arg(base_path.join("policies2.cedar"))
-        .arg(base_path.join("policies.cedarschema"))
-        .output()
-        .expect("Failed to run cedar-lean-cli");
+        .arg("policies2.cedar")
+        .arg("policies.cedarschema");
 
     check_output(
-        output,
+        &mut cmd,
         base_path.join("outputs/tabular/policies2.out"),
         false,
     )
@@ -63,16 +61,15 @@ fn test_analyze_policies_tabular_view_box_p2() {
 fn test_analyze_policies_tabular_view_box_p3() {
     let base_path = PathBuf::from("examples/analyze/view_box");
 
-    let output = Command::new("cedar-lean-cli")
+    let mut cmd = Command::cargo_bin("cedar-lean-cli").unwrap();
+    cmd.current_dir(&base_path)
         .arg("analyze")
         .arg("policies")
-        .arg(base_path.join("policies3.cedar"))
-        .arg(base_path.join("policies.cedarschema"))
-        .output()
-        .expect("Failed to run cedar-lean-cli");
+        .arg("policies3.cedar")
+        .arg("policies.cedarschema");
 
     check_output(
-        output,
+        &mut cmd,
         base_path.join("outputs/tabular/policies3.out"),
         false,
     )
@@ -82,16 +79,15 @@ fn test_analyze_policies_tabular_view_box_p3() {
 fn test_analyze_policies_tabular_view_box_p4() {
     let base_path = PathBuf::from("examples/analyze/view_box");
 
-    let output = Command::new("cedar-lean-cli")
+    let mut cmd = Command::cargo_bin("cedar-lean-cli").unwrap();
+    cmd.current_dir(&base_path)
         .arg("analyze")
         .arg("policies")
-        .arg(base_path.join("policies4.cedar"))
-        .arg(base_path.join("policies.cedarschema"))
-        .output()
-        .expect("Failed to run cedar-lean-cli");
+        .arg("policies4.cedar")
+        .arg("policies.cedarschema");
 
     check_output(
-        output,
+        &mut cmd,
         base_path.join("outputs/tabular/policies4.out"),
         false,
     )
@@ -101,16 +97,15 @@ fn test_analyze_policies_tabular_view_box_p4() {
 fn test_analyze_policies_tabular_view_box_p5() {
     let base_path = PathBuf::from("examples/analyze/view_box");
 
-    let output = Command::new("cedar-lean-cli")
+    let mut cmd = Command::cargo_bin("cedar-lean-cli").unwrap();
+    cmd.current_dir(&base_path)
         .arg("analyze")
         .arg("policies")
-        .arg(base_path.join("policies5.cedar"))
-        .arg(base_path.join("policies.cedarschema"))
-        .output()
-        .expect("Failed to run cedar-lean-cli");
+        .arg("policies5.cedar")
+        .arg("policies.cedarschema");
 
     check_output(
-        output,
+        &mut cmd,
         base_path.join("outputs/tabular/policies5.out"),
         false,
     )
@@ -120,16 +115,15 @@ fn test_analyze_policies_tabular_view_box_p5() {
 fn test_analyze_policies_tabular_online_docs() {
     let base_path = PathBuf::from("examples/analyze/online_docs");
 
-    let output = Command::new("cedar-lean-cli")
+    let mut cmd = Command::cargo_bin("cedar-lean-cli").unwrap();
+    cmd.current_dir(&base_path)
         .arg("analyze")
         .arg("policies")
-        .arg(base_path.join("policies.cedar"))
-        .arg(base_path.join("policies.cedarschema"))
-        .output()
-        .expect("Failed to run cedar-lean-cli");
+        .arg("policies.cedar")
+        .arg("policies.cedarschema");
 
     check_output(
-        output,
+        &mut cmd,
         base_path.join("outputs/tabular/policies.out"),
         false,
     )
@@ -139,17 +133,16 @@ fn test_analyze_policies_tabular_online_docs() {
 fn test_analyze_compare_tabular_view_box_trivial1() {
     let base_path = PathBuf::from("examples/analyze/view_box");
 
-    let output = Command::new("cedar-lean-cli")
+    let mut cmd = Command::cargo_bin("cedar-lean-cli").unwrap();
+    cmd.current_dir(&base_path)
         .arg("analyze")
         .arg("compare")
-        .arg(base_path.join("permit_all.cedar"))
-        .arg(base_path.join("deny_all.cedar"))
-        .arg(base_path.join("policies.cedarschema"))
-        .output()
-        .expect("Failed to run cedar-lean-cli");
+        .arg("permit_all.cedar")
+        .arg("deny_all.cedar")
+        .arg("policies.cedarschema");
 
     check_output(
-        output,
+        &mut cmd,
         base_path.join("outputs/tabular/compare_trivial1.out"),
         false,
     )
@@ -159,17 +152,16 @@ fn test_analyze_compare_tabular_view_box_trivial1() {
 fn test_analyze_compare_tabular_view_box_trivial2() {
     let base_path = PathBuf::from("examples/analyze/view_box");
 
-    let output = Command::new("cedar-lean-cli")
+    let mut cmd = Command::cargo_bin("cedar-lean-cli").unwrap();
+    cmd.current_dir(&base_path)
         .arg("analyze")
         .arg("compare")
-        .arg(base_path.join("deny_all.cedar"))
-        .arg(base_path.join("permit_all.cedar"))
-        .arg(base_path.join("policies.cedarschema"))
-        .output()
-        .expect("Failed to run cedar-lean-cli");
+        .arg("deny_all.cedar")
+        .arg("permit_all.cedar")
+        .arg("policies.cedarschema");
 
     check_output(
-        output,
+        &mut cmd,
         base_path.join("outputs/tabular/compare_trivial2.out"),
         false,
     )
@@ -179,17 +171,16 @@ fn test_analyze_compare_tabular_view_box_trivial2() {
 fn test_analyze_compare_tabular_view_box_trivial3() {
     let base_path = PathBuf::from("examples/analyze/view_box");
 
-    let output = Command::new("cedar-lean-cli")
+    let mut cmd = Command::cargo_bin("cedar-lean-cli").unwrap();
+    cmd.current_dir(&base_path)
         .arg("analyze")
         .arg("compare")
-        .arg(base_path.join("empty.cedar"))
-        .arg(base_path.join("deny_all.cedar"))
-        .arg(base_path.join("policies.cedarschema"))
-        .output()
-        .expect("Failed to run cedar-lean-cli");
+        .arg("empty.cedar")
+        .arg("deny_all.cedar")
+        .arg("policies.cedarschema");
 
     check_output(
-        output,
+        &mut cmd,
         base_path.join("outputs/tabular/compare_trivial3.out"),
         false,
     )
@@ -199,17 +190,16 @@ fn test_analyze_compare_tabular_view_box_trivial3() {
 fn test_analyze_compare_tabular_view_box_trivial4() {
     let base_path = PathBuf::from("examples/analyze/view_box");
 
-    let output = Command::new("cedar-lean-cli")
+    let mut cmd = Command::cargo_bin("cedar-lean-cli").unwrap();
+    cmd.current_dir(&base_path)
         .arg("analyze")
         .arg("compare")
-        .arg(base_path.join("permit_all.cedar"))
-        .arg(base_path.join("empty.cedar"))
-        .arg(base_path.join("policies.cedarschema"))
-        .output()
-        .expect("Failed to run cedar-lean-cli");
+        .arg("permit_all.cedar")
+        .arg("empty.cedar")
+        .arg("policies.cedarschema");
 
     check_output(
-        output,
+        &mut cmd,
         base_path.join("outputs/tabular/compare_trivial4.out"),
         false,
     )
@@ -219,17 +209,16 @@ fn test_analyze_compare_tabular_view_box_trivial4() {
 fn test_analyze_compare_tabular_view_box_basic_6_cmp_7() {
     let base_path = PathBuf::from("examples/analyze/view_box");
 
-    let output = Command::new("cedar-lean-cli")
+    let mut cmd = Command::cargo_bin("cedar-lean-cli").unwrap();
+    cmd.current_dir(&base_path)
         .arg("analyze")
         .arg("compare")
-        .arg(base_path.join("policies6.cedar"))
-        .arg(base_path.join("policies7.cedar"))
-        .arg(base_path.join("policies.cedarschema"))
-        .output()
-        .expect("Failed to run cedar-lean-cli");
+        .arg("policies6.cedar")
+        .arg("policies7.cedar")
+        .arg("policies.cedarschema");
 
     check_output(
-        output,
+        &mut cmd,
         base_path.join("outputs/tabular/compare_basic_6_7.out"),
         false,
     )
@@ -239,17 +228,16 @@ fn test_analyze_compare_tabular_view_box_basic_6_cmp_7() {
 fn test_analyze_compare_tabular_view_box_basic_6_cmp_8() {
     let base_path = PathBuf::from("examples/analyze/view_box");
 
-    let output = Command::new("cedar-lean-cli")
+    let mut cmd = Command::cargo_bin("cedar-lean-cli").unwrap();
+    cmd.current_dir(&base_path)
         .arg("analyze")
         .arg("compare")
-        .arg(base_path.join("policies6.cedar"))
-        .arg(base_path.join("policies8.cedar"))
-        .arg(base_path.join("policies.cedarschema"))
-        .output()
-        .expect("Failed to run cedar-lean-cli");
+        .arg("policies6.cedar")
+        .arg("policies8.cedar")
+        .arg("policies.cedarschema");
 
     check_output(
-        output,
+        &mut cmd,
         base_path.join("outputs/tabular/compare_basic_6_8.out"),
         false,
     )
@@ -259,17 +247,16 @@ fn test_analyze_compare_tabular_view_box_basic_6_cmp_8() {
 fn test_analyze_compare_tabular_view_box_basic_6_cmp_9() {
     let base_path = PathBuf::from("examples/analyze/view_box");
 
-    let output = Command::new("cedar-lean-cli")
+    let mut cmd = Command::cargo_bin("cedar-lean-cli").unwrap();
+    cmd.current_dir(&base_path)
         .arg("analyze")
         .arg("compare")
-        .arg(base_path.join("policies6.cedar"))
-        .arg(base_path.join("policies9.cedar"))
-        .arg(base_path.join("policies.cedarschema"))
-        .output()
-        .expect("Failed to run cedar-lean-cli");
+        .arg("policies6.cedar")
+        .arg("policies9.cedar")
+        .arg("policies.cedarschema");
 
     check_output(
-        output,
+        &mut cmd,
         base_path.join("outputs/tabular/compare_basic_6_9.out"),
         false,
     )
@@ -279,17 +266,16 @@ fn test_analyze_compare_tabular_view_box_basic_6_cmp_9() {
 fn test_analyze_compare_tabular_view_box_basic_6_cmp_10() {
     let base_path = PathBuf::from("examples/analyze/view_box");
 
-    let output = Command::new("cedar-lean-cli")
+    let mut cmd = Command::cargo_bin("cedar-lean-cli").unwrap();
+    cmd.current_dir(&base_path)
         .arg("analyze")
         .arg("compare")
-        .arg(base_path.join("policies6.cedar"))
-        .arg(base_path.join("policies10.cedar"))
-        .arg(base_path.join("policies.cedarschema"))
-        .output()
-        .expect("Failed to run cedar-lean-cli");
+        .arg("policies6.cedar")
+        .arg("policies10.cedar")
+        .arg("policies.cedarschema");
 
     check_output(
-        output,
+        &mut cmd,
         base_path.join("outputs/tabular/compare_basic_6_10.out"),
         false,
     )
@@ -299,17 +285,16 @@ fn test_analyze_compare_tabular_view_box_basic_6_cmp_10() {
 fn test_analyze_compare_tabular_arithmetic_1_cmp_2() {
     let base_path = PathBuf::from("examples/analyze/arithmetic");
 
-    let output = Command::new("cedar-lean-cli")
+    let mut cmd = Command::cargo_bin("cedar-lean-cli").unwrap();
+    cmd.current_dir(&base_path)
         .arg("analyze")
         .arg("compare")
-        .arg(base_path.join("policies1.cedar"))
-        .arg(base_path.join("policies2.cedar"))
-        .arg(base_path.join("policies.cedarschema"))
-        .output()
-        .expect("Failed to run cedar-lean-cli");
+        .arg("policies1.cedar")
+        .arg("policies2.cedar")
+        .arg("policies.cedarschema");
 
     check_output(
-        output,
+        &mut cmd,
         base_path.join("outputs/tabular/compare_1_2.out"),
         false,
     )
@@ -319,17 +304,16 @@ fn test_analyze_compare_tabular_arithmetic_1_cmp_2() {
 fn test_analyze_compare_tabular_arithmetic_3_cmp_4() {
     let base_path = PathBuf::from("examples/analyze/arithmetic");
 
-    let output = Command::new("cedar-lean-cli")
+    let mut cmd = Command::cargo_bin("cedar-lean-cli").unwrap();
+    cmd.current_dir(&base_path)
         .arg("analyze")
         .arg("compare")
-        .arg(base_path.join("policies3.cedar"))
-        .arg(base_path.join("policies4.cedar"))
-        .arg(base_path.join("policies.cedarschema"))
-        .output()
-        .expect("Failed to run cedar-lean-cli");
+        .arg("policies3.cedar")
+        .arg("policies4.cedar")
+        .arg("policies.cedarschema");
 
     check_output(
-        output,
+        &mut cmd,
         base_path.join("outputs/tabular/compare_3_4.out"),
         false,
     )
@@ -339,17 +323,16 @@ fn test_analyze_compare_tabular_arithmetic_3_cmp_4() {
 fn test_analyze_compare_tabular_arithmetic_3_cmp_5() {
     let base_path = PathBuf::from("examples/analyze/arithmetic");
 
-    let output = Command::new("cedar-lean-cli")
+    let mut cmd = Command::cargo_bin("cedar-lean-cli").unwrap();
+    cmd.current_dir(&base_path)
         .arg("analyze")
         .arg("compare")
-        .arg(base_path.join("policies3.cedar"))
-        .arg(base_path.join("policies5.cedar"))
-        .arg(base_path.join("policies.cedarschema"))
-        .output()
-        .expect("Failed to run cedar-lean-cli");
+        .arg("policies3.cedar")
+        .arg("policies5.cedar")
+        .arg("policies.cedarschema");
 
     check_output(
-        output,
+        &mut cmd,
         base_path.join("outputs/tabular/compare_3_5.out"),
         false,
     )
@@ -359,17 +342,16 @@ fn test_analyze_compare_tabular_arithmetic_3_cmp_5() {
 fn test_analyze_compare_tabular_arithmetic_4_cmp_5() {
     let base_path = PathBuf::from("examples/analyze/arithmetic");
 
-    let output = Command::new("cedar-lean-cli")
+    let mut cmd = Command::cargo_bin("cedar-lean-cli").unwrap();
+    cmd.current_dir(&base_path)
         .arg("analyze")
         .arg("compare")
-        .arg(base_path.join("policies4.cedar"))
-        .arg(base_path.join("policies5.cedar"))
-        .arg(base_path.join("policies.cedarschema"))
-        .output()
-        .expect("Failed to run cedar-lean-cli");
+        .arg("policies4.cedar")
+        .arg("policies5.cedar")
+        .arg("policies.cedarschema");
 
     check_output(
-        output,
+        &mut cmd,
         base_path.join("outputs/tabular/compare_4_5.out"),
         false,
     )
@@ -379,17 +361,16 @@ fn test_analyze_compare_tabular_arithmetic_4_cmp_5() {
 fn test_analyze_compare_tabular_arithmetic_7_cmp_9() {
     let base_path = PathBuf::from("examples/analyze/arithmetic");
 
-    let output = Command::new("cedar-lean-cli")
+    let mut cmd = Command::cargo_bin("cedar-lean-cli").unwrap();
+    cmd.current_dir(&base_path)
         .arg("analyze")
         .arg("compare")
-        .arg(base_path.join("policies7.cedar"))
-        .arg(base_path.join("policies9.cedar"))
-        .arg(base_path.join("policies.cedarschema"))
-        .output()
-        .expect("Failed to run cedar-lean-cli");
+        .arg("policies7.cedar")
+        .arg("policies9.cedar")
+        .arg("policies.cedarschema");
 
     check_output(
-        output,
+        &mut cmd,
         base_path.join("outputs/tabular/compare_7_9.out"),
         false,
     )
@@ -399,17 +380,16 @@ fn test_analyze_compare_tabular_arithmetic_7_cmp_9() {
 fn test_analyze_compare_tabular_arithmetic_6_cmp_8() {
     let base_path = PathBuf::from("examples/analyze/arithmetic");
 
-    let output = Command::new("cedar-lean-cli")
+    let mut cmd = Command::cargo_bin("cedar-lean-cli").unwrap();
+    cmd.current_dir(&base_path)
         .arg("analyze")
         .arg("compare")
-        .arg(base_path.join("policies6.cedar"))
-        .arg(base_path.join("policies8.cedar"))
-        .arg(base_path.join("policies.cedarschema"))
-        .output()
-        .expect("Failed to run cedar-lean-cli");
+        .arg("policies6.cedar")
+        .arg("policies8.cedar")
+        .arg("policies.cedarschema");
 
     check_output(
-        output,
+        &mut cmd,
         base_path.join("outputs/tabular/compare_6_8.out"),
         false,
     )
@@ -419,17 +399,16 @@ fn test_analyze_compare_tabular_arithmetic_6_cmp_8() {
 fn test_analyze_compare_tabular_arithmetic_7_cmp_10() {
     let base_path = PathBuf::from("examples/analyze/arithmetic");
 
-    let output = Command::new("cedar-lean-cli")
+    let mut cmd = Command::cargo_bin("cedar-lean-cli").unwrap();
+    cmd.current_dir(&base_path)
         .arg("analyze")
         .arg("compare")
-        .arg(base_path.join("policies7.cedar"))
-        .arg(base_path.join("policies10.cedar"))
-        .arg(base_path.join("policies.cedarschema"))
-        .output()
-        .expect("Failed to run cedar-lean-cli");
+        .arg("policies7.cedar")
+        .arg("policies10.cedar")
+        .arg("policies.cedarschema");
 
     check_output(
-        output,
+        &mut cmd,
         base_path.join("outputs/tabular/compare_7_10.out"),
         false,
     )
@@ -439,17 +418,16 @@ fn test_analyze_compare_tabular_arithmetic_7_cmp_10() {
 fn test_analyze_compare_tabular_globs_a_star_cmp_a_star_star() {
     let base_path = PathBuf::from("examples/analyze/globs");
 
-    let output = Command::new("cedar-lean-cli")
+    let mut cmd = Command::cargo_bin("cedar-lean-cli").unwrap();
+    cmd.current_dir(&base_path)
         .arg("analyze")
         .arg("compare")
-        .arg(base_path.join("a_star.cedar"))
-        .arg(base_path.join("a_star_star.cedar"))
-        .arg(base_path.join("policies.cedarschema"))
-        .output()
-        .expect("Failed to run cedar-lean-cli");
+        .arg("a_star.cedar")
+        .arg("a_star_star.cedar")
+        .arg("policies.cedarschema");
 
     check_output(
-        output,
+        &mut cmd,
         base_path.join("outputs/tabular/equivalent.out"),
         false,
     )
@@ -459,17 +437,16 @@ fn test_analyze_compare_tabular_globs_a_star_cmp_a_star_star() {
 fn test_analyze_compare_tabular_globs_a_star_cmp_a_a_star() {
     let base_path = PathBuf::from("examples/analyze/globs");
 
-    let output = Command::new("cedar-lean-cli")
+    let mut cmd = Command::cargo_bin("cedar-lean-cli").unwrap();
+    cmd.current_dir(&base_path)
         .arg("analyze")
         .arg("compare")
-        .arg(base_path.join("a_star.cedar"))
-        .arg(base_path.join("a_a_star.cedar"))
-        .arg(base_path.join("policies.cedarschema"))
-        .output()
-        .expect("Failed to run cedar-lean-cli");
+        .arg("a_star.cedar")
+        .arg("a_a_star.cedar")
+        .arg("policies.cedarschema");
 
     check_output(
-        output,
+        &mut cmd,
         base_path.join("outputs/tabular/more_permissive.out"),
         false,
     )
@@ -479,17 +456,16 @@ fn test_analyze_compare_tabular_globs_a_star_cmp_a_a_star() {
 fn test_analyze_compare_tabular_globs_a_star_cmp_a_star_non_a() {
     let base_path = PathBuf::from("examples/analyze/globs");
 
-    let output = Command::new("cedar-lean-cli")
+    let mut cmd = Command::cargo_bin("cedar-lean-cli").unwrap();
+    cmd.current_dir(&base_path)
         .arg("analyze")
         .arg("compare")
-        .arg(base_path.join("a_star.cedar"))
-        .arg(base_path.join("a_star_non_a.cedar"))
-        .arg(base_path.join("policies.cedarschema"))
-        .output()
-        .expect("Failed to run cedar-lean-cli");
+        .arg("a_star.cedar")
+        .arg("a_star_non_a.cedar")
+        .arg("policies.cedarschema");
 
     check_output(
-        output,
+        &mut cmd,
         base_path.join("outputs/tabular/more_permissive.out"),
         false,
     )
@@ -499,17 +475,16 @@ fn test_analyze_compare_tabular_globs_a_star_cmp_a_star_non_a() {
 fn test_analyze_compare_tabular_globs_a_a_star_cmp_a_star_non_a() {
     let base_path = PathBuf::from("examples/analyze/globs");
 
-    let output = Command::new("cedar-lean-cli")
+    let mut cmd = Command::cargo_bin("cedar-lean-cli").unwrap();
+    cmd.current_dir(&base_path)
         .arg("analyze")
         .arg("compare")
-        .arg(base_path.join("a_a_star.cedar"))
-        .arg(base_path.join("a_star_non_a.cedar"))
-        .arg(base_path.join("policies.cedarschema"))
-        .output()
-        .expect("Failed to run cedar-lean-cli");
+        .arg("a_a_star.cedar")
+        .arg("a_star_non_a.cedar")
+        .arg("policies.cedarschema");
 
     check_output(
-        output,
+        &mut cmd,
         base_path.join("outputs/tabular/less_permissive.out"),
         false,
     )
@@ -519,17 +494,16 @@ fn test_analyze_compare_tabular_globs_a_a_star_cmp_a_star_non_a() {
 fn test_analyze_compare_tabular_globs_a_star_star_a() {
     let base_path = PathBuf::from("examples/analyze/globs");
 
-    let output = Command::new("cedar-lean-cli")
+    let mut cmd = Command::cargo_bin("cedar-lean-cli").unwrap();
+    cmd.current_dir(&base_path)
         .arg("analyze")
         .arg("compare")
-        .arg(base_path.join("a_star.cedar"))
-        .arg(base_path.join("star_a.cedar"))
-        .arg(base_path.join("policies.cedarschema"))
-        .output()
-        .expect("Failed to run cedar-lean-cli");
+        .arg("a_star.cedar")
+        .arg("star_a.cedar")
+        .arg("policies.cedarschema");
 
     check_output(
-        output,
+        &mut cmd,
         base_path.join("outputs/tabular/disjoint.out"),
         false,
     )
@@ -539,17 +513,16 @@ fn test_analyze_compare_tabular_globs_a_star_star_a() {
 fn test_analyze_compare_tabular_globs_star_a_cmp_star_b() {
     let base_path = PathBuf::from("examples/analyze/globs");
 
-    let output = Command::new("cedar-lean-cli")
+    let mut cmd = Command::cargo_bin("cedar-lean-cli").unwrap();
+    cmd.current_dir(&base_path)
         .arg("analyze")
         .arg("compare")
-        .arg(base_path.join("star_a.cedar"))
-        .arg(base_path.join("star_b.cedar"))
-        .arg(base_path.join("policies.cedarschema"))
-        .output()
-        .expect("Failed to run cedar-lean-cli");
+        .arg("star_a.cedar")
+        .arg("star_b.cedar")
+        .arg("policies.cedarschema");
 
     check_output(
-        output,
+        &mut cmd,
         base_path.join("outputs/tabular/disjoint.out"),
         false,
     )
@@ -559,17 +532,16 @@ fn test_analyze_compare_tabular_globs_star_a_cmp_star_b() {
 fn test_analyze_compare_tabular_globs_a_cmp_star_other() {
     let base_path = PathBuf::from("examples/analyze/globs");
 
-    let output = Command::new("cedar-lean-cli")
+    let mut cmd = Command::cargo_bin("cedar-lean-cli").unwrap();
+    cmd.current_dir(&base_path)
         .arg("analyze")
         .arg("compare")
-        .arg(base_path.join("a_star.cedar"))
-        .arg(base_path.join("other.cedar"))
-        .arg(base_path.join("policies.cedarschema"))
-        .output()
-        .expect("Failed to run cedar-lean-cli");
+        .arg("a_star.cedar")
+        .arg("other.cedar")
+        .arg("policies.cedarschema");
 
     check_output(
-        output,
+        &mut cmd,
         base_path.join("outputs/tabular/disjoint.out"),
         false,
     )
@@ -579,17 +551,16 @@ fn test_analyze_compare_tabular_globs_a_cmp_star_other() {
 fn test_analyze_compare_tabular_sets1() {
     let base_path = PathBuf::from("examples/analyze/sets");
 
-    let output = Command::new("cedar-lean-cli")
+    let mut cmd = Command::cargo_bin("cedar-lean-cli").unwrap();
+    cmd.current_dir(&base_path)
         .arg("analyze")
         .arg("compare")
-        .arg(base_path.join("src1.cedar"))
-        .arg(base_path.join("tgt1.cedar"))
-        .arg(base_path.join("policies.cedarschema"))
-        .output()
-        .expect("Failed to run cedar-lean-cli");
+        .arg("src1.cedar")
+        .arg("tgt1.cedar")
+        .arg("policies.cedarschema");
 
     check_output(
-        output,
+        &mut cmd,
         base_path.join("outputs/tabular/equivalent.out"),
         false,
     )
@@ -599,17 +570,16 @@ fn test_analyze_compare_tabular_sets1() {
 fn test_analyze_compare_tabular_sets2() {
     let base_path = PathBuf::from("examples/analyze/sets");
 
-    let output = Command::new("cedar-lean-cli")
+    let mut cmd = Command::cargo_bin("cedar-lean-cli").unwrap();
+    cmd.current_dir(&base_path)
         .arg("analyze")
         .arg("compare")
-        .arg(base_path.join("src2.cedar"))
-        .arg(base_path.join("tgt2.cedar"))
-        .arg(base_path.join("policies.cedarschema"))
-        .output()
-        .expect("Failed to run cedar-lean-cli");
+        .arg("src2.cedar")
+        .arg("tgt2.cedar")
+        .arg("policies.cedarschema");
 
     check_output(
-        output,
+        &mut cmd,
         base_path.join("outputs/tabular/equivalent.out"),
         false,
     )
@@ -619,17 +589,16 @@ fn test_analyze_compare_tabular_sets2() {
 fn test_analyze_compare_tabular_sets3() {
     let base_path = PathBuf::from("examples/analyze/sets");
 
-    let output = Command::new("cedar-lean-cli")
+    let mut cmd = Command::cargo_bin("cedar-lean-cli").unwrap();
+    cmd.current_dir(&base_path)
         .arg("analyze")
         .arg("compare")
-        .arg(base_path.join("src3.cedar"))
-        .arg(base_path.join("tgt3.cedar"))
-        .arg(base_path.join("policies.cedarschema"))
-        .output()
-        .expect("Failed to run cedar-lean-cli");
+        .arg("src3.cedar")
+        .arg("tgt3.cedar")
+        .arg("policies.cedarschema");
 
     check_output(
-        output,
+        &mut cmd,
         base_path.join("outputs/tabular/less_permissive.out"),
         false,
     )
@@ -639,17 +608,16 @@ fn test_analyze_compare_tabular_sets3() {
 fn test_analyze_compare_tabular_sets4() {
     let base_path = PathBuf::from("examples/analyze/sets");
 
-    let output = Command::new("cedar-lean-cli")
+    let mut cmd = Command::cargo_bin("cedar-lean-cli").unwrap();
+    cmd.current_dir(&base_path)
         .arg("analyze")
         .arg("compare")
-        .arg(base_path.join("src4.cedar"))
-        .arg(base_path.join("tgt4.cedar"))
-        .arg(base_path.join("policies.cedarschema"))
-        .output()
-        .expect("Failed to run cedar-lean-cli");
+        .arg("src4.cedar")
+        .arg("tgt4.cedar")
+        .arg("policies.cedarschema");
 
     check_output(
-        output,
+        &mut cmd,
         base_path.join("outputs/tabular/more_permissive.out"),
         false,
     )
@@ -659,17 +627,16 @@ fn test_analyze_compare_tabular_sets4() {
 fn test_analyze_compare_tabular_sets5a() {
     let base_path = PathBuf::from("examples/analyze/sets");
 
-    let output = Command::new("cedar-lean-cli")
+    let mut cmd = Command::cargo_bin("cedar-lean-cli").unwrap();
+    cmd.current_dir(&base_path)
         .arg("analyze")
         .arg("compare")
-        .arg(base_path.join("src5.cedar"))
-        .arg(base_path.join("tgt5a.cedar"))
-        .arg(base_path.join("policies.cedarschema"))
-        .output()
-        .expect("Failed to run cedar-lean-cli");
+        .arg("src5.cedar")
+        .arg("tgt5a.cedar")
+        .arg("policies.cedarschema");
 
     check_output(
-        output,
+        &mut cmd,
         base_path.join("outputs/tabular/more_permissive.out"),
         false,
     )
@@ -679,17 +646,16 @@ fn test_analyze_compare_tabular_sets5a() {
 fn test_analyze_compare_tabular_sets5b() {
     let base_path = PathBuf::from("examples/analyze/sets");
 
-    let output = Command::new("cedar-lean-cli")
+    let mut cmd = Command::cargo_bin("cedar-lean-cli").unwrap();
+    cmd.current_dir(&base_path)
         .arg("analyze")
         .arg("compare")
-        .arg(base_path.join("src5.cedar"))
-        .arg(base_path.join("tgt5b.cedar"))
-        .arg(base_path.join("policies.cedarschema"))
-        .output()
-        .expect("Failed to run cedar-lean-cli");
+        .arg("src5.cedar")
+        .arg("tgt5b.cedar")
+        .arg("policies.cedarschema");
 
     check_output(
-        output,
+        &mut cmd,
         base_path.join("outputs/tabular/more_permissive.out"),
         false,
     )
@@ -699,17 +665,16 @@ fn test_analyze_compare_tabular_sets5b() {
 fn test_analyze_compare_tabular_sets5c() {
     let base_path = PathBuf::from("examples/analyze/sets");
 
-    let output = Command::new("cedar-lean-cli")
+    let mut cmd = Command::cargo_bin("cedar-lean-cli").unwrap();
+    cmd.current_dir(&base_path)
         .arg("analyze")
         .arg("compare")
-        .arg(base_path.join("src5.cedar"))
-        .arg(base_path.join("tgt5c.cedar"))
-        .arg(base_path.join("policies.cedarschema"))
-        .output()
-        .expect("Failed to run cedar-lean-cli");
+        .arg("src5.cedar")
+        .arg("tgt5c.cedar")
+        .arg("policies.cedarschema");
 
     check_output(
-        output,
+        &mut cmd,
         base_path.join("outputs/tabular/more_permissive.out"),
         false,
     )
@@ -719,17 +684,16 @@ fn test_analyze_compare_tabular_sets5c() {
 fn test_analyze_compare_tabular_sets6() {
     let base_path = PathBuf::from("examples/analyze/sets");
 
-    let output = Command::new("cedar-lean-cli")
+    let mut cmd = Command::cargo_bin("cedar-lean-cli").unwrap();
+    cmd.current_dir(&base_path)
         .arg("analyze")
         .arg("compare")
-        .arg(base_path.join("src6.cedar"))
-        .arg(base_path.join("tgt6.cedar"))
-        .arg(base_path.join("policies.cedarschema"))
-        .output()
-        .expect("Failed to run cedar-lean-cli");
+        .arg("src6.cedar")
+        .arg("tgt6.cedar")
+        .arg("policies.cedarschema");
 
     check_output(
-        output,
+        &mut cmd,
         base_path.join("outputs/tabular/more_permissive.out"),
         false,
     )
@@ -739,17 +703,16 @@ fn test_analyze_compare_tabular_sets6() {
 fn test_analyze_compare_tabular_sets7a() {
     let base_path = PathBuf::from("examples/analyze/sets");
 
-    let output = Command::new("cedar-lean-cli")
+    let mut cmd = Command::cargo_bin("cedar-lean-cli").unwrap();
+    cmd.current_dir(&base_path)
         .arg("analyze")
         .arg("compare")
-        .arg(base_path.join("src7.cedar"))
-        .arg(base_path.join("tgt7a.cedar"))
-        .arg(base_path.join("policies.cedarschema"))
-        .output()
-        .expect("Failed to run cedar-lean-cli");
+        .arg("src7.cedar")
+        .arg("tgt7a.cedar")
+        .arg("policies.cedarschema");
 
     check_output(
-        output,
+        &mut cmd,
         base_path.join("outputs/tabular/more_permissive.out"),
         false,
     )
@@ -759,17 +722,16 @@ fn test_analyze_compare_tabular_sets7a() {
 fn test_analyze_compare_tabular_sets7b() {
     let base_path = PathBuf::from("examples/analyze/sets");
 
-    let output = Command::new("cedar-lean-cli")
+    let mut cmd = Command::cargo_bin("cedar-lean-cli").unwrap();
+    cmd.current_dir(&base_path)
         .arg("analyze")
         .arg("compare")
-        .arg(base_path.join("src7.cedar"))
-        .arg(base_path.join("tgt7b.cedar"))
-        .arg(base_path.join("policies.cedarschema"))
-        .output()
-        .expect("Failed to run cedar-lean-cli");
+        .arg("src7.cedar")
+        .arg("tgt7b.cedar")
+        .arg("policies.cedarschema");
 
     check_output(
-        output,
+        &mut cmd,
         base_path.join("outputs/tabular/disjoint.out"),
         false,
     )
@@ -779,17 +741,16 @@ fn test_analyze_compare_tabular_sets7b() {
 fn test_analyze_compare_tabular_misc1() {
     let base_path = PathBuf::from("examples/analyze/misc");
 
-    let output = Command::new("cedar-lean-cli")
+    let mut cmd = Command::cargo_bin("cedar-lean-cli").unwrap();
+    cmd.current_dir(&base_path)
         .arg("analyze")
         .arg("compare")
-        .arg(base_path.join("src1.cedar"))
-        .arg(base_path.join("tgt1.cedar"))
-        .arg(base_path.join("policies1.cedarschema"))
-        .output()
-        .expect("Failed to run cedar-lean-cli");
+        .arg("src1.cedar")
+        .arg("tgt1.cedar")
+        .arg("policies1.cedarschema");
 
     check_output(
-        output,
+        &mut cmd,
         base_path.join("outputs/tabular/policies1.out"),
         false,
     )
@@ -799,16 +760,15 @@ fn test_analyze_compare_tabular_misc1() {
 fn test_analyze_policies_tabular_demo1() {
     let base_path = PathBuf::from("examples/analyze/file_share_demo");
 
-    let output = Command::new("cedar-lean-cli")
+    let mut cmd = Command::cargo_bin("cedar-lean-cli").unwrap();
+    cmd.current_dir(&base_path)
         .arg("analyze")
         .arg("policies")
-        .arg(base_path.join("policies1.cedar"))
-        .arg(base_path.join("policies.cedarschema"))
-        .output()
-        .expect("Failed to run cedar-lean-cli");
+        .arg("policies1.cedar")
+        .arg("policies.cedarschema");
 
     check_output(
-        output,
+        &mut cmd,
         base_path.join("outputs/tabular/analyze1.out"),
         false,
     )
@@ -818,16 +778,15 @@ fn test_analyze_policies_tabular_demo1() {
 fn test_analyze_policies_tabular_demo2() {
     let base_path = PathBuf::from("examples/analyze/file_share_demo");
 
-    let output = Command::new("cedar-lean-cli")
+    let mut cmd = Command::cargo_bin("cedar-lean-cli").unwrap();
+    cmd.current_dir(&base_path)
         .arg("analyze")
         .arg("policies")
-        .arg(base_path.join("policies2.cedar"))
-        .arg(base_path.join("policies.cedarschema"))
-        .output()
-        .expect("Failed to run cedar-lean-cli");
+        .arg("policies2.cedar")
+        .arg("policies.cedarschema");
 
     check_output(
-        output,
+        &mut cmd,
         base_path.join("outputs/tabular/analyze2.out"),
         false,
     )
@@ -837,16 +796,15 @@ fn test_analyze_policies_tabular_demo2() {
 fn test_analyze_policies_tabular_demo3() {
     let base_path = PathBuf::from("examples/analyze/file_share_demo");
 
-    let output = Command::new("cedar-lean-cli")
+    let mut cmd = Command::cargo_bin("cedar-lean-cli").unwrap();
+    cmd.current_dir(&base_path)
         .arg("analyze")
         .arg("policies")
-        .arg(base_path.join("policies3.cedar"))
-        .arg(base_path.join("policies.cedarschema"))
-        .output()
-        .expect("Failed to run cedar-lean-cli");
+        .arg("policies3.cedar")
+        .arg("policies.cedarschema");
 
     check_output(
-        output,
+        &mut cmd,
         base_path.join("outputs/tabular/analyze3.out"),
         false,
     )
@@ -856,16 +814,15 @@ fn test_analyze_policies_tabular_demo3() {
 fn test_analyze_policies_tabular_demo4() {
     let base_path = PathBuf::from("examples/analyze/file_share_demo");
 
-    let output = Command::new("cedar-lean-cli")
+    let mut cmd = Command::cargo_bin("cedar-lean-cli").unwrap();
+    cmd.current_dir(&base_path)
         .arg("analyze")
         .arg("policies")
-        .arg(base_path.join("policies4.cedar"))
-        .arg(base_path.join("policies.cedarschema"))
-        .output()
-        .expect("Failed to run cedar-lean-cli");
+        .arg("policies4.cedar")
+        .arg("policies.cedarschema");
 
     check_output(
-        output,
+        &mut cmd,
         base_path.join("outputs/tabular/analyze4.out"),
         false,
     )
@@ -875,17 +832,16 @@ fn test_analyze_policies_tabular_demo4() {
 fn test_analyze_compare_tabular_demo_2_1() {
     let base_path = PathBuf::from("examples/analyze/file_share_demo");
 
-    let output = Command::new("cedar-lean-cli")
+    let mut cmd = Command::cargo_bin("cedar-lean-cli").unwrap();
+    cmd.current_dir(&base_path)
         .arg("analyze")
         .arg("compare")
-        .arg(base_path.join("policies2.cedar"))
-        .arg(base_path.join("policies1.cedar"))
-        .arg(base_path.join("policies.cedarschema"))
-        .output()
-        .expect("Failed to run cedar-lean-cli");
+        .arg("policies2.cedar")
+        .arg("policies1.cedar")
+        .arg("policies.cedarschema");
 
     check_output(
-        output,
+        &mut cmd,
         base_path.join("outputs/tabular/compare_2_1.out"),
         false,
     )
@@ -895,17 +851,16 @@ fn test_analyze_compare_tabular_demo_2_1() {
 fn test_analyze_compare_tabular_demo_3_2() {
     let base_path = PathBuf::from("examples/analyze/file_share_demo");
 
-    let output = Command::new("cedar-lean-cli")
+    let mut cmd = Command::cargo_bin("cedar-lean-cli").unwrap();
+    cmd.current_dir(&base_path)
         .arg("analyze")
         .arg("compare")
-        .arg(base_path.join("policies3.cedar"))
-        .arg(base_path.join("policies2.cedar"))
-        .arg(base_path.join("policies.cedarschema"))
-        .output()
-        .expect("Failed to run cedar-lean-cli");
+        .arg("policies3.cedar")
+        .arg("policies2.cedar")
+        .arg("policies.cedarschema");
 
     check_output(
-        output,
+        &mut cmd,
         base_path.join("outputs/tabular/compare_3_2.out"),
         false,
     )
@@ -915,17 +870,16 @@ fn test_analyze_compare_tabular_demo_3_2() {
 fn test_analyze_compare_tabular_demo_4_3() {
     let base_path = PathBuf::from("examples/analyze/file_share_demo");
 
-    let output = Command::new("cedar-lean-cli")
+    let mut cmd = Command::cargo_bin("cedar-lean-cli").unwrap();
+    cmd.current_dir(&base_path)
         .arg("analyze")
         .arg("compare")
-        .arg(base_path.join("policies4.cedar"))
-        .arg(base_path.join("policies3.cedar"))
-        .arg(base_path.join("policies.cedarschema"))
-        .output()
-        .expect("Failed to run cedar-lean-cli");
+        .arg("policies4.cedar")
+        .arg("policies3.cedar")
+        .arg("policies.cedarschema");
 
     check_output(
-        output,
+        &mut cmd,
         base_path.join("outputs/tabular/compare_4_3.out"),
         false,
     )


### PR DESCRIPTION
These tests would previously fail if you didn't put `cedar-lean-cli` on your path by, e.g., `cargo install`