### PR TITLE
Generate wrong number of args for extension function calls

### DIFF
--- a/cedar-policy-generators/src/expr.rs
+++ b/cedar-policy-generators/src/expr.rs
@@ -1320,7 +1320,7 @@ impl ExprGenerator<'_> {
             .iter()
             .map(|param_ty| self.generate_expr_for_type(param_ty, max_depth, u))
             .collect::<Result<_>>()?;
-        if self.settings.enable_arbitrary_func_call && u.ratio::<u8>(1, 10)? {
+        if self.settings.enable_arbitrary_func_call && u.ratio::<u8>(1, 20)? {
             let last_param_ty = func
                 .parameter_types
                 .last()


### PR DESCRIPTION
Allows us to test that cedar-policy/cedar#1863 actually disables variadic isInRange calls by sometimes generating extra arguments to an extension function call. The Lean model has not been updated to handle variadic calls, so it will return an error as expected. Differential testing will assert that Rust also errors. 