### PR TITLE
Allow wrong number of arugments error in abac-type-directed

### DIFF
--- a/cedar-drt/fuzz/fuzz_targets/abac-type-directed.rs
+++ b/cedar-drt/fuzz/fuzz_targets/abac-type-directed.rs
@@ -143,18 +143,6 @@ fuzz_target!(|input: FuzzTargetInput| {
             time_function(|| run_auth_test(&lean_engine, &request, &policyset, &entities));
 
         info!("{}{}", TOTAL_MSG, total_dur.as_nanos());
-
-        // additional invariant:
-        // type-directed fuzzing should never produce wrong-number-of-arguments errors
-        assert_eq!(
-            rust_res
-                .diagnostics()
-                .errors()
-                .map(ToString::to_string)
-                .filter(|err| err.contains("wrong number of arguments"))
-                .collect::<Vec<String>>(),
-            Vec::<String>::new()
-        );
     }
 
     if let Ok(test_name) = std::env::var("DUMP_TEST_NAME") {


### PR DESCRIPTION
This is now possible after a generator change

*Issue #, if available:*

*Description of changes:*


