### PR TITLE
Share `FuzzTargetInput` struct for abac targets

### DIFF
--- a/cedar-drt/fuzz/Cargo.toml
+++ b/cedar-drt/fuzz/Cargo.toml
@@ -26,6 +26,7 @@ prost = "0.14"
 rand = { version = "0.9", features = ["small_rng"] }
 rand_chacha = { version = "0.9", optional = true }
 rayon = { version = "1.5", optional = true }
+ref-cast = "1.0"
 regex = "1"
 serde = "1.0"
 serde_json = "1.0"

--- a/cedar-drt/fuzz/fuzz_targets/abac-type-directed.rs
+++ b/cedar-drt/fuzz/fuzz_targets/abac-type-directed.rs
@@ -18,108 +18,21 @@
 use cedar_drt::{
     dump::dump,
     logger::{initialize_log, TOTAL_MSG},
-    tests::{drop_some_entities, run_auth_test},
+    tests::run_auth_test,
     CedarLeanEngine,
 };
 
-use cedar_drt_inner::{fuzz_target, schemas};
+use cedar_drt_inner::{abac::FuzzTargetInput, fuzz_target};
 
-use cedar_policy::{Authorizer, Entities, Policy, PolicyId, PolicySet, Schema, SchemaFragment};
-
-use cedar_policy_generators::{
-    abac::{ABACPolicy, ABACRequest},
-    err::Error,
-    hierarchy::HierarchyGenerator,
-    schema,
-    settings::ABACSettings,
-};
-
+use cedar_policy::{Authorizer, Policy, PolicyId, PolicySet, SchemaFragment};
 use cedar_testing::cedar_test_impl::time_function;
 
-use libfuzzer_sys::arbitrary::{self, Arbitrary, MaxRecursionReached, Unstructured};
+use libfuzzer_sys::arbitrary::{Arbitrary, Unstructured};
 use log::{debug, info};
 use std::convert::TryFrom;
 
-/// Input expected by this fuzz target:
-/// An ABAC hierarchy, policy, and 8 associated requests
-#[derive(Debug, Clone)]
-pub struct FuzzTargetInput {
-    /// generated schema
-    pub schema: schema::Schema,
-    /// generated entity slice
-    pub entities: Entities,
-    /// generated policy
-    pub policy: ABACPolicy,
-    /// the requests to try for this hierarchy and policy. We try 8 requests per
-    /// policy/hierarchy
-    pub requests: [ABACRequest; 8],
-}
-
-/// settings for this fuzz target
-const SETTINGS: ABACSettings = ABACSettings {
-    match_types: true,
-    enable_extensions: true,
-    max_depth: 3,
-    max_width: 3,
-    enable_additional_attributes: false,
-    enable_like: true,
-    enable_action_groups_and_attrs: true,
-    enable_arbitrary_func_call: true,
-    enable_unknowns: false,
-    enable_action_in_constraints: true,
-    per_action_request_env_limit: ABACSettings::default_per_action_request_env_limit(),
-    total_action_request_env_limit: ABACSettings::default_total_action_request_env_limit(),
-};
-
-impl<'a> Arbitrary<'a> for FuzzTargetInput {
-    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
-        let schema = schema::Schema::arbitrary(SETTINGS.clone(), u)?;
-        let hierarchy = schema.arbitrary_hierarchy(u)?;
-        let policy = schema.arbitrary_policy(&hierarchy, u)?;
-
-        let requests = [
-            schema.arbitrary_request(&hierarchy, u)?,
-            schema.arbitrary_request(&hierarchy, u)?,
-            schema.arbitrary_request(&hierarchy, u)?,
-            schema.arbitrary_request(&hierarchy, u)?,
-            schema.arbitrary_request(&hierarchy, u)?,
-            schema.arbitrary_request(&hierarchy, u)?,
-            schema.arbitrary_request(&hierarchy, u)?,
-            schema.arbitrary_request(&hierarchy, u)?,
-        ];
-        let all_entities = Entities::try_from(hierarchy).map_err(|_| Error::NotEnoughData)?;
-        let cedar_schema = Schema::try_from(schema.clone()).unwrap();
-        let entities = drop_some_entities(all_entities.into(), u)?.into();
-        let entities = schemas::add_actions_to_entities(&cedar_schema, entities)?;
-        Ok(Self {
-            schema,
-            entities,
-            policy,
-            requests,
-        })
-    }
-
-    fn try_size_hint(
-        depth: usize,
-    ) -> std::result::Result<(usize, Option<usize>), MaxRecursionReached> {
-        Ok(arbitrary::size_hint::and_all(&[
-            schema::Schema::arbitrary_size_hint(depth)?,
-            HierarchyGenerator::size_hint(depth),
-            schema::Schema::arbitrary_policy_size_hint(&SETTINGS, depth),
-            schema::Schema::arbitrary_request_size_hint(depth),
-            schema::Schema::arbitrary_request_size_hint(depth),
-            schema::Schema::arbitrary_request_size_hint(depth),
-            schema::Schema::arbitrary_request_size_hint(depth),
-            schema::Schema::arbitrary_request_size_hint(depth),
-            schema::Schema::arbitrary_request_size_hint(depth),
-            schema::Schema::arbitrary_request_size_hint(depth),
-            schema::Schema::arbitrary_request_size_hint(depth),
-        ]))
-    }
-}
-
 // Type-directed fuzzing of ABAC hierarchy/policy/requests.
-fuzz_target!(|input: FuzzTargetInput| {
+fuzz_target!(|input: FuzzTargetInput<true>| {
     initialize_log();
     let lean_engine = CedarLeanEngine::new();
     let mut policyset = PolicySet::new();
@@ -139,7 +52,7 @@ fuzz_target!(|input: FuzzTargetInput| {
 
     for request in requests.iter() {
         debug!("Request : {request}");
-        let (rust_res, total_dur) =
+        let (_, total_dur) =
             time_function(|| run_auth_test(&lean_engine, &request, &policyset, &entities));
 
         info!("{}{}", TOTAL_MSG, total_dur.as_nanos());

--- a/cedar-drt/fuzz/fuzz_targets/batched-evaluation-drt.rs
+++ b/cedar-drt/fuzz/fuzz_targets/batched-evaluation-drt.rs
@@ -16,98 +16,15 @@
 
 #![no_main]
 use cedar_drt::{logger::initialize_log, CedarLeanEngine};
-use cedar_drt_inner::{fuzz_target, schemas};
+use cedar_drt_inner::{abac::FuzzTargetInput, fuzz_target};
 
-use cedar_policy::{Entities, Policy, PolicySet, Schema, TestEntityLoader};
+use cedar_policy::{Policy, PolicySet, Schema, TestEntityLoader};
 
-use cedar_policy_generators::{
-    abac::{ABACPolicy, ABACRequest},
-    err::Error,
-    hierarchy::HierarchyGenerator,
-    schema,
-    settings::ABACSettings,
-};
-use libfuzzer_sys::arbitrary::{self, Arbitrary, Unstructured};
-
-/// Input expected by this fuzz target
-#[derive(Debug, Clone)]
-pub struct FuzzTargetInput {
-    /// generated schema
-    pub schema: schema::Schema,
-    /// generated entity slice
-    pub entities: Entities,
-    /// generated policy
-    pub policy: ABACPolicy,
-    /// the requests to try for this hierarchy and policy. We try 8 requests per
-    /// policy/hierarchy
-    pub requests: [ABACRequest; 8],
-}
-
-/// settings for this fuzz target
-const SETTINGS: ABACSettings = ABACSettings {
-    match_types: true,
-    enable_extensions: true,
-    max_depth: 7,
-    max_width: 7,
-    enable_additional_attributes: false,
-    enable_like: true,
-    enable_action_groups_and_attrs: true,
-    enable_arbitrary_func_call: true,
-    enable_unknowns: false,
-    enable_action_in_constraints: true,
-    per_action_request_env_limit: ABACSettings::default_per_action_request_env_limit(),
-    total_action_request_env_limit: ABACSettings::default_total_action_request_env_limit(),
-};
-
-impl<'a> Arbitrary<'a> for FuzzTargetInput {
-    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
-        let schema = schema::Schema::arbitrary(SETTINGS.clone(), u)?;
-        let hierarchy = schema.arbitrary_hierarchy(u)?;
-        let policy = schema.arbitrary_policy(&hierarchy, u)?;
-
-        let requests = [
-            schema.arbitrary_request(&hierarchy, u)?,
-            schema.arbitrary_request(&hierarchy, u)?,
-            schema.arbitrary_request(&hierarchy, u)?,
-            schema.arbitrary_request(&hierarchy, u)?,
-            schema.arbitrary_request(&hierarchy, u)?,
-            schema.arbitrary_request(&hierarchy, u)?,
-            schema.arbitrary_request(&hierarchy, u)?,
-            schema.arbitrary_request(&hierarchy, u)?,
-        ];
-        let all_entities = Entities::try_from(hierarchy).map_err(|_| Error::NotEnoughData)?;
-        let cedar_schema = Schema::try_from(schema.clone()).unwrap();
-        let entities = schemas::add_actions_to_entities(&cedar_schema, all_entities)?;
-        Ok(Self {
-            schema,
-            entities,
-            policy,
-            requests,
-        })
-    }
-
-    fn try_size_hint(
-        depth: usize,
-    ) -> arbitrary::Result<(usize, Option<usize>), arbitrary::MaxRecursionReached> {
-        Ok(arbitrary::size_hint::and_all(&[
-            schema::Schema::arbitrary_size_hint(depth)?,
-            HierarchyGenerator::size_hint(depth),
-            schema::Schema::arbitrary_policy_size_hint(&SETTINGS, depth),
-            schema::Schema::arbitrary_request_size_hint(depth),
-            schema::Schema::arbitrary_request_size_hint(depth),
-            schema::Schema::arbitrary_request_size_hint(depth),
-            schema::Schema::arbitrary_request_size_hint(depth),
-            schema::Schema::arbitrary_request_size_hint(depth),
-            schema::Schema::arbitrary_request_size_hint(depth),
-            schema::Schema::arbitrary_request_size_hint(depth),
-            schema::Schema::arbitrary_request_size_hint(depth),
-        ]))
-    }
-}
+use libfuzzer_sys::arbitrary::{Arbitrary, Unstructured};
 
 // This target tests a property that batched evaluation, if succeeds, should
 // produce the same authorization decision based on the Lean model output
-fuzz_target!(|input: FuzzTargetInput| {
+fuzz_target!(|input: FuzzTargetInput<true>| {
     let ffi = CedarLeanEngine::new();
     initialize_log();
 
@@ -117,7 +34,7 @@ fuzz_target!(|input: FuzzTargetInput| {
         policyset.add(policy.clone()).unwrap();
         let mut loader = TestEntityLoader::new(&input.entities);
         log::debug!("policy: {policyset}");
-        let iteration = (SETTINGS.max_depth + 1) as u32;
+        let iteration = (FuzzTargetInput::<true>::settings().max_depth + 1) as u32;
 
         for req in input.requests {
             let req = req.into();

--- a/cedar-drt/fuzz/fuzz_targets/batched-evaluation-pbt.rs
+++ b/cedar-drt/fuzz/fuzz_targets/batched-evaluation-pbt.rs
@@ -16,100 +16,17 @@
 
 #![no_main]
 use cedar_drt::logger::initialize_log;
-use cedar_drt_inner::{fuzz_target, schemas};
+use cedar_drt_inner::{abac::FuzzTargetInput, fuzz_target};
 
-use cedar_policy::{Authorizer, Entities, Policy, PolicySet, Schema, TestEntityLoader};
+use cedar_policy::{Authorizer, Policy, PolicySet, Schema, TestEntityLoader};
 
 use cedar_policy_core::batched_evaluator::err::BatchedEvalError;
-use cedar_policy_generators::{
-    abac::{ABACPolicy, ABACRequest},
-    err::Error,
-    hierarchy::HierarchyGenerator,
-    schema,
-    settings::ABACSettings,
-};
-use libfuzzer_sys::arbitrary::{self, Arbitrary, Unstructured};
-
-/// Input expected by this fuzz target
-#[derive(Debug, Clone)]
-pub struct FuzzTargetInput {
-    /// generated schema
-    pub schema: schema::Schema,
-    /// generated entity slice
-    pub entities: Entities,
-    /// generated policy
-    pub policy: ABACPolicy,
-    /// the requests to try for this hierarchy and policy. We try 8 requests per
-    /// policy/hierarchy
-    pub requests: [ABACRequest; 8],
-}
-
-/// settings for this fuzz target
-const SETTINGS: ABACSettings = ABACSettings {
-    match_types: true,
-    enable_extensions: true,
-    max_depth: 7,
-    max_width: 7,
-    enable_additional_attributes: false,
-    enable_like: true,
-    enable_action_groups_and_attrs: true,
-    enable_arbitrary_func_call: true,
-    enable_unknowns: false,
-    enable_action_in_constraints: true,
-    per_action_request_env_limit: ABACSettings::default_per_action_request_env_limit(),
-    total_action_request_env_limit: ABACSettings::default_total_action_request_env_limit(),
-};
-
-impl<'a> Arbitrary<'a> for FuzzTargetInput {
-    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
-        let schema = schema::Schema::arbitrary(SETTINGS.clone(), u)?;
-        let hierarchy = schema.arbitrary_hierarchy(u)?;
-        let policy = schema.arbitrary_policy(&hierarchy, u)?;
-
-        let requests = [
-            schema.arbitrary_request(&hierarchy, u)?,
-            schema.arbitrary_request(&hierarchy, u)?,
-            schema.arbitrary_request(&hierarchy, u)?,
-            schema.arbitrary_request(&hierarchy, u)?,
-            schema.arbitrary_request(&hierarchy, u)?,
-            schema.arbitrary_request(&hierarchy, u)?,
-            schema.arbitrary_request(&hierarchy, u)?,
-            schema.arbitrary_request(&hierarchy, u)?,
-        ];
-        let all_entities = Entities::try_from(hierarchy).map_err(|_| Error::NotEnoughData)?;
-        let cedar_schema = Schema::try_from(schema.clone()).unwrap();
-        let entities = schemas::add_actions_to_entities(&cedar_schema, all_entities)?;
-        Ok(Self {
-            schema,
-            entities,
-            policy,
-            requests,
-        })
-    }
-
-    fn try_size_hint(
-        depth: usize,
-    ) -> arbitrary::Result<(usize, Option<usize>), arbitrary::MaxRecursionReached> {
-        Ok(arbitrary::size_hint::and_all(&[
-            schema::Schema::arbitrary_size_hint(depth)?,
-            HierarchyGenerator::size_hint(depth),
-            schema::Schema::arbitrary_policy_size_hint(&SETTINGS, depth),
-            schema::Schema::arbitrary_request_size_hint(depth),
-            schema::Schema::arbitrary_request_size_hint(depth),
-            schema::Schema::arbitrary_request_size_hint(depth),
-            schema::Schema::arbitrary_request_size_hint(depth),
-            schema::Schema::arbitrary_request_size_hint(depth),
-            schema::Schema::arbitrary_request_size_hint(depth),
-            schema::Schema::arbitrary_request_size_hint(depth),
-            schema::Schema::arbitrary_request_size_hint(depth),
-        ]))
-    }
-}
+use libfuzzer_sys::arbitrary::{Arbitrary, Unstructured};
 
 // This target tests a property that batched evaluation, if succeeds, should
 // produce the same authorization decision of normal authorization where the
 // the entire in-memory entity store is provided
-fuzz_target!(|input: FuzzTargetInput| {
+fuzz_target!(|input: FuzzTargetInput<true>| {
     initialize_log();
 
     if let Ok(schema) = Schema::try_from(input.schema) {
@@ -118,7 +35,7 @@ fuzz_target!(|input: FuzzTargetInput| {
         policyset.add(policy.clone()).unwrap();
         let mut loader = TestEntityLoader::new(&input.entities);
         log::debug!("policy: {policyset}");
-        let iteration = (SETTINGS.max_depth + 1) as u32;
+        let iteration = (FuzzTargetInput::<true>::settings().max_depth + 1) as u32;
 
         for req in input.requests {
             let req = req.into();

--- a/cedar-drt/fuzz/fuzz_targets/entity-slicing-drt-type-directed.rs
+++ b/cedar-drt/fuzz/fuzz_targets/entity-slicing-drt-type-directed.rs
@@ -16,135 +16,54 @@
 
 #![no_main]
 use cedar_drt::logger::initialize_log;
-use cedar_drt_inner::fuzz_target;
+use cedar_drt_inner::{abac::FuzzTargetInput, fuzz_target};
 
 use cedar_policy::{
     compute_entity_manifest, Authorizer, Entities, EntityManifestError, Policy, PolicySet, Request,
     Schema, Validator,
 };
 
-use cedar_policy_generators::{
-    abac::{ABACPolicy, ABACRequest},
-    hierarchy::{Hierarchy, HierarchyGenerator},
-    schema,
-    settings::ABACSettings,
-};
-use libfuzzer_sys::arbitrary::{self, Arbitrary, Unstructured};
+use libfuzzer_sys::arbitrary::{Arbitrary, Unstructured};
 use log::debug;
 use std::convert::TryFrom;
 
-/// Input expected by this fuzz target:
-/// An ABAC hierarchy, schema, and 8 associated policies
-#[derive(Debug, Clone)]
-struct FuzzTargetInput {
-    /// generated schema
-    pub schema: schema::Schema,
-    /// generated hierarchy
-    pub hierarchy: Hierarchy,
-    /// the policy which we will see if it validates
-    pub policy: ABACPolicy,
-    /// the requests to try, if the policy validates.
-    /// We try 8 requests per validated policy.
-    pub requests: [ABACRequest; 8],
-}
-
-/// settings for this fuzz target
-const SETTINGS: ABACSettings = ABACSettings {
-    match_types: true,
-    enable_extensions: true,
-    max_depth: 7,
-    max_width: 7,
-    enable_additional_attributes: true,
-    enable_like: true,
-    enable_action_groups_and_attrs: true,
-    enable_arbitrary_func_call: true,
-    enable_unknowns: false,
-    enable_action_in_constraints: true,
-    per_action_request_env_limit: ABACSettings::default_per_action_request_env_limit(),
-    total_action_request_env_limit: ABACSettings::default_total_action_request_env_limit(),
-};
-
-impl<'a> Arbitrary<'a> for FuzzTargetInput {
-    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
-        let schema: schema::Schema = schema::Schema::arbitrary(SETTINGS.clone(), u)?;
-        let hierarchy = schema.arbitrary_hierarchy(u)?;
-        let policy = schema.arbitrary_policy(&hierarchy, u)?;
-        let requests = [
-            schema.arbitrary_request(&hierarchy, u)?,
-            schema.arbitrary_request(&hierarchy, u)?,
-            schema.arbitrary_request(&hierarchy, u)?,
-            schema.arbitrary_request(&hierarchy, u)?,
-            schema.arbitrary_request(&hierarchy, u)?,
-            schema.arbitrary_request(&hierarchy, u)?,
-            schema.arbitrary_request(&hierarchy, u)?,
-            schema.arbitrary_request(&hierarchy, u)?,
-        ];
-        Ok(Self {
-            schema,
-            hierarchy,
-            policy,
-            requests,
-        })
-    }
-
-    fn try_size_hint(
-        depth: usize,
-    ) -> arbitrary::Result<(usize, Option<usize>), arbitrary::MaxRecursionReached> {
-        Ok(arbitrary::size_hint::and_all(&[
-            schema::Schema::arbitrary_size_hint(depth)?,
-            HierarchyGenerator::size_hint(depth),
-            schema::Schema::arbitrary_policy_size_hint(&SETTINGS, depth),
-            schema::Schema::arbitrary_request_size_hint(depth),
-            schema::Schema::arbitrary_request_size_hint(depth),
-            schema::Schema::arbitrary_request_size_hint(depth),
-            schema::Schema::arbitrary_request_size_hint(depth),
-            schema::Schema::arbitrary_request_size_hint(depth),
-            schema::Schema::arbitrary_request_size_hint(depth),
-            schema::Schema::arbitrary_request_size_hint(depth),
-            schema::Schema::arbitrary_request_size_hint(depth),
-        ]))
-    }
-}
-
 // The main fuzz target. This is for PBT on the validator
-fuzz_target!(|input: FuzzTargetInput| {
+fuzz_target!(|input: FuzzTargetInput<true>| {
     initialize_log();
     if let Ok(schema) = Schema::try_from(input.schema) {
         debug!("Schema: {:?}", schema);
-        if let Ok(entities) = Entities::try_from(input.hierarchy.clone()) {
-            let mut policyset = PolicySet::new();
-            let policy: Policy = input.policy.into();
-            policyset.add(policy.clone()).unwrap();
-            let manifest = match compute_entity_manifest(&Validator::new(schema), &policyset) {
-                Ok(manifest) => manifest,
-                Err(
-                    EntityManifestError::UnsupportedCedarFeature(_)
-                    | EntityManifestError::Validation(_),
-                ) => {
-                    return;
-                }
-                Err(e) => panic!("failed to produce an entity manifest: {e}"),
-            };
-
-            let authorizer = Authorizer::new();
-            debug!("Policies: {policyset}");
-            debug!("Entities: {}", entities.as_ref());
-            for abac_request in input.requests.into_iter() {
-                let request = Request::from(abac_request);
-                debug!("Request: {request}");
-                let entity_slice: Entities = manifest
-                    .slice_entities(entities.as_ref(), request.as_ref())
-                    .expect("failed to slice entities")
-                    .into();
-                debug!("Entity slice: {}", entity_slice.as_ref());
-                let ans_original = authorizer.is_authorized(&request, &policyset, &entities);
-                let ans_slice = authorizer.is_authorized(&request, &policyset, &entity_slice);
-                assert_eq!(
-                    ans_original.decision(),
-                    ans_slice.decision(),
-                    "Authorization decision differed with and without entity slicing!"
-                );
+        let mut policyset = PolicySet::new();
+        let policy: Policy = input.policy.into();
+        policyset.add(policy.clone()).unwrap();
+        let manifest = match compute_entity_manifest(&Validator::new(schema), &policyset) {
+            Ok(manifest) => manifest,
+            Err(
+                EntityManifestError::UnsupportedCedarFeature(_)
+                | EntityManifestError::Validation(_),
+            ) => {
+                return;
             }
+            Err(e) => panic!("failed to produce an entity manifest: {e}"),
+        };
+
+        let authorizer = Authorizer::new();
+        debug!("Policies: {policyset}");
+        debug!("Entities: {}", input.entities.as_ref());
+        for abac_request in input.requests.into_iter() {
+            let request = Request::from(abac_request);
+            debug!("Request: {request}");
+            let entity_slice: Entities = manifest
+                .slice_entities(input.entities.as_ref(), request.as_ref())
+                .expect("failed to slice entities")
+                .into();
+            debug!("Entity slice: {}", entity_slice.as_ref());
+            let ans_original = authorizer.is_authorized(&request, &policyset, &input.entities);
+            let ans_slice = authorizer.is_authorized(&request, &policyset, &entity_slice);
+            assert_eq!(
+                ans_original.decision(),
+                ans_slice.decision(),
+                "Authorization decision differed with and without entity slicing!"
+            );
         }
     }
 });

--- a/cedar-drt/fuzz/fuzz_targets/validation-pbt-type-directed.rs
+++ b/cedar-drt/fuzz/fuzz_targets/validation-pbt-type-directed.rs
@@ -17,95 +17,16 @@
 #![no_main]
 
 use cedar_drt::logger::initialize_log;
-use cedar_drt_inner::fuzz_target;
+use cedar_drt_inner::{abac::FuzzTargetInput, fuzz_target};
 
 use cedar_policy::{
-    AuthorizationError, Authorizer, Entities, EvaluationError, Policy, PolicySet, Request, Schema,
+    AuthorizationError, Authorizer, EvaluationError, Policy, PolicySet, Request, Schema,
     ValidationMode, Validator,
 };
 
-use cedar_policy_generators::{
-    abac::{ABACPolicy, ABACRequest},
-    hierarchy::{Hierarchy, HierarchyGenerator},
-    schema,
-    settings::ABACSettings,
-};
-use libfuzzer_sys::arbitrary::{self, Arbitrary, Unstructured};
+use libfuzzer_sys::arbitrary::{Arbitrary, Unstructured};
 use log::debug;
 use std::convert::TryFrom;
-
-/// Input expected by this fuzz target:
-/// An ABAC hierarchy, schema, and 8 associated policies
-#[derive(Debug, Clone)]
-struct FuzzTargetInput {
-    /// generated schema
-    pub schema: schema::Schema,
-    /// generated hierarchy
-    pub hierarchy: Hierarchy,
-    /// the policy which we will see if it validates
-    pub policy: ABACPolicy,
-    /// the requests to try, if the policy validates.
-    /// We try 8 requests per validated policy.
-    pub requests: [ABACRequest; 8],
-}
-
-/// settings for this fuzz target
-const SETTINGS: ABACSettings = ABACSettings {
-    match_types: true,
-    enable_extensions: true,
-    max_depth: 7,
-    max_width: 7,
-    enable_additional_attributes: true,
-    enable_like: true,
-    enable_action_groups_and_attrs: true,
-    enable_arbitrary_func_call: true,
-    enable_unknowns: false,
-    enable_action_in_constraints: true,
-    per_action_request_env_limit: ABACSettings::default_per_action_request_env_limit(),
-    total_action_request_env_limit: ABACSettings::default_total_action_request_env_limit(),
-};
-
-impl<'a> Arbitrary<'a> for FuzzTargetInput {
-    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
-        let schema: schema::Schema = schema::Schema::arbitrary(SETTINGS.clone(), u)?;
-        let hierarchy = schema.arbitrary_hierarchy(u)?;
-        let policy = schema.arbitrary_policy(&hierarchy, u)?;
-        let requests = [
-            schema.arbitrary_request(&hierarchy, u)?,
-            schema.arbitrary_request(&hierarchy, u)?,
-            schema.arbitrary_request(&hierarchy, u)?,
-            schema.arbitrary_request(&hierarchy, u)?,
-            schema.arbitrary_request(&hierarchy, u)?,
-            schema.arbitrary_request(&hierarchy, u)?,
-            schema.arbitrary_request(&hierarchy, u)?,
-            schema.arbitrary_request(&hierarchy, u)?,
-        ];
-        Ok(Self {
-            schema,
-            hierarchy,
-            policy,
-            requests,
-        })
-    }
-
-    fn try_size_hint(
-        depth: usize,
-    ) -> arbitrary::Result<(usize, Option<usize>), arbitrary::MaxRecursionReached> {
-        Ok(arbitrary::size_hint::and_all(&[
-            schema::Schema::arbitrary_size_hint(depth)?,
-            HierarchyGenerator::size_hint(depth),
-            schema::Schema::arbitrary_policy_size_hint(&SETTINGS, depth),
-            schema::Schema::arbitrary_request_size_hint(depth),
-            schema::Schema::arbitrary_request_size_hint(depth),
-            schema::Schema::arbitrary_request_size_hint(depth),
-            schema::Schema::arbitrary_request_size_hint(depth),
-            schema::Schema::arbitrary_request_size_hint(depth),
-            schema::Schema::arbitrary_request_size_hint(depth),
-            schema::Schema::arbitrary_request_size_hint(depth),
-            schema::Schema::arbitrary_request_size_hint(depth),
-        ]))
-    }
-}
 
 /// helper function that just tells us whether a policyset passes validation
 fn passes_validation(validator: &Validator, policyset: &PolicySet, mode: ValidationMode) -> bool {
@@ -113,74 +34,70 @@ fn passes_validation(validator: &Validator, policyset: &PolicySet, mode: Validat
 }
 
 // The main fuzz target. This is for PBT on the validator
-fuzz_target!(|input: FuzzTargetInput| {
+fuzz_target!(|input: FuzzTargetInput<true>| {
     initialize_log();
     // preserve the schema in string format, which may be needed for error messages later
     let schemafile_string = input.schema.schemafile_string();
     if let Ok(schema) = Schema::try_from(input.schema) {
         debug!("Schema: {:?}", schema);
-        if let Ok(entities) = Entities::try_from(input.hierarchy.clone()) {
-            let validator = Validator::new(schema);
-            let mut policyset = PolicySet::new();
-            let policy: Policy = input.policy.into();
-            policyset.add(policy.clone()).unwrap();
-            let passes_strict = passes_validation(&validator, &policyset, ValidationMode::Strict);
-            let passes_permissive =
-                passes_validation(&validator, &policyset, ValidationMode::Permissive);
-            if passes_permissive {
-                // policy successfully validated, let's make sure we don't get any
-                // dynamic type errors
-                let authorizer = Authorizer::new();
-                debug!("Policies: {policyset}");
-                debug!("Entities: {}", entities.as_ref());
-                for r in input.requests.into_iter() {
-                    let q = Request::from(r);
-                    debug!("Request: {q}");
-                    let ans = authorizer.is_authorized(&q, &policyset, &entities);
+        let validator = Validator::new(schema);
+        let mut policyset = PolicySet::new();
+        let policy: Policy = input.policy.into();
+        policyset.add(policy.clone()).unwrap();
+        let passes_strict = passes_validation(&validator, &policyset, ValidationMode::Strict);
+        let passes_permissive =
+            passes_validation(&validator, &policyset, ValidationMode::Permissive);
+        if passes_permissive {
+            // policy successfully validated, let's make sure we don't get any
+            // dynamic type errors
+            let authorizer = Authorizer::new();
+            debug!("Policies: {policyset}");
+            debug!("Entities: {}", input.entities.as_ref());
+            for r in input.requests.into_iter() {
+                let q = Request::from(r);
+                debug!("Request: {q}");
+                let ans = authorizer.is_authorized(&q, &policyset, &input.entities);
 
-                    let unexpected_errs = ans
-                        .diagnostics()
-                        .errors()
-                        .filter_map(|error| match error {
-                            AuthorizationError::PolicyEvaluationError(err) => {
-                                match err.inner() {
-                                    // Evaluation errors the validator should prevent.
-                                    EvaluationError::RecordAttrDoesNotExist(_)
-                                    | EvaluationError::EntityAttrDoesNotExist(_)
-                                    | EvaluationError::FailedExtensionFunctionLookup(_)
-                                    | EvaluationError::TypeError(_)
-                                    | EvaluationError::WrongNumArguments(_) => {
-                                        Some(error.to_string())
-                                    }
-                                    // Evaluation errors it shouldn't prevent. Not
-                                    // written with a catch all so that we must
-                                    // consider if a new error type should cause
-                                    // this target to fail.
-                                    EvaluationError::EntityDoesNotExist(_)
-                                    | EvaluationError::IntegerOverflow(_)
-                                    | EvaluationError::UnlinkedSlot(_)
-                                    | EvaluationError::FailedExtensionFunctionExecution(_)
-                                    | EvaluationError::NonValue(_)
-                                    | EvaluationError::RecursionLimit(_) => None,
-                                }
+                let unexpected_errs = ans
+                    .diagnostics()
+                    .errors()
+                    .filter_map(|error| match error {
+                        AuthorizationError::PolicyEvaluationError(err) => {
+                            match err.inner() {
+                                // Evaluation errors the validator should prevent.
+                                EvaluationError::RecordAttrDoesNotExist(_)
+                                | EvaluationError::EntityAttrDoesNotExist(_)
+                                | EvaluationError::FailedExtensionFunctionLookup(_)
+                                | EvaluationError::TypeError(_)
+                                | EvaluationError::WrongNumArguments(_) => Some(error.to_string()),
+                                // Evaluation errors it shouldn't prevent. Not
+                                // written with a catch all so that we must
+                                // consider if a new error type should cause
+                                // this target to fail.
+                                EvaluationError::EntityDoesNotExist(_)
+                                | EvaluationError::IntegerOverflow(_)
+                                | EvaluationError::UnlinkedSlot(_)
+                                | EvaluationError::FailedExtensionFunctionExecution(_)
+                                | EvaluationError::NonValue(_)
+                                | EvaluationError::RecursionLimit(_) => None,
                             }
-                        })
-                        .collect::<Vec<_>>();
+                        }
+                    })
+                    .collect::<Vec<_>>();
 
-                    assert_eq!(
-                        unexpected_errs,
-                        Vec::<String>::new(),
-                        "validated policy produced unexpected errors {unexpected_errs:?}!\npolicies:\n{policyset}\nentities:\n{}\nschema:\n{schemafile_string}\nrequest:\n{q}\n",
-                        entities.as_ref()
-                    )
-                }
-            } else {
-                assert!(
-                    !passes_strict,
-                    "policy fails permissive validation but passes strict validation!\npolicies:\n{policyset}\nentities:\n{}\nschema:\n{schemafile_string}\n",
-                    entities.as_ref()
-                );
+                assert_eq!(
+                    unexpected_errs,
+                    Vec::<String>::new(),
+                    "validated policy produced unexpected errors {unexpected_errs:?}!\npolicies:\n{policyset}\nentities:\n{}\nschema:\n{schemafile_string}\nrequest:\n{q}\n",
+                    input.entities.as_ref()
+                )
             }
+        } else {
+            assert!(
+                !passes_strict,
+                "policy fails permissive validation but passes strict validation!\npolicies:\n{policyset}\nentities:\n{}\nschema:\n{schemafile_string}\n",
+                input.entities.as_ref()
+            );
         }
     }
 });

--- a/cedar-drt/fuzz/fuzz_targets/validation-pbt.rs
+++ b/cedar-drt/fuzz/fuzz_targets/validation-pbt.rs
@@ -16,305 +16,17 @@
 
 #![no_main]
 use cedar_drt::logger::initialize_log;
-use cedar_drt_inner::fuzz_target;
+use cedar_drt_inner::{abac::FuzzTargetInput, fuzz_target};
 
 use cedar_policy::{
-    AuthorizationError, Authorizer, Entities, EvaluationError, Policy, PolicySet, Request, Schema,
+    AuthorizationError, Authorizer, EvaluationError, Policy, PolicySet, Request, Schema,
     ValidationMode, Validator,
 };
 
-use cedar_policy_generators::{
-    abac::{ABACPolicy, ABACRequest},
-    err::{Error, Result},
-    hierarchy::{Hierarchy, HierarchyGenerator},
-    schema,
-    settings::ABACSettings,
-};
 use itertools::Itertools;
-use libfuzzer_sys::arbitrary::{self, Arbitrary, Unstructured};
+use libfuzzer_sys::arbitrary::{Arbitrary, Unstructured};
 use log::debug;
 use std::convert::TryFrom;
-
-/// Input expected by this fuzz target:
-/// An ABAC hierarchy, schema, and 8 associated policies
-#[derive(Debug, Clone)]
-struct FuzzTargetInput {
-    /// generated schema
-    pub schema: schema::Schema,
-    /// generated hierarchy
-    pub hierarchy: Hierarchy,
-    /// the policy which we will see if it validates
-    pub policy: ABACPolicy,
-    /// the requests to try, if the policy validates.
-    /// We try 8 requests per validated policy.
-    pub requests: [ABACRequest; 8],
-}
-
-/// settings for this fuzz target
-const SETTINGS: ABACSettings = ABACSettings {
-    match_types: false,
-    enable_extensions: true,
-    max_depth: 7,
-    max_width: 7,
-    enable_additional_attributes: true,
-    enable_like: true,
-    enable_action_groups_and_attrs: true,
-    enable_arbitrary_func_call: true,
-    enable_unknowns: false,
-    enable_action_in_constraints: true,
-    per_action_request_env_limit: ABACSettings::default_per_action_request_env_limit(),
-    total_action_request_env_limit: ABACSettings::default_total_action_request_env_limit(),
-};
-
-const LOG_FILENAME_GENERATION_START: &str = "./logs/01_generation_start.txt";
-const LOG_FILENAME_GENERATED_SCHEMA: &str = "./logs/02_generated_schema.txt";
-const LOG_FILENAME_GENERATED_HIERARCHY: &str = "./logs/03_generated_hierarchy.txt";
-const LOG_FILENAME_GENERATED_POLICY: &str = "./logs/04_generated_policy.txt";
-const LOG_FILENAME_GENERATED_REQUESTS: &str = "./logs/05_generated_requests.txt";
-const LOG_FILENAME_SCHEMA_VALID: &str = "./logs/06_schema_valid.txt";
-const LOG_FILENAME_HIERARCHY_VALID: &str = "./logs/07_hierarchy_valid.txt";
-const LOG_FILENAME_VALIDATION_PASS: &str = "./logs/08_validation_pass.txt";
-
-const LOG_FILENAME_ERR_NOT_ENOUGH_DATA: &str = "./logs/err_not_enough_data.txt";
-const LOG_FILENAME_ERR_EMPTY_CHOOSE: &str = "./logs/err_empty_choose.txt";
-const LOG_FILENAME_ERR_TOO_DEEP: &str = "./logs/err_too_deep.txt";
-const LOG_FILENAME_ERR_NO_VALID_TYPES: &str = "./logs/err_no_valid_types.txt";
-const LOG_FILENAME_ERR_EXTENSIONS_DISABLED: &str = "./logs/err_extensions_disabled.txt";
-const LOG_FILENAME_ERR_LIKE_DISABLED: &str = "./logs/err_like_disabled.txt";
-const LOG_FILENAME_ERR_CONTEXT: &str = "./logs/err_context.txt";
-const LOG_FILENAME_ERR_INCORRECT_FORMAT: &str = "./logs/err_incorrect_format.txt";
-const LOG_FILENAME_ERR_OTHER: &str = "./logs/err_other.txt";
-const LOG_FILENAME_ENTITIES_ERROR: &str = "./logs/err_entities.txt";
-const LOG_FILENAME_SCHEMA_ERROR: &str = "./logs/err_schema.txt";
-const LOG_FILENAME_TOO_MANY_REQ_ENVS_ERROR: &str = "./logs/err_too_many_req_envs.txt";
-const LOG_FILENAME_TOO_MANY_REQ_ENVS_PER_ACTION_ERROR: &str =
-    "./logs/err_too_many_req_envs_per_action.txt";
-
-// In the below, "vyes" means the schema passed validation, while "vno" means we
-// got to the point of running the validator but validation failed
-const LOG_FILENAME_TOTAL_ENTITY_TYPES: &str = "./logs/schemastats/total_entity_types";
-const LOG_FILENAME_TOTAL_ACTIONS: &str = "./logs/schemastats/total_actions";
-const LOG_FILENAME_APPLIES_TO_NONE: &str = "./logs/schemastats/applies_to_none";
-const LOG_FILENAME_APPLIES_TO_PRINCIPAL_LEN: &str = "./logs/schemastats/applies_to_principal_len";
-const LOG_FILENAME_APPLIES_TO_RESOURCE_LEN: &str = "./logs/schemastats/applies_to_resource_len";
-const LOG_FILENAME_TOTAL_ENTITIES: &str = "./logs/hierarchystats/total_entities";
-const LOG_FILENAME_TOTAL_SUBEXPRESSIONS: &str = "./logs/policystats/total_subexpressions";
-
-/// Append to the given filename to indicate we've reached the corresponding
-/// checkpoint, or the corresponding event has happened
-fn checkpoint(filename: impl AsRef<std::path::Path>) {
-    if std::env::var("FUZZ_LOG_STATS").is_ok() {
-        use std::io::Write;
-        let mut file = std::fs::OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(filename.as_ref())
-            .unwrap();
-        writeln!(file, "y").unwrap();
-    }
-}
-
-fn log_err<T>(res: Result<T>, doing_what: &str) -> Result<T> {
-    if std::env::var("FUZZ_LOG_STATS").is_ok() {
-        match &res {
-            Err(Error::EntitiesError(_)) => {
-                checkpoint(LOG_FILENAME_ENTITIES_ERROR.to_string() + "_" + doing_what)
-            }
-            Err(Error::SchemaError(_)) => {
-                checkpoint(LOG_FILENAME_SCHEMA_ERROR.to_string() + "_" + doing_what)
-            }
-            Err(Error::NotEnoughData) => {
-                checkpoint(LOG_FILENAME_ERR_NOT_ENOUGH_DATA.to_string() + "_" + doing_what)
-            }
-            Err(Error::EmptyChoose {
-                doing_what: doing_2,
-            }) => checkpoint(
-                LOG_FILENAME_ERR_EMPTY_CHOOSE.to_string()
-                    + "_"
-                    + doing_what
-                    + "_"
-                    + &doing_2.replace(' ', "_"),
-            ),
-            Err(Error::TooDeep) => {
-                checkpoint(LOG_FILENAME_ERR_TOO_DEEP.to_string() + "_" + doing_what)
-            }
-            Err(Error::NoValidPrincipalOrResourceTypes) => {
-                checkpoint(LOG_FILENAME_ERR_NO_VALID_TYPES.to_string() + "_" + doing_what)
-            }
-            Err(Error::ExtensionsDisabled) => {
-                checkpoint(LOG_FILENAME_ERR_EXTENSIONS_DISABLED.to_string() + "_" + doing_what)
-            }
-            Err(Error::LikeDisabled) => {
-                checkpoint(LOG_FILENAME_ERR_LIKE_DISABLED.to_string() + "_" + doing_what)
-            }
-            Err(Error::ContextError(_)) => {
-                checkpoint(LOG_FILENAME_ERR_CONTEXT.to_string() + "_" + doing_what)
-            }
-            Err(Error::IncorrectFormat {
-                doing_what: doing_2,
-            }) => checkpoint(
-                LOG_FILENAME_ERR_INCORRECT_FORMAT.to_string()
-                    + "_"
-                    + doing_what
-                    + "_"
-                    + &doing_2.replace(' ', "_"),
-            ),
-            Err(Error::OtherArbitrary(_)) => {
-                checkpoint(LOG_FILENAME_ERR_OTHER.to_string() + "_" + doing_what)
-            }
-            Err(Error::TooManyReqEnvs(..)) => {
-                checkpoint(LOG_FILENAME_TOO_MANY_REQ_ENVS_ERROR.to_string() + "_" + doing_what)
-            }
-            Err(Error::TooManyReqEnvsPerAction(..)) => checkpoint(
-                LOG_FILENAME_TOO_MANY_REQ_ENVS_PER_ACTION_ERROR.to_string() + "_" + doing_what,
-            ),
-            Ok(_) => (),
-        }
-    }
-    res
-}
-
-fn maybe_log_schemastats(schema: Option<&Schema>, suffix: &str) {
-    if std::env::var("FUZZ_LOG_STATS").is_ok() {
-        let schema = schema.expect("should be SOME if FUZZ_LOG_STATS is ok");
-        checkpoint(
-            LOG_FILENAME_TOTAL_ENTITY_TYPES.to_string()
-                + "_"
-                + suffix
-                + "_"
-                + &format!("{:03}", schema.entity_types().count()),
-        );
-        checkpoint(
-            LOG_FILENAME_TOTAL_ACTIONS.to_string()
-                + "_"
-                + suffix
-                + "_"
-                + &format!("{:03}", schema.actions().count()),
-        );
-        for action in schema.actions() {
-            let n_principals = schema.principals_for_action(action).unwrap().count();
-            let n_resources = schema.resources_for_action(action).unwrap().count();
-            // Cartesian product is empty. So action applies to None
-            if n_principals == 0 || n_resources == 0 {
-                checkpoint(LOG_FILENAME_APPLIES_TO_NONE.to_string() + "_" + suffix);
-            } else {
-                checkpoint(
-                    LOG_FILENAME_APPLIES_TO_PRINCIPAL_LEN.to_string()
-                        + "_"
-                        + suffix
-                        + "_"
-                        + &format!("{:03}", n_principals),
-                );
-                checkpoint(
-                    LOG_FILENAME_APPLIES_TO_RESOURCE_LEN.to_string()
-                        + "_"
-                        + suffix
-                        + "_"
-                        + &format!("{:03}", n_resources),
-                );
-            }
-        }
-    }
-}
-
-fn maybe_log_hierarchystats(hierarchy: &Hierarchy, suffix: &str) {
-    if std::env::var("FUZZ_LOG_STATS").is_ok() {
-        checkpoint(
-            LOG_FILENAME_TOTAL_ENTITIES.to_string()
-                + "_"
-                + suffix
-                + "_"
-                + &format!("{:03}", hierarchy.num_entities()),
-        );
-    }
-}
-
-fn maybe_log_policystats(policy: &Policy, suffix: &str) {
-    if std::env::var("FUZZ_LOG_STATS").is_ok() {
-        let total_subexpressions = policy.as_ref().condition().subexpressions().count();
-        checkpoint(
-            LOG_FILENAME_TOTAL_SUBEXPRESSIONS.to_string()
-                + "_"
-                + suffix
-                + "_"
-                + &format!("{:03}", total_subexpressions),
-        );
-    }
-}
-
-impl<'a> Arbitrary<'a> for FuzzTargetInput {
-    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
-        checkpoint(LOG_FILENAME_GENERATION_START);
-        let schema: schema::Schema = log_err(
-            schema::Schema::arbitrary(SETTINGS.clone(), u),
-            "generating_schema",
-        )?;
-        checkpoint(LOG_FILENAME_GENERATED_SCHEMA);
-        let hierarchy = log_err(schema.arbitrary_hierarchy(u), "generating_hierarchy")?;
-        checkpoint(LOG_FILENAME_GENERATED_HIERARCHY);
-        let policy = log_err(schema.arbitrary_policy(&hierarchy, u), "generating_policy")?;
-        checkpoint(LOG_FILENAME_GENERATED_POLICY);
-        let requests = [
-            log_err(
-                schema.arbitrary_request(&hierarchy, u),
-                "generating_request",
-            )?,
-            log_err(
-                schema.arbitrary_request(&hierarchy, u),
-                "generating_request",
-            )?,
-            log_err(
-                schema.arbitrary_request(&hierarchy, u),
-                "generating_request",
-            )?,
-            log_err(
-                schema.arbitrary_request(&hierarchy, u),
-                "generating_request",
-            )?,
-            log_err(
-                schema.arbitrary_request(&hierarchy, u),
-                "generating_request",
-            )?,
-            log_err(
-                schema.arbitrary_request(&hierarchy, u),
-                "generating_request",
-            )?,
-            log_err(
-                schema.arbitrary_request(&hierarchy, u),
-                "generating_request",
-            )?,
-            log_err(
-                schema.arbitrary_request(&hierarchy, u),
-                "generating_request",
-            )?,
-        ];
-        checkpoint(LOG_FILENAME_GENERATED_REQUESTS);
-        Ok(Self {
-            schema,
-            hierarchy,
-            policy,
-            requests,
-        })
-    }
-
-    fn try_size_hint(
-        depth: usize,
-    ) -> arbitrary::Result<(usize, Option<usize>), arbitrary::MaxRecursionReached> {
-        Ok(arbitrary::size_hint::and_all(&[
-            schema::Schema::arbitrary_size_hint(depth)?,
-            HierarchyGenerator::size_hint(depth),
-            schema::Schema::arbitrary_policy_size_hint(&SETTINGS, depth),
-            schema::Schema::arbitrary_request_size_hint(depth),
-            schema::Schema::arbitrary_request_size_hint(depth),
-            schema::Schema::arbitrary_request_size_hint(depth),
-            schema::Schema::arbitrary_request_size_hint(depth),
-            schema::Schema::arbitrary_request_size_hint(depth),
-            schema::Schema::arbitrary_request_size_hint(depth),
-            schema::Schema::arbitrary_request_size_hint(depth),
-            schema::Schema::arbitrary_request_size_hint(depth),
-        ]))
-    }
-}
 
 /// helper function that just tells us whether a policyset passes validation
 fn passes_validation(validator: &Validator, policyset: &PolicySet, mode: ValidationMode) -> bool {
@@ -322,84 +34,70 @@ fn passes_validation(validator: &Validator, policyset: &PolicySet, mode: Validat
 }
 
 // The main fuzz target. This is for PBT on the validator
-fuzz_target!(|input: FuzzTargetInput| {
+fuzz_target!(|input: FuzzTargetInput<false>| {
     initialize_log();
     // preserve the schema in string format, which may be needed for error messages later
     let schemafile_string = input.schema.schemafile_string();
     if let Ok(schema) = Schema::try_from(input.schema) {
         debug!("Schema: {:?}", schema);
-        checkpoint(LOG_FILENAME_SCHEMA_VALID);
-        if let Ok(entities) = Entities::try_from(input.hierarchy.clone()) {
-            checkpoint(LOG_FILENAME_HIERARCHY_VALID);
-            let validator = Validator::new(schema.clone());
-            let mut policyset = PolicySet::new();
-            let policy: Policy = input.policy.into();
-            policyset.add(policy.clone()).unwrap();
-            let passes_strict = passes_validation(&validator, &policyset, ValidationMode::Strict);
-            let passes_permissive =
-                passes_validation(&validator, &policyset, ValidationMode::Permissive);
-            if passes_permissive {
-                checkpoint(LOG_FILENAME_VALIDATION_PASS);
-                let suffix = if passes_strict { "vyes" } else { "vpermissive" };
-                maybe_log_schemastats(Some(&schema), suffix);
-                maybe_log_hierarchystats(&input.hierarchy, suffix);
-                maybe_log_policystats(&policy, suffix);
-                // policy successfully validated, let's make sure we don't get any
-                // dynamic type errors
-                let authorizer = Authorizer::new();
-                debug!("Policies: {policyset}");
-                debug!("Entities: {}", entities.as_ref());
-                for r in input.requests.into_iter() {
-                    let q = Request::from(r);
-                    debug!("Request: {q}");
-                    let ans = authorizer.is_authorized(&q, &policyset, &entities);
+        let validator = Validator::new(schema.clone());
+        let mut policyset = PolicySet::new();
+        let policy: Policy = input.policy.into();
+        policyset.add(policy.clone()).unwrap();
+        let passes_strict = passes_validation(&validator, &policyset, ValidationMode::Strict);
+        let passes_permissive =
+            passes_validation(&validator, &policyset, ValidationMode::Permissive);
+        if passes_permissive {
+            // policy successfully validated, let's make sure we don't get any
+            // dynamic type errors
+            let authorizer = Authorizer::new();
+            debug!("Policies: {policyset}");
+            debug!("Entities: {}", input.entities.as_ref());
+            for r in input.requests.into_iter() {
+                let q = Request::from(r);
+                debug!("Request: {q}");
+                let ans = authorizer.is_authorized(&q, &policyset, &input.entities);
 
-                    let unexpected_errs = ans
-                        .diagnostics()
-                        .errors()
-                        .filter_map(|error| match error {
-                            AuthorizationError::PolicyEvaluationError(error) => {
-                                match error.inner() {
-                                    // Evaluation errors the validator should prevent.
-                                    EvaluationError::RecordAttrDoesNotExist(_)
-                                    | EvaluationError::EntityAttrDoesNotExist(_)
-                                    | EvaluationError::FailedExtensionFunctionLookup(_)
-                                    | EvaluationError::TypeError(_)
-                                    | EvaluationError::WrongNumArguments(_) => {
-                                        Some(error.to_string())
-                                    }
-                                    // Evaluation errors it shouldn't prevent. Not
-                                    // written with a catch all so that we must
-                                    // consider if a new error type should cause
-                                    // this target to fail.
-                                    EvaluationError::EntityDoesNotExist(_)
-                                    | EvaluationError::IntegerOverflow(_)
-                                    | EvaluationError::UnlinkedSlot(_)
-                                    | EvaluationError::FailedExtensionFunctionExecution(_)
-                                    | EvaluationError::NonValue(_)
-                                    | EvaluationError::RecursionLimit(_) => None,
-                                }
+                let unexpected_errs = ans
+                    .diagnostics()
+                    .errors()
+                    .filter_map(|error| match error {
+                        AuthorizationError::PolicyEvaluationError(error) => {
+                            match error.inner() {
+                                // Evaluation errors the validator should prevent.
+                                EvaluationError::RecordAttrDoesNotExist(_)
+                                | EvaluationError::EntityAttrDoesNotExist(_)
+                                | EvaluationError::FailedExtensionFunctionLookup(_)
+                                | EvaluationError::TypeError(_)
+                                | EvaluationError::WrongNumArguments(_) => Some(error.to_string()),
+                                // Evaluation errors it shouldn't prevent. Not
+                                // written with a catch all so that we must
+                                // consider if a new error type should cause
+                                // this target to fail.
+                                EvaluationError::EntityDoesNotExist(_)
+                                | EvaluationError::IntegerOverflow(_)
+                                | EvaluationError::UnlinkedSlot(_)
+                                | EvaluationError::FailedExtensionFunctionExecution(_)
+                                | EvaluationError::NonValue(_)
+                                | EvaluationError::RecursionLimit(_) => None,
                             }
-                        })
-                        .collect_vec();
+                        }
+                    })
+                    .collect_vec();
 
-                    assert_eq!(
-                        unexpected_errs,
-                        Vec::<String>::new(),
-                        "validated policy produced unexpected errors {unexpected_errs:?}!\npolicies:\n{policyset}\nentities:\n{}\nschema:\n{schemafile_string}\nrequest:\n{q}\n",
-                        entities.as_ref()
-                    )
-                }
-            } else {
-                maybe_log_schemastats(Some(&schema), "vno");
-                maybe_log_hierarchystats(&input.hierarchy, "vno");
-                maybe_log_policystats(&policy, "vno");
-                assert!(
-                    !passes_strict,
-                    "policy fails permissive validation but passes strict validation!\npolicies:\n{policyset}\nentities:\n{}\nschema:\n{schemafile_string}\n",
-                    entities.as_ref()
-                );
+                assert_eq!(
+                    unexpected_errs,
+                    Vec::<String>::new(),
+                    "validated policy produced unexpected errors {unexpected_errs:?}!\npolicies:\n{policyset}\nentities:\n{}\nschema:\n{schemafile_string}\nrequest:\n{q}\n",
+                    input.entities.as_ref()
+                )
             }
+        } else {
+            assert!(
+                !passes_strict,
+                "policy fails permissive validation but passes strict validation!\npolicies:\n{policyset}\nentities:\n{}\nschema:\n{schemafile_string}\n",
+                input.entities.as_ref()
+            );
         }
     }
 });

--- a/cedar-drt/fuzz/src/abac.rs
+++ b/cedar-drt/fuzz/src/abac.rs
@@ -1,0 +1,110 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! Holds common structures used for defining the inputs to ABAC fuzz targets.
+
+use cedar_drt::tests::drop_some_entities;
+use cedar_policy::{Entities, Schema};
+use cedar_policy_generators::{
+    abac::{ABACPolicy, ABACRequest},
+    hierarchy::HierarchyGenerator,
+    schema,
+    settings::ABACSettings,
+};
+use libfuzzer_sys::arbitrary::{self, Arbitrary, Error, MaxRecursionReached, Unstructured};
+
+use crate::schemas;
+
+/// Common input used by ABAC fuzz targets:
+/// An ABAC hierarchy, policy, and 8 associated requests
+#[derive(Debug, Clone)]
+pub struct FuzzTargetInput<const TYPE_DIRECTED: bool> {
+    /// generated schema
+    pub schema: schema::Schema,
+    /// generated entity slice
+    pub entities: Entities,
+    /// generated policy
+    pub policy: ABACPolicy,
+    /// the requests to try for this hierarchy and policy. We try 8 requests per
+    /// policy/hierarchy
+    pub requests: [ABACRequest; 8],
+}
+
+impl<const TYPE_DIRECTED: bool> FuzzTargetInput<TYPE_DIRECTED> {
+    pub fn settings() -> ABACSettings {
+        ABACSettings {
+            match_types: TYPE_DIRECTED,
+            enable_extensions: true,
+            max_depth: 3,
+            max_width: 3,
+            enable_additional_attributes: false,
+            enable_like: true,
+            enable_action_groups_and_attrs: true,
+            enable_arbitrary_func_call: true,
+            enable_unknowns: false,
+            enable_action_in_constraints: true,
+            per_action_request_env_limit: ABACSettings::default_per_action_request_env_limit(),
+            total_action_request_env_limit: ABACSettings::default_total_action_request_env_limit(),
+        }
+    }
+}
+
+impl<'a, const TYPE_DIRECTED: bool> Arbitrary<'a> for FuzzTargetInput<TYPE_DIRECTED> {
+    fn arbitrary(u: &mut Unstructured<'_>) -> arbitrary::Result<Self> {
+        let schema = schema::Schema::arbitrary(Self::settings(), u)?;
+        let hierarchy = schema.arbitrary_hierarchy(u)?;
+        let policy = schema.arbitrary_policy(&hierarchy, u)?;
+
+        let requests = [
+            schema.arbitrary_request(&hierarchy, u)?,
+            schema.arbitrary_request(&hierarchy, u)?,
+            schema.arbitrary_request(&hierarchy, u)?,
+            schema.arbitrary_request(&hierarchy, u)?,
+            schema.arbitrary_request(&hierarchy, u)?,
+            schema.arbitrary_request(&hierarchy, u)?,
+            schema.arbitrary_request(&hierarchy, u)?,
+            schema.arbitrary_request(&hierarchy, u)?,
+        ];
+        let all_entities = Entities::try_from(hierarchy).map_err(|_| Error::NotEnoughData)?;
+        let cedar_schema = Schema::try_from(schema.clone()).unwrap();
+        let entities = drop_some_entities(all_entities.into(), u)?.into();
+        let entities = schemas::add_actions_to_entities(&cedar_schema, entities)?;
+        Ok(Self {
+            schema,
+            entities,
+            policy,
+            requests,
+        })
+    }
+
+    fn try_size_hint(
+        depth: usize,
+    ) -> std::result::Result<(usize, Option<usize>), MaxRecursionReached> {
+        Ok(arbitrary::size_hint::and_all(&[
+            schema::Schema::arbitrary_size_hint(depth)?,
+            HierarchyGenerator::size_hint(depth),
+            schema::Schema::arbitrary_policy_size_hint(&Self::settings(), depth),
+            schema::Schema::arbitrary_request_size_hint(depth),
+            schema::Schema::arbitrary_request_size_hint(depth),
+            schema::Schema::arbitrary_request_size_hint(depth),
+            schema::Schema::arbitrary_request_size_hint(depth),
+            schema::Schema::arbitrary_request_size_hint(depth),
+            schema::Schema::arbitrary_request_size_hint(depth),
+            schema::Schema::arbitrary_request_size_hint(depth),
+            schema::Schema::arbitrary_request_size_hint(depth),
+        ]))
+    }
+}

--- a/cedar-drt/fuzz/src/lib.rs
+++ b/cedar-drt/fuzz/src/lib.rs
@@ -18,6 +18,7 @@ mod prt;
 #[cfg(not(feature = "prt"))]
 pub use libfuzzer_sys::fuzz_target;
 
+pub mod abac;
 pub mod roundtrip_entities;
 pub mod schemas;
 pub mod symcc;


### PR DESCRIPTION
This structure and it's `Arbitrary` impl were duplicated between many fuzz targets. Pull it into module we can share.

The generalizing preservers whether or not target was type-direceted, but there are some changes in behavior:
* `enable_action_groups_and_attrs` is now `true` for all targets. The document reason for this being `false` is outdated. We've supported action groups since before the first public release. Looking at the generator code this does not actually do anything with  actions attributes. As future refactoring, we should remove this setting.
* `additional_attributes` is now `false` for all targets. This option causes the generators to produce `"additionalAttribtutes": true` in the schema, but this always results in an error when constructing the schema. There should be no reason to generate this. As a future refactoring we should remove this setting.
* changes to `max_width` and `max_depth` are both now 7. These are either 3 or 7 everywhere with no documented reason. The exact
* All targets now use `drop_some_entities` to have a small chance of leaving dangling entity references. I think this is generally a good change since it allows us to test error behavior where we didn't previously.  
* All targets now call `add_actions_to_entities` to construct an `Entities` containing the actions

I can make this more general to allow configuration of more parameters if someone thinks these changes are consequential, but I tend to think that there wasn't too much thought put into the exact settings configuration for each target, so changing them is acceptable.

Also, I deleted a bunch of logging code in `validation-pbt`. I'm pretty sure we don't use this anywhere.

I know it's a large diff, but I would appreciate some spot checks to make sure I haven't deleted anything consequential.