### PR TITLE
Free up disk space in DRT action

### DIFF
--- a/.github/workflows/build_and_test_drt_reusable.yml
+++ b/.github/workflows/build_and_test_drt_reusable.yml
@@ -21,6 +21,12 @@ jobs:
         toolchain:
           - stable
     steps:
+      - name: Free up disk space
+        run: |
+          sudo rm -rf /usr/local/lib/android/sdk
+          sudo rm -rf /usr/local/.ghcup
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/share/swift
       - name: Checkout cedar-spec
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
*Description of changes:* The `build_and_test_drt` jobs in CI are failing consistently because there's no space left on device (see [this run](https://github.com/cedar-policy/cedar-spec/actions/runs/18542983454/job/52856757468) for example). This PR adds a step to free up space by deleting some SDKs and compilers we don't use (more than 10GBs according to [this post](https://dev.to/mathio/squeezing-disk-space-from-github-actions-runners-an-engineers-guide-3pjg)).


