### PR TITLE
Ignore UnconvertibleEntityTypeShape errors in convert-schema-json-to-cedar

### DIFF
--- a/cedar-drt/fuzz/fuzz_targets/convert-schema-json-to-cedar.rs
+++ b/cedar-drt/fuzz/fuzz_targets/convert-schema-json-to-cedar.rs
@@ -61,6 +61,7 @@ fuzz_target!(|src: String| {
                 ) | cedar_policy_core::validator::cedar_schema::fmt::ToCedarSchemaSyntaxError::UnconvertibleEntityTypeShape(_),
             ) => {
                 // Currently, we ignore name-collisions errors, as JSON schemas encountering name-collisions errors are not supported for conversion to Cedar format; see cedar#1272
+                // We also ignore entity type shapes that are not supported in the Cedar schema syntax format; see cedar#1702
                 return;
             }
         }


### PR DESCRIPTION
*Issue #, if available:*
N/A 

*Description of changes:*
Ignores `UnconvertibleEntityTypeShape` errors in convert-schema-json-to-cedar to prevent fuzzing failures related to https://github.com/cedar-policy/cedar/issues/1702 until support for common type-shaped entity types is added for Cedar schema syntax.


