### PR TITLE
Improve debugging for policy set equivalence failures

### DIFF
--- a/cedar-drt/src/parsing_utils.rs
+++ b/cedar-drt/src/parsing_utils.rs
@@ -137,12 +137,12 @@ pub fn check_policy_set_equivalence(set1: &PolicySet, set2: &PolicySet) {
         .map(PreservedTemplate::from)
         .collect::<HashSet<PreservedTemplate>>();
     // Check that the sets of preserved templates are equal
-    assert_eq!(t1, t2, "{}", similar_asserts::SimpleDiff::from_str(
-        &set1.to_string(),
-        &set2.to_string(),
-        "LHS",
-        "RHS",
-    ));
+    assert_eq!(
+        t1,
+        t2,
+        "{}",
+        similar_asserts::SimpleDiff::from_str(&set1.to_string(), &set2.to_string(), "LHS", "RHS",)
+    );
 }
 
 /// Converts an ast policy set to Cedar text, removing linked policies.


### PR DESCRIPTION
Pretty-prints the two policy sets, rather than (only) printing the Debug representations which are hard to read.

