### PR TITLE
Revert Lean test implementation's validation comparison mode

### DIFF
--- a/cedar-drt/src/lean_engine.rs
+++ b/cedar-drt/src/lean_engine.rs
@@ -212,6 +212,6 @@ impl CedarTestImplementation for CedarLeanEngine {
 
     /// `ValidationComparisonMode` that should be used for this `CedarTestImplementation`
     fn validation_comparison_mode(&self) -> ValidationComparisonMode {
-        ValidationComparisonMode::AgreeOnAll
+        ValidationComparisonMode::AgreeOnValid
     }
 }

--- a/cedar-drt/src/tests.rs
+++ b/cedar-drt/src/tests.rs
@@ -155,7 +155,7 @@ pub fn run_val_test(
     compare_validation_results(
         policies,
         &schema,
-        custom_impl.validation_comparison_mode(),
+        ValidationComparisonMode::AgreeOnAll,
         rust_res,
         definitional_res,
     );
@@ -176,7 +176,7 @@ pub fn run_level_val_test(
     compare_validation_results(
         policies,
         &schema,
-        custom_impl.validation_comparison_mode(),
+        ValidationComparisonMode::AgreeOnAll,
         rust_res,
         definitional_res,
     );


### PR DESCRIPTION
But we'll override the implementation's option in cedar-drt.

*Issue #, if available:*

*Description of changes:*


