### PR TITLE
fix warnings in cedar-policy-generators

### DIFF
--- a/cedar-policy-generators/src/gen.rs
+++ b/cedar-policy-generators/src/gen.rs
@@ -59,7 +59,7 @@ macro_rules! accum {
 macro_rules! gen {
     ($u:expr, $($ws:expr => $vs:expr),+) => {
         {
-            let x = $u.int_in_range::<u8>(0..=(($crate::accum!($([$ws => $vs])+)-1)))?;
+            let x = $u.int_in_range::<u8>(0..=($crate::accum!($([$ws => $vs])+)-1))?;
             $crate::gen_inner!(x, $([$ws => $vs])+)
         }
     };
@@ -71,7 +71,7 @@ macro_rules! gen {
 macro_rules! uniform {
     ($u:expr, $($es:expr),+) => {
         {
-            let x = $u.int_in_range::<u8>(0..=(($crate::accum!($([1 => $es])+)-1)))?;
+            let x = $u.int_in_range::<u8>(0..=($crate::accum!($([1 => $es])+)-1))?;
             $crate::gen_inner!(x, $([1 => $es])+)
         }
     };

--- a/cedar-policy-generators/src/policy.rs
+++ b/cedar-policy-generators/src/policy.rs
@@ -550,6 +550,6 @@ impl GeneratedLinkedPolicy {
         }
         let template_id = cedar_policy::PolicyId::new(self.template_id);
         let policy_id = cedar_policy::PolicyId::new(self.id);
-        policyset.link(template_id, policy_id, vals.into()).unwrap();
+        policyset.link(template_id, policy_id, vals).unwrap();
     }
 }

--- a/cedar-policy-generators/src/schema.rs
+++ b/cedar-policy-generators/src/schema.rs
@@ -26,7 +26,6 @@ use crate::request::Request;
 use crate::schema_gen::SchemaGen;
 use crate::settings::ABACSettings;
 use crate::size_hint_utils::{size_hint_for_choose, size_hint_for_range, size_hint_for_ratio};
-use crate::{accum, gen, gen_inner, uniform};
 use arbitrary::{self, Arbitrary, MaxRecursionReached, Unstructured};
 use cedar_policy_core::ast::{self, Effect, EntityType, EntityUID, PolicyID, UnreservedId};
 use cedar_policy_core::est;


### PR DESCRIPTION
Fix warnings (for unused imports) and while we're here, the remaining clippy lints, for cedar-policy-generators.

Hopefully, with these changes the "Build and test DRT" CI target will be succeeding on `main` again. (It denies warnings, including the warning for unused imports which this PR fixes.)

