### PR TITLE
tiny optimization in CompiledPolicies.allowAll

### DIFF
--- a/cedar-lean/Cedar/SymCCOpt/CompiledPolicies.lean
+++ b/cedar-lean/Cedar/SymCCOpt/CompiledPolicies.lean
@@ -101,13 +101,12 @@ A `CompiledPolicies` that represents the policyset that allows all requests in
 the `εnv`.
 -/
 def CompiledPolicies.allowAll (εnv : SymEnv) : CompiledPolicies :=
-  let footprint := SymCC.footprint verifyAlwaysAllows.allowAll.toExpr εnv
   {
     term := .bool true
     εnv
     policies := [verifyAlwaysAllows.allowAll]
-    footprint
-    acyclicity := footprint.map (SymCC.acyclicity · εnv.entities)
+    footprint := Set.empty
+    acyclicity := Set.empty
   }
 
 /--

--- a/cedar-lean/Cedar/Thm/SymCC/Opt/AllowDeny.lean
+++ b/cedar-lean/Cedar/Thm/SymCC/Opt/AllowDeny.lean
@@ -15,6 +15,7 @@
 -/
 
 import Cedar.SymCC
+import Cedar.Thm.SymCC.Term.PE
 
 /-!
 Proofs about various functions applied to `allowAll` and `denyAll` policies, and empty policy sets.
@@ -50,10 +51,26 @@ theorem isAuthorized_empty (εnv : SymEnv) :
   SymCC.isAuthorized [] εnv = .ok (.bool false)
 := by
   simp [SymCC.isAuthorized, SymCC.satisfiedPolicies]
-  simp [
-    Factory.and, Factory.or, Factory.not, Factory.anyTrue, Factory.eq, Factory.eq.simplify,
-    Factory.someOf, Term.typeOf, TermPrim.typeOf
-  ]
+  simp [pe_and_false_left, Factory.anyTrue, Factory.someOf]
+
+/--
+`SymCC.compile` on `verifyAlwaysAllows.allowAll.toExpr`
+-/
+private theorem compile_allowAll (εnv : SymEnv) :
+  SymCC.compile verifyAlwaysAllows.allowAll.toExpr εnv = .ok (⊙true)
+:= by
+  simp [verifyAlwaysAllows.allowAll]
+  simp [Policy.toExpr, PrincipalScope.toExpr, ActionScope.toExpr, ResourceScope.toExpr, Scope.toExpr, Conditions.toExpr, Condition.toExpr]
+  simp [compile, compilePrim, compileAnd]
+  simp [pe_ite_true, pe_ifSome_some, pe_option_get_some, Factory.someOf, Term.typeOf, TermPrim.typeOf]
+
+/--
+`SymCC.compile` on a literal bool
+-/
+private theorem compile_bool (b : Bool) (εnv : SymEnv) :
+  SymCC.compile (.lit (.bool b)) εnv = .ok (⊙b)
+:= by
+  simp [compile, compilePrim]
 
 /--
 `SymCC.isAuthorized` on `verifyAlwaysAllows.allowAll`
@@ -61,10 +78,15 @@ theorem isAuthorized_empty (εnv : SymEnv) :
 theorem isAuthorized_allowAll (εnv : SymEnv) :
   SymCC.isAuthorized [verifyAlwaysAllows.allowAll] εnv = .ok (.bool true)
 := by
-  simp [verifyAlwaysAllows.allowAll, SymCC.isAuthorized, SymCC.satisfiedPolicies, compileWithEffect]
+  simp [SymCC.isAuthorized, SymCC.satisfiedPolicies, compileWithEffect, compile_allowAll]
+  simp [verifyAlwaysAllows.allowAll, Factory.anyTrue, Factory.someOf, pe_eq_same, pe_or_true_left, pe_not_false, pe_and_true_left]
+
+/--
+`SymCC.footprint` on `verifyAlwaysAllows.allowAll.toExpr`
+-/
+theorem footprint_allowAll (εnv : SymEnv) :
+  SymCC.footprint verifyAlwaysAllows.allowAll.toExpr εnv = Data.Set.empty
+:= by
+  simp [verifyAlwaysAllows.allowAll]
   simp [Policy.toExpr, PrincipalScope.toExpr, ActionScope.toExpr, ResourceScope.toExpr, Scope.toExpr, Conditions.toExpr, Condition.toExpr]
-  simp [compile, compilePrim, compileAnd]
-  simp [
-    Factory.and, Factory.or, Factory.not, Factory.anyTrue, Factory.eq, Factory.eq.simplify, Factory.ite, Factory.ite.simplify,
-    Factory.someOf, Factory.noneOf, Factory.ifSome, Factory.isNone, Factory.option.get, Term.typeOf, TermPrim.typeOf
-  ]
+  simp [footprint, footprint.ofBranch, footprint.ofEntity, compile_bool, Factory.someOf, TermType.isOptionEntityType, Term.typeOf, TermPrim.typeOf]

--- a/cedar-lean/Cedar/Thm/SymCC/Opt/Verifier.lean
+++ b/cedar-lean/Cedar/Thm/SymCC/Opt/Verifier.lean
@@ -239,7 +239,7 @@ theorem verifyAlwaysAllowsOpt_eqv_verifyAlwaysAllows_ok {ps wps : Policies} {cps
   apply verifyImpliesOpt_eqv_verifyImplies_ok _ hcps (wellTypedPolicies_allowAll Γ) hwps
   simp [CompiledPolicies.compile, Except.mapError, do_eq_ok, wellTypedPolicies_allowAll]
   rw [Opt.isAuthorized.correctness]
-  simp [isAuthorized_allowAll, CompiledPolicies.allowAll, cps_compile_produces_the_right_env hcps, footprints_singleton]
+  simp [isAuthorized_allowAll, footprint_allowAll, CompiledPolicies.allowAll, cps_compile_produces_the_right_env hcps, footprints_singleton, Data.Set.map_empty]
 
 /--
 This theorem covers the "happy path" -- showing that if optimized policy


### PR DESCRIPTION
Instead of actually calling `SymCC.footprint` to compute, just use `Set.empty`, which is what `SymCC.footprint` would eventually return anyway


