### PR TITLE
various cleanups for mapUnion

### DIFF
--- a/cedar-lean/Cedar/Data/List.lean
+++ b/cedar-lean/Cedar/Data/List.lean
@@ -93,16 +93,27 @@ def mapM₃ {m : Type u → Type v} [Monad m] {γ : Type u} [SizeOf α] [SizeOf 
   (xs : List (α × β)) (f : { x : α × β // sizeOf x.snd < 1 + (1 + sizeOf xs) } → m γ) : m (List γ) :=
   xs.attach₃.mapM f
 
+/--
+Generalization of `List.flatMap` from the standard library:
+works for `f` returning various collection types, not just `List`.
+
+That said, if your `f` does return `List`, you may want to use `flatMap`
+instead, as there is a large library of lemmas about it in the standard library.
+-/
 def mapUnion {α β} [Union α] [EmptyCollection α] (f : β → α) (bs : List β) : α :=
   bs.foldl (λ a b => a ∪ f b) ∅
 
 def mapUnion₁ {α β} [Union α] [EmptyCollection α]
   (xs : List β) (f : {x : β // x ∈ xs} → α) : α :=
-  xs.attach.foldl (λ a b => a ∪ f b) ∅
+  xs.attach.mapUnion f
 
 def mapUnion₂ {α β γ} [Union α] [EmptyCollection α] [SizeOf β] [SizeOf γ]
   (xs : List (β × γ)) (f : {x : β × γ // sizeOf x.snd < 1 + sizeOf xs} → α) : α :=
-  xs.attach₂.foldl (λ a b => a ∪ f b) ∅
+  xs.attach₂.mapUnion f
+
+def mapUnion₃ [Union α] [EmptyCollection α] [SizeOf β] [SizeOf γ]
+  (xs : List (β × γ)) (f : {x : β × γ // sizeOf x.snd < 1 + (1 + sizeOf xs) } → α) : α :=
+  xs.attach₃.mapUnion f
 
 def isSortedBy {α β} [LT β] [DecidableLT β] (l : List α) (f : α → β) : Bool :=
   match l with

--- a/cedar-lean/Cedar/Spec/Slice.lean
+++ b/cedar-lean/Cedar/Spec/Slice.lean
@@ -29,7 +29,7 @@ open Cedar.Data
 
 def Value.sliceEUIDs : Value → Set EntityUID
   | .prim (.entityUID uid) => Set.singleton uid
-  | .record (Map.mk avs) => avs.attach₃.mapUnion λ e => e.val.snd.sliceEUIDs
+  | .record (Map.mk avs) => avs.mapUnion₃ λ e => e.val.snd.sliceEUIDs
   | .prim _ | set _ | .ext _ => ∅
 
 def EntityData.sliceEUIDs (ed : EntityData) : Set EntityUID :=
@@ -49,5 +49,5 @@ where
     | 0 => ∅
     | level + 1 =>
       let eds := work.elts.filterMap es.find?
-      let slice := List.mapUnion id $ eds.map (λ ed => sliceAtLevel ed.sliceEUIDs level)
+      let slice := eds.mapUnion λ ed => sliceAtLevel ed.sliceEUIDs level
       work ∪ slice

--- a/cedar-lean/Cedar/SymCC/Concretizer.lean
+++ b/cedar-lean/Cedar/SymCC/Concretizer.lean
@@ -38,8 +38,8 @@ def Prim.entityUIDs : Prim → Set EntityUID
 
 def Value.entityUIDs : Value → Set EntityUID
   | .prim p              => p.entityUIDs
-  | .set (Set.mk vs)     => vs.attach.mapUnion (λ ⟨v, _⟩ => v.entityUIDs)
-  | .record (Map.mk avs) => avs.attach₃.mapUnion (λ ⟨(_, v), _⟩ => v.entityUIDs)
+  | .set (Set.mk vs)     => vs.mapUnion₁ (λ ⟨v, _⟩ => v.entityUIDs)
+  | .record (Map.mk avs) => avs.mapUnion₃ (λ ⟨(_, v), _⟩ => v.entityUIDs)
   | .ext _               => Set.empty
 
 def Value.entityUID? : Value → Option EntityUID
@@ -81,8 +81,8 @@ def Expr.entityUIDs : Expr → Set EntityUID
   | .getAttr x₁ _
   | .hasAttr x₁ _      => x₁.entityUIDs
   | .set xs
-  | .call _ xs         => xs.attach.mapUnion (λ ⟨x, _⟩ => x.entityUIDs)
-  | .record axs        => axs.attach₂.mapUnion (λ ⟨(_, x), _⟩ => x.entityUIDs)
+  | .call _ xs         => xs.mapUnion₁ (λ ⟨x, _⟩ => x.entityUIDs)
+  | .record axs        => axs.mapUnion₂ (λ ⟨(_, x), _⟩ => x.entityUIDs)
 
 end Cedar.Spec
 
@@ -143,9 +143,9 @@ def Term.entityUIDs : Term → Set EntityUID
   | .none _              => Set.empty
   | .prim p              => p.entityUIDs
   | .some t              => t.entityUIDs
-  | .set (Set.mk ts) _   => ts.attach.mapUnion (λ ⟨t, _⟩ => t.entityUIDs)
-  | .record (Map.mk ats) => ats.attach₃.mapUnion (λ ⟨(_, t), _⟩ => t.entityUIDs)
-  | .app _ ts _          => ts.attach.mapUnion (λ ⟨t, _⟩ => t.entityUIDs)
+  | .set (Set.mk ts) _   => ts.mapUnion₁ (λ ⟨t, _⟩ => t.entityUIDs)
+  | .record (Map.mk ats) => ats.mapUnion₃ (λ ⟨(_, t), _⟩ => t.entityUIDs)
+  | .app _ ts _          => ts.mapUnion₁ (λ ⟨t, _⟩ => t.entityUIDs)
 
 def Term.entityUID? : Term → Option EntityUID
   | .prim (.entity uid) => .some uid

--- a/cedar-lean/Cedar/SymCC/Enforcer.lean
+++ b/cedar-lean/Cedar/SymCC/Enforcer.lean
@@ -66,8 +66,8 @@ def footprint (x : Expr) (εnv : SymEnv) : Set Term :=
   | .hasAttr x₁ _
   | .unaryApp _ x₁     => footprint x₁ εnv
   | .call _ xs
-  | .set xs            => xs.attach.mapUnion (λ ⟨xᵢ, _⟩ => footprint xᵢ εnv)
-  | .record axs        => axs.attach₂.mapUnion (λ ⟨(_, xᵢ), _⟩ => footprint xᵢ εnv)
+  | .set xs            => xs.mapUnion₁ (λ ⟨xᵢ, _⟩ => footprint xᵢ εnv)
+  | .record axs        => axs.mapUnion₂ (λ ⟨(_, xᵢ), _⟩ => footprint xᵢ εnv)
 where
   ofEntity : Set Term :=
     match compile x εnv with
@@ -131,7 +131,7 @@ Returns the ground acyclicity and transitivity assumptions for xs and env.
 def enforce (xs : List Expr) (εnv : SymEnv) : Set Term :=
   let ts := footprints xs εnv
   let ac := ts.elts.map (acyclicity · εnv.entities)
-  let tr := ts.elts.mapUnion (λ t => ts.elts.map (transitivity t · εnv.entities))
+  let tr := ts.elts.flatMap (λ t => ts.elts.map (transitivity t · εnv.entities))
   Set.make (ac ∪ tr)
 
 namespace Cedar.SymCC

--- a/cedar-lean/Cedar/SymCCOpt/Enforcer.lean
+++ b/cedar-lean/Cedar/SymCCOpt/Enforcer.lean
@@ -25,14 +25,14 @@ open Cedar.Data Cedar.Spec Factory
 Returns the ground acyclicity and transitivity assumptions for a single `CompiledPolicy`.
 -/
 def enforceCompiledPolicy (cp : CompiledPolicy) : Set Term :=
-  let tr := cp.footprint.elts.mapUnion (λ t => cp.footprint.elts.map (transitivity t · cp.εnv.entities))
+  let tr := cp.footprint.elts.flatMap (λ t => cp.footprint.elts.map (transitivity t · cp.εnv.entities))
   Set.make (cp.acyclicity.elts ++ tr)
 
 /--
 Returns the ground acyclicity and transitivity assumptions for a single `CompiledPolicies`.
 -/
 def enforceCompiledPolicies (cps : CompiledPolicies) : Set Term :=
-  let tr := cps.footprint.elts.mapUnion (λ t => cps.footprint.elts.map (transitivity t · cps.εnv.entities))
+  let tr := cps.footprint.elts.flatMap (λ t => cps.footprint.elts.map (transitivity t · cps.εnv.entities))
   Set.make (cps.acyclicity.elts ++ tr)
 
 /--
@@ -42,7 +42,7 @@ Caller guarantees that `cp₁` and `cp₂` were compiled for the same `εnv`.
 def enforcePairCompiledPolicy (cp₁ : CompiledPolicy) (cp₂ : CompiledPolicy) : Set Term :=
   assert! cp₁.εnv = cp₂.εnv
   let footprint := cp₁.footprint ++ cp₂.footprint
-  let tr := footprint.elts.mapUnion (λ t => footprint.elts.map (transitivity t · cp₁.εnv.entities))
+  let tr := footprint.elts.flatMap (λ t => footprint.elts.map (transitivity t · cp₁.εnv.entities))
   Set.make (cp₁.acyclicity.elts ++ cp₂.acyclicity.elts ++ tr)
 
 /--
@@ -52,7 +52,7 @@ Caller guarantees that `cps₁` and `cps₂` were compiled for the same `εnv`.
 def enforcePairCompiledPolicies (cps₁ : CompiledPolicies) (cps₂ : CompiledPolicies) : Set Term :=
   assert! cps₁.εnv = cps₂.εnv
   let footprint := cps₁.footprint ++ cps₂.footprint
-  let tr := footprint.elts.mapUnion (λ t => footprint.elts.map (transitivity t · cps₁.εnv.entities))
+  let tr := footprint.elts.flatMap (λ t => footprint.elts.map (transitivity t · cps₁.εnv.entities))
   Set.make (cps₁.acyclicity.elts ++ cps₂.acyclicity.elts ++ tr)
 
 namespace Cedar.SymCC

--- a/cedar-lean/Cedar/Thm/Data/List/Lemmas.lean
+++ b/cedar-lean/Cedar/Thm/Data/List/Lemmas.lean
@@ -156,6 +156,17 @@ theorem map_attach₃_snd [SizeOf α] [SizeOf β] {xs : List (α × β)} (f : β
 := by
   simp [attach₃, map_pmap_subtype_snd]
 
+/-! ### flatMap -/
+
+/--
+As of this writing, the standard-library lemma `List.exists_of_mem_flatMap` is a
+`→`, but it's trivial to extend it to `↔` and makes some things easier, so we do
+that here
+-/
+theorem exists_iff_mem_flatMap {α β} [DecidableEq β] {f : α → List β} {xs : List α} {b : β} :
+  b ∈ List.flatMap f xs ↔ ∃ a ∈ xs, b ∈ f a
+:= by grind
+
 /-! ### Forall₂ -/
 
 /--

--- a/cedar-lean/Cedar/Thm/SymCC/Concretizer/Lit.lean
+++ b/cedar-lean/Cedar/Thm/SymCC/Concretizer/Lit.lean
@@ -162,21 +162,21 @@ theorem wf_term_implies_valid_uids {t : Term} {εs : SymEntities} :
     exact wf_term_implies_valid_uids hwf uid hin
   case set ts _ =>
     cases ts ; rename_i ts
-    simp only [List.attach_def, List.mapUnion_pmap_subtype Term.entityUIDs] at hin
-    rw [Set.mem_mapUnion_iff_mem_exists] at hin
+    simp only [List.mapUnion₁_eq_mapUnion Term.entityUIDs] at hin
+    rw [List.mem_mapUnion_iff_mem_exists] at hin
     replace ⟨t', hin', hin⟩ := hin
     replace hwf := wf_term_set_implies_wf_elt hwf hin'
     exact wf_term_implies_valid_uids hwf uid hin
   case record ats =>
     cases ats ; rename_i ats
-    simp only [List.attach₃, List.mapUnion_pmap_subtype λ x : Attr × Term => x.snd.entityUIDs] at hin
-    rw [Set.mem_mapUnion_iff_mem_exists] at hin
+    simp only [List.mapUnion₃_eq_mapUnion λ x : Attr × Term => x.snd.entityUIDs] at hin
+    rw [List.mem_mapUnion_iff_mem_exists] at hin
     replace ⟨at', hin', hin⟩ := hin
     replace hwf := wf_term_record_implies_wf_value hwf hin'
     exact wf_term_implies_valid_uids hwf uid hin
   case app ts _ =>
-    simp only [List.attach_def, List.mapUnion_pmap_subtype Term.entityUIDs] at hin
-    rw [Set.mem_mapUnion_iff_mem_exists] at hin
+    simp only [List.mapUnion₁_eq_mapUnion Term.entityUIDs] at hin
+    rw [List.mem_mapUnion_iff_mem_exists] at hin
     replace ⟨t', hin', hin⟩ := hin
     cases hwf ; rename_i hwf _
     specialize hwf t' hin'
@@ -250,12 +250,12 @@ private theorem valid_refs_implies_valid_uids {x : Expr} {εs : SymEntities} :
     · exact ih₂ hin
     · exact ih₃ hin
   case set_valid ih | call_valid ih =>
-    simp only [List.attach_def, List.mapUnion_pmap_subtype, Set.mem_mapUnion_iff_mem_exists] at hin
+    simp only [List.mapUnion₁_eq_mapUnion, List.mem_mapUnion_iff_mem_exists] at hin
     replace ⟨x', hin', hin⟩ := hin
     exact ih x' hin' hin
   case record_valid ih =>
-    simp only [List.attach₂, List.mapUnion_pmap_subtype λ x : Attr × Expr => x.snd.entityUIDs,
-      Set.mem_mapUnion_iff_mem_exists] at hin
+    simp only [List.mapUnion₂_eq_mapUnion λ x : Attr × Expr => x.snd.entityUIDs,
+      List.mem_mapUnion_iff_mem_exists] at hin
     replace ⟨ax', hin', hin⟩ := hin
     exact ih ax' hin' hin
 
@@ -288,7 +288,7 @@ private theorem wf_uf_implies_valid_uids {uf : UnaryFunction} {εs : SymEntities
     simp only [UnaryFunction.WellFormed, UDF.WellFormed] at hwf
     rcases hin with hin | hin
     · exact wf_term_implies_valid_uids hwf.left.left _ hin
-    · rw [Set.mem_mapUnion_iff_mem_exists] at hin
+    · rw [List.mem_mapUnion_iff_mem_exists] at hin
       replace ⟨(tᵢ, tₒ), hin, hin'⟩ := hin
       simp only [Set.mem_union_iff_mem_or] at hin'
       replace hwf := hwf.right.right.right tᵢ tₒ hin
@@ -310,7 +310,7 @@ private theorem wf_δ_implies_ancs_valid_uids {δ : SymEntityData} {ety : Entity
 := by
   intro hwδ uid hin
   simp only [SymEntityData.entityUIDs.ancs] at hin
-  rw [Set.mem_mapUnion_iff_mem_exists] at hin
+  rw [List.mem_mapUnion_iff_mem_exists] at hin
   replace ⟨(ancTy, ancF), hin', hin⟩ := hin
   simp only at hin
   rw [Map.in_list_iff_find?_some hwδ.right.right.right.right.left] at hin'
@@ -349,7 +349,7 @@ private theorem wf_εs_implies_valid_uids {εs : SymEntities} :
 := by
   intro hwε uid hin
   simp only [SymEntities.entityUIDs] at hin
-  rw [Set.mem_mapUnion_iff_mem_exists] at hin
+  rw [List.mem_mapUnion_iff_mem_exists] at hin
   replace ⟨(ety, δ), hin', hin⟩ := hin
   simp at hin
   replace ⟨hwm, hwε⟩ := hwε

--- a/cedar-lean/Cedar/Thm/SymCC/Concretizer/Same.lean
+++ b/cedar-lean/Cedar/Thm/SymCC/Concretizer/Same.lean
@@ -194,7 +194,7 @@ private theorem concretize?_some_InSymAncestors {uid anc : EntityUID} {δ : SymE
   SameEntityData.InSymAncestors uid δ anc
 := by
   simp only [SameEntityData.InSymAncestors]
-  simp only [Set.mem_mapUnion_iff_mem_exists, id_eq] at hin
+  simp only [List.mem_mapUnion_iff_mem_exists, id_eq] at hin
   replace ⟨s, hin⟩ := hin
   replace ha := List.mapM_some_implies_all_from_some ha
   specialize ha s hin.left
@@ -239,7 +239,7 @@ private theorem concretize?_some_InAncestors {uid : EntityUID} {δ : SymEntityDa
   subst heq
   exists anc
   replace hin : anc ∈ id s := by simp only [id_eq, hin]
-  simp only [Set.mem_mem_implies_mem_mapUnion hin hs, and_self]
+  simp only [List.mem_mem_implies_mem_mapUnion hin hs, and_self]
 
 theorem concretize?_taggedValueFor_some_implies {tuid : Term} {tag tag' : Tag} {v : Value} {τs : SymTags} :
   SymEntityData.concretize?.taggedValueFor τs tuid tag = some (tag', v) →

--- a/cedar-lean/Cedar/Thm/SymCC/Concretizer/WF.lean
+++ b/cedar-lean/Cedar/Thm/SymCC/Concretizer/WF.lean
@@ -159,24 +159,24 @@ private theorem expr_entityUIDs_valid_refs {x : Expr} {uids : Set EntityUID} {es
   case case9 ih =>          -- hasAttr
     exact Expr.ValidRefs.hasAttr_valid (ih hsub)
   case case10 ih =>         -- set
-    simp only [List.attach_def, List.mapUnion_pmap_subtype] at hsub
+    simp only [List.mapUnion₁_eq_mapUnion] at hsub
     apply Expr.ValidRefs.set_valid
     intro xᵢ hᵢ
-    have hsubᵢ := Set.mem_implies_subset_mapUnion Expr.entityUIDs hᵢ
+    have hsubᵢ := List.mem_implies_subset_mapUnion Expr.entityUIDs hᵢ
     replace hsubᵢ := Set.subset_trans hsubᵢ hsub
     exact ih xᵢ hᵢ hsubᵢ
   case case11 ih =>         -- call
-    simp only [List.attach_def, List.mapUnion_pmap_subtype] at hsub
+    simp only [List.mapUnion₁_eq_mapUnion] at hsub
     apply Expr.ValidRefs.call_valid
     intro xᵢ hᵢ
-    have hsubᵢ := Set.mem_implies_subset_mapUnion Expr.entityUIDs hᵢ
+    have hsubᵢ := List.mem_implies_subset_mapUnion Expr.entityUIDs hᵢ
     replace hsubᵢ := Set.subset_trans hsubᵢ hsub
     exact ih xᵢ hᵢ hsubᵢ
   case case12 ih =>         -- record
-    simp only [List.attach₂, List.mapUnion_pmap_subtype λ x : Attr × Expr => x.snd.entityUIDs] at hsub
+    simp only [List.mapUnion₂_eq_mapUnion λ x : Attr × Expr => x.snd.entityUIDs] at hsub
     apply Expr.ValidRefs.record_valid
     intro (aᵢ, xᵢ) hᵢ
-    have hsubᵢ := Set.mem_implies_subset_mapUnion (λ x : Attr × Expr => x.snd.entityUIDs) hᵢ
+    have hsubᵢ := List.mem_implies_subset_mapUnion (λ x : Attr × Expr => x.snd.entityUIDs) hᵢ
     replace hsubᵢ := Set.subset_trans hsubᵢ hsub
     simp only at hsubᵢ
     apply ih aᵢ xᵢ _ hsubᵢ
@@ -265,10 +265,10 @@ private theorem app_value?_some_implies_entityUIDs {f : UnaryFunction} {t : Term
   · simp only [← hv]
     rename_i t' heq
     rw [Set.union_comm]
-    apply @Set.subset_trans _ _ _ (f.table.kvs.mapUnion (λ x => x.fst.entityUIDs ∪ x.snd.entityUIDs)) _ _ (Set.subset_union _ _)
+    apply Set.subset_trans (s₂ := f.table.kvs.mapUnion (λ x => x.fst.entityUIDs ∪ x.snd.entityUIDs)) _ (Set.subset_union _ _)
     simp only [Set.subset_def]
     intro uid hin
-    rw [Set.mem_mapUnion_iff_mem_exists]
+    rw [List.mem_mapUnion_iff_mem_exists]
     exists (t, t')
     constructor
     · exact Map.find?_mem_toList heq
@@ -329,22 +329,22 @@ private theorem concretize?_δ_ancs_some_implies_entityUIDs {uid : EntityUID} {�
   (List.mapUnion id ancs).WellFormed ∧
   List.mapUnion id ancs ⊆ SymEntityData.entityUIDs.ancs δ
 := by
-  simp only [Set.mapUnion_wf, SymEntityData.entityUIDs.ancs, true_and]
-  simp only [← List.mapM_some_eq_filterMap hs, Set.mapUnion_filterMap, Set.subset_def]
+  simp only [List.mapUnion_wf, SymEntityData.entityUIDs.ancs, true_and]
+  simp only [← List.mapM_some_eq_filterMap hs, List.mapUnion_filterMap, Set.subset_def]
   intro uid' hin
-  rw [Set.mem_mapUnion_iff_mem_exists] at hin
+  rw [List.mem_mapUnion_iff_mem_exists] at hin
   replace ⟨(ety, uf), hin, hinᵤ⟩ := hin
   replace ⟨anc, _, hs⟩ := List.mapM_some_implies_all_some hs _ hin
   simp only at hs
   simp only [hs, Option.mapD_some, id_eq] at hinᵤ
-  rw [Set.mem_mapUnion_iff_mem_exists]
+  rw [List.mem_mapUnion_iff_mem_exists]
   exists (ety, uf)
   simp only [hin, true_and]
   replace hs := term_setOfEntityUIDs?_some_value? hs
   apply Set.mem_subset_mem _ (app_value?_some_implies_entityUIDs hs hwu.right)
   unfold Value.entityUIDs
-  simp only [List.attach_def, List.mapUnion_pmap_subtype]
-  rw [Set.mapUnion_eq_mapUnion_id_map, Set.mem_mapUnion_iff_mem_exists]
+  simp only [List.mapUnion₁_eq_mapUnion]
+  rw [List.mapUnion_eq_mapUnion_id_map, List.mem_mapUnion_iff_mem_exists]
   exists (Set.singleton uid')
   simp only [List.mem_map, id_eq, Set.mem_singleton, and_true]
   exists uid'
@@ -408,9 +408,9 @@ private theorem concretize?_δ_tags_some_implies_ws_entityUIDs {uid : EntityUID}
   cases hτs : δ.tags <;> simp only [hτs, Option.some.injEq] at hs
   case none =>
     subst hs
-    simp only [Map.empty, value_record_entityUIDs_def, List.mapUnion,
-      EmptyCollection.emptyCollection, Map.kvs, List.foldl_nil, Set.subset_def, Set.empty_no_elts,
-      false_implies, implies_true, and_true]
+    simp only [Map.empty, value_record_entityUIDs_def, Map.kvs, List.mapUnion_nil,
+      EmptyCollection.emptyCollection, Set.subset_def, Set.empty_no_elts, false_implies,
+      implies_true, and_true]
     apply Value.WellStructured.record_ws
     · intro a v hf
       replace hf := Map.find?_mem_toList hf
@@ -443,7 +443,7 @@ private theorem concretize?_δ_tags_some_implies_ws_entityUIDs {uid : EntityUID}
     · simp only [value_record_entityUIDs_def, Map.kvs, SymEntityData.entityUIDs.tags, hτs,
         Set.subset_def]
       intro uid' hin
-      rw [Set.mem_mapUnion_iff_mem_exists] at hin
+      rw [List.mem_mapUnion_iff_mem_exists] at hin
       replace ⟨(t, v), hin, hin'⟩ := hin
       simp only at hin'
       replace ⟨t', htvs, heq⟩ := List.mapM_some_implies_all_from_some htvs (t, v) hin
@@ -495,7 +495,7 @@ private theorem δ_entityUIDs_subset_εs_entityUIDs {ety : EntityType} {δ : Sym
   simp only [SymEntities.entityUIDs]
   have h : SymEntityData.entityUIDs ety δ = (λ x => SymEntityData.entityUIDs x.fst x.snd) (ety, δ) := by simp only
   rw [h]
-  apply Set.mem_implies_subset_mapUnion (λ x : EntityType × SymEntityData => SymEntityData.entityUIDs x.fst x.snd)
+  apply List.mem_implies_subset_mapUnion (λ x : EntityType × SymEntityData => SymEntityData.entityUIDs x.fst x.snd)
   exact Map.find?_mem_toList hf
 
 private theorem concretize?_εs_wf {uids : Set EntityUID} {es : Entities} {εs : SymEntities} :

--- a/cedar-lean/Cedar/Thm/SymCC/Concretizer/WFValue.lean
+++ b/cedar-lean/Cedar/Thm/SymCC/Concretizer/WFValue.lean
@@ -30,13 +30,13 @@ theorem value_set_entityUIDs_def {vs : Set Value} :
   (Value.set vs).entityUIDs = vs.elts.mapUnion Value.entityUIDs
 := by
   unfold Value.entityUIDs
-  simp only [List.attach_def, List.mapUnion_pmap_subtype]
+  simp only [List.mapUnion₁_eq_mapUnion]
 
 theorem value_record_entityUIDs_def {avs : Map Attr Value} :
   (Value.record avs).entityUIDs = avs.kvs.mapUnion λ (_, v) => v.entityUIDs
 := by
   rw [Value.entityUIDs]
-  simp only [List.attach₃, List.mapUnion_pmap_subtype λ av : Attr × Value => av.snd.entityUIDs]
+  simp only [List.mapUnion₃_eq_mapUnion λ av : Attr × Value => av.snd.entityUIDs]
 
 theorem value_ws_closed_implies_wf {v : Value} {es : Entities} :
   v.WellStructured →
@@ -59,7 +59,7 @@ theorem value_ws_closed_implies_wf {v : Value} {es : Entities} :
     intro uid huid
     apply hca uid
     simp only [value_set_entityUIDs_def]
-    apply Set.mem_mem_implies_mem_mapUnion huid
+    apply List.mem_mem_implies_mem_mapUnion huid
     exact (Set.in_list_iff_in_set _ _).mp hv
   case record_ws h₂ ih =>
     apply Value.WellFormed.record_wf _ h₂
@@ -67,7 +67,7 @@ theorem value_ws_closed_implies_wf {v : Value} {es : Entities} :
     apply ih a v hf
     intro uid huid
     apply hca uid
-    simp only [value_record_entityUIDs_def, Set.mem_mapUnion_iff_mem_exists]
+    simp only [value_record_entityUIDs_def, List.mem_mapUnion_iff_mem_exists]
     exists (a, v)
     simp only [huid, and_true]
     exact Map.find?_mem_toList hf
@@ -236,8 +236,8 @@ private theorem term_set_value?_some_implies_eq_entityUIDs {ts : List Term} {ty 
   replace ⟨vs, hm, hv⟩ := term_set_value?_some_implies hv
   subst hv
   unfold Value.entityUIDs
-  simp only [Term.entityUIDs, List.attach_def, List.mapUnion_pmap_subtype, Set.make]
-  apply Set.map_eqv_implies_mapUnion_eq
+  simp only [Term.entityUIDs, List.mapUnion₁_eq_mapUnion, Set.make]
+  apply List.map_eqv_implies_mapUnion_eq
   simp only [List.Equiv, List.subset_def, List.mem_map, forall_exists_index, and_imp,
     forall_apply_eq_imp_iff₂]
   constructor
@@ -265,11 +265,11 @@ private theorem term_record_value?_some_implies_eq_entityUIDs {ats : List (Attr 
   replace ⟨avs, hm, hv⟩ := term_record_value?_some_implies hv
   subst hv
   simp only [Term.entityUIDs, Value.entityUIDs,
-    ← List.mapM_some_eq_filterMap hm, List.attach₃,
-    List.mapUnion_pmap_subtype (λ x : Attr × Term => x.snd.entityUIDs),
-    List.mapUnion_pmap_subtype (λ x : Attr × Value => x.snd.entityUIDs),
-    List.filterMap_filterMap, Set.mapUnion_filterMap]
-  apply Set.mapUnion_congr
+    ← List.mapM_some_eq_filterMap hm,
+    List.mapUnion₃_eq_mapUnion (λ x : Attr × Term => x.snd.entityUIDs),
+    List.mapUnion₃_eq_mapUnion (λ x : Attr × Value => x.snd.entityUIDs),
+    List.filterMap_filterMap, List.mapUnion_filterMap]
+  apply List.mapUnion_congr
   intro (aᵢ, tᵢ) hin
   replace ⟨(a', vopt), hm, hv⟩ := List.mapM_some_implies_all_some hm (aᵢ, tᵢ) hin
   simp only at hv

--- a/cedar-lean/Cedar/Thm/SymCC/Enforcer/Compile.lean
+++ b/cedar-lean/Cedar/Thm/SymCC/Enforcer/Compile.lean
@@ -820,7 +820,7 @@ private theorem compile_interpret_on_footprint_ihs {xs : List Expr} {ts : List T
   (hI₁ : I₁.WellFormed εnv.entities)
   (hI₂ : I₂.WellFormed εnv.entities)
   (hsm : εnv.SameOn ft I₁ I₂)
-  (hft : List.mapUnion (fun x => footprint x εnv) xs ⊆ ft)
+  (hft : xs.mapUnion (footprint · εnv) ⊆ ft)
   (hok : ∀ t ∈ ts, ∃ x ∈ xs, compile x εnv = .ok t)
   (ih  : ∀ x ∈ xs, CompileInterpretOnFootprint x ft εnv I₁ I₂) :
   ∀ t ∈ ts, t.interpret I₁ = t.interpret I₂
@@ -828,7 +828,7 @@ private theorem compile_interpret_on_footprint_ihs {xs : List Expr} {ts : List T
   intro t ht
   replace ⟨x, hx, hok⟩ := hok t ht
   apply ih x hx (hwε x hx) hI₁ hI₂ hsm _ hok
-  exact Set.subset_trans (Set.mem_implies_subset_mapUnion (footprint · εnv) hx) hft
+  exact Set.subset_trans (List.mem_implies_subset_mapUnion (footprint · εnv) hx) hft
 
 private theorem compile_interpret_set_on_footprint {xs : List Expr} {ft : Set Term} {εnv : SymEnv} {I₁ I₂ : Interpretation} {t : Term}
   (hwε : εnv.WellFormedFor (.set xs))
@@ -841,7 +841,7 @@ private theorem compile_interpret_set_on_footprint {xs : List Expr} {ft : Set Te
   t.interpret I₁ = t.interpret I₂
 := by
   replace hwε := wf_εnv_for_set_implies hwε
-  simp only [footprint, List.attach_def, List.mapUnion_pmap_subtype (footprint · εnv) ] at hft
+  simp only [footprint, List.mapUnion₁_eq_mapUnion (footprint · εnv)] at hft
   replace ⟨ts, ha, hok⟩ := compile_set_ok_implies hok
   replace ⟨ty, hd, tl, heq, hty, hok⟩ := compileSet_ok_implies hok
   subst hok
@@ -896,10 +896,10 @@ private theorem compile_interpret_record_on_footprint {axs : List (Attr × Expr)
     CompileInterpretOnFootprint x₁ ft εnv I₁ I₂) :
   t.interpret I₁ = t.interpret I₂
 := by
-  simp only [footprint, List.attach₂, List.mapUnion_pmap_subtype (λ x : Attr × Expr => footprint x.snd εnv)] at hft
+  simp only [footprint, List.mapUnion₂_eq_mapUnion (λ x : Attr × Expr => footprint x.snd εnv)] at hft
   replace hft : ∀ ax ∈ axs, footprint ax.snd εnv ⊆ ft := by
     intro x hx
-    have h := Set.mem_implies_subset_mapUnion (fun x : Attr × Expr => footprint x.snd εnv) hx
+    have h := List.mem_implies_subset_mapUnion (fun x : Attr × Expr => footprint x.snd εnv) hx
     simp only at h
     exact Set.subset_trans h hft
   replace hwε := wf_εnv_for_record_implies hwε
@@ -937,7 +937,7 @@ private theorem compile_interpret_call_on_footprint {xfn : ExtFun} {xs : List Ex
   (ih  : ∀ x ∈ xs, CompileInterpretOnFootprint x ft εnv I₁ I₂) :
   t.interpret I₁ = t.interpret I₂
 := by
-  simp only [footprint, List.attach_def, List.mapUnion_pmap_subtype (footprint · εnv) ] at hft
+  simp only [footprint, List.mapUnion₁_eq_mapUnion (footprint · εnv)] at hft
   replace hwε := wf_εnv_for_call_implies hwε
   replace ⟨ts, ha, hok⟩ := compile_call_ok_implies hok
   have hwts := compile_wfs hwε ha

--- a/cedar-lean/Cedar/Thm/SymCC/Enforcer/Enforce.lean
+++ b/cedar-lean/Cedar/Thm/SymCC/Enforcer/Enforce.lean
@@ -36,7 +36,7 @@ private def acyclic (ft : Set Term) (εs : SymEntities) : List Term :=
   ft.elts.map (acyclicity · εs)
 
 private def transitive (ft : Set Term) (εs : SymEntities) : List Term :=
-  ft.elts.mapUnion (λ t => ft.elts.map (transitivity t · εs))
+  ft.elts.flatMap (λ t => ft.elts.map (transitivity t · εs))
 
 private theorem enforce_def {xs : List Expr} {εnv : SymEnv} :
   enforce xs εnv =
@@ -72,7 +72,7 @@ private theorem swf_implies_transitive {xs : List Expr} {env : Env} {εnv : SymE
   (hin : t ∈ transitive (footprints xs εnv) εnv.entities) :
   Term.interpret I t = Term.prim (TermPrim.bool true)
 := by
-  simp only [transitive, List.mem_mapUnion_iff_mem_exists] at hin
+  simp only [transitive, List.exists_iff_mem_flatMap] at hin
   replace ⟨t₁, hin₁, hin⟩ := hin
   simp only [List.mem_map] at hin
   replace ⟨t₂, hin₂, hin⟩ := hin
@@ -131,7 +131,7 @@ private theorem mem_terms_mem_entityUIDs {uid : EntityUID} {ts : Set Term} :
 := by
   intro hin
   unfold Term.entityUIDs
-  simp only [List.attach_def, List.mapUnion_pmap_subtype, Set.mem_mapUnion_iff_mem_exists]
+  simp only [List.mapUnion₁_eq_mapUnion, List.mem_mapUnion_iff_mem_exists]
   exists Term.entity uid
   simp only [Set.in_list_iff_in_set, hin, Term.entityUIDs, TermPrim.entityUIDs,
     Set.mem_singleton_iff_eq, and_self]
@@ -143,7 +143,7 @@ private theorem mem_entityUIDs_mem_terms {uid : EntityUID} {ts : Set Term} {ety 
 := by
   intro ⟨hwf, hlit⟩ hin
   unfold Term.entityUIDs at hin
-  simp only [List.attach_def, List.mapUnion_pmap_subtype, Set.mem_mapUnion_iff_mem_exists] at hin
+  simp only [List.mapUnion₁_eq_mapUnion, List.mem_mapUnion_iff_mem_exists] at hin
   replace ⟨t, hinₜ, hin⟩ := hin
   have hwt := wf_term_set_implies_wf_elt hwf hinₜ
   have hty := wf_term_set_implies_typeOf_elt hwf hinₜ
@@ -327,7 +327,7 @@ private theorem transitive_implies_Transitive_uuf_uuf
     have ⟨t₁, hin₁, ht₁⟩ := mem_footprintUIDs_mem_footprints hwε hsε.right hI hft₁
     have ⟨t₂, hin₂, ht₂⟩ := mem_footprintUIDs_mem_footprints hwε hsε.right hI hft₂
     specialize hok (transitivity t₁ t₂ εnv.entities)
-    simp only [transitive, List.mem_mapUnion_iff_mem_exists, List.mem_map, forall_exists_index, and_imp] at hok
+    simp only [transitive, List.exists_iff_mem_flatMap, List.mem_map, forall_exists_index, and_imp] at hok
     specialize hok t₁ hin₁ t₂ hin₂ rfl
     simp only [mem_footprintUIDs_implies_eq_ancs hwε hI hδ₁ hf₁ hft₁] at heq₁
     simp only [mem_footprintUIDs_implies_eq_ancs hwε hI hδ₂ hf₂ hft₂] at heq₂
@@ -366,11 +366,11 @@ private theorem transitive_implies_Transitive_udf_udf
   uid₃ ∈ d₁.ancestors
 := by
   have htr := hsε.right.right.right.left uid₁ δ₁ uid₂ δ₂ hδ₁ hδ₂
-  simp only [SymEntityData.knownAncestors, Set.mem_mapUnion_iff_mem_exists, forall_exists_index, and_imp] at htr
+  simp only [SymEntityData.knownAncestors, List.mem_mapUnion_iff_mem_exists, forall_exists_index, and_imp] at htr
   specialize htr (uid₂.ty, .udf f₁₂) (Map.find?_mem_toList hf₁)
   simp only [SymEntityData.knownAncestors.ancs, heq₁, mem_terms_mem_entityUIDs hu₂₁, Set.subset_def, true_implies] at htr
   specialize htr uid₃
-  simp only [Set.mem_mapUnion_iff_mem_exists, forall_exists_index, and_imp] at htr
+  simp only [List.mem_mapUnion_iff_mem_exists, forall_exists_index, and_imp] at htr
   specialize htr (uid₃.ty, .udf f₂₃) (Map.find?_mem_toList hf₂)
   simp only [SymEntityData.knownAncestors.ancs, heq₂, mem_terms_mem_entityUIDs hu₃₂, true_implies] at htr
   replace ⟨(ety₃, f₁₃), hin₁₃, htr⟩ := htr

--- a/cedar-lean/Cedar/Thm/SymCC/Enforcer/Extractor.lean
+++ b/cedar-lean/Cedar/Thm/SymCC/Enforcer/Extractor.lean
@@ -34,7 +34,7 @@ open Data Spec SymCC Factory
 private theorem footprintUIDs_wf {xs : List Expr} {εnv : SymEnv} {I : Interpretation} :
   (Interpretation.repair.footprintUIDs (footprints xs εnv) I).WellFormed
 := by
-  simp only [Interpretation.repair.footprintUIDs, Set.mapUnion_wf]
+  simp only [Interpretation.repair.footprintUIDs, List.mapUnion_wf]
 
 private theorem footprintUIDs_valid {xs : List Expr} {εnv : SymEnv} {I : Interpretation}
   (hwε : εnv.WellFormed)
@@ -44,7 +44,7 @@ private theorem footprintUIDs_valid {xs : List Expr} {εnv : SymEnv} {I : Interp
 := by
   simp only [Interpretation.repair.footprintUIDs]
   intro uid hin
-  simp only [Set.mem_mapUnion_iff_mem_exists, Function.comp_apply] at hin
+  simp only [List.mem_mapUnion_iff_mem_exists, Function.comp_apply] at hin
   replace ⟨t, hinₓ, hin⟩ := hin
   rw [Set.in_list_iff_in_set, mem_footprints_iff] at hinₓ
   replace ⟨x, hinₓ, hinₜ⟩ := hinₓ
@@ -238,13 +238,13 @@ private theorem footprintAncestors_eq {xs : List Expr} {ety ancTy : EntityType} 
   apply Map.mem_toList_find?
   · simp only [Map.wf_iff_sorted, Map.toList, Map.kvs]
     rw [@List.map_eq_implies_sortedBy _ _ _ _ _ _ id _ εnv.entities.uufAncestors.elts]
-    · simp only [SymEntities.uufAncestors, ← Set.wf_iff_sorted, Set.mapUnion_wf]
+    · simp only [SymEntities.uufAncestors, ← Set.wf_iff_sorted, List.mapUnion_wf]
     · simp only [List.map_map]
       apply List.map_congr
       simp only [Function.comp_apply, id_eq, implies_true]
   · simp only [Map.toList, Map.kvs, List.mem_map, Prod.mk.injEq]
     exists f
-    simp only [SymEntities.uufAncestors, Set.in_list_iff_in_set, Set.mem_mapUnion_iff_mem_exists,
+    simp only [SymEntities.uufAncestors, Set.in_list_iff_in_set, List.mem_mapUnion_iff_mem_exists,
       Function.comp_apply, and_self, and_true]
     exists (ety, δ)
     replace hδ := Map.find?_mem_toList hδ
@@ -327,7 +327,7 @@ theorem mem_footprintUIDs_mem_footprints {uid : EntityUID} {xs : List Expr} {εn
   (hin : uid ∈ Interpretation.repair.footprintUIDs (footprints xs εnv) I) :
   ∃ t ∈ footprints xs εnv, t.interpret I = Term.some (Term.entity uid)
 := by
-  simp only [Interpretation.repair.footprintUIDs, Set.mem_mapUnion_iff_mem_exists,
+  simp only [Interpretation.repair.footprintUIDs, List.mem_mapUnion_iff_mem_exists,
     Set.in_list_iff_in_set, Function.comp_apply] at hin
   replace ⟨t, hinₜ, hin⟩ := hin
   have hinₜ' := hinₜ
@@ -348,7 +348,7 @@ theorem mem_mem_footprints_footprintUIDs {t : Term} {uid : EntityUID} {xs : List
   (ht  : t.interpret I = Term.some (Term.entity uid)) :
   uid ∈ Interpretation.repair.footprintUIDs (footprints xs εnv) I
 := by
-  simp only [Interpretation.repair.footprintUIDs, Set.mem_mapUnion_iff_mem_exists, Function.comp_apply]
+  simp only [Interpretation.repair.footprintUIDs, List.mem_mapUnion_iff_mem_exists, Function.comp_apply]
   exists t
   simp only [Set.in_list_iff_in_set, hin, ht, Term.entityUIDs, TermPrim.entityUIDs,
     Set.mem_singleton, and_self]
@@ -395,7 +395,7 @@ private theorem type_of_ancestor_uuf_eq {εnv : SymEnv} {f : UUF}
   (hf : f ∈ εnv.entities.uufAncestors) :
   ∃ ety aty, f.arg = .entity ety ∧ f.out = .set (.entity aty)
 := by
-  simp only [SymEntities.uufAncestors, Set.mem_mapUnion_iff_mem_exists,
+  simp only [SymEntities.uufAncestors, List.mem_mapUnion_iff_mem_exists,
     Function.comp_apply] at hf
   replace ⟨(ety, δ), hδ, hf⟩ := hf
   simp only [SymEntityData.uufAncestors, ← Set.make_mem, List.mem_filterMap, Function.comp_apply] at hf
@@ -484,7 +484,7 @@ theorem sym_entities_entityUIDs_include_enums
   uid ∈ (SymEnv.interpret I εnv).entities.entityUIDs
 := by
   simp only [SymEntities.entityUIDs]
-  apply (Set.mem_mapUnion_iff_mem_exists uid).mpr
+  apply (List.mem_mapUnion_iff_mem_exists uid).mpr
   exists (uid.ty, SymEntityData.interpret I δ)
   constructor
   · simp only [SymEnv.interpret, SymEntities.interpret]

--- a/cedar-lean/Cedar/Thm/SymCC/Enforcer/Footprint.lean
+++ b/cedar-lean/Cedar/Thm/SymCC/Enforcer/Footprint.lean
@@ -50,12 +50,14 @@ def footprint_wf (x : Expr) (εnv : SymEnv) :
   (footprint x εnv).WellFormed
 := by
   cases x
-  all_goals simp [footprint, footprint_ofEntity_wf, footprint_ofBranch_wf, footprint_wf, Set.empty_wf, Set.mapUnion_wf, Set.union_wf]
+  all_goals simp [footprint, footprint_ofEntity_wf, footprint_ofBranch_wf, footprint_wf,
+    List.mapUnion₁_eq_mapUnion (footprint · εnv), List.mapUnion₂_eq_mapUnion (λ x => footprint x.snd εnv),
+    Set.empty_wf, List.mapUnion_wf, Set.union_wf]
 
 def footprints_wf (xs : List Expr) (εnv : SymEnv) :
   (footprints xs εnv).WellFormed
 := by
-  simp [footprints, Data.Set.mapUnion_wf]
+  simp [footprints, List.mapUnion_wf]
 
 def SymEntities.SameOn (εs : SymEntities) (ft : Set Term) (I₁ I₂ : Interpretation) : Prop :=
   ∀ ety δ,
@@ -83,7 +85,7 @@ open Data Spec SymCC Factory
 theorem mem_footprints_iff {xs : List Expr} {εnv : SymEnv} {t : Term} :
   t ∈ footprints xs εnv ↔ ∃ x ∈ xs, t ∈ footprint x εnv
 := by
-  simp only [footprints, Set.mem_mapUnion_iff_mem_exists]
+  simp only [footprints, List.mem_mapUnion_iff_mem_exists]
 
 private theorem mem_footprint_ofBranch_mem {x : Expr} {t : Term} {εnv : SymEnv} {ft₁ ft₂ ft₃ : Set Term}
   (hin : t ∈ footprint.ofBranch εnv x ft₁ ft₂ ft₃) :
@@ -161,13 +163,12 @@ theorem mem_footprint_option_entity {x : Expr} {εnv : SymEnv} {t : Term} :
   case case8 ih | case9 ih =>
     exact ih hin
   case case10 _ _ ih | case11 _ ih =>
-    simp only [List.attach_def, List.mapUnion_pmap_subtype (footprint · εnv),
-      Set.mem_mapUnion_iff_mem_exists] at hin
+    simp only [List.mapUnion₁_eq_mapUnion (footprint · εnv), List.mem_mapUnion_iff_mem_exists] at hin
     replace ⟨xᵢ, hinᵢ, hin⟩ := hin
     exact ih xᵢ hinᵢ hin
   case case12 _ ih =>
-    simp only [List.attach₂, List.mapUnion_pmap_subtype λ y : Attr × Expr => footprint y.snd εnv,
-      Set.mem_mapUnion_iff_mem_exists] at hin
+    simp only [List.mapUnion₂_eq_mapUnion λ y : Attr × Expr => footprint y.snd εnv,
+      List.mem_mapUnion_iff_mem_exists] at hin
     replace ⟨(aᵢ, xᵢ), hinᵢ, hin⟩ := hin
     simp only at hin ih
     exact ih aᵢ xᵢ (List.sizeOf_attach₂ hinᵢ) hin
@@ -235,15 +236,15 @@ private theorem mem_footprint_exists_wf_prop {p : Expr → Prop} {x : Expr} {t�
     replace hwε := wf_εnv_for_set_implies hwε
     replace hwe := hset hp
   case case10 _ _ ih | case11 _ ih =>
-    simp only [List.attach_def, List.mapUnion_pmap_subtype (footprint · εnv),
-      Set.mem_mapUnion_iff_mem_exists] at hin
+    simp only [List.mapUnion₁_eq_mapUnion (footprint · εnv),
+      List.mem_mapUnion_iff_mem_exists] at hin
     replace ⟨xᵢ, hinᵢ, hin⟩ := hin
     exact ih xᵢ hinᵢ (hwε xᵢ hinᵢ) (hwe xᵢ hinᵢ) hin
   case case12 _ ih =>
     replace hwε := wf_εnv_for_record_implies hwε
     replace hwe := hrec hp
-    simp only [List.attach₂, List.mapUnion_pmap_subtype λ y : Attr × Expr => footprint y.snd εnv,
-      Set.mem_mapUnion_iff_mem_exists] at hin
+    simp only [List.mapUnion₂_eq_mapUnion λ y : Attr × Expr => footprint y.snd εnv,
+      List.mem_mapUnion_iff_mem_exists] at hin
     replace ⟨(aᵢ, xᵢ), hinᵢ, hin⟩ := hin
     simp only at hin ih
     exact ih aᵢ xᵢ (List.sizeOf_attach₂ hinᵢ) (hwε _ hinᵢ) (hwe _ hinᵢ) hin
@@ -306,19 +307,18 @@ theorem mem_footprints_wf {xs : List Expr} {t : Term} {εnv : SymEnv}
 theorem footprints_empty {εnv : SymEnv} :
   footprints [] εnv = ∅
 := by
-  simp [footprints, Set.mapUnion_empty]
+  simp [footprints, List.mapUnion_nil]
 
 theorem footprints_singleton {x : Expr} {εnv : SymEnv} :
   footprints [x] εnv = footprint x εnv
 := by
-  simp [SymCC.footprints, List.mapUnion, EmptyCollection.emptyCollection]
-  rw [Data.Set.union_empty_left (footprint_wf x εnv)]
+  simp [SymCC.footprints, List.mapUnion_singleton (f := (footprint · εnv)) (by simp [footprint_wf])]
 
 theorem footprints_append {xs₁ xs₂ : List Expr} {εnv : SymEnv} :
   footprints (xs₁ ++ xs₂) εnv = footprints xs₁ εnv ++ footprints xs₂ εnv
 := by
   simp [footprints]
-  apply Data.Set.mapUnion_append
+  apply List.mapUnion_append
   intro x _ ; apply footprint_wf
 
 theorem footprint_subset_footprints {x : Expr} {xs : List Expr} {εnv : SymEnv} :

--- a/cedar-lean/Cedar/Thm/SymCC/Env/ofEnv.lean
+++ b/cedar-lean/Cedar/Thm/SymCC/Env/ofEnv.lean
@@ -1529,7 +1529,7 @@ theorem in_ancsUDF_implies_in_ancestors
       Factory.setOf,
     ] at hmem
     unfold Term.entityUIDs at hmem
-    have ⟨s, hmem_s, hmem_uid'⟩ := (Set.mem_mapUnion_iff_mem_exists _).mp hmem
+    have ⟨s, hmem_s, hmem_uid'⟩ := (List.mem_mapUnion_iff_mem_exists _).mp hmem
     replace ⟨s, hmem_s⟩ := s
     have := (Set.make_mem _ _).mpr hmem_s
     have ⟨anc', hmem_anc', hanc'⟩ := List.mem_filterMap.mp this
@@ -1559,7 +1559,7 @@ theorem in_ancestors_implies_in_ancsUDF
     Factory.setOf,
   ]
   unfold Term.entityUIDs
-  apply (Set.mem_mapUnion_iff_mem_exists _).mpr
+  apply (List.mem_mapUnion_iff_mem_exists _).mpr
   simp only [List.mem_attach, true_and, Subtype.exists, exists_prop]
   exists .prim (.entity uid')
   constructor
@@ -1650,7 +1650,7 @@ theorem ofEnv_entities_is_transitive
   -- Case: `uid₁`: standard; `uid₂`: standard
   -- Case: `uid₁`: action; `uid₂`: standard
   any_goals
-    have ⟨⟨ety, f_anc⟩, hmem_ety_f_anc, hmem_uid₁⟩ := (Set.mem_mapUnion_iff_mem_exists _).mp huid_anc₂
+    have ⟨⟨ety, f_anc⟩, hmem_ety_f_anc, hmem_uid₁⟩ := (List.mem_mapUnion_iff_mem_exists _).mp huid_anc₂
     simp only [SymEntityData.ofStandardEntityType ] at hmem_ety_f_anc
     have := Map.make_mem_list_mem hmem_ety_f_anc
     replace ⟨ancTy, hmem_ancTy, heq_ancTy⟩ := List.mem_map.mp this
@@ -1663,7 +1663,7 @@ theorem ofEnv_entities_is_transitive
     ] at hmem_uid₁
     contradiction
   -- Case: `uid₁`: standard; `uid₂`: action
-  · have ⟨⟨ety, f_anc⟩, hmem_ety_f_anc, hmem_uid₂⟩ := (Set.mem_mapUnion_iff_mem_exists _).mp hanc
+  · have ⟨⟨ety, f_anc⟩, hmem_ety_f_anc, hmem_uid₂⟩ := (List.mem_mapUnion_iff_mem_exists _).mp hanc
     simp only [SymEntityData.ofStandardEntityType ] at hmem_ety_f_anc
     have := Map.make_mem_list_mem hmem_ety_f_anc
     replace ⟨ancTy, hmem_ancTy, heq_ancTy⟩ := List.mem_map.mp this
@@ -1676,8 +1676,8 @@ theorem ofEnv_entities_is_transitive
     ] at hmem_uid₂
     contradiction
   -- Case: `uid₁`: action; `uid₂`: action
-  · have ⟨⟨ety₁, f_anc₁⟩, hmem_ety_f_anc₁, hmem_uid₁⟩ := (Set.mem_mapUnion_iff_mem_exists _).mp hanc
-    have ⟨⟨ety₂, f_anc₂⟩, hmem_ety_f_anc₂, hmem_uid₂⟩ := (Set.mem_mapUnion_iff_mem_exists _).mp huid_anc₂
+  · have ⟨⟨ety₁, f_anc₁⟩, hmem_ety_f_anc₁, hmem_uid₁⟩ := (List.mem_mapUnion_iff_mem_exists _).mp hanc
+    have ⟨⟨ety₂, f_anc₂⟩, hmem_ety_f_anc₂, hmem_uid₂⟩ := (List.mem_mapUnion_iff_mem_exists _).mp huid_anc₂
     have := Map.make_mem_list_mem hmem_ety_f_anc₁
     replace ⟨ancTy₁, hmem_ancTy₁, heq_ancTy₁⟩ := List.mem_map.mp this
     simp only [Prod.mk.injEq] at heq_ancTy₁
@@ -1727,7 +1727,7 @@ theorem ofEnv_entities_is_transitive
       hδ₁, heq_ety₁,
       SymEntityData.ofActionType,
     ]
-    apply (Set.mem_mapUnion_iff_mem_exists _).mpr
+    apply (List.mem_mapUnion_iff_mem_exists _).mpr
     exists (uid.ty, SymEntityData.ofActionType.ancsUDF uid₁.ty Γ.acts uid.ty)
     constructor
     · apply (Map.in_list_iff_find?_some (Map.make_wf _)).mpr

--- a/cedar-lean/Cedar/Thm/SymCC/Opt/Authorizer.lean
+++ b/cedar-lean/Cedar/Thm/SymCC/Opt/Authorizer.lean
@@ -124,9 +124,9 @@ theorem Opt.satisfiedPolicies.correctness (effect : Effect) (ps : Policies) (εn
   case ok ress hress =>
     specialize this ress
     simp_all [Except.map, ← this.left, footprints]
-    conv => lhs ; rw [Data.Set.mapUnion_eq_mapUnion_id_map]
-    simp [this, Data.Set.mapUnion_filterMap]
-    apply Data.Set.mapUnion_congr
+    conv => lhs ; rw [List.mapUnion_eq_mapUnion_id_map]
+    simp [this, List.mapUnion_filterMap]
+    apply List.mapUnion_congr
     intro p hp
     simp only [Option.mapD, id_eq]
     grind
@@ -156,8 +156,8 @@ theorem Opt.isAuthorized.correctness (ps : Policies) (εnv : SymEnv) :
   simp_do_let SymCC.satisfiedPolicies .permit ps εnv ; rename_i pt hpermit
   simp only [Except.ok.injEq, Opt.CompileResult.mk.injEq, true_and]
   simp [footprints]
-  rw [Data.Set.mapUnion_union_mapUnion]
-  · apply Data.Set.map_eqv_implies_mapUnion_eq
+  rw [List.mapUnion_union_mapUnion]
+  · apply List.map_eqv_implies_mapUnion_eq
     simp [List.Equiv, List.subset_def]
     constructor
     intro ts h₁

--- a/cedar-lean/Cedar/Thm/SymCC/Opt/CompiledPolicies.lean
+++ b/cedar-lean/Cedar/Thm/SymCC/Opt/CompiledPolicies.lean
@@ -57,11 +57,11 @@ theorem intoCompiledPolicies_correctness {p : Policy} {Γ : Validation.TypeEnv} 
   simp [Opt.isAuthorized, Opt.satisfiedPolicies, Opt.compileWithEffect]
   cases p'.effect <;> simp [Factory.anyTrue, Factory.or, Factory.not, Factory.and]
   all_goals {
-    cases h : Opt.compile p'.toExpr (SymEnv.ofEnv Γ) <;> simp [Data.Set.mapUnion_empty]
+    cases h : Opt.compile p'.toExpr (SymEnv.ofEnv Γ) <;> simp [List.mapUnion_nil]
     have hwf := Opt.compile_footprint_wf h
-    simp [EmptyCollection.emptyCollection, Data.Set.union_empty_right Data.Set.mapUnion_wf, Data.Set.union_empty_left Data.Set.mapUnion_wf]
-    rw [Data.Set.mapUnion_cons (by simp [hwf])]
-    simp [Data.Set.mapUnion_empty, EmptyCollection.emptyCollection, Data.Set.union_empty_right hwf]
+    simp [EmptyCollection.emptyCollection, Data.Set.union_empty_right List.mapUnion_wf, Data.Set.union_empty_left List.mapUnion_wf]
+    rw [List.mapUnion_cons (by simp [hwf])]
+    simp [List.mapUnion_nil, EmptyCollection.emptyCollection, Data.Set.union_empty_right hwf]
   }
 
 /--

--- a/cedar-lean/Cedar/Thm/SymCC/Opt/Compiler.lean
+++ b/cedar-lean/Cedar/Thm/SymCC/Opt/Compiler.lean
@@ -229,56 +229,56 @@ private theorem Opt.compileCall.correctness (xfn : ExtFun) (ress : List Opt.Comp
   all_goals first
   | simp only [Opt.compileCall₀.correctness] | simp only [Opt.compileCall₁.correctness] | simp only [Opt.compileCall₂.correctness] | simp only [Opt.compileCallWithError₁.correctness] | simp only [Opt.compileCallWithError₂.correctness] | symm
   · rename_i res ; simp_do_let SymCC.compileCall₀ Ext.Decimal.decimal res.term
-    rw [Data.Set.mapUnion_singleton (by apply hwf res (by simp))]
+    rw [List.mapUnion_singleton (by apply hwf res (by simp))]
   · rename_i res₁ res₂ ; simp_do_let SymCC.compileCall₂ _ Decimal.lessThan res₁.term res₂.term
-    rw [Data.Set.mapUnion_cons hwf]
-    rw [Data.Set.mapUnion_singleton (by apply hwf res₂ (by simp))]
+    rw [List.mapUnion_cons hwf]
+    rw [List.mapUnion_singleton (by apply hwf res₂ (by simp))]
   · rename_i res₁ res₂ ; simp_do_let SymCC.compileCall₂ _ Decimal.lessThanOrEqual res₁.term res₂.term
-    rw [Data.Set.mapUnion_cons hwf]
-    rw [Data.Set.mapUnion_singleton (by apply hwf res₂ (by simp))]
+    rw [List.mapUnion_cons hwf]
+    rw [List.mapUnion_singleton (by apply hwf res₂ (by simp))]
   · rename_i res₁ res₂ ; simp_do_let SymCC.compileCall₂ _ Decimal.greaterThan res₁.term res₂.term
-    rw [Data.Set.mapUnion_cons hwf]
-    rw [Data.Set.mapUnion_singleton (by apply hwf res₂ (by simp))]
+    rw [List.mapUnion_cons hwf]
+    rw [List.mapUnion_singleton (by apply hwf res₂ (by simp))]
   · rename_i res₁ res₂ ; simp_do_let SymCC.compileCall₂ _ Decimal.greaterThanOrEqual res₁.term res₂.term
-    rw [Data.Set.mapUnion_cons hwf]
-    rw [Data.Set.mapUnion_singleton (by apply hwf res₂ (by simp))]
+    rw [List.mapUnion_cons hwf]
+    rw [List.mapUnion_singleton (by apply hwf res₂ (by simp))]
   · rename_i res ; simp_do_let SymCC.compileCall₀ Ext.IPAddr.ip res.term
-    rw [Data.Set.mapUnion_singleton (by apply hwf res (by simp))]
+    rw [List.mapUnion_singleton (by apply hwf res (by simp))]
   · rename_i res ; simp_do_let SymCC.compileCall₁ _ IPAddr.isIpv4 res.term
-    rw [Data.Set.mapUnion_singleton (by apply hwf res (by simp))]
+    rw [List.mapUnion_singleton (by apply hwf res (by simp))]
   · rename_i res ; simp_do_let SymCC.compileCall₁ _ IPAddr.isIpv6 res.term
-    rw [Data.Set.mapUnion_singleton (by apply hwf res (by simp))]
+    rw [List.mapUnion_singleton (by apply hwf res (by simp))]
   · rename_i res ; simp_do_let SymCC.compileCall₁ _ IPAddr.isLoopback res.term
-    rw [Data.Set.mapUnion_singleton (by apply hwf res (by simp))]
+    rw [List.mapUnion_singleton (by apply hwf res (by simp))]
   · rename_i res ; simp_do_let SymCC.compileCall₁ _ IPAddr.isMulticast res.term
-    rw [Data.Set.mapUnion_singleton (by apply hwf res (by simp))]
+    rw [List.mapUnion_singleton (by apply hwf res (by simp))]
   · rename_i res₁ res₂ ; simp_do_let SymCC.compileCall₂ _ IPAddr.isInRange res₁.term res₂.term
-    rw [Data.Set.mapUnion_cons hwf]
-    rw [Data.Set.mapUnion_singleton (by apply hwf res₂ (by simp))]
+    rw [List.mapUnion_cons hwf]
+    rw [List.mapUnion_singleton (by apply hwf res₂ (by simp))]
   · rename_i res ; simp_do_let SymCC.compileCall₀ Ext.Datetime.datetime res.term
-    rw [Data.Set.mapUnion_singleton (by apply hwf res (by simp))]
+    rw [List.mapUnion_singleton (by apply hwf res (by simp))]
   · rename_i res ; simp_do_let SymCC.compileCall₀ Ext.Datetime.duration res.term
-    rw [Data.Set.mapUnion_singleton (by apply hwf res (by simp))]
+    rw [List.mapUnion_singleton (by apply hwf res (by simp))]
   · rename_i res₁ res₂ ; simp_do_let SymCC.compileCallWithError₂ _ _ Datetime.offset res₁.term res₂.term
-    rw [Data.Set.mapUnion_cons hwf]
-    rw [Data.Set.mapUnion_singleton (by apply hwf res₂ (by simp))]
+    rw [List.mapUnion_cons hwf]
+    rw [List.mapUnion_singleton (by apply hwf res₂ (by simp))]
   · rename_i res₁ res₂ ; simp_do_let SymCC.compileCallWithError₂ _ _ Datetime.durationSince res₁.term res₂.term
-    rw [Data.Set.mapUnion_cons hwf]
-    rw [Data.Set.mapUnion_singleton (by apply hwf res₂ (by simp))]
+    rw [List.mapUnion_cons hwf]
+    rw [List.mapUnion_singleton (by apply hwf res₂ (by simp))]
   · rename_i res ; simp_do_let SymCC.compileCallWithError₁ _ Datetime.toDate res.term
-    rw [Data.Set.mapUnion_singleton (by apply hwf res (by simp))]
+    rw [List.mapUnion_singleton (by apply hwf res (by simp))]
   · rename_i res ; simp_do_let SymCC.compileCall₁ _ Datetime.toTime res.term
-    rw [Data.Set.mapUnion_singleton (by apply hwf res (by simp))]
+    rw [List.mapUnion_singleton (by apply hwf res (by simp))]
   · rename_i res ; simp_do_let SymCC.compileCall₁ _ Duration.toMilliseconds res.term
-    rw [Data.Set.mapUnion_singleton (by apply hwf res (by simp))]
+    rw [List.mapUnion_singleton (by apply hwf res (by simp))]
   · rename_i res ; simp_do_let SymCC.compileCall₁ _ Duration.toSeconds res.term
-    rw [Data.Set.mapUnion_singleton (by apply hwf res (by simp))]
+    rw [List.mapUnion_singleton (by apply hwf res (by simp))]
   · rename_i res ; simp_do_let SymCC.compileCall₁ _ Duration.toMinutes res.term
-    rw [Data.Set.mapUnion_singleton (by apply hwf res (by simp))]
+    rw [List.mapUnion_singleton (by apply hwf res (by simp))]
   · rename_i res ; simp_do_let SymCC.compileCall₁ _ Duration.toHours res.term
-    rw [Data.Set.mapUnion_singleton (by apply hwf res (by simp))]
+    rw [List.mapUnion_singleton (by apply hwf res (by simp))]
   · rename_i res ; simp_do_let SymCC.compileCall₁ _ Duration.toDays res.term
-    rw [Data.Set.mapUnion_singleton (by apply hwf res (by simp))]
+    rw [List.mapUnion_singleton (by apply hwf res (by simp))]
   · rw [do_error]
     split <;> simp_all
     all_goals {
@@ -522,14 +522,14 @@ theorem Opt.compile_footprint_wf {x : Expr} {εnv : SymEnv} {res : Opt.CompileRe
       · simp
       · split
         · split <;> simp
-          intro h ; subst res ; simp [Data.Set.mapUnion_wf]
+          intro h ; subst res ; simp [List.mapUnion_wf]
         · simp
   case record axs =>
     rw [do_eq_ok]
     intro h ; replace ⟨aress, haress, h⟩ := h
     simp at h ; subst res
     -- we could make the remainder of this case a separate lemma `Opt.compileRecord_footprint_wf`, but leaving it inline for now
-    simp [Opt.compileRecord, Data.Set.mapUnion_wf]
+    simp [Opt.compileRecord, List.mapUnion_wf]
   case call xfn args =>
     rw [List.mapM₁_eq_mapM (Opt.compile · εnv)]
     simp_do_let args.mapM (Opt.compile · εnv)
@@ -954,7 +954,7 @@ theorem Opt.compile.correctness.set (ls : List Expr) (εnv : SymEnv) :
 := by
   simp [Opt.compile, SymCC.compile, footprint]
   rw [List.mapM₁_eq_mapM (Opt.compile · εnv), List.mapM₁_eq_mapM (SymCC.compile · εnv)]
-  rw [List.mapUnion_attach (footprint · εnv)]
+  rw [List.mapUnion₁_eq_mapUnion (footprint · εnv)]
   simp_do_let ls.mapM (Opt.compile · εnv) <;> rename_i hmap₁
   <;> simp_do_let ls.mapM (SymCC.compile · εnv) <;> rename_i hmap₂
   case error.error e₁ e₂ =>
@@ -989,7 +989,7 @@ theorem Opt.compile.correctness.set (ls : List Expr) (εnv : SymEnv) :
       exact Opt.compile.correctness x εnv
     )
     subst ts₂ ; simp
-    apply Data.Set.map_eqv_implies_mapUnion_eq (by simp [h₂, List.Equiv.refl])
+    apply List.map_eqv_implies_mapUnion_eq (by simp [h₂, List.Equiv.refl])
 termination_by 1 + 2 * sizeOf ls
 
 /--
@@ -1005,7 +1005,7 @@ theorem Opt.compile.correctness.record (m : List (Attr × Expr)) (εnv : SymEnv)
   simp [Opt.compile, SymCC.compile, footprint]
   simp only [List.mapM₂_eq_mapM (λ x => do Except.ok (x.fst, ← Opt.compile x.snd εnv)) m]
   simp only [List.mapM₂_eq_mapM (λ x => do Except.ok (x.fst, ← SymCC.compile x.snd εnv)) m]
-  rw [List.mapUnion_attach₂ (λ x => footprint x.snd εnv)]
+  rw [List.mapUnion₂_eq_mapUnion (λ x => footprint x.snd εnv)]
   simp_do_let m.mapM (m := SymCC.Result) _ <;> rename_i hmap₁
   <;> simp_do_let m.mapM (m := SymCC.Result) _ <;> rename_i hmap₂
   case error.error e₁ e₂ =>
@@ -1043,7 +1043,7 @@ theorem Opt.compile.correctness.record (m : List (Attr × Expr)) (εnv : SymEnv)
       exact Opt.compile.correctness pair.snd εnv
     )
     subst ts₂ ; simp
-    apply Data.Set.map_eqv_implies_mapUnion_eq (by simp [h₂, List.Equiv.refl])
+    apply List.map_eqv_implies_mapUnion_eq (by simp [h₂, List.Equiv.refl])
 termination_by 1 + 2 * sizeOf m
 
 /--
@@ -1058,7 +1058,7 @@ theorem Opt.compile.correctness.call (xfn : ExtFun) (args : List Expr) (εnv : S
 := by
   simp [Opt.compile, SymCC.compile, footprint]
   rw [List.mapM₁_eq_mapM (Opt.compile · εnv), List.mapM₁_eq_mapM (SymCC.compile · εnv)]
-  rw [List.mapUnion_attach (footprint · εnv)]
+  rw [List.mapUnion₁_eq_mapUnion (footprint · εnv)]
   simp_do_let args.mapM (Opt.compile · εnv) <;> rename_i hmap₁
   <;> simp_do_let args.mapM (SymCC.compile · εnv) <;> rename_i hmap₂
   case error.error e₁ e₂ =>
@@ -1093,7 +1093,7 @@ theorem Opt.compile.correctness.call (xfn : ExtFun) (args : List Expr) (εnv : S
         exact Opt.compile.correctness x εnv
       )
       subst ts₂ ; simp
-      apply Data.Set.map_eqv_implies_mapUnion_eq (by simp [h₂, List.Equiv.refl])
+      apply List.map_eqv_implies_mapUnion_eq (by simp [h₂, List.Equiv.refl])
     case hwf =>
       intro res hres
       have ⟨arg, harg, h₁⟩ := List.mapM_ok_implies_all_from_ok hmap₁ res hres

--- a/cedar-lean/Cedar/Thm/SymCC/Opt/Enforcer.lean
+++ b/cedar-lean/Cedar/Thm/SymCC/Opt/Enforcer.lean
@@ -52,16 +52,15 @@ theorem enforceCompiledPolicy_eqv_enforce_ok {p wp : Policy} {cp : CompiledPolic
       rename_i h₂
       replace ⟨t', h₂, ht⟩ := h₂ ; subst t ; rename Term => t
       rw [Data.Set.in_list_iff_in_set] at *
-      rw [Data.Set.mem_mapUnion_iff_mem_exists] at h₂
+      rw [List.mem_mapUnion_iff_mem_exists] at h₂
       replace ⟨s, hs, h₂⟩ := h₂
       simp at hs ; subst s
       simp [Data.Set.mem_map]
       exists t
     · right
       rename_i h₂
-      simp [List.mem_mapUnion_iff_mem_exists] at *
       replace ⟨s, hs, t', ht', h₂⟩ := h₂ ; subst t ; rename Term => t
-      simp [Data.Set.in_list_iff_in_set, Data.Set.mem_mapUnion_iff_mem_exists] at *
+      simp [Data.Set.in_list_iff_in_set, List.mem_mapUnion_iff_mem_exists] at *
       exists s
       simp [hs]
       exists t
@@ -72,18 +71,16 @@ theorem enforceCompiledPolicy_eqv_enforce_ok {p wp : Policy} {cp : CompiledPolic
       simp [Data.Set.in_list_iff_in_set, Data.Set.mem_map] at h₂
       replace ⟨t', ht', h₂⟩ := h₂ ; subst t ; rename Term => t
       exists t
-      simp [Data.Set.in_list_iff_in_set, Data.Set.mem_mapUnion_iff_mem_exists]
+      simp [Data.Set.in_list_iff_in_set, List.mem_mapUnion_iff_mem_exists]
       exact ht'
     · right
       rename_i h₂
-      rw [List.mem_mapUnion_iff_mem_exists] at *
-      simp only [List.mem_map] at *
       replace ⟨s, hs, t', ht', h₂⟩ := h₂ ; subst t ; rename Term => t
       exists s
       rw [Data.Set.in_list_iff_in_set] at *
-      simp [Data.Set.mem_mapUnion_iff_mem_exists, hs]
+      simp [List.mem_mapUnion_iff_mem_exists, hs]
       exists t
-      simp [Data.Set.in_list_iff_in_set, Data.Set.mem_mapUnion_iff_mem_exists, ht']
+      simp [Data.Set.in_list_iff_in_set, List.mem_mapUnion_iff_mem_exists, ht']
 
 /--
 This theorem covers the "happy path" -- showing that if optimized policy
@@ -183,11 +180,11 @@ theorem enforcePairCompiledPolicies_eqv_enforce_ok {ps₁ ps₂ wps₁ wps₂ : 
       case' inr => right ; left
       all_goals {
         simp [footprints] at h₁
-        rw [Data.Set.mem_mapUnion_iff_mem_exists] at h₁
+        rw [List.mem_mapUnion_iff_mem_exists] at h₁
         replace ⟨x, h₁, h₂⟩ := h₁
         simp [Data.Set.mem_map]
         exists t₂
-        simp [Data.Set.mem_mapUnion_iff_mem_exists]
+        simp [List.mem_mapUnion_iff_mem_exists]
         exists x
         apply And.intro _ h₂
         rw [List.mem_map] at h₁

--- a/cedar-lean/Cedar/Thm/SymCC/Opt/Extractor.lean
+++ b/cedar-lean/Cedar/Thm/SymCC/Opt/Extractor.lean
@@ -42,13 +42,13 @@ theorem cp_extractOpt?_eqv_extract? {cps : List CompiledPolicy} {I : Interpretat
     replace ⟨hεnv', hεnv⟩ := hεnv ; subst εnv'
     simp_all only [reduceCtorEq, not_false_eq_true, List.map_cons, Function.comp_apply, footprints]
     congr 3
-    rw [Data.Set.mapUnion_cons]
-    · rw [Data.Set.mapUnion_cons]
+    rw [List.mapUnion_cons]
+    · rw [List.mapUnion_cons]
       · congr 1
         · replace ⟨p, Γ, hcompile⟩ := hcompile { term, εnv, policy, footprint, acyclicity } (by simp)
           apply cp_compile_produces_the_right_footprint hcompile
-        · rw [Data.Set.mapUnion_map (footprint_wf · εnv)]
-          apply Data.Set.mapUnion_congr
+        · rw [List.mapUnion_map]
+          apply List.mapUnion_congr
           intro cp hcp
           replace ⟨p, Γ, hcompile⟩ := hcompile cp (by simp [hcp])
           simp [cp_compile_produces_the_right_footprint hcompile, hεnv cp hcp]
@@ -83,41 +83,39 @@ theorem cps_extractOpt?_eqv_extract? {cpss : List CompiledPolicies} {I : Interpr
     congr 3
     · grind
     · replace ⟨⟨ps, Γ, hcompile⟩, hcompile'⟩ := hcompile
-      rw [Data.Set.mapUnion_cons]
-      · rw [Data.Set.mapUnion_append (by simp [footprint_wf])]
-        rw [Data.Set.mapUnion_map (by simp [footprint_wf])]
-        rw [Data.Set.mapUnion_map (by simp [footprint_wf])]
+      rw [List.mapUnion_cons]
+      · rw [List.mapUnion_append (by simp [footprint_wf])]
+        rw [List.mapUnion_map, List.mapUnion_map]
         simp only [Union.union, HAppend.hAppend]
         congr 1
         · have := cps_compile_produces_the_right_footprint hcompile ; simp at this ; subst footprint
           simp only [footprints]
-          apply Data.Set.mapUnion_map (by simp [footprint_wf])
-        · rw [← Data.Set.eq_means_eqv Data.Set.mapUnion_wf Data.Set.mapUnion_wf]
+          apply List.mapUnion_map
+        · rw [← Data.Set.eq_means_eqv List.mapUnion_wf List.mapUnion_wf]
           simp [List.Equiv, List.subset_def]
           constructor
           · intro t
             simp only [Data.Set.in_list_iff_in_set]
-            simp only [Data.Set.mem_mapUnion_iff_mem_exists t, List.mem_flatMap,
+            simp only [List.mem_mapUnion_iff_mem_exists t, List.mem_flatMap,
               Function.comp_apply, forall_exists_index, and_imp]
             intro cps hcps ht
             replace ⟨ps', Γ', hcompile'⟩ := hcompile' cps hcps
             have hfoot := cps_compile_produces_the_right_footprint hcompile'
             simp only [footprints] at hfoot
-            rw [Data.Set.mapUnion_map (by simp [footprint_wf])] at hfoot
-            rw [← Data.Set.eq_means_eqv] at hfoot
+            rw [List.mapUnion_map, ← Data.Set.eq_means_eqv] at hfoot
             · simp [List.Equiv, List.subset_def, Data.Set.in_list_iff_in_set] at hfoot
               replace ⟨hfoot, hfoot'⟩ := hfoot
               specialize hfoot ht
-              rw [Data.Set.mem_mapUnion_iff_mem_exists] at hfoot
+              rw [List.mem_mapUnion_iff_mem_exists] at hfoot
               replace ⟨p, hp, hfoot⟩ := hfoot
               exists p
               rw [hεnv cps hcps] at *
               grind
-            · simp [hfoot, Data.Set.mapUnion_wf]
-            · simp [Data.Set.mapUnion_wf]
+            · simp [hfoot, List.mapUnion_wf]
+            · simp [List.mapUnion_wf]
           · intro t
             simp only [Data.Set.in_list_iff_in_set]
-            simp only [Data.Set.mem_mapUnion_iff_mem_exists t, List.mem_flatMap,
+            simp only [List.mem_mapUnion_iff_mem_exists t, List.mem_flatMap,
               Function.comp_apply, forall_exists_index, and_imp]
             intro p cps hcps hp ht
             exists cps
@@ -125,7 +123,7 @@ theorem cps_extractOpt?_eqv_extract? {cpss : List CompiledPolicies} {I : Interpr
             have hfoot := cps_compile_produces_the_right_footprint hcompile'
             simp only [hcps, hfoot, footprints, true_and]
             rw [hεnv cps hcps] at *
-            apply Data.Set.mem_mem_implies_mem_mapUnion (s := p.toExpr) ht
+            apply List.mem_mem_implies_mem_mapUnion (s := p.toExpr) ht
             simp only [List.mem_map]
             exists p
       · intro cps hcps

--- a/cedar-lean/Cedar/Thm/Validation/Slice/Reachable.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Slice/Reachable.lean
@@ -224,7 +224,7 @@ theorem in_work_then_in_slice {entities : Entities} {work : Set EntityUID} {euid
   : euid ∈ Entities.sliceAtLevel.sliceAtLevel entities work (n + 1)
 := by
   simp only [Entities.sliceAtLevel.sliceAtLevel]
-  let slice' := ((List.filterMap (Map.find? entities) work.elts).map λ ed => Entities.sliceAtLevel.sliceAtLevel entities ed.sliceEUIDs n).mapUnion id
+  let slice' := (work.elts.filterMap (Map.find? entities)).mapUnion λ ed => Entities.sliceAtLevel.sliceAtLevel entities ed.sliceEUIDs n
   have ⟨ _, hc ⟩ := Set.mem_union_iff_mem_or work slice' euid
   apply hc
   simp [hw]
@@ -243,17 +243,14 @@ theorem slice_contains_reachable {n: Nat} {work : Set EntityUID} {euid : EntityU
     exact in_work_then_in_slice hw
   case step ed euid' hf hi hw =>
     simp only [Entities.sliceAtLevel.sliceAtLevel]
-    let slice' := ((List.filterMap (Map.find? entities) work.elts).map λ ed => Entities.sliceAtLevel.sliceAtLevel entities ed.sliceEUIDs n).mapUnion id
+    let slice' := (work.elts.filterMap (Map.find? entities)).mapUnion λ ed => Entities.sliceAtLevel.sliceAtLevel entities ed.sliceEUIDs n
     rw [Set.mem_union_iff_mem_or]
     right
     cases n
     case _ => cases hw
     case _ n' =>
-      simp only [Set.mem_mapUnion_iff_mem_exists, List.mem_map, List.mem_filterMap]
-      exists Entities.sliceAtLevel.sliceAtLevel entities ed.sliceEUIDs (n' + 1)
+      simp only [List.mem_mapUnion_iff_mem_exists, List.mem_filterMap]
+      exists ed
       and_intros
-      · exists ed
-        and_intros
-        · exists euid'
-        · rfl
+      · exists euid'
       · exact slice_contains_reachable hw

--- a/cedar-lean/Cedar/Thm/Validation/Slice/Reachable/Basic.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Slice/Reachable/Basic.lean
@@ -57,10 +57,10 @@ theorem in_val_then_val_slice {v path euid}
     simp [Value.sliceEUIDs, Set.mem_singleton]
   case record attrs =>
     suffices h : ∃ kv ∈ attrs.kvs, euid ∈ kv.snd.sliceEUIDs by
-      unfold Value.sliceEUIDs List.attach₃
+      unfold Value.sliceEUIDs
       simpa [
-        Set.mem_mapUnion_iff_mem_exists,
-        List.mapUnion_pmap_subtype (λ e : (Attr × Value) => e.snd.sliceEUIDs) attrs.1
+        List.mem_mapUnion_iff_mem_exists,
+        List.mapUnion₃_eq_mapUnion (λ e : (Attr × Value) => e.snd.sliceEUIDs)
       ] using h
     cases path <;> cases hv
     rename_i a _ v ha hv

--- a/cedar-lean/Cedar/Thm/Validation/Slice/Reachable/BinaryApp.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Slice/Reachable/BinaryApp.lean
@@ -41,7 +41,7 @@ theorem reachable_tag_step {n : Nat} {euid euid' : EntityUID} {start : Set Entit
   case in_start n' hi =>
     have he₄ : euid' ∈ ed.sliceEUIDs := by
       suffices h : ∃ v ∈ ed.tags.values, euid' ∈ v.sliceEUIDs by
-        simp [h, EntityData.sliceEUIDs, Set.mem_union_iff_mem_or, Set.mem_mapUnion_iff_mem_exists]
+        simp [h, EntityData.sliceEUIDs, Set.mem_union_iff_mem_or, List.mem_mapUnion_iff_mem_exists]
       exists tv
       constructor
       · exact Map.find?_some_implies_in_values he₂

--- a/cedar-lean/Cedar/Thm/Validation/Slice/Reachable/GetAttr.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Slice/Reachable/GetAttr.lean
@@ -40,7 +40,7 @@ theorem reachable_attr_step {n : Nat} {euid euid' : EntityUID} {start : Set Enti
   case in_start n' hi =>
     have he₄ : euid' ∈ ed.sliceEUIDs := by
       suffices h : ∃ v ∈ ed.attrs.values, euid' ∈ v.sliceEUIDs by
-        simp [h, EntityData.sliceEUIDs, Set.mem_union_iff_mem_or, Set.mem_mapUnion_iff_mem_exists]
+        simp [h, EntityData.sliceEUIDs, Set.mem_union_iff_mem_or, List.mem_mapUnion_iff_mem_exists]
       cases he₂
       rename_i v a path ha hv
       exists v

--- a/cedar-lean/Cedar/Thm/Validation/Slice/Reachable/Var.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Slice/Reachable/Var.lean
@@ -42,9 +42,9 @@ theorem var_entity_reachable {var : Var} {v : Value} {n : Nat} {request : Reques
     case principal | action | resource => simp
     case context v a path hf' hv =>
       suffices h : ∃ kv ∈ request.context.kvs, euid ∈ kv.snd.sliceEUIDs by
-        unfold Value.sliceEUIDs List.attach₃
+        unfold Value.sliceEUIDs
         right
-        simpa [List.mapUnion_pmap_subtype  (·.snd.sliceEUIDs) request.context.kvs, Set.mem_mapUnion_iff_mem_exists] using h
+        simpa [List.mapUnion₃_eq_mapUnion (·.snd.sliceEUIDs) request.context.kvs, List.mem_mapUnion_iff_mem_exists] using h
       exists (a, v)
       constructor
       · exact Map.find?_mem_toList hf'


### PR DESCRIPTION
- create (and consistently use) `mapUnion₁`, `mapUnion₂`, `mapUnion₃` rather than directly calling `attach` variants
- likewise create (and consistently use) lemmas `mapUnion₁_eq_mapUnion` and friends
- For the few cases where we were using `mapUnion` to create a List (rather than a Set), use the standard-library function `List.flatMap` instead
- Move `mapUnion`-related lemmas to the `List` namespace, even when the function `f` returns a `Set`, because the function is still called `List.mapUnion` so this matches conventions
- Rename `mapUnion_empty` to `mapUnion_nil`, matching standard library naming conventions
- Remove an unnecessary precondition from one `mapUnion` lemma