### PR TITLE
Models and proofs of correctness for permissions queries algorithms

### DIFF
--- a/cedar-lean/Cedar/PQ.lean
+++ b/cedar-lean/Cedar/PQ.lean
@@ -14,9 +14,5 @@
  limitations under the License.
 -/
 
-import Cedar.Data
-import Cedar.Spec
-import Cedar.Thm
-import Cedar.Validation
-import Cedar.TPE
-import Cedar.PQ
+import Cedar.PQ.Discretionary
+import Cedar.PQ.ResourceScan

--- a/cedar-lean/Cedar/PQ/Discretionary.lean
+++ b/cedar-lean/Cedar/PQ/Discretionary.lean
@@ -1,0 +1,106 @@
+/-
+ Copyright Cedar Contributors
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-/
+
+import Cedar.PQ.ResourcesForPrincipal
+import Cedar.Validation
+
+/-!
+This file defines a permission query algorithm for "discretionary" Cedar policies.
+Discretionary policies are those with specific constraints on principal, action,
+and resource scopes, with no additional conditions.
+-/
+
+namespace Cedar.PQ
+
+open Cedar.Data
+open Cedar.Spec
+open Cedar.Validation
+
+/--
+Determines if a policy is discretionary. A policy is discretionary if:
+- Principal scope is eq, mem, or isMem
+- Action scope is eq
+- Resource scope is eq
+- No `when` or `unless` conditions
+-/
+def isPolicyDiscretionary (p : Policy) : Bool :=
+  (match p.principalScope.scope with
+  | .eq _ | .mem _ | .isMem _ _ => true
+  | _ => false) &&
+  (match p.actionScope with
+  | .actionScope (.eq _) => true
+  | _ => false) &&
+  (match p.resourceScope.scope with
+  | .eq _ => true
+  | _ => false) &&
+  p.condition == []
+
+/-- Checks if all policies in a list are discretionary. -/
+def arePoliciesDiscretionary (policies : Policies) : Bool :=
+  policies.all isPolicyDiscretionary
+
+/--
+Filters policies to those that apply to a specific principal and resource type.
+Returns policies where:
+- The resource scope matches the given resource type
+- The principal scope includes the given principal (directly or through groups)
+-/
+def policiesForPrincipalAndResourceType
+  (ps : Policies)
+  (principal : EntityUID)
+  (principal_groups : Set EntityUID)
+  (rty : EntityType) :
+  Policies
+:= ps.filter λ p =>
+  (match p.resourceScope.scope with
+  | .eq e => e.ty == rty
+  | _ => false) &&
+  (match p.principalScope.scope.bound with
+  | .some b => b == principal || principal_groups.contains b
+  | .none => false)
+
+/--
+Creates a map from resources to the policies that apply to them.
+Only considers policies with concrete resource scopes (eq).
+-/
+def policiesByResource (ps : Policies) : Map EntityUID Policies :=
+  match ps with
+  | [] => Map.empty
+  | p :: ps' =>
+    let m := policiesByResource ps'
+    match p.resourceScope.scope with
+    | .eq resource =>
+      let existing := m.find? resource |>.getD []
+      m.filter (λ r _ => r != resource) ++ Map.make [(resource, p :: existing)]
+    | _ => m
+
+/--
+Computes the set of resources that a principal can access for discretionary policies.
+This is the main entry point for discretionary access control queries.
+-/
+def discretionaryResourcesForPrincipal
+  (pq : ResourcesForPrincipalRequest)
+  (es : Entities)
+  (ps : Policies) :
+  Set EntityUID
+:=
+  let principal_groups := es.ancestorsOrEmpty pq.principal
+  let principal_policies := policiesForPrincipalAndResourceType ps pq.principal principal_groups pq.resourceType
+  let resource_policy_map := policiesByResource principal_policies
+  Map.keys ∘ resource_policy_map.filter $
+    λ resource rps => (isAuthorized (pq.req resource) es rps).decision == .allow
+
+end Cedar.PQ

--- a/cedar-lean/Cedar/PQ/Discretionary.lean
+++ b/cedar-lean/Cedar/PQ/Discretionary.lean
@@ -87,8 +87,8 @@ def discretionaryResourcesForPrincipal
   let principal_groups := es.ancestorsOrEmpty pq.principal
   let principal_policies := policiesForPrincipalAndResourceType ps pq.principal principal_groups pq.resourceType
   let resource_policy_map := policiesByResource principal_policies
-  Map.keys ∘ resource_policy_map.filter $
-    λ resource rps => (isAuthorized (pq.req resource) es rps).decision == .allow
+  (resource_policy_map.filter
+    λ resource rps => (isAuthorized (pq.req resource) es rps).decision == .allow).keys
 
 /--
 Determines if a policy is discretionary. A policy is discretionary if:

--- a/cedar-lean/Cedar/PQ/ResourceScan.lean
+++ b/cedar-lean/Cedar/PQ/ResourceScan.lean
@@ -19,13 +19,13 @@ import Cedar.PQ.ResourceScan.PolicySlice
 import Cedar.PQ.ResourceScan.ResourceCandidates
 
 /-!
-This file defines a permission query algorithm for Cedar policy by iterating
-over the possible resource.
+This file defines a permission query algorithm for Cedar policies by iterating
+over the possible resources.
 
 The algorithm includes three optimizations:
-1. Policy slicing is used to evaluate only relevant policies given the principal
-   and resource type.
-2. Resources candidates are selected based on what could possibly be authorized
+1. Policy slicing to evaluate only relevant policies given the principal and
+   resource type.
+2. Resource candidate selection based on what could possibly be authorized
    given the resources in the policy scopes. This optimization only applies when
    all policy constrain the resource. Otherwise, it fall back to checking every
    resource.

--- a/cedar-lean/Cedar/PQ/ResourceScan.lean
+++ b/cedar-lean/Cedar/PQ/ResourceScan.lean
@@ -1,0 +1,54 @@
+/-
+ Copyright Cedar Contributors
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-/
+
+import Cedar.PQ.ResourcesForPrincipal
+import Cedar.PQ.ResourceScan.PolicySlice
+import Cedar.PQ.ResourceScan.ResourceCandidates
+
+/-!
+This file defines a permission query algorithm for Cedar policy by iterating
+over the possible resource.
+
+The algorithm includes three optimizations:
+1. Policy slicing is used to evaluate only relevant policies given the principal
+   and resource type.
+2. Resources candidates are selected based on what could possibly be authorized
+   given the resources in the policy scopes. This optimization only applies when
+   all policy constrain the resource. Otherwise, it fall back to checking every
+   resource.
+3. Level-based entity slicing to limit the amount of entity data required when
+   evaluating the authorization request for each resource.
+-/
+
+namespace Cedar.PQ
+
+open Cedar.Data
+open Cedar.Spec
+open Cedar.Validation
+
+def scanResourcesForPrincipal
+  (level : Nat)
+  (schema : Schema)
+  (pq : ResourcesForPrincipalRequest)
+  (entities : Entities)
+  (policies : Policies) :
+  Set EntityUID
+:=
+  let policySlice := policySliceByResourceType pq policies entities schema
+  let entityScan := resource_candidates pq policies entities
+  entityScan.filter λ resource =>
+    let entitySlice := entities.sliceAtLevel (pq.req resource) level
+    (isAuthorized (pq.req resource) entitySlice policySlice).decision == .allow

--- a/cedar-lean/Cedar/PQ/ResourceScan.lean
+++ b/cedar-lean/Cedar/PQ/ResourceScan.lean
@@ -48,7 +48,7 @@ def scanResourcesForPrincipal
   Set EntityUID
 :=
   let policySlice := policySliceByResourceType pq policies entities schema
-  let entityScan := resource_candidates pq policies entities
+  let entityScan := resourceCandidates pq policies entities
   entityScan.filter λ resource =>
     let entitySlice := entities.sliceAtLevel (pq.req resource) level
     (isAuthorized (pq.req resource) entitySlice policySlice).decision == .allow

--- a/cedar-lean/Cedar/PQ/ResourceScan/PolicySlice.lean
+++ b/cedar-lean/Cedar/PQ/ResourceScan/PolicySlice.lean
@@ -1,0 +1,59 @@
+/-
+ Copyright Cedar Contributors
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-/
+
+import Cedar.Validation.Types
+import Cedar.PQ.ResourcesForPrincipal
+
+namespace Cedar.PQ
+
+open Cedar.Data
+open Cedar.Spec
+open Cedar.Validation
+
+def isUnqualifiedPolicy (p : Policy) : Bool :=
+  p.principalScope.scope.bound == none &&
+  p.resourceScope.scope.bound == none
+
+def isPrincipalPolicyUnqualifiedResource (principal : EntityUID) (p : Policy) : Bool :=
+  p.principalScope.scope.bound == some principal &&
+  p.resourceScope.scope.bound == none
+
+def isUnqualifiedPrincipalResourceTypePolicy (resourceType : EntityType) (p : Policy) : Bool :=
+  p.principalScope.scope.bound == none &&
+  match p.resourceScope.scope.bound with
+  | some e => e.ty == resourceType
+  | none => true
+
+def isPrincipalPolicyForResourceType (principal : EntityUID) (resourceType : EntityType) (p : Policy) : Bool :=
+  p.principalScope.scope.bound == some principal &&
+  match p.resourceScope.scope.bound with
+  | some e => e.ty == resourceType
+  | none => true
+
+def isPrincipalParentPolicy (principalAncestor : EntityUID) (resourceType : EntityType) (p : Policy) : Bool :=
+  p.principalScope.scope.bound == some principalAncestor &&
+  match p.resourceScope.scope.bound with
+  | some e => e.ty == resourceType
+  | none => true
+
+def policySliceByResourceType (pq : ResourcesForPrincipalRequest) (policies : Policies) (entities : Entities) (schema : Schema)  : Policies :=
+  let resourceAncestorTypes := schema.ancestorTypes pq.resourceType
+  policies.filter λ p =>
+      isUnqualifiedPolicy p ||
+      resourceAncestorTypes.any (isUnqualifiedPrincipalResourceTypePolicy · p) ||
+      isPrincipalPolicyUnqualifiedResource pq.principal p ||
+      resourceAncestorTypes.any (isPrincipalPolicyForResourceType pq.principal · p) ||
+      resourceAncestorTypes.any ((entities.ancestorsOrEmpty pq.principal).any λ group => isPrincipalParentPolicy group · p)

--- a/cedar-lean/Cedar/PQ/ResourceScan/PolicySlice.lean
+++ b/cedar-lean/Cedar/PQ/ResourceScan/PolicySlice.lean
@@ -43,12 +43,6 @@ def isPrincipalPolicyForResourceType (principal : EntityUID) (resourceType : Ent
   | some e => e.ty == resourceType
   | none => true
 
-def isPrincipalParentPolicy (principalAncestor : EntityUID) (resourceType : EntityType) (p : Policy) : Bool :=
-  p.principalScope.scope.bound == some principalAncestor &&
-  match p.resourceScope.scope.bound with
-  | some e => e.ty == resourceType
-  | none => true
-
 def policySliceByResourceType (pq : ResourcesForPrincipalRequest) (policies : Policies) (entities : Entities) (schema : Schema)  : Policies :=
   let resourceAncestorTypes := schema.ancestorTypes pq.resourceType
   policies.filter λ p =>
@@ -56,4 +50,4 @@ def policySliceByResourceType (pq : ResourcesForPrincipalRequest) (policies : Po
       resourceAncestorTypes.any (isUnqualifiedPrincipalResourceTypePolicy · p) ||
       isPrincipalPolicyUnqualifiedResource pq.principal p ||
       resourceAncestorTypes.any (isPrincipalPolicyForResourceType pq.principal · p) ||
-      resourceAncestorTypes.any ((entities.ancestorsOrEmpty pq.principal).any λ group => isPrincipalParentPolicy group · p)
+      resourceAncestorTypes.any ((entities.ancestorsOrEmpty pq.principal).any λ group => isPrincipalPolicyForResourceType group · p)

--- a/cedar-lean/Cedar/PQ/ResourceScan/ResourceCandidates.lean
+++ b/cedar-lean/Cedar/PQ/ResourceScan/ResourceCandidates.lean
@@ -1,0 +1,74 @@
+/-
+ Copyright Cedar Contributors
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-/
+
+import Cedar.Spec.Entities
+import Cedar.Spec.Policy
+import Cedar.Validation.Validator
+import Cedar.PQ.ResourcesForPrincipal
+
+namespace Cedar.PQ
+
+open Cedar.Data
+open Cedar.Spec
+open Cedar.Validation
+
+/--
+  If this is an RBAC policy, i.e., it constraints the resource to be `in` or
+  `==` to a concrete entity in the policy scope, return a list of entities which
+  it could apply to. It may or may not actually apply to those resources
+  depending on the policy condition and the exact authorization request made.
+  Returns `None` for non-rbac policies, indicating that all resources might be
+  authorized.
+-/
+def resource_candidates_for_policy (p : Policy) (es : Entities) : Option (List EntityUID) :=
+  match p.effect with
+  | .permit =>
+    match p.resourceScope.scope with
+    | .is _ | .any => none
+    | .eq euid => some [euid]
+    | .isMem _ euid | .mem euid => some $ euid :: (es.descendantsOrEmpty euid).elts
+  | .forbid => some []
+
+/--
+  Apply `resource_candidates_for_policy` across all policies in the policy
+  store. A resources is returned if access to it might be authorized by any
+  policy in the store. If any policy return `None`, indicating that it is
+  non-rbac, then the whole policy store is non-rbac, meaning all resources might
+  be authorized, and this function also returns `None`.
+-/
+def resource_candidates_for_policies (ps : Policies) (es : Entities) : Option (List EntityUID) :=
+  (ps.mapM (resource_candidates_for_policy · es)).map List.flatten
+
+/--
+  Computes the resources candidates that must be checked for a
+  resources-for-principals permissions query.
+
+  For rbac policy sets, this takes the candidates as determined by
+  `resources_candidates_for_policies` and additionally filters them to include
+  only entities which have the requested resource type and are present in the
+  entity store.
+
+  For non-rbac policy sets (where `resources_candidates_for_policies` returns
+  `None`), this assumes all entities need to be checked, so it only filters
+  candidates based on their entity type.
+-/
+def resource_candidates (pq : ResourcesForPrincipalRequest) (ps : Policies) (es : Entities): Set EntityUID :=
+  let candidates := resource_candidates_for_policies ps es
+  es.keys.filter λ e =>
+    e.ty == pq.resourceType &&
+    match candidates with
+    | .some candidates => candidates.contains e
+    | .none => true

--- a/cedar-lean/Cedar/PQ/ResourceScan/ResourceCandidates.lean
+++ b/cedar-lean/Cedar/PQ/ResourceScan/ResourceCandidates.lean
@@ -26,15 +26,14 @@ open Cedar.Spec
 open Cedar.Validation
 
 /--
-  If this policy is a `permit` policy constrains the resource to be `in` or `==`
-  to a concrete entity in the policy scope, return a list of entities which it
-  could apply to. It may or may not actually apply to those resources depending
-  on the policy condition and the exact authorization request made.  If it's a
-  `forbid` policy, return an empty list since the policy can never authorize any
-  request.  Returns `None` for other policies, indicating that any resources
-  might be authorized.
+  If this is a `permit` policy whose scope constrains the resource to be `in` or
+  `==` a concrete entity, return a list of the entities it could apply to. It may
+  or may not actually apply to those resources, depending on the policy condition
+  and the exact authorization request made. If it is a `forbid` policy, return an
+  empty list, since a `forbid` policy can never authorize a request. Returns
+  `none` for any other policy, indicating that any resource might be authorized.
 -/
-def resource_candidates_for_policy (p : Policy) (es : Entities) : Option (List EntityUID) :=
+def resourceCandidatesForPolicy (p : Policy) (es : Entities) : Option (List EntityUID) :=
   match p.effect with
   | .permit =>
     match p.resourceScope.scope with
@@ -44,30 +43,27 @@ def resource_candidates_for_policy (p : Policy) (es : Entities) : Option (List E
   | .forbid => some []
 
 /--
-  Apply `resource_candidates_for_policy` across all policies in the policy
-  store. A resources is returned if access to it might be authorized by any
-  policy in the store. If any policy return `None`, indicating that it does not
-  constrain the resource, then we assume all resources might be authorized, and
-  this function also returns `None`.
+  Apply `resourceCandidatesForPolicy` across all policies in the policy store. A
+  resource is returned if access to it might be authorized by any policy in the
+  store. If any policy returns `none`, indicating that it does not constrain the
+  resource, then any resource might be authorized and this function also returns
+  `none`.
 -/
-def resource_candidates_for_policies (ps : Policies) (es : Entities) : Option (List EntityUID) :=
-  ps.mapM (resource_candidates_for_policy · es)|>.map List.flatten
+def resourceCandidatesForPolicies (ps : Policies) (es : Entities) : Option (List EntityUID) :=
+  ps.mapM (resourceCandidatesForPolicy · es)|>.map List.flatten
 
 /--
-  Computes the resources candidates that must be checked for a
-  resources-for-principals permissions query.
+  Computes the candidate resources that must be checked for a
+  resources-for-principal permissions query.
 
-  If all policies contains have a resource constraint, this takes the candidates
-  as determined by `resources_candidates_for_policies` and additionally filters
-  them to include only entities which have the requested resource type and are
-  present in the entity store.
-
-  If any policy does not have a resource constraint (`resources_candidates_for_policies` returns `None`),
-  this assumes all entities need to be checked, so it only filters candidates
-  based on their entity type.
+  Candidates are always drawn from the entity store and restricted to the
+  requested resource type. When every policy constrains the resource
+  (`resourceCandidatesForPolicies` returns `some`), candidates are additionally
+  restricted to that list; otherwise every entity of the requested type must be
+  checked.
 -/
-def resource_candidates (pq : ResourcesForPrincipalRequest) (ps : Policies) (es : Entities): Set EntityUID :=
-  let candidates := resource_candidates_for_policies ps es
+def resourceCandidates (pq : ResourcesForPrincipalRequest) (ps : Policies) (es : Entities): Set EntityUID :=
+  let candidates := resourceCandidatesForPolicies ps es
   es.keys.filter λ e =>
     e.ty == pq.resourceType &&
     match candidates with

--- a/cedar-lean/Cedar/PQ/ResourcesForPrincipal.lean
+++ b/cedar-lean/Cedar/PQ/ResourcesForPrincipal.lean
@@ -14,9 +14,20 @@
  limitations under the License.
 -/
 
-import Cedar.Data
-import Cedar.Spec
-import Cedar.Thm
-import Cedar.Validation
-import Cedar.TPE
-import Cedar.PQ
+import Cedar.Spec.Request
+import Cedar.Spec.Entities
+import Cedar.Spec.Policy
+
+namespace Cedar.PQ
+
+open Cedar.Data
+open Cedar.Spec
+
+structure ResourcesForPrincipalRequest where
+  principal : EntityUID
+  action : EntityUID
+  resourceType : EntityType
+  context : Map Attr Value
+
+def ResourcesForPrincipalRequest.req (pq : ResourcesForPrincipalRequest) (resource : EntityUID) : Request :=
+  Request.mk pq.principal pq.action resource pq.context

--- a/cedar-lean/Cedar/Spec/Entities.lean
+++ b/cedar-lean/Cedar/Spec/Entities.lean
@@ -43,6 +43,10 @@ public def Entities.ancestors (es : Entities) (uid : EntityUID) : Result (Set En
   .ok d.ancestors
 
 @[expose]
+public def Entities.descendantsOrEmpty (es : Entities) (uid : EntityUID) : Set EntityUID :=
+  Set.mk $ es.toList.filter (·.snd.ancestors.contains uid) |> .map (·.fst)
+
+@[expose]
 public def Entities.ancestorsOrEmpty (es : Entities) (uid : EntityUID) : Set EntityUID :=
   match es.find? uid with
   | some d => d.ancestors

--- a/cedar-lean/Cedar/Spec/Entities.lean
+++ b/cedar-lean/Cedar/Spec/Entities.lean
@@ -42,9 +42,14 @@ public def Entities.ancestors (es : Entities) (uid : EntityUID) : Result (Set En
   let d ← es.findOrErr uid .entityDoesNotExist
   .ok d.ancestors
 
+/--
+The entities in `es` that list `uid` among their ancestors. Empty when `uid` has
+no descendants, including when `uid` is absent from `es`. This is the converse of
+`Entities.ancestorsOrEmpty`, and requires scanning the whole store.
+-/
 @[expose]
 public def Entities.descendantsOrEmpty (es : Entities) (uid : EntityUID) : Set EntityUID :=
-  Set.mk $ es.toList.filter (·.snd.ancestors.contains uid) |> .map (·.fst)
+  (es.filter λ _ ed => ed.ancestors.contains uid).keys
 
 @[expose]
 public def Entities.ancestorsOrEmpty (es : Entities) (uid : EntityUID) : Set EntityUID :=

--- a/cedar-lean/Cedar/Thm.lean
+++ b/cedar-lean/Cedar/Thm.lean
@@ -24,4 +24,5 @@ import Cedar.Thm.Validation
 import Cedar.Thm.WellTyped
 import Cedar.Thm.TPE
 import Cedar.Thm.BatchedEvaluator
+import Cedar.Thm.PQ
 import Cedar.Thm.WellTypedVerification

--- a/cedar-lean/Cedar/Thm/Data/Map.lean
+++ b/cedar-lean/Cedar/Thm/Data/Map.lean
@@ -1863,9 +1863,9 @@ public theorem find?_filter_if_find? {α : Type u} {β : Type v} [BEq α] [Lawfu
       simp_all
   · contradiction
 
-public theorem mem_filter_if_find? {α β : Type _} [LT α] [DecidableLT α] [DecidableEq α]  {m : Map α β} {k : α} {v : β} {f : α → β → Bool} :
-  f k v = true → m.find? k = some v → v ∈ (m.filter f).values :=
-by
+public theorem mem_filter_if_find? {α : Type u} {β : Type v} [LT α] [DecidableLT α] [DecidableEq α] {m : Map α β} {k : α} {v : β} {f : α → β → Bool} :
+  f k v = true → m.find? k = some v → v ∈ (m.filter f).values
+:= by
   intro hf hfind
   exact Map.find?_some_implies_in_values (Map.find?_filter_if_find? hfind hf)
 

--- a/cedar-lean/Cedar/Thm/Data/Map.lean
+++ b/cedar-lean/Cedar/Thm/Data/Map.lean
@@ -1863,6 +1863,12 @@ public theorem find?_filter_if_find? {α : Type u} {β : Type v} [BEq α] [Lawfu
       simp_all
   · contradiction
 
+public theorem mem_filter_if_find? {α β : Type _} [LT α] [DecidableLT α] [DecidableEq α]  {m : Map α β} {k : α} {v : β} {f : α → β → Bool} :
+  f k v = true → m.find? k = some v → v ∈ (m.filter f).values :=
+by
+  intro hf hfind
+  exact Map.find?_some_implies_in_values (Map.find?_filter_if_find? hfind hf)
+
 public theorem find?_filter_iff_find {α : Type u} {β : Type v} [BEq α] [LawfulBEq α] [DecidableEq α] [LT α] [StrictLT α] [DecidableLT α]
   {k : α} {val : β} {m : Map α β} {p : α → β → Bool} :
   m.WellFormed →
@@ -1894,7 +1900,7 @@ public theorem filter_contains_if_find_matching {α : Type u} {β : Type v} [BEq
   exact Map.find?_filter_if_find? hfind hpred
 
 public theorem find_matching_iff_filter_contains {α : Type u} {β : Type v} [BEq α] [LawfulBEq α] [LT α] [DecidableLT α] [StrictLT α] [DecidableEq α]
-  {k : α} {m : Map α β} (p : α → β → Bool) :
+  {k : α} {m : Map α β} {p : α → β → Bool} :
   m.WellFormed →
   ((∃ v, m.find? k = some v ∧ p k v = true) ↔ (m.filter p).contains k)
 := by

--- a/cedar-lean/Cedar/Thm/PQ.lean
+++ b/cedar-lean/Cedar/Thm/PQ.lean
@@ -1,0 +1,88 @@
+/-
+ Copyright Cedar Contributors
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-/
+
+import Cedar.Thm.PQ.Discretionary
+import Cedar.Thm.PQ.ResourceScan
+
+/-!
+Proves correctness of two implementation of "permission queries", algorithms for
+listing all resources a principal is authorized to perform an action on.
+-/
+
+namespace Cedar.PQ
+
+open Cedar.Spec
+open Cedar.Data
+open Cedar.Thm
+open Cedar.Validation
+
+/--
+The first algorithm scans resources in the entity store, evaluating policies for
+each resource to see if access is permitted. This algorithm applies optimization
+to restrict the sets of policies, entities and candidate resources.  Defined in
+Cedar.PQ.ResourceScan with the main correctness theorem in
+Cedar.Thm.PQ.ResourceScan.
+
+A resource is returned by `scanResourcesForPrincipal` if and only if it exists
+in the entity store, has the requested resource type, and authorization allows
+access to the resource for the requested principal and action.
+-/
+theorem resource_scan_correct (n : Nat) (schema : Schema) (req : ResourcesForPrincipalRequest) (entities : Entities) (policies : Policies) (r : EntityUID) :
+    validateWithLevel policies schema n = .ok () →
+    schema.validateWellFormed = .ok () →
+    validateRequest schema (req.req r) = .ok () →
+    validateEntities schema entities = .ok () →
+    (r ∈ scanResourcesForPrincipal n schema req entities policies ↔
+    (r ∈ entities ∧ r.ty = req.resourceType ∧ (isAuthorized (req.req r) entities policies).decision = .allow))
+:= by
+  intro h₁ h₂ h₃ h₄
+  constructor
+  · intro h_mem
+    have h_req_eq : Request.mk req.principal req.action r req.context = req.req r := by
+      simp only [ResourcesForPrincipalRequest.req]
+    have h_sound := resource_scan_sound n schema req entities policies r h₁ h₂ h₃ h₄ h_mem
+    simp [h_sound]
+  · intro ⟨h₅, h_ty, h_allow⟩
+    exact resource_scan_complete n schema req entities policies r h₁ h₂ h₃ h₄ h₅ h_ty h_allow
+
+/--
+The second algorithm assumes policies are "discretionary" (have particular
+restricted form), and uses this assumption to limit the candidate resources to
+only the resources which appear explicitly authorized in a policy's scope.
+Defined in Cedar.PQ.Discretionary with the main correctness theorem in
+Cedar.Thm.PQ.Discretionary.
+
+Given a discretionary policy set, a resource is returned by
+`discretionaryResourcesForPrincipal` if and only if it has the requested
+resource type and authorization allows access for the resources with the request
+principal and action.
+
+Notably this theorem does not guarantee that the returned resources actually
+exist in the set of entities. This is by design as the query algorithm
+effectively uses the resource scope conditions in the policy store as the set of
+resource entities.
+-/
+theorem discretionary_resource_for_principal_correct :
+  arePoliciesDiscretionary ps = true →
+    (r ∈ discretionaryResourcesForPrincipal pq es ps ↔ (r.ty = pq.resourceType ∧ (isAuthorized (pq.req r) es ps).decision = .allow))
+:= by
+  intro h_discretionary
+  constructor
+  · exact discretionary_resource_for_principal_sound h_discretionary
+  · intro ⟨h_ty, h_auth⟩
+    exact discretionary_resource_for_principal_complete h_discretionary h_ty h_auth
+
+end PQ

--- a/cedar-lean/Cedar/Thm/PQ.lean
+++ b/cedar-lean/Cedar/Thm/PQ.lean
@@ -50,11 +50,7 @@ theorem resource_scan_correct (n : Nat) (schema : Schema) (req : ResourcesForPri
 := by
   intro h₁ h₂ h₃ h₄
   constructor
-  · intro h_mem
-    have h_req_eq : Request.mk req.principal req.action r req.context = req.req r := by
-      simp only [ResourcesForPrincipalRequest.req]
-    have h_sound := resource_scan_sound n schema req entities policies r h₁ h₂ h₃ h₄ h_mem
-    simp [h_sound]
+  · exact resource_scan_sound n schema req entities policies r h₁ h₂ h₃ h₄
   · intro ⟨h₅, h_ty, h_allow⟩
     exact resource_scan_complete n schema req entities policies r h₁ h₂ h₃ h₄ h₅ h_ty h_allow
 

--- a/cedar-lean/Cedar/Thm/PQ/Discretionary.lean
+++ b/cedar-lean/Cedar/Thm/PQ/Discretionary.lean
@@ -1,0 +1,91 @@
+/-
+ Copyright Cedar Contributors
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-/
+import Cedar.Thm.PQ.Discretionary.DiscretionaryPolicy
+import Cedar.Thm.PQ.Discretionary.PoliciesForPrincipalAndResourceType
+import Cedar.Thm.PQ.Discretionary.PoliciesByResource
+import Cedar.Thm.PolicySlice
+import Cedar.Thm.Authorization
+
+/-!
+Proves correctness of permission queries for discretionary policies.
+-/
+
+namespace Cedar.PQ
+
+open Cedar.Spec
+open Cedar.Data
+open Cedar.Thm
+
+section
+variable {pq : ResourcesForPrincipalRequest} {es : Entities} {ps : Policies} {r : EntityUID}
+
+theorem discretionary_resource_for_principal_sound :
+  arePoliciesDiscretionary ps = true →
+  r ∈ discretionaryResourcesForPrincipal pq es ps →
+  (r.ty = pq.resourceType ∧ (isAuthorized (pq.req r) es ps).decision = .allow)
+:= by
+  intro h₁ h₂
+  simp only [discretionaryResourcesForPrincipal, Function.comp_apply] at h₂
+  rw [Map.in_keys_iff_contains, ←Map.find_matching_iff_filter_contains (policiesByResource_wf _)] at h₂
+  replace ⟨rps, h₂, h₃⟩ := h₂
+  have h_r_ty : r.ty = pq.resourceType := by
+    have h₃ : (policiesByResource (policiesForPrincipalAndResourceType ps pq.principal (es.ancestorsOrEmpty pq.principal) pq.resourceType)).contains r := by
+      simp [Map.contains, h₂]
+    replace ⟨ rp, h₃, h₄ ⟩ := policiesByResource_keys_from_input h₃
+    replace ⟨⟨re, h₃, h₅⟩, _⟩ := policiesForPrincipalAndResourceType_scope_constraint h₃
+    grind
+  have h_sound_slice := policiesByResource_policiesForPrincipalAndResourceType_composed_sound_slice h_r_ty h₁ h₂
+  have h_auth_eq := isAuthorized_eq_for_sound_policy_slice (pq.req r) es rps ps h_sound_slice
+  constructor
+  · exact h_r_ty
+  · simpa [←h_auth_eq] using h₃
+
+theorem discretionary_resource_for_principal_complete :
+  arePoliciesDiscretionary ps = true →
+  r.ty = pq.resourceType →
+  (isAuthorized (pq.req r) es ps).decision = .allow →
+  r ∈ discretionaryResourcesForPrincipal pq es ps
+:= by
+  simp only [discretionaryResourcesForPrincipal, Function.comp_apply]
+  intro h₁ h₂ h₃
+  rw [Map.in_keys_iff_contains]
+  apply Map.filter_contains_if_find_matching
+  simp only [beq_iff_eq]
+  have h_permit := allowed_only_if_explicitly_permitted (pq.req r) es ps h₃
+  simp only [IsExplicitlyPermitted, HasSatisfiedEffect] at h_permit
+  have ⟨policy, h_policy_in_ps, h_policy_effect, h_policy_satisfied⟩ := h_permit
+  have h_discretionary : isPolicyDiscretionary policy := by
+    simp only [arePoliciesDiscretionary, List.all_eq_true] at h₁
+    exact h₁ policy h_policy_in_ps
+  have ⟨⟨pb, h_principal_scope⟩, h_action_scope, h_resource_scope, h_condition⟩ :=
+    discretionary_policy_structure_from_satisfaction h_discretionary h_policy_satisfied
+  have h_in_prtp : policy ∈ policiesForPrincipalAndResourceType ps pq.principal (es.ancestorsOrEmpty pq.principal) pq.resourceType := by
+    simp only [policiesForPrincipalAndResourceType, List.mem_filter, Bool.and_eq_true]
+    apply And.intro h_policy_in_ps
+    simp only [ResourcesForPrincipalRequest.req, Set.contains_prop_bool_equiv] at h_principal_scope
+    simp [h_resource_scope, h_principal_scope, ResourcesForPrincipalRequest.req, h₂]
+  have h_map_entry : ∃ rps, (policiesByResource _).find? r = some rps ∧ policy ∈ rps :=
+    policiesByResource_contains_policy h_in_prtp h_resource_scope
+  have ⟨rps, h_find, h_policy_in_rps⟩ := h_map_entry
+  exists rps
+  constructor
+  · exact h_find
+  · have h_sound := policiesByResource_policiesForPrincipalAndResourceType_composed_sound_slice h₂ h₁ h_find
+    have h_auth_eq := isAuthorized_eq_for_sound_policy_slice (pq.req r) es rps ps h_sound
+    rw [h_auth_eq]
+    exact h₃
+
+end

--- a/cedar-lean/Cedar/Thm/PQ/Discretionary/DiscretionaryPolicy.lean
+++ b/cedar-lean/Cedar/Thm/PQ/Discretionary/DiscretionaryPolicy.lean
@@ -45,7 +45,7 @@ theorem eq_scope_authorizes_principal {policy : Policy} {req : Request} {es : En
   have h_eval : evaluate policy.toExpr req es = .ok (.prim (.bool true)) := by
     simpa [satisfied] using h_satisfied
   have h_principal := and_true_implies_left_true h_eval
-  replace h_scope : policy.3.1 = Scope.eq p := h_scope
+  replace h_scope : policy.principalScope.1 = Scope.eq p := h_scope
   simpa [h_scope, evaluate, Var.eqEntityUID, apply₂, PrincipalScope.toExpr, Scope.toExpr] using h_principal
 
 theorem mem_scope_authorizes_principal_ancestor {policy : Policy} {req : Request} {es : Entities} {p : EntityUID} :
@@ -57,7 +57,7 @@ theorem mem_scope_authorizes_principal_ancestor {policy : Policy} {req : Request
   have h_eval : evaluate policy.toExpr req es = .ok (.prim (.bool true)) := by
     simpa [satisfied] using h_satisfied
   replace h_eval := and_true_implies_left_true h_eval
-  replace h_scope : policy.3.1 = Scope.mem p := h_scope
+  replace h_scope : policy.principalScope.1 = Scope.mem p := h_scope
   simp only [PrincipalScope.toExpr, Scope.toExpr, h_scope, evaluate, Var.inEntityUID, apply₂, inₑ] at h_eval
   cases h_eq : (req.principal == p)
   · right
@@ -73,7 +73,7 @@ theorem is_mem_scope_authorizes_principal_ancestor {policy : Policy} {req : Requ
   have h_eval : evaluate policy.toExpr req es = .ok (.prim (.bool true)) := by
     simpa [satisfied] using h_satisfied
   replace h_eval := and_true_implies_left_true h_eval
-  replace h_scope : policy.3.1 = Scope.isMem ty p := h_scope
+  replace h_scope : policy.principalScope.1 = Scope.isMem ty p := h_scope
   simp only [PrincipalScope.toExpr, Scope.toExpr, h_scope] at h_eval
   replace h_eval := and_true_implies_right_true h_eval
   simp only [evaluate, Var.inEntityUID, apply₂, inₑ] at h_eval
@@ -118,7 +118,7 @@ theorem eq_resource_authorizes_resource {policy : Policy} {req : Request} {es : 
   have h_eval : evaluate policy.toExpr req es = .ok (.prim (.bool true)) := by
     simpa [satisfied] using h_satisfied
   replace h_eval := and_true_implies_left_true ∘ and_true_implies_right_true ∘ and_true_implies_right_true $ h_eval
-  replace h_scope : policy.5.1 = Scope.eq r := h_scope
+  replace h_scope : policy.resourceScope.1 = Scope.eq r := h_scope
   simpa [ResourceScope.toExpr, Scope.toExpr, h_scope, evaluate, Var.eqEntityUID, apply₂] using h_eval
 
 theorem discretionary_policy_has_expected_shape {policy : Policy} :

--- a/cedar-lean/Cedar/Thm/PQ/Discretionary/DiscretionaryPolicy.lean
+++ b/cedar-lean/Cedar/Thm/PQ/Discretionary/DiscretionaryPolicy.lean
@@ -1,0 +1,170 @@
+/-
+ Copyright Cedar Contributors
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-/
+
+import Cedar.PQ.Discretionary
+import Cedar.Thm.Authorization
+
+/-!
+This file contains theorems describing the shape and behavior of discretionary policies
+-/
+
+namespace Cedar.PQ
+
+open Cedar.Data
+open Cedar.Spec
+open Cedar.Validation
+open Cedar.Thm
+
+inductive DiscretionaryPolicy (policy : Policy) : Prop where
+  | discretionary {p a r: EntityUID}
+    (hp : policy.principalScope.scope.bound = .some p)
+    (ha : policy.actionScope = .actionScope (.eq a))
+    (hr : policy.resourceScope.scope = .eq r)
+    (hc : policy.condition = []) :
+    DiscretionaryPolicy policy
+
+theorem eq_scope_authorizes_principal {policy : Policy} {req : Request} {es : Entities} {p : EntityUID} :
+  satisfied policy req es = true →
+  policy.principalScope.scope = .eq p →
+  req.principal = p
+:= by
+  intro h_satisfied h_scope
+  have h_eval : evaluate policy.toExpr req es = .ok (.prim (.bool true)) := by
+    simpa [satisfied] using h_satisfied
+  have h_principal := and_true_implies_left_true h_eval
+  replace h_scope : policy.3.1 = Scope.eq p := h_scope
+  simpa [h_scope, evaluate, Var.eqEntityUID, apply₂, PrincipalScope.toExpr, Scope.toExpr] using h_principal
+
+theorem mem_scope_authorizes_principal_ancestor {policy : Policy} {req : Request} {es : Entities} {p : EntityUID} :
+  satisfied policy req es = true →
+  policy.principalScope.scope = .mem p →
+  p = req.principal ∨ (es.ancestorsOrEmpty req.principal).contains p
+:= by
+  intro h_satisfied h_scope
+  have h_eval : evaluate policy.toExpr req es = .ok (.prim (.bool true)) := by
+    simpa [satisfied] using h_satisfied
+  replace h_eval := and_true_implies_left_true h_eval
+  replace h_scope : policy.3.1 = Scope.mem p := h_scope
+  simp only [PrincipalScope.toExpr, Scope.toExpr, h_scope, evaluate, Var.inEntityUID, apply₂, inₑ] at h_eval
+  cases h_eq : (req.principal == p)
+  · right
+    simpa [h_eq] using h_eval
+  · exact .inl $ beq_iff_eq.mp h_eq|>.symm
+
+theorem is_mem_scope_authorizes_principal_ancestor {policy : Policy} {req : Request} {es : Entities} {ty : EntityType} {p : EntityUID} :
+  satisfied policy req es = true →
+  policy.principalScope.scope = .isMem ty p →
+  p = req.principal ∨ (es.ancestorsOrEmpty req.principal).contains p
+:= by
+  intro h_satisfied h_scope
+  have h_eval : evaluate policy.toExpr req es = .ok (.prim (.bool true)) := by
+    simpa [satisfied] using h_satisfied
+  replace h_eval := and_true_implies_left_true h_eval
+  replace h_scope : policy.3.1 = Scope.isMem ty p := h_scope
+  simp only [PrincipalScope.toExpr, Scope.toExpr, h_scope] at h_eval
+  replace h_eval := and_true_implies_right_true h_eval
+  simp only [evaluate, Var.inEntityUID, apply₂, inₑ] at h_eval
+  cases h_eq : (req.principal == p)
+  · right
+    simpa [h_eq] using h_eval
+  · exact .inl $ beq_iff_eq.mp h_eq|>.symm
+
+theorem bound_authorizes_principal_ancestor {policy : Policy} {req : Request} {es : Entities} {p : EntityUID} :
+  satisfied policy req es = true →
+  policy.principalScope.scope.bound = .some p →
+  p = req.principal ∨ (es.ancestorsOrEmpty req.principal).contains p
+:= by
+  intro h_satisfied h_bound
+  cases h_scope : policy.principalScope.scope
+  case any | is =>
+    simp only [Scope.bound, h_scope, reduceCtorEq] at h_bound
+  all_goals
+    simp [Scope.bound, h_scope] at h_bound
+    subst h_bound
+  · simp [eq_scope_authorizes_principal h_satisfied h_scope]
+  · simpa using mem_scope_authorizes_principal_ancestor h_satisfied h_scope
+  · simpa using is_mem_scope_authorizes_principal_ancestor h_satisfied h_scope
+
+theorem eq_action_authorizes_action {policy : Policy} {req : Request} {es : Entities} {a : EntityUID} :
+  satisfied policy req es = true →
+  policy.actionScope = .actionScope (.eq a) →
+  req.action = a
+:= by
+  intro h_satisfied h_scope
+  have h_eval : evaluate policy.toExpr req es = .ok (.prim (.bool true)) := by
+    simpa [satisfied] using h_satisfied
+  replace h_action := and_true_implies_left_true (and_true_implies_right_true h_eval)
+  simpa [h_scope, evaluate, Var.eqEntityUID, apply₂, ActionScope.toExpr, Scope.toExpr] using h_action
+
+theorem eq_resource_authorizes_resource {policy : Policy} {req : Request} {es : Entities} {r : EntityUID} :
+  satisfied policy req es = true →
+  policy.resourceScope.scope = .eq r →
+  req.resource = r
+:= by
+  intro h_satisfied h_scope
+  have h_eval : evaluate policy.toExpr req es = .ok (.prim (.bool true)) := by
+    simpa [satisfied] using h_satisfied
+  replace h_eval := and_true_implies_left_true ∘ and_true_implies_right_true ∘ and_true_implies_right_true $ h_eval
+  replace h_scope : policy.5.1 = Scope.eq r := h_scope
+  simpa [ResourceScope.toExpr, Scope.toExpr, h_scope, evaluate, Var.eqEntityUID, apply₂] using h_eval
+
+theorem discretionary_policy_has_expected_shape {policy : Policy} :
+  isPolicyDiscretionary policy = true → DiscretionaryPolicy policy
+:= by
+  intro h_discretionary
+  simp only [isPolicyDiscretionary, List.beq_nil_eq, Bool.and_eq_true, List.isEmpty_iff] at h_discretionary
+  have ⟨⟨⟨h_principal_ok, h_action_ok⟩, h_resource_ok⟩, h_condition_empty⟩ := h_discretionary
+  have ⟨_, h_p⟩  : ∃ b, policy.principalScope.scope.bound = .some b := by
+    cases h_p : policy.principalScope.scope <;>
+      simp only [h_p, Bool.false_eq_true] at h_principal_ok
+    all_goals
+      simp [Scope.bound]
+  have ⟨_, h_a⟩ : ∃ a, policy.actionScope = ActionScope.actionScope (Scope.eq a) := by
+    cases h_a : policy.actionScope <;>
+      simp only [h_a, Bool.false_eq_true] at h_action_ok
+    rename_i a_scope
+    cases a_scope <;>
+      simp only [Bool.false_eq_true] at h_action_ok
+    simp
+  cases h_r : policy.resourceScope.scope <;>
+    simp only [h_r, Bool.false_eq_true] at h_resource_ok
+  exact DiscretionaryPolicy.discretionary h_p h_a h_r h_condition_empty
+
+theorem discretionary_policy_structure_from_satisfaction {policy : Policy} {req : Request} {es : Entities} :
+  isPolicyDiscretionary policy = true →
+  satisfied policy req es = true →
+  (∃ b, policy.principalScope.scope.bound = .some b ∧
+    (b = req.principal ∨ (es.ancestorsOrEmpty req.principal).contains b)) ∧
+  policy.actionScope = .actionScope (.eq req.action) ∧
+  policy.resourceScope.scope = .eq req.resource ∧
+  policy.condition = []
+:= by
+  intro h_discretionary h_satisfied
+
+  have ⟨h_principal_bound, h_action_bound, h_resource_bound, h_condition⟩ :=
+    discretionary_policy_has_expected_shape h_discretionary
+  have h_principal_match : _ = req.principal ∨ (es.ancestorsOrEmpty req.principal).contains _ :=
+    bound_authorizes_principal_ancestor h_satisfied h_principal_bound
+  have h_action_match : req.action = _ :=
+    eq_action_authorizes_action h_satisfied h_action_bound
+  have h_resource_match : req.resource = _ :=
+    eq_resource_authorizes_resource h_satisfied h_resource_bound
+
+  and_intros
+  · exact ⟨_, h_principal_bound, h_principal_match⟩
+  · rw [h_action_bound, h_action_match]
+  · rw [h_resource_bound, h_resource_match]
+  · exact h_condition

--- a/cedar-lean/Cedar/Thm/PQ/Discretionary/PoliciesByResource.lean
+++ b/cedar-lean/Cedar/Thm/PQ/Discretionary/PoliciesByResource.lean
@@ -1,0 +1,210 @@
+/-
+ Copyright Cedar Contributors
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-/
+
+import Cedar.Data.Map
+import Cedar.Thm.PolicySlice
+import Cedar.Thm.Authorization
+import Cedar.PQ.Discretionary
+import Cedar.Thm.PQ.Discretionary.DiscretionaryPolicy
+import Cedar.Thm.PQ.Discretionary.PoliciesForPrincipalAndResourceType
+
+namespace Cedar.PQ
+
+open Cedar.Data
+open Cedar.Data.Map
+open Cedar.Spec
+open Cedar.Validation
+open Cedar.Thm
+
+/-!
+This file contains theorems about the policiesByResource function and its properties.
+-/
+
+theorem policiesByResource_wf (ps : Policies) :
+  (policiesByResource ps).WellFormed
+:= by
+  unfold policiesByResource
+  cases ps
+  case nil =>
+    exact Map.wf_empty
+  case cons h t =>
+    simp only
+    split
+    · apply Map.make_wf
+    · exact policiesByResource_wf t
+
+theorem policiesByResource_keys_from_input {ps : Policies} {r : EntityUID} :
+  (policiesByResource ps).contains r →
+  ∃ p ∈ ps, p.resourceScope.scope = .eq r
+:= by
+  intro h₁
+  cases ps <;> unfold policiesByResource at h₁
+  · simp [Map.empty, Map.contains, Map.find?, Map.toList] at h₁
+  · rename_i p ps'
+    split at h₁
+    · rw [Map.contains_append] at h₁
+      cases h₁
+      · rename_i r' h₁ h₂
+        cases h₃ : r != r'
+        · replace h₃ : r = r' := by
+            simpa using h₃
+          simp [h₃, h₁]
+        · have h₄ : (policiesByResource ps').contains r := by
+            rw [←Map.find_matching_iff_filter_contains (policiesByResource_wf _)] at h₂
+            replace ⟨v, h₂, h₃⟩ := h₂
+            simp [Map.contains, Option.isSome, h₂]
+          have ih := policiesByResource_keys_from_input h₄
+          simp [ih]
+      · rename_i r' h₁ h₂
+        replace h₂ : r' = r := by
+          simpa [Map.singleton_contains] using h₂
+        simp [h₁, h₂]
+    · have ih := policiesByResource_keys_from_input h₁
+      simp [ih]
+
+theorem policiesByResource_then_scope_eq {ps : Policies} {r : EntityUID} {rps : Policies} {p : Policy} :
+  (policiesByResource ps).find? r = some rps → p ∈ rps →
+  p ∈ ps ∧ p.resourceScope.scope = .eq r
+:= by
+  cases ps
+  · simp [policiesByResource, Map.not_find?_of_empty]
+  · simp only [policiesByResource, List.mem_cons]
+    split
+    · intro h₁ h₄
+      rename_i r' h₂
+      cases h₃ : r == r'
+      · replace h₃ : r ≠ r' := by simpa using h₃
+        rw [Map.find?_append_left] at h₁
+        · rename_i tail _
+          replace h₁ : (policiesByResource tail).find? r = some rps := by
+            exact Map.find?_filter_iff_find (policiesByResource_wf _)|>.mpr h₁|>.left
+          have ih := policiesByResource_then_scope_eq h₁ h₄
+          exact .intro (.inr ih.left) ih.right
+        · rename_i h t _
+          have h_mem_iff_r := Map.singleton_contains r r' (h :: ((policiesByResource t).find? r').getD [])
+          grind
+      · simp at h₃; subst h₃
+        rw [Map.find?_append_right] at h₁
+        · simp only [singleton_find?, Option.some.injEq] at h₁
+          simp only [←h₁, List.mem_cons] at h₄
+          cases h₄
+          · rename_i h₄
+            rw [←h₄] at h₂
+            exact .intro (.inl h₄) h₂
+          · rename_i t _ h₅
+            cases h₄ : (policiesByResource t).find? r
+            case none =>
+              simp [h₄] at h₅
+            case some =>
+              rename_i ps
+              replace h₅ : p ∈ ps := by simpa [h₄] using h₅
+              have ih := policiesByResource_then_scope_eq h₄ h₅
+              simp [ih]
+        · apply Map.filter_not_contains
+    · intro h₁ h₂
+      have ih := policiesByResource_then_scope_eq h₁ h₂
+      simp [ih]
+
+theorem policiesByResource_subset {ps : Policies} {r : EntityUID} {rps : Policies} :
+  (policiesByResource ps).find? r = some rps → rps ⊆ ps
+:= by
+  intro h₁ p h₂
+  exact (policiesByResource_then_scope_eq h₁ h₂).left
+
+theorem policiesByResource_contains_policy {ps : Policies} {policy : Policy} {r : EntityUID} :
+  policy ∈ ps →
+  policy.resourceScope.scope = .eq r →
+  ∃ rps, (policiesByResource ps).find? r = some rps ∧ policy ∈ rps
+:= by
+  intro h₁ h₂
+  cases h₁
+  · rename_i t
+    exists policy :: ((policiesByResource t).find? r).getD []
+    simp only [policiesByResource, h₂, List.mem_cons, true_or, and_true]
+    rw [Map.find?_append_right]
+    · apply Map.singleton_find?
+    · apply Map.filter_not_contains
+  · rename_i h t ht
+    have ⟨rps, ih₁, ih₂⟩ := policiesByResource_contains_policy ht h₂
+    simp only [policiesByResource]
+    cases h₃ : h.resourceScope.scope <;> simp only [ih₁, ih₂, Option.some.injEq, exists_eq_left']
+    rename_i r'
+    cases h₄ : r == r'
+    · exists rps
+      apply (And.intro · ih₂)
+      replace h₄ : r ≠ r' := by simpa using h₄
+      rw [Map.find?_append_left]
+      · replace h₄ : (r != r') = true := by simp [h₄]
+        exact Map.find?_filter_if_find? ih₁ h₄
+      · have h_mem_if_r := Map.singleton_contains r r' (h :: ((policiesByResource t).find? r').getD [])
+        grind
+    · replace h₄ : r = r' := by simpa using h₄
+      subst h₄
+      exists h :: rps
+      and_intros
+      · rw [Map.find?_append_right]
+        · simp [Map.singleton_find?, ih₁]
+        · simp [Map.filter_not_contains]
+      · simp [ih₂]
+
+theorem policiesByResource_def {ps : Policies} {resource : EntityUID} {rps : Policies} {p : Policy} :
+  (policiesByResource ps).find? resource = some rps →
+  (p ∈ rps ↔ (p ∈ ps ∧ p.resourceScope.scope = .eq resource))
+:= by
+  intro h₁
+  constructor
+  · exact policiesByResource_then_scope_eq h₁
+  · intro h₂
+    replace ⟨rps', h₂⟩ := policiesByResource_contains_policy h₂.left h₂.right
+    replace h₁ : rps' = rps := by
+      simpa [h₂.left] using h₁
+    rw [←h₁]
+    exact h₂.right
+
+theorem policiesByResource_sound_slice {ps rps : Policies} {req : Request} {es : Entities} :
+  arePoliciesDiscretionary ps = true →
+  (policiesByResource ps).find? req.resource = some rps →
+  IsSoundPolicySlice req es rps ps
+:= by
+  intro h₁ h₂
+  rw [is_sound_policy_slice_def_equiv]
+  apply And.intro (policiesByResource_subset h₂)
+  intro p h₃ h₄
+  replace h₁ : isPolicyDiscretionary p = true := by
+    simp only [arePoliciesDiscretionary, List.all_eq_true] at h₁
+    exact h₁ p h₃
+  replace ⟨_, _, h₁, _⟩ := discretionary_policy_has_expected_shape h₁
+  rename_i r' _ _ _
+  have hr : r' ≠ req.resource := by
+    grind [policiesByResource_def]
+  exact resource_ne_evaluates_false h₁ hr
+
+theorem policiesByResource_policiesForPrincipalAndResourceType_composed_sound_slice {pq : ResourcesForPrincipalRequest} {r : EntityUID} {es : Entities} {ps rps : Policies} :
+  r.ty = pq.resourceType →
+  arePoliciesDiscretionary ps = true →
+  (policiesByResource (policiesForPrincipalAndResourceType ps pq.principal (es.ancestorsOrEmpty pq.principal) pq.resourceType)).find? r = some rps →
+  IsSoundPolicySlice (pq.req r) es rps ps
+:= by
+  intro h₁ h_discretionary₁ h₃
+  have h_sound₁ := policiesForPrincipalAndResourceType_sound_slice es h₁ h_discretionary₁
+  have h_discretionary₂ : arePoliciesDiscretionary ((policiesForPrincipalAndResourceType ps pq.principal (es.ancestorsOrEmpty pq.principal) pq.resourceType)) = true := by
+    simp only [arePoliciesDiscretionary, List.all_eq_true] at ⊢ h_discretionary₁
+    intro p hmem
+    exact h_discretionary₁ p (h_sound₁.left hmem)
+  have h_sound₂ := @policiesByResource_sound_slice _ _ (pq.req r) es h_discretionary₂ h₃
+  exact sound_slice_transitive h_sound₁ h_sound₂
+
+end Cedar.PQ

--- a/cedar-lean/Cedar/Thm/PQ/Discretionary/PoliciesForPrincipalAndResourceType.lean
+++ b/cedar-lean/Cedar/Thm/PQ/Discretionary/PoliciesForPrincipalAndResourceType.lean
@@ -1,0 +1,140 @@
+/-
+ Copyright Cedar Contributors
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-/
+
+import Cedar.Thm.PolicySlice
+import Cedar.Thm.PQ.Discretionary.DiscretionaryPolicy
+import Cedar.Thm.Authorization
+
+namespace Cedar.PQ
+
+open Cedar.Data
+open Cedar.Spec
+open Cedar.Validation
+open Cedar.Thm
+
+/-!
+This file contains theorems about the policiesForPrincipalAndResourceType function and its properties.
+-/
+
+theorem policiesForPrincipalAndResourceType_scope_constraint {ps : Policies} {principal : EntityUID} {principal_groups : Set EntityUID} {rty : EntityType} {p : Policy} :
+  p ∈ policiesForPrincipalAndResourceType ps principal principal_groups rty →
+  (∃ e, p.resourceScope.scope = .eq e ∧ e.ty = rty) ∧
+  (∃ b, p.principalScope.scope.bound = some b ∧ (b = principal ∨ principal_groups.contains b))
+:= by
+  intro h
+  rw [policiesForPrincipalAndResourceType, List.mem_filter, Bool.and_eq_true] at h
+  have ⟨_, h_resource, h_principal⟩ := h
+  constructor
+  · cases hr : p.resourceScope.scope
+    case eq e =>
+      simpa [hr] using h_resource
+    all_goals
+      simp [hr] at h_resource
+  · cases hp : p.principalScope.scope.bound
+    case none =>
+      simp [hp] at h_principal
+    case some b =>
+      simpa [hp] using h_principal
+
+theorem policiesForPrincipalAndResourceType_subset {ps : Policies} {principal : EntityUID} {principal_groups : Set EntityUID} {rty : EntityType} :
+  policiesForPrincipalAndResourceType ps principal principal_groups rty ⊆ ps
+:= by
+  intro p h
+  simp only [policiesForPrincipalAndResourceType, List.mem_filter] at h
+  exact h.1
+
+theorem principal_not_in_ancestors_evaluates_false {p : Policy} {pe : EntityUID} {req : Request} {es : Entities} :
+  p.principalScope.scope.bound = some pe →
+  pe ≠ req.principal → (es.ancestorsOrEmpty req.principal).contains pe = false →
+  evaluate p.toExpr req es = .ok false
+:= by
+  intro h₁ h₂ h₃
+  apply principal_scope_false_then_policy_false
+  simp only [PrincipalScope.toExpr, Scope.toExpr]
+  split <;> rename_i h₄ <;> first
+  | replace h₁ : none = some pe := by
+      simp [Scope.bound, PrincipalScope.scope, h₄] at h₁
+    contradiction
+  | rename_i euid
+    replace h₁ : euid = pe := by
+      simpa [Scope.bound, PrincipalScope.scope, h₄] using h₁
+    subst h₁
+  · suffices h : req.principal ≠ euid by
+      simpa [evaluate, Var.eqEntityUID, apply₂] using h
+    exact (h₂ ·.symm)
+  · suffices h : req.principal ≠ euid ∧ (es.ancestorsOrEmpty req.principal).contains euid = false by
+      simpa [evaluate, Var.inEntityUID, apply₂, inₑ] using h
+    exact .intro (h₂ ·.symm) h₃
+  · apply left_bool_right_false_implies_and_false
+    · simp [Var.isEntityType, producesBool, evaluate, apply₁]
+    · suffices h : req.principal ≠ euid ∧ (es.ancestorsOrEmpty req.principal).contains euid = false by
+        simpa [evaluate, Var.inEntityUID, apply₂, inₑ] using h
+      exact .intro (h₂ ·.symm) h₃
+
+theorem resource_ne_evaluates_false {p : Policy} {r : EntityUID} {req : Request} {es : Entities} :
+  p.resourceScope.scope = .eq r →
+  r ≠ req.resource →
+  evaluate p.toExpr req es = .ok false
+:= by
+  intro h₁ h₂
+  apply resource_scope_false_then_policy_false
+  simp only [ResourceScope.toExpr, Scope.toExpr]
+  split
+  all_goals
+    rename_i h₄
+    simp only [h₄, ResourceScope.scope, reduceCtorEq] at h₁
+  rename_i r'
+  simp only [Scope.eq.injEq] at h₁
+  subst h₁
+  suffices h : req.resource ≠ r' by
+    simpa [evaluate, Var.eqEntityUID, apply₂] using h
+  intro h
+  simp [h] at h₂
+
+theorem resource_ne_type_evaluates_false {p : Policy} {r : EntityUID} {req : Request} {es : Entities} :
+  p.resourceScope.scope = .eq r →
+  r.ty ≠ req.resource.ty →
+  evaluate p.toExpr req es = .ok false
+:= by
+  intro h₁ h₂
+  suffices h₂ : r ≠ req.resource by
+    exact resource_ne_evaluates_false h₁ h₂
+  intro h₃
+  simp [h₃] at h₂
+
+theorem policiesForPrincipalAndResourceType_sound_slice {pq : ResourcesForPrincipalRequest} {r : EntityUID} {ps : Policies} (es : Entities) :
+  r.ty = pq.resourceType →
+  arePoliciesDiscretionary ps = true →
+  IsSoundPolicySlice (pq.req r) es (policiesForPrincipalAndResourceType ps pq.principal (es.ancestorsOrEmpty pq.principal) pq.resourceType) ps
+:= by
+  rw [is_sound_policy_slice_def_equiv]
+  unfold IsSoundPolicySliceFalseDef
+  simp only [policiesForPrincipalAndResourceType_subset, true_and]
+  intro h₁ h₂ p h₃ h₄
+  simp only [arePoliciesDiscretionary, List.all_eq_true] at h₂
+  have ⟨hp, ha, hr, hc⟩ :=
+    discretionary_policy_has_expected_shape (h₂ p h₃)
+  rename_i p a r'
+  cases h₅ : r'.ty == r.ty
+  · replace h₅ : r'.ty ≠ (pq.req r).resource.ty := by
+      simp only [h₁, beq_eq_false_iff_ne] at h₅
+      simp [ResourcesForPrincipalRequest.req, h₁, h₅]
+    exact resource_ne_type_evaluates_false hr h₅
+  · replace ⟨h₄, h₆⟩ : p ≠ pq.principal ∧ (es.ancestorsOrEmpty pq.principal).contains p = false := by
+      simpa [hr, ←h₁, hp, h₃, h₅, policiesForPrincipalAndResourceType] using h₄
+    exact principal_not_in_ancestors_evaluates_false hp h₄ h₆
+
+end Cedar.PQ

--- a/cedar-lean/Cedar/Thm/PQ/ResourceScan.lean
+++ b/cedar-lean/Cedar/Thm/PQ/ResourceScan.lean
@@ -1,0 +1,109 @@
+/-
+ Copyright Cedar Contributors
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-/
+
+import Cedar.Data.Set
+import Cedar.PQ.ResourceScan
+import Cedar.Thm.PQ.ResourceScan.PolicySlice
+import Cedar.Thm.PQ.ResourceScan.ResourceCandidates
+
+namespace Cedar.PQ
+
+open Cedar.Data
+open Cedar.Spec
+open Cedar.Thm
+open Cedar.Validation
+
+/-!
+Proves correctness of permission queries using a optimized resource-scan algorithm
+-/
+
+theorem subset_policies_preserves_valid_with_level :
+  ps' ⊆ ps →
+  validateWithLevel ps schema level = .ok () →
+  validateWithLevel ps' schema level = .ok ()
+:= by
+  intro hsub hvalid
+  replace hvalid : ∀ p ∈ ps', (typecheckPolicyWithEnvironments (typecheckPolicyWithLevel · level) p schema) = .ok () := by
+    intro p hp
+    replace hp := List.subset_def.mp hsub hp
+    exact List.forM_ok_implies_all_ok _ _ hvalid p hp
+  exact List.all_ok_implies_forM_ok _ _ hvalid
+
+
+theorem resource_scan_sound (n : Nat) (schema : Schema) (req : ResourcesForPrincipalRequest) (entities : Entities) (policies : Policies) (r : EntityUID) :
+    validateWithLevel policies schema n = .ok () →
+    schema.validateWellFormed = .ok () →
+    validateRequest schema (Request.mk req.principal req.action r req.context) = .ok () →
+    validateEntities schema entities = .ok () →
+    r ∈ scanResourcesForPrincipal n schema req entities policies →
+    r ∈ entities ∧ r.ty = req.resourceType ∧
+    (isAuthorized (req.req r) entities policies).decision = .allow
+:= by
+  intros h_ps_valid hswf hrv hve h_r_mem_query
+  have hwf := request_and_entities_validate_implies_instance_of_wf_schema _  _ _ hswf hrv hve
+  unfold scanResourcesForPrincipal at h_r_mem_query
+
+  replace ⟨ h_r_mem_candidates, h_allow ⟩ :
+    r ∈ resource_candidates req policies entities  ∧
+    (isAuthorized (req.req r) (entities.sliceAtLevel (req.req r) n) (policySliceByResourceType req policies entities schema)).decision = Decision.allow
+  := by
+    simp only [Set.mem_filter, beq_iff_eq] at h_r_mem_query
+    exact h_r_mem_query
+
+  have ⟨h_r_ty, h_r_mem_es⟩  :
+    r.ty = req.resourceType ∧
+    r ∈ entities
+  := resource_candidates_sound h_r_mem_candidates
+
+  have ⟨h_pslice_eq, h_pslice_valid⟩ :
+    isAuthorized (req.req r) entities (policySliceByResourceType req policies entities schema) = isAuthorized (req.req r) entities policies ∧
+    validateWithLevel (policySliceByResourceType req policies entities schema) schema n = .ok ()
+  := by
+    have hp := policy_slice_sound (ps := policies) h_r_ty hwf
+    and_intros
+    · exact isAuthorized_eq_for_sound_policy_slice _ _ _ _ hp
+    · exact subset_policies_preserves_valid_with_level hp.left h_ps_valid
+
+  replace h_eslice_eq : isAuthorized (req.req r) entities _ = isAuthorized (req.req r) (entities.sliceAtLevel (req.req r) n) _ :=
+    validate_with_level_is_sound_wf hwf h_pslice_valid
+
+  and_intros
+  · exact h_r_mem_es
+  · exact h_r_ty
+  · rw [←h_pslice_eq, h_eslice_eq]
+    exact h_allow
+
+theorem resource_scan_complete (n : Nat) (schema : Schema) (req : ResourcesForPrincipalRequest) (entities : Entities) (policies : Policies) (r : EntityUID) :
+    validateWithLevel policies schema n = .ok () →
+    schema.validateWellFormed = .ok () →
+    validateRequest schema (req.req r) = .ok () →
+    validateEntities schema entities = .ok () →
+    r ∈ entities →
+    r.ty = req.resourceType →
+    (isAuthorized (req.req r) entities policies).decision = .allow →
+    r ∈ scanResourcesForPrincipal n schema req entities policies
+:= by
+  intros h₃ hswf hrv hve h₇ h₈ h₁₀
+  have hwf := request_and_entities_validate_implies_instance_of_wf_schema _ _ _ hswf hrv hve
+  unfold scanResourcesForPrincipal
+  simp only [Set.mem_filter, beq_iff_eq]
+  and_intros
+  · exact resource_candidates_complete h₈ h₇ h₁₀
+  · have h_p_s := policy_slice_sound (ps := policies) h₈ hwf
+    have he := validate_with_level_is_sound_wf hwf (subset_policies_preserves_valid_with_level h_p_s.left h₃)
+    replace h_p_s := isAuthorized_eq_for_sound_policy_slice _ _ _ _ h_p_s
+    rw [←he, h_p_s]
+    exact h₁₀

--- a/cedar-lean/Cedar/Thm/PQ/ResourceScan.lean
+++ b/cedar-lean/Cedar/Thm/PQ/ResourceScan.lean
@@ -43,10 +43,25 @@ theorem subset_policies_preserves_valid_with_level :
   exact List.all_ok_implies_forM_ok _ _ hvalid
 
 
+/--
+The structural half of soundness: every resource returned by the scan exists in
+the entity store and has the requested type. This holds with no validation
+hypotheses, since it follows from the candidate filter alone.
+-/
+theorem resource_scan_sound_shape (n : Nat) (schema : Schema) (req : ResourcesForPrincipalRequest) (entities : Entities) (policies : Policies) (r : EntityUID) :
+    r ∈ scanResourcesForPrincipal n schema req entities policies →
+    r ∈ entities ∧ r.ty = req.resourceType
+:= by
+  intro h_r_mem_query
+  unfold scanResourcesForPrincipal at h_r_mem_query
+  simp only [Set.mem_filter, beq_iff_eq] at h_r_mem_query
+  have ⟨h_r_ty, h_r_mem_es⟩ := resource_candidates_sound h_r_mem_query.left
+  exact .intro h_r_mem_es h_r_ty
+
 theorem resource_scan_sound (n : Nat) (schema : Schema) (req : ResourcesForPrincipalRequest) (entities : Entities) (policies : Policies) (r : EntityUID) :
     validateWithLevel policies schema n = .ok () →
     schema.validateWellFormed = .ok () →
-    validateRequest schema (Request.mk req.principal req.action r req.context) = .ok () →
+    validateRequest schema (req.req r) = .ok () →
     validateEntities schema entities = .ok () →
     r ∈ scanResourcesForPrincipal n schema req entities policies →
     r ∈ entities ∧ r.ty = req.resourceType ∧
@@ -54,19 +69,14 @@ theorem resource_scan_sound (n : Nat) (schema : Schema) (req : ResourcesForPrinc
 := by
   intros h_ps_valid hswf hrv hve h_r_mem_query
   have hwf := request_and_entities_validate_implies_instance_of_wf_schema _  _ _ hswf hrv hve
+  have ⟨h_r_mem_es, h_r_ty⟩ := resource_scan_sound_shape n schema req entities policies r h_r_mem_query
   unfold scanResourcesForPrincipal at h_r_mem_query
 
-  replace ⟨ h_r_mem_candidates, h_allow ⟩ :
-    r ∈ resource_candidates req policies entities  ∧
+  replace h_allow :
     (isAuthorized (req.req r) (entities.sliceAtLevel (req.req r) n) (policySliceByResourceType req policies entities schema)).decision = Decision.allow
   := by
     simp only [Set.mem_filter, beq_iff_eq] at h_r_mem_query
-    exact h_r_mem_query
-
-  have ⟨h_r_ty, h_r_mem_es⟩  :
-    r.ty = req.resourceType ∧
-    r ∈ entities
-  := resource_candidates_sound h_r_mem_candidates
+    exact h_r_mem_query.right
 
   have ⟨h_pslice_eq, h_pslice_valid⟩ :
     isAuthorized (req.req r) entities (policySliceByResourceType req policies entities schema) = isAuthorized (req.req r) entities policies ∧

--- a/cedar-lean/Cedar/Thm/PQ/ResourceScan/PolicySlice.lean
+++ b/cedar-lean/Cedar/Thm/PQ/ResourceScan/PolicySlice.lean
@@ -1,0 +1,117 @@
+/-
+ Copyright Cedar Contributors
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-/
+
+import Cedar.Data
+import Cedar.Thm.PolicySlice
+
+import Cedar.PQ.ResourceScan.PolicySlice
+import Cedar.Thm.PQ.ResourceScan.PolicySlice.Any
+import Cedar.Thm.PQ.ResourceScan.PolicySlice.Mem
+
+namespace Cedar.PQ
+
+open Cedar.Data
+open Cedar.Spec
+open Cedar.Thm
+open Cedar.Validation
+
+theorem subset_excludes_false_scope_implies_sound_slice
+    (h_sub : slice ⊆ policies)
+    (hpr_false : ∀ p ∈ policies, p ∉ slice →
+      evaluate p.principalScope.toExpr req entities = .ok false ∨
+      evaluate p.resourceScope.toExpr req entities = .ok false) :
+    IsSoundPolicySlice req entities slice policies
+:= by
+  rw [is_sound_policy_slice_def_equiv]
+  apply And.intro h_sub
+  intro p hp hnp
+  specialize hpr_false p hp hnp
+  have h_false : evaluate p.toExpr req entities = .ok false := by
+    cases hpr_false
+    case inl hp_false => exact principal_scope_false_then_policy_false hp_false
+    case inr hr_false => exact resource_scope_false_then_policy_false hr_false
+  exact h_false
+
+theorem policy_slice_subset :
+∀ (pq : ResourcesForPrincipalRequest) policies entities schema,
+  policySliceByResourceType pq policies entities schema ⊆ policies
+:= by
+  intro pq ps entities schema
+  simp only [policySliceByResourceType, List.mem_filter, List.subset_def]
+  intro _ h
+  exact h.left
+
+theorem policy_slice_sound : ∀ {pq ps es schema r},
+    r.ty = pq.resourceType →
+    InstanceOfWellFormedSchema schema (pq.req r) es →
+    IsSoundPolicySlice (pq.req r) es (policySliceByResourceType pq ps es schema) ps := by
+  intro pq policies entities schema resource hr hwf
+  apply subset_excludes_false_scope_implies_sound_slice (policy_slice_subset pq policies entities schema)
+  simp only [policySliceByResourceType, List.mem_filter, Bool.or_eq_true, not_and, not_or, Bool.not_eq_true]
+  intro p hp hnp
+  specialize hnp hp
+  simp only [Set.any, List.any_eq_false, Bool.not_eq_true, List.any_eq_true, not_exists, not_and] at hnp
+  have ⟨⟨⟨⟨hnp₁, hnp₂⟩, hnp₃⟩, hnp₄⟩, hnp₅⟩ := hnp ; clear hnp
+
+  cases hpp : p.3.1
+  case any =>
+    right
+    exact principal_any_false hpp hnp₁ hnp₂ hr hwf
+
+  case is ety =>
+    right
+    exact principal_is_ty_false hpp hnp₁ hnp₂ hr hwf
+
+  case eq euid =>
+    cases heuid : decide (euid = pq.principal)
+    · left
+      suffices hp_neq : pq.principal ≠ euid from by
+        simp [hpp, ResourcesForPrincipalRequest.req, Scope.toExpr, PrincipalScope.toExpr, Var.eqEntityUID, evaluate, apply₂, hp_neq]
+      intro heuid'
+      simp [←heuid'] at heuid
+    · right
+      simp only [decide_eq_true_eq] at heuid
+      subst euid
+      replace hpp : p.principalScope.scope.bound = .some pq.principal := by
+        simp only [Scope.bound, PrincipalScope.scope, hpp]
+      exact principal_bound_false hr hwf (Or.intro_left _ (Eq.refl _)) hpp hnp₃ hnp₄ hnp₅
+
+  case mem euid =>
+    cases heuid₁ : pq.principal == euid || (entities.ancestorsOrEmpty pq.principal).contains euid <;> simp at heuid₁
+    · left
+      simp [PrincipalScope.toExpr, ResourcesForPrincipalRequest.req, Scope.toExpr, Var.inEntityUID, evaluate, apply₂, inₑ, heuid₁, hpp]
+    · right
+      exact principal_mem_false hr hwf (heuid₁.imp id Set.contains_prop_bool_equiv.mpr) hpp hnp₃ hnp₄ hnp₅
+
+  case isMem ety euid =>
+    cases heuid₁ : pq.principal == euid || (entities.ancestorsOrEmpty pq.principal).contains euid <;> simp at heuid₁
+    · left
+      suffices hp_in_false : evaluate (Var.principal.inEntityUID euid) (pq.req resource) entities = .ok false from by
+        have ⟨_, hp_is_bool⟩  : ∃ (b : Bool), evaluate (Var.principal.isEntityType ety) (pq.req resource)  entities = .ok b := by
+          simp [evaluate, Var.isEntityType, apply₁]
+        have hp_false := and_bool_operands_is_boolean_and hp_is_bool hp_in_false
+        simp only [Bool.and_false] at hp_false
+        simp only [hpp, PrincipalScope.toExpr]
+        exact hp_false
+      simp [ResourcesForPrincipalRequest.req, Var.inEntityUID, evaluate, apply₂,  inₑ, heuid₁]
+    · right
+      exact principal_is_ty_mem_false hr hwf (heuid₁.imp id Set.contains_prop_bool_equiv.mpr) hpp hnp₃ hnp₄ hnp₅
+
+theorem isAuthorized_eq_for_policy_slice {pq : ResourcesForPrincipalRequest} (entities : Entities) (policies : Policies) (schema : Schema) :
+  resource.ty = pq.resourceType →
+  InstanceOfWellFormedSchema schema (pq.req resource) entities →
+  isAuthorized (pq.req resource) entities (policySliceByResourceType pq policies entities schema)  = isAuthorized (pq.req resource) entities policies
+:= (isAuthorized_eq_for_sound_policy_slice _ _ _ _ $ policy_slice_sound · ·)

--- a/cedar-lean/Cedar/Thm/PQ/ResourceScan/PolicySlice.lean
+++ b/cedar-lean/Cedar/Thm/PQ/ResourceScan/PolicySlice.lean
@@ -66,7 +66,7 @@ theorem policy_slice_sound : ∀ {pq ps es schema r},
   simp only [Set.any, List.any_eq_false, Bool.not_eq_true, List.any_eq_true, not_exists, not_and] at hnp
   have ⟨⟨⟨⟨hnp₁, hnp₂⟩, hnp₃⟩, hnp₄⟩, hnp₅⟩ := hnp ; clear hnp
 
-  cases hpp : p.3.1
+  cases hpp : p.principalScope.1
   case any =>
     right
     exact principal_any_false hpp hnp₁ hnp₂ hr hwf

--- a/cedar-lean/Cedar/Thm/PQ/ResourceScan/PolicySlice/Any.lean
+++ b/cedar-lean/Cedar/Thm/PQ/ResourceScan/PolicySlice/Any.lean
@@ -35,10 +35,7 @@ theorem principal_any_resource_eq_false {pq : ResourcesForPrincipalRequest}  {sc
     simpa [Var.eqEntityUID, evaluate, apply₂] using h
   intro heuid
   simp only [←heuid] at hnp₂
-  specialize hnp₂ pq.resourceType
-  have hin : pq.resourceType ∈ schema.ancestorTypes pq.resourceType := by
-    simp [Schema.ancestorTypes, Set.mem_union, Set.mem_singleton]
-  specialize hnp₂ hin
+  have := hnp₂ pq.resourceType mem_ancestorTypes_self
   contradiction
 
 theorem principal_any_resource_in_false {pq : ResourcesForPrincipalRequest}
@@ -53,10 +50,7 @@ theorem principal_any_resource_in_false {pq : ResourcesForPrincipalRequest}
   · intro heuid
     have hty : resource.ty ≠ pq.resourceType := by
       simp only [←heuid] at hnp₂
-      specialize hnp₂ pq.resourceType
-      have hin : pq.resourceType ∈ schema.ancestorTypes pq.resourceType := by
-        simp [Schema.ancestorTypes, Set.mem_union, Set.mem_singleton]
-      exact hnp₂ hin
+      exact hnp₂ pq.resourceType mem_ancestorTypes_self
     contradiction
   · have hnin : euid.ty ∉ schema.ancestorTypes resource.ty := by
       simpa [←hr] using hnp₂ euid.ty
@@ -75,7 +69,7 @@ theorem principal_bound_none_false {pq : ResourcesForPrincipalRequest}
   simp only [hpp] at hnp₁ hnp₂
   simp only [Scope.bound, ResourceScope.scope] at hnp₁ hnp₂
   simp only [ResourceScope.toExpr, Scope.toExpr]
-  cases hpr : p.5.1
+  cases hpr : p.resourceScope.1
   case is _ | any =>
     simp [hpr] at hnp₁
 

--- a/cedar-lean/Cedar/Thm/PQ/ResourceScan/PolicySlice/Any.lean
+++ b/cedar-lean/Cedar/Thm/PQ/ResourceScan/PolicySlice/Any.lean
@@ -1,0 +1,118 @@
+/-
+ Copyright Cedar Contributors
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-/
+import Cedar.Data
+import Cedar.Thm.Validation
+
+import Cedar.PQ.ResourcesForPrincipal
+import Cedar.PQ.ResourceScan.PolicySlice
+
+namespace Cedar.PQ
+
+open Cedar.Data
+open Cedar.Spec
+open Cedar.Thm
+open Cedar.Validation
+
+theorem principal_any_resource_eq_false {pq : ResourcesForPrincipalRequest}  {schema: Schema}
+  (hnp₂ : ∀ x ∈ schema.ancestorTypes pq.resourceType, euid.ty ≠ x)
+  (hr : resource.ty = pq.resourceType) :
+  evaluate (Var.resource.eqEntityUID euid) (pq.req resource) entities = .ok false
+:= by
+  suffices h : (pq.req resource).resource ≠ euid by
+    simpa [Var.eqEntityUID, evaluate, apply₂] using h
+  intro heuid
+  simp only [←heuid] at hnp₂
+  specialize hnp₂ pq.resourceType
+  have hin : pq.resourceType ∈ schema.ancestorTypes pq.resourceType := by
+    simp [Schema.ancestorTypes, Set.mem_union, Set.mem_singleton]
+  specialize hnp₂ hin
+  contradiction
+
+theorem principal_any_resource_in_false {pq : ResourcesForPrincipalRequest}
+  (hnp₂ : ∀ x ∈ schema.ancestorTypes pq.resourceType, euid.ty ≠ x)
+  (hr : resource.ty = pq.resourceType)
+  (hwf : InstanceOfWellFormedSchema schema (pq.req resource) entities) :
+  evaluate (Var.resource.inEntityUID euid) (pq.req resource) entities = .ok false
+:= by
+  suffices h : resource ≠ euid ∧ (entities.ancestorsOrEmpty resource).contains euid = false by
+    simpa [ResourcesForPrincipalRequest.req, evaluate, Var.inEntityUID, apply₂, inₑ] using h
+  and_intros
+  · intro heuid
+    have hty : resource.ty ≠ pq.resourceType := by
+      simp only [←heuid] at hnp₂
+      specialize hnp₂ pq.resourceType
+      have hin : pq.resourceType ∈ schema.ancestorTypes pq.resourceType := by
+        simp [Schema.ancestorTypes, Set.mem_union, Set.mem_singleton]
+      exact hnp₂ hin
+    contradiction
+  · have hnin : euid.ty ∉ schema.ancestorTypes resource.ty := by
+      simpa [←hr] using hnp₂ euid.ty
+    exact instance_of_wf_schema_not_ancestor_type_implies_not_ancestor hwf hnin
+
+theorem principal_bound_none_false {pq : ResourcesForPrincipalRequest}
+  (hpp : p.principalScope.scope.bound = none)
+  (hnp₁ : isUnqualifiedPolicy p = false)
+  (hnp₂ : ∀ x ∈ schema.ancestorTypes pq.resourceType, isUnqualifiedPrincipalResourceTypePolicy x p = false)
+  (hr : resource.ty = pq.resourceType)
+  (hwf : InstanceOfWellFormedSchema schema (pq.req resource) entities) :
+  evaluate p.resourceScope.toExpr (pq.req resource) entities = Except.ok (Value.prim (Prim.bool false))
+:= by
+  unfold isUnqualifiedPrincipalResourceTypePolicy at hnp₂
+  unfold isUnqualifiedPolicy at hnp₁
+  simp only [hpp] at hnp₁ hnp₂
+  simp only [Scope.bound, ResourceScope.scope] at hnp₁ hnp₂
+  simp only [ResourceScope.toExpr, Scope.toExpr]
+  cases hpr : p.5.1
+  case is _ | any =>
+    simp [hpr] at hnp₁
+
+  case eq euid =>
+    simp only [hpr, BEq.rfl, Bool.true_and, beq_eq_false_iff_ne, ne_eq] at hnp₂
+    exact principal_any_resource_eq_false hnp₂ hr
+
+  case mem euid =>
+    simp only [hpr, BEq.rfl,  Bool.true_and, beq_eq_false_iff_ne, ne_eq] at hnp₂
+    exact principal_any_resource_in_false hnp₂ hr hwf
+
+  case isMem ty euid =>
+    suffices hnot_in : evaluate (Var.resource.inEntityUID euid) (pq.req resource) entities = .ok (.prim (.bool false)) from by
+      have h_var_is_bool : producesBool (Var.resource.isEntityType ty) (pq.req resource) entities := by
+        simp [producesBool, evaluate, Var.isEntityType, apply₁]
+      exact left_bool_right_false_implies_and_false h_var_is_bool hnot_in
+    simp only [BEq.rfl, hpr, Bool.true_and, beq_eq_false_iff_ne, ne_eq] at hnp₂
+    exact principal_any_resource_in_false hnp₂ hr hwf
+
+theorem principal_any_false {pq : ResourcesForPrincipalRequest}
+  (hpp : p.principalScope.scope = Scope.any)
+  (hnp₁ : isUnqualifiedPolicy p = false)
+  (hnp₂ : ∀ x ∈ (schema.ancestorTypes pq.resourceType).elts, isUnqualifiedPrincipalResourceTypePolicy x p = false)
+  (hr : resource.ty = pq.resourceType)
+  (hwf : InstanceOfWellFormedSchema schema (pq.req resource) entities) :
+  evaluate p.resourceScope.toExpr (pq.req resource) entities = Except.ok (Value.prim (Prim.bool false))
+:= by
+  have h_bound : p.principalScope.scope.bound = none := by simp [hpp, Scope.bound]
+  exact principal_bound_none_false h_bound hnp₁ hnp₂ hr hwf
+
+theorem principal_is_ty_false {pq : ResourcesForPrincipalRequest}
+  (hpp : p.principalScope.scope = Scope.is ty)
+  (hnp₁ : isUnqualifiedPolicy p = false)
+  (hnp₂ : ∀ x ∈ (schema.ancestorTypes pq.resourceType).elts, isUnqualifiedPrincipalResourceTypePolicy x p = false)
+  (hr : resource.ty = pq.resourceType)
+  (hwf : InstanceOfWellFormedSchema schema (pq.req resource) entities) :
+  evaluate p.resourceScope.toExpr (pq.req resource) entities = Except.ok (Value.prim (Prim.bool false))
+:= by
+  have h_bound : p.principalScope.scope.bound = none := by simp [hpp, Scope.bound]
+  exact principal_bound_none_false h_bound hnp₁ hnp₂ hr hwf

--- a/cedar-lean/Cedar/Thm/PQ/ResourceScan/PolicySlice/Mem.lean
+++ b/cedar-lean/Cedar/Thm/PQ/ResourceScan/PolicySlice/Mem.lean
@@ -1,0 +1,169 @@
+/-
+ Copyright Cedar Contributors
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-/
+
+import Cedar.Data
+import Cedar.Thm.Validation
+
+import Cedar.PQ.ResourcesForPrincipal
+import Cedar.PQ.ResourceScan.PolicySlice
+
+namespace Cedar.PQ
+
+open Cedar.Data
+open Cedar.Spec
+open Cedar.Thm
+open Cedar.Validation
+
+theorem principal_mem_then_resource_eq_false {entities : Entities} {euid' : EntityUID} :
+  (euid = principal → euid'.ty ≠ resource.ty) →
+  (euid ∈ entities.ancestorsOrEmpty principal → euid'.ty ≠ resource.ty) →
+  principal = euid ∨ (entities.ancestorsOrEmpty principal).contains euid →
+  resource ≠ euid'
+:= by
+  intro hnp₄ hnp₅ heuid₁
+  suffices hty : euid'.ty ≠ resource.ty from by
+    intro heuid
+    rw [heuid] at hty
+    contradiction
+  cases heuid₁
+  · rename_i heuid
+    symm at heuid
+    exact hnp₄ heuid
+  · rename_i hin
+    simp only [Set.contains_prop_bool_equiv] at hin
+    exact hnp₅ hin
+
+theorem not_mem_then_resource_is_mem_false :
+  req.resource ≠ euid →
+  (entities.ancestorsOrEmpty req.resource).contains euid = false →
+  evaluate ((Var.resource.isEntityType ty).and (Var.resource.inEntityUID euid)) req entities = .ok false
+:= by
+  intros hneq hnot_in
+  cases hty : ty == req.resource.ty
+  · simp [Var.isEntityType, evaluate, apply₁, hty, Result.as, Coe.coe, Value.asBool]
+  · simp at hty
+    subst hty
+    have hr_is_true : evaluate (Var.resource.isEntityType req.resource.ty) req entities = .ok true := by
+      simp [evaluate, Var.isEntityType, apply₁]
+    have hr_in_bool : producesBool (Var.resource.inEntityUID euid) req entities := by
+      simp [producesBool, Var.inEntityUID, evaluate, apply₂]
+    simp only [producesBool] at hr_in_bool
+    split at hr_in_bool <;> try contradiction
+    clear hr_in_bool ; rename_i b hr_in_bool
+    have his_elim := and_bool_operands_is_boolean_and hr_is_true hr_in_bool
+    simp only [Bool.true_and] at his_elim
+    rw [his_elim, ←hr_in_bool]
+    simp [evaluate, Var.inEntityUID, apply₂, inₑ, hnot_in, hneq]
+
+theorem principal_bound_false {pq : ResourcesForPrincipalRequest}
+  (hr : resource.ty = pq.resourceType)
+  (hwf : InstanceOfWellFormedSchema schema (pq.req resource) entities)
+  (heuid₁ : pq.principal = euid ∨ (entities.ancestorsOrEmpty pq.principal).contains euid = true)
+  (hpp : p.principalScope.scope.bound = .some euid)
+  (hnp₃ : isPrincipalPolicyUnqualifiedResource pq.principal p = false)
+  (hnp₄ : ∀ x ∈ (schema.ancestorTypes pq.resourceType).elts, isPrincipalPolicyForResourceType pq.principal x p = false)
+  (hnp₅ : ∀ x ∈ (schema.ancestorTypes pq.resourceType).elts, ∀ x₁ ∈ (entities.ancestorsOrEmpty pq.principal).elts, isPrincipalParentPolicy x₁ x p = false) :
+  evaluate p.resourceScope.toExpr (pq.req resource) entities = Except.ok (Value.prim (Prim.bool false))
+:= by
+  simp only [isPrincipalPolicyUnqualifiedResource] at hnp₃
+  simp only [isPrincipalPolicyForResourceType] at hnp₄
+  simp only [isPrincipalParentPolicy] at hnp₅
+  simp only [hpp, Option.some_beq_some, Option.beq_none, Bool.and_eq_false_imp, beq_iff_eq, Option.isNone_eq_false_iff] at hnp₃ hnp₄ hnp₅
+  simp only [Scope.bound] at hnp₃ hnp₄ hnp₅
+  simp only [ResourceScope.toExpr, Scope.toExpr]
+  cases hpr : p.5.1
+  case any | is =>
+    simp only [ResourceScope.scope, hpr, Option.isSome_none, Bool.false_eq_true, imp_false, Bool.true_eq_false] at hnp₃ hnp₅
+    cases heuid₁
+    · rename_i heuid
+      subst heuid
+      simp at hnp₃
+    · rename_i heuid₁
+      have : euid ≠ euid := by
+        simp only [Set.contains, List.contains_eq_mem, decide_eq_true_eq] at heuid₁
+        simp only [Schema.ancestorTypes, Set.mem_elts_iff_mem_set, Set.mem_union, Set.mem_singleton, forall_eq_or_imp] at hnp₅
+        exact hnp₅.left euid heuid₁
+      contradiction
+
+  case eq euid' =>
+    simp only [ResourceScope.scope, hpr, beq_eq_false_iff_ne, ne_eq] at hnp₄ hnp₅
+    suffices h : (pq.req resource).resource ≠ euid' by
+      simpa [Var.eqEntityUID, evaluate, apply₂] using h
+    cases heuid₁
+    · intro heuid'
+      subst euid'
+      rename_i heuid
+      subst euid
+      simp only [Schema.ancestorTypes, Set.mem_elts_iff_mem_set, Set.mem_union, Set.mem_singleton, forall_const, forall_eq_or_imp] at hnp₄
+      simp [hr, ResourcesForPrincipalRequest.req] at hnp₄
+    · rename_i heuid₁
+      simp only [Set.contains, List.elem_eq_contains, List.contains_eq_mem, decide_eq_true_eq] at heuid₁
+      intro heuid'
+      subst heuid'
+      simp only [Schema.ancestorTypes, Set.mem_elts_iff_mem_set, Set.mem_union, Set.mem_singleton, forall_eq_or_imp] at hnp₅
+      replace ⟨hnp₅, hnp₆⟩ := hnp₅
+      specialize hnp₅ euid heuid₁
+      simp [hr, ResourcesForPrincipalRequest.req] at hnp₅
+
+  case isMem _ euid' | mem euid' =>
+    simp only [hpr, ResourceScope.scope] at hnp₄ hnp₅
+    suffices hnot_in : resource ≠ euid' ∧ (entities.ancestorsOrEmpty resource).contains euid' = false from by
+      first
+      | exact not_mem_then_resource_is_mem_false hnot_in.left hnot_in.right
+      | simp [ResourcesForPrincipalRequest.req, evaluate, Var.inEntityUID, apply₂, inₑ, hnot_in]
+    rw [←hr] at hnp₄ hnp₅
+    and_intros
+    · simp [Schema.ancestorTypes, Set.mem_union, Set.mem_singleton, Set.mem_elts_iff_mem_set] at hnp₅ hnp₄
+      replace ⟨hnp₅, hnp₆⟩ := hnp₅
+      replace ⟨hnp₄, hnp₇⟩ := hnp₄
+      exact principal_mem_then_resource_eq_false hnp₄ (hnp₅ euid · (by rfl)) heuid₁
+    · have h₁ : euid'.ty ∉ schema.ancestorTypes resource.ty := by
+        specialize hnp₅ euid'.ty
+        specialize hnp₄ euid'.ty
+        cases heuid₁ <;> rename_i heuid₁
+        · simpa [heuid₁, Set.mem_elts_iff_mem_set] using hnp₄
+        · simp only [Set.contains_prop_bool_equiv] at heuid₁
+          replace hnp₅ := (hnp₅ · euid heuid₁)
+          simpa [Set.mem_elts_iff_mem_set] using hnp₅
+      exact instance_of_wf_schema_not_ancestor_type_implies_not_ancestor hwf h₁
+
+theorem principal_mem_false {pq : ResourcesForPrincipalRequest}
+  (hr : resource.ty = pq.resourceType)
+  (hwf : InstanceOfWellFormedSchema schema (pq.req resource) entities)
+  (heuid₁ : pq.principal = euid ∨ (entities.ancestorsOrEmpty pq.principal).contains euid = true)
+  (hpp : p.principalScope.scope = .mem euid)
+  (hnp₃ : isPrincipalPolicyUnqualifiedResource pq.principal p = false)
+  (hnp₄ : ∀ x ∈ (schema.ancestorTypes pq.resourceType).elts, isPrincipalPolicyForResourceType pq.principal x p = false)
+  (hnp₅ : ∀ x ∈ (schema.ancestorTypes pq.resourceType).elts, ∀ x₁ ∈ (entities.ancestorsOrEmpty pq.principal).elts, isPrincipalParentPolicy x₁ x p = false) :
+  evaluate p.resourceScope.toExpr (pq.req resource) entities = Except.ok (Value.prim (Prim.bool false))
+:= by
+  replace hpp : p.principalScope.scope.bound = .some euid := by
+    simp [Scope.bound, hpp]
+  exact principal_bound_false hr hwf heuid₁ hpp hnp₃ hnp₄ hnp₅
+
+theorem principal_is_ty_mem_false {pq : ResourcesForPrincipalRequest}
+  (hr : resource.ty = pq.resourceType)
+  (hwf : InstanceOfWellFormedSchema schema (pq.req resource) entities)
+  (heuid₁ : pq.principal = euid ∨ (entities.ancestorsOrEmpty pq.principal).contains euid = true)
+  (hpp : p.principalScope.scope = .isMem ty euid)
+  (hnp₃ : isPrincipalPolicyUnqualifiedResource pq.principal p = false)
+  (hnp₄ : ∀ x ∈ (schema.ancestorTypes pq.resourceType).elts, isPrincipalPolicyForResourceType pq.principal x p = false)
+  (hnp₅ : ∀ x ∈ (schema.ancestorTypes pq.resourceType).elts, ∀ x₁ ∈ (entities.ancestorsOrEmpty pq.principal).elts, isPrincipalParentPolicy x₁ x p = false) :
+  evaluate p.resourceScope.toExpr (pq.req resource) entities = Except.ok (Value.prim (Prim.bool false))
+:= by
+  replace hpp : p.principalScope.scope.bound = .some euid := by
+    simp [Scope.bound, hpp]
+  exact principal_bound_false hr hwf heuid₁ hpp hnp₃ hnp₄ hnp₅

--- a/cedar-lean/Cedar/Thm/PQ/ResourceScan/PolicySlice/Mem.lean
+++ b/cedar-lean/Cedar/Thm/PQ/ResourceScan/PolicySlice/Mem.lean
@@ -75,16 +75,15 @@ theorem principal_bound_false {pq : ResourcesForPrincipalRequest}
   (hpp : p.principalScope.scope.bound = .some euid)
   (hnp₃ : isPrincipalPolicyUnqualifiedResource pq.principal p = false)
   (hnp₄ : ∀ x ∈ (schema.ancestorTypes pq.resourceType).elts, isPrincipalPolicyForResourceType pq.principal x p = false)
-  (hnp₅ : ∀ x ∈ (schema.ancestorTypes pq.resourceType).elts, ∀ x₁ ∈ (entities.ancestorsOrEmpty pq.principal).elts, isPrincipalParentPolicy x₁ x p = false) :
+  (hnp₅ : ∀ x ∈ (schema.ancestorTypes pq.resourceType).elts, ∀ x₁ ∈ (entities.ancestorsOrEmpty pq.principal).elts, isPrincipalPolicyForResourceType x₁ x p = false) :
   evaluate p.resourceScope.toExpr (pq.req resource) entities = Except.ok (Value.prim (Prim.bool false))
 := by
   simp only [isPrincipalPolicyUnqualifiedResource] at hnp₃
-  simp only [isPrincipalPolicyForResourceType] at hnp₄
-  simp only [isPrincipalParentPolicy] at hnp₅
+  simp only [isPrincipalPolicyForResourceType] at hnp₄ hnp₅
   simp only [hpp, Option.some_beq_some, Option.beq_none, Bool.and_eq_false_imp, beq_iff_eq, Option.isNone_eq_false_iff] at hnp₃ hnp₄ hnp₅
   simp only [Scope.bound] at hnp₃ hnp₄ hnp₅
   simp only [ResourceScope.toExpr, Scope.toExpr]
-  cases hpr : p.5.1
+  cases hpr : p.resourceScope.1
   case any | is =>
     simp only [ResourceScope.scope, hpr, Option.isSome_none, Bool.false_eq_true, imp_false, Bool.true_eq_false] at hnp₃ hnp₅
     cases heuid₁
@@ -147,7 +146,7 @@ theorem principal_mem_false {pq : ResourcesForPrincipalRequest}
   (hpp : p.principalScope.scope = .mem euid)
   (hnp₃ : isPrincipalPolicyUnqualifiedResource pq.principal p = false)
   (hnp₄ : ∀ x ∈ (schema.ancestorTypes pq.resourceType).elts, isPrincipalPolicyForResourceType pq.principal x p = false)
-  (hnp₅ : ∀ x ∈ (schema.ancestorTypes pq.resourceType).elts, ∀ x₁ ∈ (entities.ancestorsOrEmpty pq.principal).elts, isPrincipalParentPolicy x₁ x p = false) :
+  (hnp₅ : ∀ x ∈ (schema.ancestorTypes pq.resourceType).elts, ∀ x₁ ∈ (entities.ancestorsOrEmpty pq.principal).elts, isPrincipalPolicyForResourceType x₁ x p = false) :
   evaluate p.resourceScope.toExpr (pq.req resource) entities = Except.ok (Value.prim (Prim.bool false))
 := by
   replace hpp : p.principalScope.scope.bound = .some euid := by
@@ -161,7 +160,7 @@ theorem principal_is_ty_mem_false {pq : ResourcesForPrincipalRequest}
   (hpp : p.principalScope.scope = .isMem ty euid)
   (hnp₃ : isPrincipalPolicyUnqualifiedResource pq.principal p = false)
   (hnp₄ : ∀ x ∈ (schema.ancestorTypes pq.resourceType).elts, isPrincipalPolicyForResourceType pq.principal x p = false)
-  (hnp₅ : ∀ x ∈ (schema.ancestorTypes pq.resourceType).elts, ∀ x₁ ∈ (entities.ancestorsOrEmpty pq.principal).elts, isPrincipalParentPolicy x₁ x p = false) :
+  (hnp₅ : ∀ x ∈ (schema.ancestorTypes pq.resourceType).elts, ∀ x₁ ∈ (entities.ancestorsOrEmpty pq.principal).elts, isPrincipalPolicyForResourceType x₁ x p = false) :
   evaluate p.resourceScope.toExpr (pq.req resource) entities = Except.ok (Value.prim (Prim.bool false))
 := by
   replace hpp : p.principalScope.scope.bound = .some euid := by

--- a/cedar-lean/Cedar/Thm/PQ/ResourceScan/ResourceCandidates.lean
+++ b/cedar-lean/Cedar/Thm/PQ/ResourceScan/ResourceCandidates.lean
@@ -1,0 +1,166 @@
+/-
+ Copyright Cedar Contributors
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-/
+import Cedar.Data
+import Cedar.Thm.Authorization
+
+import Cedar.PQ.ResourceScan.ResourceCandidates
+
+namespace Cedar.PQ
+
+open Cedar.Data
+open Cedar.Spec
+open Cedar.Thm
+open Cedar.Validation
+
+theorem not_descendant_implies_not_ancestor {es : Entities} :
+  ¬ (es.descendantsOrEmpty e₀).contains e₁ →
+  ¬ (es.ancestorsOrEmpty e₁).contains e₀
+:= by
+  simp only [Entities.descendantsOrEmpty, Entities.ancestorsOrEmpty]
+  intro h
+  cases he₁ : es.find? e₁ <;> simp
+  · exact Set.not_mem_empty _
+  · rename_i ed
+    suffices h₁ : ¬e₀ ∈ ed.ancestors from by
+      simpa [Set.contains] using h₁
+    replace h : ∀ ed, (e₁, ed) ∈ es.toList → e₀ ∉ ed.ancestors := by
+      simpa [← Set.mem_set_iff_mem_mk] using h
+    exact h ed (Map.find?_mem_toList he₁)
+
+theorem descendant_implies_ancestor {es : Entities} :
+  es.WellFormed →
+  (es.descendantsOrEmpty e₀).contains e₁ →
+  (es.ancestorsOrEmpty e₁).contains e₀
+:= by
+  intro hwf
+  simp only [Entities.descendantsOrEmpty, Entities.ancestorsOrEmpty]
+  cases he₁ : es.find? e₁ <;> simp
+  · replace he₁ := Map.find?_none_all_absent he₁
+    simp [← Set.mem_set_iff_mem_mk, he₁]
+  · rename_i ed
+    suffices h :  ∀ ed', (e₁, ed') ∈ es.toList → e₀ ∈ ed'.ancestors → e₀ ∈ ed.ancestors from by
+      simpa [← Set.mem_set_iff_mem_mk] using h
+    intro ed' he₁'
+    have hed : ed' = ed := by
+      replace he₁' := Map.mem_toList_find? hwf he₁'
+      simpa [he₁'] using he₁
+    rw [←hed]
+    exact id
+
+theorem descendant_eq_ancestor {es : Entities} :
+  es.WellFormed →
+  (es.descendantsOrEmpty e₀).contains e₁ = (es.ancestorsOrEmpty e₁).contains e₀
+:= by
+  intro hwf
+  cases h₁ : (es.descendantsOrEmpty e₀).contains e₁
+  · have h₂ := @not_descendant_implies_not_ancestor e₀ e₁ es
+    simp only [Bool.not_eq_true] at h₂
+    exact (h₂ h₁).symm
+  · exact (descendant_implies_ancestor hwf h₁).symm
+
+theorem resource_candidates_for_policy_complete {p : Policy}
+  (hc : resource_candidates_for_policy p es = some candidates)
+  (hr : req.resource ∉ candidates)
+  (hp : p.effect = .permit) :
+  evaluate p.toExpr req es = .ok false
+:= by
+  suffices hr_false : evaluate p.resourceScope.toExpr req es = .ok false from
+    resource_scope_false_then_policy_false hr_false
+  simp only [resource_candidates_for_policy, hp] at hc
+  split at hc <;> try contradiction
+  all_goals
+    simp only [Option.some.injEq] at hc
+    rw [←hc] at hr ; clear hc
+    rename_i euid hs
+    have hneq : req.resource ≠ euid := by
+      intro heq
+      simp [heq] at hr
+    simp only [ResourceScope.scope] at hs
+    simp only [ResourceScope.toExpr, Scope.toExpr, hs]
+  · simp [Var.eqEntityUID, evaluate, apply₂, hneq]
+  · rename_i ty
+    have hnin : ¬ (es.descendantsOrEmpty euid).contains req.resource := by
+      rw [Bool.not_eq_true, Set.not_contains_prop_bool_equiv]
+      simp only [List.mem_cons, not_or] at hr
+      exact hr.right
+    replace hnin := not_descendant_implies_not_ancestor hnin
+    cases his : ty == req.resource.ty <;>
+      simp [Var.inEntityUID, Var.isEntityType, Result.as, Coe.coe, Value.asBool, evaluate, apply₁, apply₂, inₑ,  his, hnin, hneq]
+  · have hnin : ¬ (es.descendantsOrEmpty euid).contains req.resource := by
+      rw [Bool.not_eq_true, Set.not_contains_prop_bool_equiv]
+      simp only [List.mem_cons, not_or] at hr
+      exact hr.right
+    replace hnin := not_descendant_implies_not_ancestor hnin
+    simp [Var.inEntityUID, evaluate, apply₂, inₑ, hnin, hneq]
+
+theorem resource_candidates_policies_complete
+  (hc : resource_candidates_for_policies ps es = some rs)
+  (hr : req.resource ∉ rs) :
+  (isAuthorized req es ps).decision = .deny
+:= by
+  suffices h_not_permitted : ¬ IsExplicitlyPermitted req es ps from
+    default_deny _ _ _ h_not_permitted
+
+  simp only [resource_candidates_for_policies, Option.map_eq_some_iff] at hc
+  replace ⟨ _, hc, _ ⟩ := hc
+  subst rs
+
+  simp only [IsExplicitlyPermitted, HasSatisfiedEffect, not_exists, not_and]
+  intro p hp he
+
+  have ⟨ p_candidates, hc₁, hc₂ ⟩ := List.mapM_some_implies_all_some hc p hp
+  simp only [List.mem_flatten, not_exists, not_and] at hr
+
+  have h_false := resource_candidates_for_policy_complete hc₂ (hr p_candidates hc₁) he
+  simp [satisfied, h_false]
+
+theorem resource_candidates_complete'
+  (hr : resource ∉ resource_candidates pq ps es)
+  (he : resource ∈ es)
+  (hty : resource.ty = pq.resourceType) :
+  (isAuthorized (pq.req resource) es ps).decision = .deny
+:= by
+  simp only [resource_candidates, Set.mem_filter] at hr
+  cases hr₁ : resource_candidates_for_policies ps es <;> simp only [hr₁] at hr
+  case some rs =>
+    suffices hr₂ : resource ∉ rs from by
+      apply resource_candidates_policies_complete hr₁
+      simp only [ResourcesForPrincipalRequest.req]
+      exact hr₂
+    replace hr : resource ∈ Map.keys es → resource ∉ rs := by
+      simpa [hty] using hr
+    exact hr he
+  case none =>
+    replace hr : resource.ty ≠ pq.resourceType := by
+      simpa [he, Map.in_keys_iff_in_map] using hr
+    simp [hr] at hty
+
+theorem resource_candidates_complete : ∀ {pq ps es resource},
+    resource.ty = pq.resourceType →
+    resource ∈ es →
+    (isAuthorized (pq.req resource) es ps).decision = .allow  →
+    resource ∈ resource_candidates pq ps es := by
+  intro pq es ps r h₁ h₂ h₃
+  have h₄ := mt (@resource_candidates_complete' pq es ps r)
+  simp only [not_imp, Classical.not_not, and_imp] at h₄
+  apply h₄ h₂ h₁
+  simp [h₃]
+
+theorem resource_candidates_sound : ∀ {pq ps es resource},
+    resource ∈ resource_candidates pq ps es → (resource.ty = pq.resourceType ∧ resource ∈ es) := by
+  intro pq ps es r hr
+  simp only [resource_candidates, Set.mem_filter, Bool.and_eq_true, beq_iff_eq] at hr
+  exact .intro hr.right.left hr.left

--- a/cedar-lean/Cedar/Thm/PQ/ResourceScan/ResourceCandidates.lean
+++ b/cedar-lean/Cedar/Thm/PQ/ResourceScan/ResourceCandidates.lean
@@ -29,7 +29,7 @@ theorem not_descendant_implies_not_ancestor {es : Entities} :
   ¬ (es.descendantsOrEmpty e₀).contains e₁ →
   ¬ (es.ancestorsOrEmpty e₁).contains e₀
 := by
-  simp only [Entities.descendantsOrEmpty, Entities.ancestorsOrEmpty]
+  simp only [Entities.descendantsOrEmpty, Entities.ancestorsOrEmpty, Map.keys, Map.filter]
   intro h
   cases he₁ : es.find? e₁ <;> simp
   · exact Set.not_mem_empty _
@@ -46,7 +46,7 @@ theorem descendant_implies_ancestor {es : Entities} :
   (es.ancestorsOrEmpty e₁).contains e₀
 := by
   intro hwf
-  simp only [Entities.descendantsOrEmpty, Entities.ancestorsOrEmpty]
+  simp only [Entities.descendantsOrEmpty, Entities.ancestorsOrEmpty, Map.keys, Map.filter]
   cases he₁ : es.find? e₁ <;> simp
   · replace he₁ := Map.find?_none_all_absent he₁
     simp [← Set.mem_set_iff_mem_mk, he₁]
@@ -72,14 +72,14 @@ theorem descendant_eq_ancestor {es : Entities} :
   · exact (descendant_implies_ancestor hwf h₁).symm
 
 theorem resource_candidates_for_policy_complete {p : Policy}
-  (hc : resource_candidates_for_policy p es = some candidates)
+  (hc : resourceCandidatesForPolicy p es = some candidates)
   (hr : req.resource ∉ candidates)
   (hp : p.effect = .permit) :
   evaluate p.toExpr req es = .ok false
 := by
   suffices hr_false : evaluate p.resourceScope.toExpr req es = .ok false from
     resource_scope_false_then_policy_false hr_false
-  simp only [resource_candidates_for_policy, hp] at hc
+  simp only [resourceCandidatesForPolicy, hp] at hc
   split at hc <;> try contradiction
   all_goals
     simp only [Option.some.injEq] at hc
@@ -107,14 +107,14 @@ theorem resource_candidates_for_policy_complete {p : Policy}
     simp [Var.inEntityUID, evaluate, apply₂, inₑ, hnin, hneq]
 
 theorem resource_candidates_policies_complete
-  (hc : resource_candidates_for_policies ps es = some rs)
+  (hc : resourceCandidatesForPolicies ps es = some rs)
   (hr : req.resource ∉ rs) :
   (isAuthorized req es ps).decision = .deny
 := by
   suffices h_not_permitted : ¬ IsExplicitlyPermitted req es ps from
     default_deny _ _ _ h_not_permitted
 
-  simp only [resource_candidates_for_policies, Option.map_eq_some_iff] at hc
+  simp only [resourceCandidatesForPolicies, Option.map_eq_some_iff] at hc
   replace ⟨ _, hc, _ ⟩ := hc
   subst rs
 
@@ -128,13 +128,13 @@ theorem resource_candidates_policies_complete
   simp [satisfied, h_false]
 
 theorem resource_candidates_complete'
-  (hr : resource ∉ resource_candidates pq ps es)
+  (hr : resource ∉ resourceCandidates pq ps es)
   (he : resource ∈ es)
   (hty : resource.ty = pq.resourceType) :
   (isAuthorized (pq.req resource) es ps).decision = .deny
 := by
-  simp only [resource_candidates, Set.mem_filter] at hr
-  cases hr₁ : resource_candidates_for_policies ps es <;> simp only [hr₁] at hr
+  simp only [resourceCandidates, Set.mem_filter] at hr
+  cases hr₁ : resourceCandidatesForPolicies ps es <;> simp only [hr₁] at hr
   case some rs =>
     suffices hr₂ : resource ∉ rs from by
       apply resource_candidates_policies_complete hr₁
@@ -152,7 +152,7 @@ theorem resource_candidates_complete : ∀ {pq ps es resource},
     resource.ty = pq.resourceType →
     resource ∈ es →
     (isAuthorized (pq.req resource) es ps).decision = .allow  →
-    resource ∈ resource_candidates pq ps es := by
+    resource ∈ resourceCandidates pq ps es := by
   intro pq es ps r h₁ h₂ h₃
   have h₄ := mt (@resource_candidates_complete' pq es ps r)
   simp only [not_imp, Classical.not_not, and_imp] at h₄
@@ -160,7 +160,7 @@ theorem resource_candidates_complete : ∀ {pq ps es resource},
   simp [h₃]
 
 theorem resource_candidates_sound : ∀ {pq ps es resource},
-    resource ∈ resource_candidates pq ps es → (resource.ty = pq.resourceType ∧ resource ∈ es) := by
+    resource ∈ resourceCandidates pq ps es → (resource.ty = pq.resourceType ∧ resource ∈ es) := by
   intro pq ps es r hr
-  simp only [resource_candidates, Set.mem_filter, Bool.and_eq_true, beq_iff_eq] at hr
+  simp only [resourceCandidates, Set.mem_filter, Bool.and_eq_true, beq_iff_eq] at hr
   exact .intro hr.right.left hr.left

--- a/cedar-lean/Cedar/Thm/Validation/RequestEntityValidation.lean
+++ b/cedar-lean/Cedar/Thm/Validation/RequestEntityValidation.lean
@@ -287,3 +287,90 @@ theorem request_and_entities_validate_implies_instance_of_wf_schema (schema : Sc
   simp only [List.forM_ok_implies_all_ok schema.environments TypeEnv.validateWellFormed h₀ env h₁]
   assumption
   simp only [List.forM_ok_implies_all_ok schema.environments (entitiesMatchEnvironment · entities) h₂ env h₁]
+
+theorem entities_instance_of_schema_types_is_defined :
+  InstanceOfWellFormedSchema schema req entities →
+  entities.contains e → schema.ets.contains e.ty ∨ schema.acts.contains e
+:= by
+  intros hwf he
+  have ⟨env, henv, hewf, hirty, ⟨hes, hacts⟩⟩ := hwf ; clear hwf
+  simp [EntitySchema.contains, ActionSchema.contains, Option.isSome]
+  simp [Map.contains, Option.isSome] at he
+  cases he' : entities.find? e <;> simp [he'] at he
+  rename_i ed
+  specialize hes _ _ he'
+  have hets : env.ets = schema.ets := env_in_schema_ets_eq henv
+  have hacts : env.acts = schema.acts := env_in_schema_acts_eq henv
+  rw [←hets, ←hacts]
+  cases hes
+  · rename_i hes
+    unfold InstanceOfEntitySchemaEntry at hes
+    replace ⟨es, hes₁, hes₂, hes₃, hes₄, hes₅ ⟩ := hes ; clear hes
+    simp [hes₁]
+  · rename_i has
+    unfold InstanceOfActionSchemaEntry at has
+    replace ⟨hattrs, has₁, has₂, has₃, has₄ ⟩ := has ; clear has
+    simp [has₃]
+
+theorem instance_of_wf_schema_not_ancestor_type_implies_not_ancestor :
+  InstanceOfWellFormedSchema schema req entities →
+  ancestor.ty ∉ schema.ancestorTypes e.ty →
+  (entities.ancestorsOrEmpty e).contains ancestor = false
+:= by
+  intros hwf hnin
+  have ⟨env, henv, hewf, hirty, ⟨hes, hacts⟩⟩ := hwf ; clear hwf
+  unfold Entities.ancestorsOrEmpty
+  cases hed : Map.find? entities e <;> simp only
+  · simp only [Set.not_contains_prop_bool_equiv, Set.not_mem_empty, not_false_eq_true]
+  · rename_i ed
+    have hets : env.ets = schema.ets := env_in_schema_ets_eq henv
+    have hacts : env.acts = schema.acts := env_in_schema_acts_eq henv
+    specialize hes e ed hed
+    suffices hnin' : ancestor ∉ ed.ancestors from by
+      simpa [Set.not_contains_prop_bool_equiv] using hnin'
+    simp only [Schema.ancestorTypes, Set.mem_union, not_or] at hnin
+    cases hes
+    · rename_i hes ; have ⟨e_schema, hes₁, _, _, hes₂, _⟩ := hes ; clear hes
+      grind
+    · rename_i hes ; have ⟨_, _, _, ha₁, ha₂⟩ := hes ; clear hes
+      have ⟨hnin₁, hnin₂⟩ := hnin ; clear hnin
+      split at hnin₂
+      · rename_i hf
+        rw [←hets] at hf
+        exfalso ; exact wf_env_disjoint_ets_acts hewf hf ha₁
+      · rename_i ase _ hf
+        have : ase ∈ (Map.filter (λ act x => act.ty == e.ty) env.acts).values :=
+          Map.mem_filter_if_find? (by simp only [BEq.rfl]) ha₁
+        simp only [List.mem_mapUnion_iff_mem_exists, Set.mem_map] at hnin₂
+        grind
+
+theorem instance_of_wf_schema_resource_type_defined :
+  InstanceOfWellFormedSchema schema req entities →
+  schema.ets.contains req.resource.ty ∨ schema.acts.IsActionEntityType req.resource.ty
+:= by
+  simp only [InstanceOfWellFormedSchema, forall_exists_index, and_imp]
+  intro env henv hwf
+
+  have hawf : ∀ uid entry , Map.find? env.acts uid = some entry → ActionSchemaEntry.WellFormed env entry := by
+    simp only [InstanceOfWellFormedEnvironment, TypeEnv.WellFormed, ActionSchema.WellFormed] at hwf
+    grind
+
+  have ⟨aentry, hfa, happ⟩ : ∃ aentry, Map.find? env.acts env.reqty.action = some aentry ∧ env.reqty.resource ∈ aentry.appliesToResource := by
+    simp only [InstanceOfWellFormedEnvironment, TypeEnv.WellFormed, RequestType.WellFormed] at hwf
+    grind
+
+  have hrty : env.reqty.resource = req.resource.ty := by
+    simp only [InstanceOfWellFormedEnvironment, InstanceOfRequestType, InstanceOfEntityType] at hwf
+    simp [hwf]
+
+  suffices hdef : env.ets.contains env.reqty.resource ∨ env.acts.IsActionEntityType env.reqty.resource from by
+    have hets : env.ets = schema.ets := env_in_schema_ets_eq henv
+    have hacts : env.acts = schema.acts := env_in_schema_acts_eq henv
+    rw [←hrty, ←hets, ←hacts]
+    exact hdef
+
+  specialize hawf env.reqty.action aentry hfa
+  replace hawf := hawf.right.right.right.right.left
+  specialize hawf req.resource.ty
+  rw [Set.contains_prop_bool_equiv, ←hrty] at hawf
+  exact hawf happ

--- a/cedar-lean/Cedar/Thm/Validation/RequestEntityValidation.lean
+++ b/cedar-lean/Cedar/Thm/Validation/RequestEntityValidation.lean
@@ -288,29 +288,10 @@ theorem request_and_entities_validate_implies_instance_of_wf_schema (schema : Sc
   assumption
   simp only [List.forM_ok_implies_all_ok schema.environments (entitiesMatchEnvironment · entities) h₂ env h₁]
 
-theorem entities_instance_of_schema_types_is_defined :
-  InstanceOfWellFormedSchema schema req entities →
-  entities.contains e → schema.ets.contains e.ty ∨ schema.acts.contains e
-:= by
-  intros hwf he
-  have ⟨env, henv, hewf, hirty, ⟨hes, hacts⟩⟩ := hwf ; clear hwf
-  simp [EntitySchema.contains, ActionSchema.contains, Option.isSome]
-  simp [Map.contains, Option.isSome] at he
-  cases he' : entities.find? e <;> simp [he'] at he
-  rename_i ed
-  specialize hes _ _ he'
-  have hets : env.ets = schema.ets := env_in_schema_ets_eq henv
-  have hacts : env.acts = schema.acts := env_in_schema_acts_eq henv
-  rw [←hets, ←hacts]
-  cases hes
-  · rename_i hes
-    unfold InstanceOfEntitySchemaEntry at hes
-    replace ⟨es, hes₁, hes₂, hes₃, hes₄, hes₅ ⟩ := hes ; clear hes
-    simp [hes₁]
-  · rename_i has
-    unfold InstanceOfActionSchemaEntry at has
-    replace ⟨hattrs, has₁, has₂, has₃, has₄ ⟩ := has ; clear has
-    simp [has₃]
+/-- Every entity type is among its own `ancestorTypes`. -/
+theorem mem_ancestorTypes_self {schema : Schema} {ety : EntityType} :
+  ety ∈ schema.ancestorTypes ety
+:= by simp [Schema.ancestorTypes, Set.mem_union, Set.mem_singleton]
 
 theorem instance_of_wf_schema_not_ancestor_type_implies_not_ancestor :
   InstanceOfWellFormedSchema schema req entities →
@@ -343,34 +324,3 @@ theorem instance_of_wf_schema_not_ancestor_type_implies_not_ancestor :
           Map.mem_filter_if_find? (by simp only [BEq.rfl]) ha₁
         simp only [List.mem_mapUnion_iff_mem_exists, Set.mem_map] at hnin₂
         grind
-
-theorem instance_of_wf_schema_resource_type_defined :
-  InstanceOfWellFormedSchema schema req entities →
-  schema.ets.contains req.resource.ty ∨ schema.acts.IsActionEntityType req.resource.ty
-:= by
-  simp only [InstanceOfWellFormedSchema, forall_exists_index, and_imp]
-  intro env henv hwf
-
-  have hawf : ∀ uid entry , Map.find? env.acts uid = some entry → ActionSchemaEntry.WellFormed env entry := by
-    simp only [InstanceOfWellFormedEnvironment, TypeEnv.WellFormed, ActionSchema.WellFormed] at hwf
-    grind
-
-  have ⟨aentry, hfa, happ⟩ : ∃ aentry, Map.find? env.acts env.reqty.action = some aentry ∧ env.reqty.resource ∈ aentry.appliesToResource := by
-    simp only [InstanceOfWellFormedEnvironment, TypeEnv.WellFormed, RequestType.WellFormed] at hwf
-    grind
-
-  have hrty : env.reqty.resource = req.resource.ty := by
-    simp only [InstanceOfWellFormedEnvironment, InstanceOfRequestType, InstanceOfEntityType] at hwf
-    simp [hwf]
-
-  suffices hdef : env.ets.contains env.reqty.resource ∨ env.acts.IsActionEntityType env.reqty.resource from by
-    have hets : env.ets = schema.ets := env_in_schema_ets_eq henv
-    have hacts : env.acts = schema.acts := env_in_schema_acts_eq henv
-    rw [←hrty, ←hets, ←hacts]
-    exact hdef
-
-  specialize hawf env.reqty.action aentry hfa
-  replace hawf := hawf.right.right.right.right.left
-  specialize hawf req.resource.ty
-  rw [Set.contains_prop_bool_equiv, ←hrty] at hawf
-  exact hawf happ

--- a/cedar-lean/Cedar/Thm/Validation/Typechecker/WF.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Typechecker/WF.lean
@@ -519,4 +519,14 @@ theorem wf_env_implies_ancestors_of_action_is_action
   have ⟨_, _, _, _, _, hancs, _⟩ := hwf_entry
   exact hancs
 
+theorem env_in_schema_ets_eq {schema : Schema} :
+  env ∈ schema.environments →
+  env.ets = schema.ets
+:= by unfold Schema.environments; grind
+
+theorem env_in_schema_acts_eq {schema : Schema} :
+  env ∈ schema.environments →
+  env.acts = schema.acts
+:= by unfold Schema.environments; grind
+
 end Cedar.Validation

--- a/cedar-lean/Cedar/Validation/Types.lean
+++ b/cedar-lean/Cedar/Validation/Types.lean
@@ -190,6 +190,13 @@ public structure Schema where
   ets : EntitySchema
   acts : ActionSchema
 
+@[expose]
+public def Schema.ancestorTypes (schema : Schema) (ety : EntityType) : Set EntityType :=
+  Set.singleton ety ∪
+    match schema.ets.find? ety with
+      | .some entry => entry.ancestors
+      | .none       => schema.acts.filter (λ act _ => act.ty == ety)|>.values.mapUnion (·.ancestors.map (·.ty))
+
 public structure RequestType where
   principal : EntityType
   action : EntityUID


### PR DESCRIPTION
A permissions query algorithm is an procedure for enumerating resources with a specific type that a principal is authorized to access.

For each algorithm, this PR proves that a resources is listed if and only if it has the expected type and access is in fact allowed.

Specifically, the two main theorems are

```lean
theorem resource_scan_correct (n : Nat) (schema : Schema) (req : ResourcesForPrincipalRequest) (entities : Entities) (policies : Policies) (r : EntityUID) :
    validateWithLevel policies schema n = .ok () →
    schema.validateWellFormed = .ok () →
    validateRequest schema (req.req r) = .ok () →
    validateEntities schema entities = .ok () →
    (r ∈ scanResourcesForPrincipal n schema req entities policies ↔
    (r ∈ entities ∧ r.ty = req.resourceType ∧ (isAuthorized (req.req r) entities policies).decision = .allow))

theorem discretionary_resource_for_principal_correct :
  arePoliciesDiscretionary ps = true →
    (r ∈ discretionaryResourcesForPrincipal pq es ps ↔ (r.ty = pq.resourceType ∧ (isAuthorized (pq.req r) es ps).decision = .allow))
```