### PR TITLE
fix insta minor ~1.46

### DIFF
--- a/cedar-lean-cli/Cargo.toml
+++ b/cedar-lean-cli/Cargo.toml
@@ -19,7 +19,7 @@ thiserror = "2.0"
 
 [dev-dependencies]
 assert_cmd = "2.0.17"
-insta = { version = "1.46", features = ["filters"] }
+insta = { version = "~1.46", features = ["filters"] }
 
 # https://insta.rs/docs/quickstart/ recommends compiling `insta` and `similar` in release mode
 [profile.dev.package]


### PR DESCRIPTION
New minor of `insta` is breaking our tests in `cedar-lean-cli`:
https://github.com/cedar-policy/cedar/actions/runs/23649276041/job/68895049925?pr=2260

Issue: 
https://github.com/cedar-policy/cedar-spec/issues/917



