### PR TITLE
Add Cedar type generator respecting max_width and max_depth

### DIFF
--- a/cedar-policy-generators/src/abac.rs
+++ b/cedar-policy-generators/src/abac.rs
@@ -428,165 +428,155 @@ pub struct AvailableExtensionFunctions {
 impl AvailableExtensionFunctions {
     /// Create a new `AvailableExtensionFunctions` object based on the given `settings`
     pub fn create(settings: &ABACSettings) -> Self {
-        let available_ext_funcs = if settings.enable_extensions {
-            vec![
-                AvailableExtensionFunction {
-                    name: Name::parse_unqualified_name("ip").expect("should be a valid identifier"),
-                    is_constructor: true,
-                    parameter_types: vec![Type::string()],
-                    return_ty: Type::ipaddr(),
-                },
-                AvailableExtensionFunction {
-                    name: Name::parse_unqualified_name("isIpv4")
-                        .expect("should be a valid identifier"),
-                    is_constructor: false,
-                    parameter_types: vec![Type::ipaddr()],
-                    return_ty: Type::bool(),
-                },
-                AvailableExtensionFunction {
-                    name: Name::parse_unqualified_name("isIpv6")
-                        .expect("should be a valid identifier"),
-                    is_constructor: false,
-                    parameter_types: vec![Type::ipaddr()],
-                    return_ty: Type::bool(),
-                },
-                AvailableExtensionFunction {
-                    name: Name::parse_unqualified_name("isLoopback")
-                        .expect("should be a valid identifier"),
-                    is_constructor: false,
-                    parameter_types: vec![Type::ipaddr()],
-                    return_ty: Type::bool(),
-                },
-                AvailableExtensionFunction {
-                    name: Name::parse_unqualified_name("isMulticast")
-                        .expect("should be a valid identifier"),
-                    is_constructor: false,
-                    parameter_types: vec![Type::ipaddr()],
-                    return_ty: Type::bool(),
-                },
-                AvailableExtensionFunction {
-                    name: Name::parse_unqualified_name("isInRange")
-                        .expect("should be a valid identifier"),
-                    is_constructor: false,
-                    parameter_types: vec![Type::ipaddr(), Type::ipaddr()],
-                    return_ty: Type::bool(),
-                },
-                AvailableExtensionFunction {
-                    name: Name::parse_unqualified_name("decimal")
-                        .expect("should be a valid identifier"),
-                    is_constructor: true,
-                    parameter_types: vec![Type::string()],
-                    return_ty: Type::decimal(),
-                },
-                AvailableExtensionFunction {
-                    name: Name::parse_unqualified_name("lessThan")
-                        .expect("should be a valid identifier"),
-                    is_constructor: false,
-                    parameter_types: vec![Type::decimal(), Type::decimal()],
-                    return_ty: Type::bool(),
-                },
-                AvailableExtensionFunction {
-                    name: Name::parse_unqualified_name("lessThanOrEqual")
-                        .expect("should be a valid identifier"),
-                    is_constructor: false,
-                    parameter_types: vec![Type::decimal(), Type::decimal()],
-                    return_ty: Type::bool(),
-                },
-                AvailableExtensionFunction {
-                    name: Name::parse_unqualified_name("greaterThan")
-                        .expect("should be a valid identifier"),
-                    is_constructor: false,
-                    parameter_types: vec![Type::decimal(), Type::decimal()],
-                    return_ty: Type::bool(),
-                },
-                AvailableExtensionFunction {
-                    name: Name::parse_unqualified_name("greaterThanOrEqual")
-                        .expect("should be a valid identifier"),
-                    is_constructor: false,
-                    parameter_types: vec![Type::decimal(), Type::decimal()],
-                    return_ty: Type::bool(),
-                },
-                AvailableExtensionFunction {
-                    name: Name::parse_unqualified_name("datetime")
-                        .expect("should be a valid identifier"),
-                    is_constructor: true,
-                    parameter_types: vec![Type::string()],
-                    return_ty: Type::datetime(),
-                },
-                AvailableExtensionFunction {
-                    name: Name::parse_unqualified_name("offset")
-                        .expect("should be a valid identifier"),
-                    is_constructor: true,
-                    parameter_types: vec![Type::datetime(), Type::duration()],
-                    return_ty: Type::datetime(),
-                },
-                AvailableExtensionFunction {
-                    name: Name::parse_unqualified_name("durationSince")
-                        .expect("should be a valid identifier"),
-                    is_constructor: false,
-                    parameter_types: vec![Type::datetime(), Type::datetime()],
-                    return_ty: Type::duration(),
-                },
-                AvailableExtensionFunction {
-                    name: Name::parse_unqualified_name("toDate")
-                        .expect("should be a valid identifier"),
-                    is_constructor: false,
-                    parameter_types: vec![Type::datetime()],
-                    return_ty: Type::datetime(),
-                },
-                AvailableExtensionFunction {
-                    name: Name::parse_unqualified_name("toTime")
-                        .expect("should be a valid identifier"),
-                    is_constructor: false,
-                    parameter_types: vec![Type::datetime()],
-                    return_ty: Type::duration(),
-                },
-                AvailableExtensionFunction {
-                    name: Name::parse_unqualified_name("duration")
-                        .expect("should be a valid identifier"),
-                    is_constructor: true,
-                    parameter_types: vec![Type::string()],
-                    return_ty: Type::duration(),
-                },
-                AvailableExtensionFunction {
-                    name: Name::parse_unqualified_name("toMilliseconds")
-                        .expect("should be a valid identifier"),
-                    is_constructor: false,
-                    parameter_types: vec![Type::duration()],
-                    return_ty: Type::long(),
-                },
-                AvailableExtensionFunction {
-                    name: Name::parse_unqualified_name("toSeconds")
-                        .expect("should be a valid identifier"),
-                    is_constructor: false,
-                    parameter_types: vec![Type::duration()],
-                    return_ty: Type::long(),
-                },
-                AvailableExtensionFunction {
-                    name: Name::parse_unqualified_name("toMinutes")
-                        .expect("should be a valid identifier"),
-                    is_constructor: false,
-                    parameter_types: vec![Type::duration()],
-                    return_ty: Type::long(),
-                },
-                AvailableExtensionFunction {
-                    name: Name::parse_unqualified_name("toHours")
-                        .expect("should be a valid identifier"),
-                    is_constructor: false,
-                    parameter_types: vec![Type::duration()],
-                    return_ty: Type::long(),
-                },
-                AvailableExtensionFunction {
-                    name: Name::parse_unqualified_name("toDays")
-                        .expect("should be a valid identifier"),
-                    is_constructor: false,
-                    parameter_types: vec![Type::duration()],
-                    return_ty: Type::long(),
-                },
-            ]
-        } else {
-            vec![]
-        };
+        let available_ext_funcs = vec![
+            AvailableExtensionFunction {
+                name: Name::parse_unqualified_name("ip").expect("should be a valid identifier"),
+                is_constructor: true,
+                parameter_types: vec![Type::string()],
+                return_ty: Type::ipaddr(),
+            },
+            AvailableExtensionFunction {
+                name: Name::parse_unqualified_name("isIpv4").expect("should be a valid identifier"),
+                is_constructor: false,
+                parameter_types: vec![Type::ipaddr()],
+                return_ty: Type::bool(),
+            },
+            AvailableExtensionFunction {
+                name: Name::parse_unqualified_name("isIpv6").expect("should be a valid identifier"),
+                is_constructor: false,
+                parameter_types: vec![Type::ipaddr()],
+                return_ty: Type::bool(),
+            },
+            AvailableExtensionFunction {
+                name: Name::parse_unqualified_name("isLoopback")
+                    .expect("should be a valid identifier"),
+                is_constructor: false,
+                parameter_types: vec![Type::ipaddr()],
+                return_ty: Type::bool(),
+            },
+            AvailableExtensionFunction {
+                name: Name::parse_unqualified_name("isMulticast")
+                    .expect("should be a valid identifier"),
+                is_constructor: false,
+                parameter_types: vec![Type::ipaddr()],
+                return_ty: Type::bool(),
+            },
+            AvailableExtensionFunction {
+                name: Name::parse_unqualified_name("isInRange")
+                    .expect("should be a valid identifier"),
+                is_constructor: false,
+                parameter_types: vec![Type::ipaddr(), Type::ipaddr()],
+                return_ty: Type::bool(),
+            },
+            AvailableExtensionFunction {
+                name: Name::parse_unqualified_name("decimal")
+                    .expect("should be a valid identifier"),
+                is_constructor: true,
+                parameter_types: vec![Type::string()],
+                return_ty: Type::decimal(),
+            },
+            AvailableExtensionFunction {
+                name: Name::parse_unqualified_name("lessThan")
+                    .expect("should be a valid identifier"),
+                is_constructor: false,
+                parameter_types: vec![Type::decimal(), Type::decimal()],
+                return_ty: Type::bool(),
+            },
+            AvailableExtensionFunction {
+                name: Name::parse_unqualified_name("lessThanOrEqual")
+                    .expect("should be a valid identifier"),
+                is_constructor: false,
+                parameter_types: vec![Type::decimal(), Type::decimal()],
+                return_ty: Type::bool(),
+            },
+            AvailableExtensionFunction {
+                name: Name::parse_unqualified_name("greaterThan")
+                    .expect("should be a valid identifier"),
+                is_constructor: false,
+                parameter_types: vec![Type::decimal(), Type::decimal()],
+                return_ty: Type::bool(),
+            },
+            AvailableExtensionFunction {
+                name: Name::parse_unqualified_name("greaterThanOrEqual")
+                    .expect("should be a valid identifier"),
+                is_constructor: false,
+                parameter_types: vec![Type::decimal(), Type::decimal()],
+                return_ty: Type::bool(),
+            },
+            AvailableExtensionFunction {
+                name: Name::parse_unqualified_name("datetime")
+                    .expect("should be a valid identifier"),
+                is_constructor: true,
+                parameter_types: vec![Type::string()],
+                return_ty: Type::datetime(),
+            },
+            AvailableExtensionFunction {
+                name: Name::parse_unqualified_name("offset").expect("should be a valid identifier"),
+                is_constructor: true,
+                parameter_types: vec![Type::datetime(), Type::duration()],
+                return_ty: Type::datetime(),
+            },
+            AvailableExtensionFunction {
+                name: Name::parse_unqualified_name("durationSince")
+                    .expect("should be a valid identifier"),
+                is_constructor: false,
+                parameter_types: vec![Type::datetime(), Type::datetime()],
+                return_ty: Type::duration(),
+            },
+            AvailableExtensionFunction {
+                name: Name::parse_unqualified_name("toDate").expect("should be a valid identifier"),
+                is_constructor: false,
+                parameter_types: vec![Type::datetime()],
+                return_ty: Type::datetime(),
+            },
+            AvailableExtensionFunction {
+                name: Name::parse_unqualified_name("toTime").expect("should be a valid identifier"),
+                is_constructor: false,
+                parameter_types: vec![Type::datetime()],
+                return_ty: Type::duration(),
+            },
+            AvailableExtensionFunction {
+                name: Name::parse_unqualified_name("duration")
+                    .expect("should be a valid identifier"),
+                is_constructor: true,
+                parameter_types: vec![Type::string()],
+                return_ty: Type::duration(),
+            },
+            AvailableExtensionFunction {
+                name: Name::parse_unqualified_name("toMilliseconds")
+                    .expect("should be a valid identifier"),
+                is_constructor: false,
+                parameter_types: vec![Type::duration()],
+                return_ty: Type::long(),
+            },
+            AvailableExtensionFunction {
+                name: Name::parse_unqualified_name("toSeconds")
+                    .expect("should be a valid identifier"),
+                is_constructor: false,
+                parameter_types: vec![Type::duration()],
+                return_ty: Type::long(),
+            },
+            AvailableExtensionFunction {
+                name: Name::parse_unqualified_name("toMinutes")
+                    .expect("should be a valid identifier"),
+                is_constructor: false,
+                parameter_types: vec![Type::duration()],
+                return_ty: Type::long(),
+            },
+            AvailableExtensionFunction {
+                name: Name::parse_unqualified_name("toHours")
+                    .expect("should be a valid identifier"),
+                is_constructor: false,
+                parameter_types: vec![Type::duration()],
+                return_ty: Type::long(),
+            },
+            AvailableExtensionFunction {
+                name: Name::parse_unqualified_name("toDays").expect("should be a valid identifier"),
+                is_constructor: false,
+                parameter_types: vec![Type::duration()],
+                return_ty: Type::long(),
+            },
+        ];
         let constructors = available_ext_funcs
             .iter()
             .filter(|func| func.is_constructor)
@@ -695,7 +685,7 @@ impl AvailableExtensionFunctions {
 }
 
 /// A qualified type
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Arbitrary)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct QualifiedType {
     /// Type
     pub ty: Type,
@@ -705,7 +695,7 @@ pub struct QualifiedType {
 
 /// Approximation of the Cedar type system used by the type-directed
 /// generator
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Arbitrary)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Type {
     /// Bool
     Bool,
@@ -779,41 +769,6 @@ impl Type {
             "ip" => Self::IPAddr,
             _ => unreachable!("unexpected extension type"),
         }
-    }
-
-    fn arbitrary_record_inner(
-        u: &mut Unstructured<'_>,
-        max_width: Option<usize>,
-        type_gen: impl Fn(&mut Unstructured<'_>) -> Result<QualifiedType>,
-    ) -> Result<Type> {
-        let mut r: BTreeMap<SmolStr, QualifiedType> = BTreeMap::new();
-        u.arbitrary_loop(Some(0), max_width.map(|u| u as u32), |u| {
-            r.insert(u.arbitrary()?, type_gen(u)?);
-            Ok(std::ops::ControlFlow::Continue(()))
-        })?;
-        Ok(Self::Record(r))
-    }
-
-    /// Produce an arbitrary record with `max_width`
-    pub fn arbitrary_record(u: &mut Unstructured<'_>, max_width: usize) -> Result<Type> {
-        Self::arbitrary_record_inner(u, Some(max_width), |u| Ok(u.arbitrary()?))
-    }
-
-    /// `Type` has `Arbitrary` auto-derived for it, but for the case where you
-    /// want "any nonextension Type", you have this
-    pub fn arbitrary_nonextension(u: &mut Unstructured<'_>) -> Result<Type> {
-        Ok(uniform!(
-            u,
-            Type::bool(),
-            Type::long(),
-            Type::string(),
-            Type::set_of(Self::arbitrary_nonextension(u)?),
-            Self::arbitrary_record_inner(u, None, |u| Ok(QualifiedType {
-                ty: Self::arbitrary_nonextension(u)?,
-                required: u.arbitrary()?
-            }))?,
-            Type::entity(u.arbitrary()?)
-        ))
     }
 }
 

--- a/cedar-policy-generators/src/expr.rs
+++ b/cedar-policy-generators/src/expr.rs
@@ -22,6 +22,7 @@ use crate::hierarchy::{generate_uid_with_type, Hierarchy};
 use crate::schema_gen::SchemaGen;
 use crate::settings::ABACSettings;
 use crate::size_hint_utils::{size_hint_for_choose, size_hint_for_range, size_hint_for_ratio};
+use crate::types::TypeGenerator;
 use crate::{accum, gen, gen_inner, uniform};
 use arbitrary::{Arbitrary, MaxRecursionReached, Unstructured};
 use cedar_policy_core::ast;
@@ -45,6 +46,16 @@ pub struct ExprGenerator<'a> {
     /// If this is present, any literal UIDs included in generated `Expr`s will
     /// (usually) exist in the hierarchy.
     pub hierarchy: Option<&'a Hierarchy>,
+}
+
+impl<'a> ExprGenerator<'a> {
+    fn as_type_gen(&self) -> TypeGenerator<'a> {
+        TypeGenerator {
+            schema: self.schema,
+            constant_pool: self.constant_pool,
+            settings: self.settings,
+        }
+    }
 }
 
 impl ExprGenerator<'_> {
@@ -183,9 +194,6 @@ impl ExprGenerator<'_> {
                         Ok(ast::Expr::record(r).expect("can't have duplicate keys because `r` was already a HashMap"))
                     },
                     1 => {
-                        if !self.settings.enable_extensions {
-                            return Err(Error::ExtensionsDisabled);
-                        };
                         let func = self.ext_funcs.arbitrary_all(u)?;
                         let arity = if !self.settings.enable_arbitrary_func_call
                             || u.ratio::<u8>(9, 10)?
@@ -291,7 +299,7 @@ impl ExprGenerator<'_> {
                         2 => Ok(ast::Expr::val(u.arbitrary::<bool>()?)),
                         // == expression, where types on both sides match
                         5 => {
-                            let ty: Type = u.arbitrary()?;
+                            let ty = self.as_type_gen().generate_type(max_depth, u)?;
                             Ok(ast::Expr::is_eq(
                                 self.generate_expr_for_type(&ty, max_depth - 1, u)?,
                                 self.generate_expr_for_type(&ty, max_depth - 1, u)?,
@@ -299,8 +307,8 @@ impl ExprGenerator<'_> {
                         },
                         // == expression, where types do not match
                         2 => {
-                            let ty1: Type = u.arbitrary()?;
-                            let ty2: Type = u.arbitrary()?;
+                            let ty1 = self.as_type_gen().generate_type(max_depth, u)?;
+                            let ty2 = self.as_type_gen().generate_type(max_depth, u)?;
                             Ok(ast::Expr::is_eq(
                                 self.generate_expr_for_type(
                                     &ty1,
@@ -398,7 +406,7 @@ impl ExprGenerator<'_> {
                         ))},
                         // contains() on a set
                         2 => {
-                            let element_ty = u.arbitrary()?;
+                            let element_ty = self.as_type_gen().generate_type(max_depth, u)?;
                             let element = self.generate_expr_for_type(
                                 &element_ty,
                                 max_depth - 1,
@@ -415,12 +423,12 @@ impl ExprGenerator<'_> {
                         1 => Ok(ast::Expr::contains_all(
                             // doesn't require the input sets to have the same element type
                             self.generate_expr_for_type(
-                                &Type::set_of(u.arbitrary()?),
+                                &Type::set_of(self.as_type_gen().generate_type(max_depth, u)?),
                                 max_depth - 1,
                                 u,
                             )?,
                             self.generate_expr_for_type(
-                                &Type::set_of(u.arbitrary()?),
+                                &Type::set_of(self.as_type_gen().generate_type(max_depth, u)?),
                                 max_depth - 1,
                                 u,
                             )?,
@@ -429,12 +437,12 @@ impl ExprGenerator<'_> {
                         1 => Ok(ast::Expr::contains_any(
                             // doesn't require the input sets to have the same element type
                             self.generate_expr_for_type(
-                                &Type::set_of(u.arbitrary()?),
+                                &Type::set_of(self.as_type_gen().generate_type(max_depth, u)?),
                                 max_depth - 1,
                                 u,
                             )?,
                             self.generate_expr_for_type(
-                                &Type::set_of(u.arbitrary()?),
+                                &Type::set_of(self.as_type_gen().generate_type(max_depth, u)?),
                                 max_depth - 1,
                                 u,
                             )?,
@@ -442,7 +450,7 @@ impl ExprGenerator<'_> {
                         // isEmpty()
                         1 => Ok(ast::Expr::is_empty(
                             self.generate_expr_for_type(
-                                &Type::set_of(u.arbitrary()?),
+                                &Type::set_of(self.as_type_gen().generate_type(max_depth, u)?),
                                 max_depth - 1,
                                 u,
                             )?,
@@ -513,7 +521,7 @@ impl ExprGenerator<'_> {
                         // has expression on a record
                         2 => Ok(ast::Expr::has_attr(
                             self.generate_expr_for_type(
-                                &Type::arbitrary_record(u, self.settings.max_width)?,
+                                &self.as_type_gen().generate_record_type(max_depth, u)?,
                                 max_depth - 1,
                                 u,
                             )?,
@@ -714,9 +722,6 @@ impl ExprGenerator<'_> {
                     }
                 }
                 Type::IPAddr | Type::Decimal | Type::DateTime | Type::Duration => {
-                    if !self.settings.enable_extensions {
-                        return Err(Error::ExtensionsDisabled);
-                    };
                     if max_depth == 0 || u.len() < 10 {
                         self.generate_expr_for_type_structurally_recursive(target_type, u)
                     } else {

--- a/cedar-policy-generators/src/hierarchy.rs
+++ b/cedar-policy-generators/src/hierarchy.rs
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-use crate::abac::Type;
 use crate::err::{while_doing, Error, Result};
 use crate::schema_gen::SchemaGen;
 use crate::size_hint_utils::{size_hint_for_choose, size_hint_for_ratio};
@@ -543,11 +542,7 @@ impl HierarchyGenerator<'_, '_> {
                                         None,
                                         Some(schema.get_abac_settings().max_width as u32),
                                         |u| {
-                                            let attr_type = if schema.get_abac_settings().enable_extensions {
-                                                u.arbitrary()?
-                                            } else {
-                                                Type::arbitrary_nonextension(u)?
-                                            };
+                                            let attr_type = schema.type_generator().generate_type(schema.get_abac_settings().max_depth, u)?;
                                             let attr_name: String = u.arbitrary()?;
                                             attrs.insert(
                                                 attr_name.into(),

--- a/cedar-policy-generators/src/lib.rs
+++ b/cedar-policy-generators/src/lib.rs
@@ -65,3 +65,6 @@ pub mod policy_set;
 
 /// A trait that specifies what methods other generators expect from a schema
 pub mod schema_gen;
+
+/// Generates Cedar types
+pub mod types;

--- a/cedar-policy-generators/src/schema.rs
+++ b/cedar-policy-generators/src/schema.rs
@@ -257,39 +257,27 @@ pub fn arbitrary_schematype_with_bounded_depth<N: From<ast::Name>>(
         }
     };
 
-    let ty = if settings.enable_extensions {
-        uniform!(
-            u,
-            json_schema::TypeVariant::String,
-            json_schema::TypeVariant::Long,
-            json_schema::TypeVariant::Boolean,
-            set(u)?,
-            record(u)?,
-            entity_type_name_to_schema_type_variant::<N>(u.choose(entity_types)?),
-            json_schema::TypeVariant::Extension {
-                name: "ipaddr".parse().unwrap(),
-            },
-            json_schema::TypeVariant::Extension {
-                name: "decimal".parse().unwrap(),
-            },
-            json_schema::TypeVariant::Extension {
-                name: "datetime".parse().unwrap(),
-            },
-            json_schema::TypeVariant::Extension {
-                name: "duration".parse().unwrap(),
-            }
-        )
-    } else {
-        uniform!(
-            u,
-            json_schema::TypeVariant::String,
-            json_schema::TypeVariant::Long,
-            json_schema::TypeVariant::Boolean,
-            set(u)?,
-            record(u)?,
-            entity_type_name_to_schema_type_variant::<N>(u.choose(entity_types)?)
-        )
-    };
+    let ty = uniform!(
+        u,
+        json_schema::TypeVariant::String,
+        json_schema::TypeVariant::Long,
+        json_schema::TypeVariant::Boolean,
+        set(u)?,
+        record(u)?,
+        entity_type_name_to_schema_type_variant::<N>(u.choose(entity_types)?),
+        json_schema::TypeVariant::Extension {
+            name: "ipaddr".parse().unwrap(),
+        },
+        json_schema::TypeVariant::Extension {
+            name: "decimal".parse().unwrap(),
+        },
+        json_schema::TypeVariant::Extension {
+            name: "datetime".parse().unwrap(),
+        },
+        json_schema::TypeVariant::Extension {
+            name: "duration".parse().unwrap(),
+        }
+    );
 
     Ok(json_schema::Type::Type { ty, loc: None })
 }
@@ -1966,7 +1954,6 @@ mod tests {
     const ITERATION: u8 = 100;
 
     const TEST_SETTINGS: ABACSettings = ABACSettings {
-        enable_extensions: false,
         max_depth: 4,
         max_width: 4,
         enable_additional_attributes: false,

--- a/cedar-policy-generators/src/schema_gen.rs
+++ b/cedar-policy-generators/src/schema_gen.rs
@@ -12,6 +12,7 @@ use crate::{
     request::Request,
     schema::Schema,
     settings::ABACSettings,
+    types::TypeGenerator,
 };
 use arbitrary::Unstructured;
 use cedar_policy_core::{
@@ -119,6 +120,8 @@ pub trait SchemaGen: std::fmt::Debug {
     fn get_abac_settings(&self) -> &ABACSettings;
     /// Get an expression generator
     fn exprgenerator<'s>(&'s self, hierarchy: Option<&'s Hierarchy>) -> ExprGenerator<'s>;
+    /// Get a type generator
+    fn type_generator<'s>(&'s self) -> TypeGenerator<'s>;
     /// Get an arbitrary Hierarchy conforming to the schema.
     fn arbitrary_hierarchy(&self, u: &mut Unstructured<'_>) -> Result<Hierarchy>;
     /// get an arbitrary policy conforming to this schema
@@ -458,6 +461,13 @@ impl SchemaGen for ValidatorSchema<'_> {
             hierarchy,
         }
     }
+    fn type_generator<'s>(&'s self) -> TypeGenerator<'s> {
+        TypeGenerator {
+            schema: self,
+            constant_pool: &self.constant_pool,
+            settings: &self.settings,
+        }
+    }
     fn arbitrary_hierarchy(&self, u: &mut Unstructured<'_>) -> Result<Hierarchy> {
         HierarchyGenerator {
             mode: HierarchyGeneratorMode::SchemaBased { schema: self },
@@ -584,6 +594,13 @@ impl SchemaGen for Schema {
     }
     fn exprgenerator<'s>(&'s self, hierarchy: Option<&'s Hierarchy>) -> ExprGenerator<'s> {
         self.exprgenerator(hierarchy)
+    }
+    fn type_generator<'s>(&'s self) -> TypeGenerator<'s> {
+        TypeGenerator {
+            schema: self,
+            constant_pool: &self.constant_pool,
+            settings: &self.settings,
+        }
     }
     fn arbitrary_hierarchy(&self, u: &mut Unstructured<'_>) -> Result<Hierarchy> {
         HierarchyGenerator {

--- a/cedar-policy-generators/src/settings.rs
+++ b/cedar-policy-generators/src/settings.rs
@@ -27,9 +27,6 @@ pub struct ABACSettings {
     ///
     /// If false, does not attempt to match types.
     pub match_types: bool,
-    /// If true, may generate extension function calls in policies and/or
-    /// attribute values.
-    pub enable_extensions: bool,
     /// Maximum depth of an expression or type. E.g., maximum nesting of sets.
     ///
     /// This is used in the following places:
@@ -101,7 +98,6 @@ impl ABACSettings {
     pub const fn type_directed() -> Self {
         Self {
             match_types: true,
-            enable_extensions: true,
             max_depth: 7,
             max_width: 7,
             enable_additional_attributes: false,

--- a/cedar-policy-generators/src/types.rs
+++ b/cedar-policy-generators/src/types.rs
@@ -1,0 +1,89 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::collections::BTreeMap;
+
+use crate::{
+    abac::{ConstantPool, QualifiedType, Type},
+    err::Result,
+    schema_gen::SchemaGen,
+    settings::ABACSettings,
+};
+use arbitrary::Unstructured;
+
+/// Generates types based on string constants and entity types available
+#[derive(Debug)]
+pub struct TypeGenerator<'a> {
+    /// Schema, used to generate entity types drawn from the schema
+    pub schema: &'a dyn SchemaGen,
+    /// Constant pool, used to generate attribute names for record types
+    pub constant_pool: &'a ConstantPool,
+    /// General abac settings. Used here for maximum width of a type (number of attributes in record).
+    pub settings: &'a ABACSettings,
+}
+
+impl TypeGenerator<'_> {
+    /// Generate an arbitrary type, respecting `max_depth` and `max_width`
+    pub fn generate_type(&self, max_depth: usize, u: &mut Unstructured<'_>) -> Result<Type> {
+        if max_depth == 0 {
+            // Reached max-depth, so no recursion. Record types are empty and
+            // skips generating set types entirely. All other types generated.
+            uniform!(
+                u,
+                Ok(Type::bool()),
+                Ok(Type::long()),
+                Ok(Type::string()),
+                Ok(Type::ipaddr()),
+                Ok(Type::decimal()),
+                Ok(Type::datetime()),
+                Ok(Type::duration()),
+                Ok(Type::entity(self.schema.arbitrary_entity_type(u)?,)),
+                Ok(Type::record([]))
+            )
+        } else {
+            uniform!(
+                u,
+                Ok(Type::bool()),
+                Ok(Type::long()),
+                Ok(Type::string()),
+                Ok(Type::ipaddr()),
+                Ok(Type::decimal()),
+                Ok(Type::datetime()),
+                Ok(Type::duration()),
+                Ok(Type::entity(self.schema.arbitrary_entity_type(u)?,)),
+                Ok(Type::set_of(self.generate_type(max_depth - 1, u)?)),
+                self.generate_record_type(max_depth, u)
+            )
+        }
+    }
+
+    pub(crate) fn generate_record_type(
+        &self,
+        max_depth: usize,
+        u: &mut Unstructured<'_>,
+    ) -> Result<Type> {
+        let mut attrs = BTreeMap::new();
+        u.arbitrary_loop(Some(0), Some(self.settings.max_width as u32), |u| {
+            let ty = QualifiedType {
+                ty: self.generate_type(max_depth - 1, u)?,
+                required: u.arbitrary()?,
+            };
+            attrs.insert(self.constant_pool.arbitrary_string_constant(u)?, ty);
+            Ok(std::ops::ControlFlow::Continue(()))
+        })?;
+        Ok(Type::record(attrs))
+    }
+}


### PR DESCRIPTION
This change limits the depth (and width) of generated types. This should avoid a recent failure we saw in differential testing where the serialized form a symcc Term (whose depth should be roughly equal to the expression it was compiled from) exceeded the recursion limit of serde, causing an error when deserializing the Term computed in the Lean model.

We already limit depth when generating expressions, but we don't impose any limit on the size of intermediate types used inside the generator. For example, to create an `==` expression, we choose a type for the operands, and then generate expressions of that type with `max_depth - 1`. If the depth of the intermediate type was greater than the renaming expression depth, we generate the expression by structural recursion on the type rather than on `max_depth` (prior to https://github.com/cedar-policy/cedar-spec/pull/908 the generator would instead fail to generate any expression in this case). This still works to avoid infinite recursion , but it makes the actual maximum depth limited only by whatever recursion guard the `arbitrary` crate imposes. With this change the depth of expression should actually respect `max_depth`. 

Record attributes name are now pull from the constant pool and entity types are take from the schema, which should make it easier to generate well-typed expressions. 

Also removes the `enable_extensions` flag. This was always set to `true`, and if I kept it I would need to handle it properly in the new type generator which is too much trouble for something we don't use.