### PR TITLE
Don't fail fuzz targets on timeout on cex generation

### DIFF
--- a/cedar-drt/fuzz/src/symcc.rs
+++ b/cedar-drt/fuzz/src/symcc.rs
@@ -524,10 +524,16 @@ pub async fn get_cex(
     match timeout(TIMEOUT_DUR, f).await {
         Ok(Ok(None)) => None, // successfully executed, no counterexample because the property holds
         Ok(Ok(Some(cex))) => Some(cex),
-        Err(err) => panic!(
-            "found a slow unit (solver took more than {secs:.2} sec) probably worth investigating: {err}",
-            secs = TIMEOUT_DUR.as_secs_f32()
-        ),
+        Err(err) => {
+            // Exceeded timeout for solver. Skip this and continue testing, it
+            // should still be reported as a slow-unit since out solver timeout
+            // is longer than libfuzzers default (10s, I think).
+            debug!(
+                "found a slow unit (solver took more than {secs:.2} sec) probably worth investigating: {err}",
+                secs = TIMEOUT_DUR.as_secs_f32()
+            );
+            None
+        }
         Ok(Err(Error::SolverError(err))) => panic!("solver failed: {err}"),
         Ok(Err(Error::EncodeError(EncodeError::EncodeStringFailed(_))))
         | Ok(Err(Error::EncodeError(EncodeError::EncodePatternFailed(_)))) => {


### PR DESCRIPTION
We often see timeouts in this target due to long-running solver queries with bitvector operations (e.g., `x * x >= 0`). We made these errors initially so that we could investigate performance issues, but the target finds known slow solver queries too often for this to be useful.

Slow inputs will still be logged as slow-units, but with this change they will not appear as a failure. 

I'm slightly concerned that this might reintroduce some of the issues we had with managing the solver processes. I'm running locally and we'll see if things break in nightly testing. 