### PR TITLE
Restart solver after timeout

### DIFF
--- a/cedar-drt/fuzz/fuzz_targets/symcc-cex-drt.rs
+++ b/cedar-drt/fuzz/fuzz_targets/symcc-cex-drt.rs
@@ -18,7 +18,7 @@
 use cedar_drt::logger::initialize_log;
 use cedar_drt_inner::{
     fuzz_target,
-    symcc::{RUNTIME, TwoPolicyFuzzTargetInput, get_cex, get_solver, reproduce},
+    symcc::{CexError, RUNTIME, TwoPolicyFuzzTargetInput, get_cex, get_solver, reproduce},
 };
 use cedar_lean_ffi::CedarLeanFfi;
 use cedar_policy::Decision;
@@ -39,57 +39,63 @@ fuzz_target!(|input: TwoPolicyFuzzTargetInput<32>| {
             {
                 RUNTIME.block_on(async {
                     let mut solver_guard = get_solver().await;
-                    if let Some(rust_cex) = get_cex(
+                    match get_cex(
                         solver_guard
                             .symcc
                             .check_implies_with_counterexample_opt(&cpset1, &cpset2),
                     )
                     .await
                     {
-                        // important that we `take()`, replacing the solver's raw_model with `None`,
-                        // so that if a future `get_cex()` ends up not calling the solver at all,
-                        // the solver will correctly report that `get_model()` was never called
-                        let raw_model =
-                            std::mem::take(&mut solver_guard.symcc.solver_mut().raw_model);
-                        // release the solver for someone else to use, while we call Lean.
-                        // note that we do this _after_ we get the raw model, so that we
-                        // hold the solver lock while calling `get_cex` and getting the raw
-                        // model -- we don't want anyone else to use the solver in between
-                        drop(solver_guard);
-                        match raw_model {
-                            Some(raw_model) => {
-                                println!("raw model:\n{raw_model}");
-                                let lean_cex = lean_ffi
-                                    .run_check_implies_with_cex_given_raw_model(
-                                        &policyset1,
-                                        &policyset2,
-                                        lean_schema.clone(),
-                                        &req_env,
-                                        &raw_model,
-                                    )
-                                    .unwrap()
-                                    .try_into()
-                                    .unwrap();
-                                assert_eq!(rust_cex, lean_cex);
+                        Ok(rust_cex) => {
+                            // important that we `take()`, replacing the solver's raw_model with `None`,
+                            // so that if a future `get_cex()` ends up not calling the solver at all,
+                            // the solver will correctly report that `get_model()` was never called
+                            let raw_model =
+                                std::mem::take(&mut solver_guard.symcc.solver_mut().raw_model);
+                            // release the solver for someone else to use, while we call Lean.
+                            // note that we do this _after_ we get the raw model, so that we
+                            // hold the solver lock while calling `get_cex` and getting the raw
+                            // model -- we don't want anyone else to use the solver in between
+                            drop(solver_guard);
+                            match raw_model {
+                                Some(raw_model) => {
+                                    println!("raw model:\n{raw_model}");
+                                    let lean_cex = lean_ffi
+                                        .run_check_implies_with_cex_given_raw_model(
+                                            &policyset1,
+                                            &policyset2,
+                                            lean_schema.clone(),
+                                            &req_env,
+                                            &raw_model,
+                                        )
+                                        .unwrap()
+                                        .try_into()
+                                        .unwrap();
+                                    assert_eq!(rust_cex, lean_cex);
+                                }
+                                None => {
+                                    // `get_cex()` returned Ok, but `raw_model` was None.
+                                    // As of this writing, this (only?) happens when SymCC reduces
+                                    // all asserts to constant `true` without calling the solver.
+                                    // In that case, we have a model on the Rust side, but it is not
+                                    // produced by a solver because the solver was never called.
+                                    // We can't call the Lean with a `raw_model` because we don't
+                                    // have one, so we'll just skip the Rust-Lean check in this case.
+                                }
                             }
-                            None => {
-                                // `get_cex()` returned Some, but `raw_model` was None.
-                                // As of this writing, this (only?) happens when SymCC reduces
-                                // all asserts to constant `true` without calling the solver.
-                                // In that case, we have a model on the Rust side, but it is not
-                                // produced by a solver because the solver was never called.
-                                // We can't call the Lean with a `raw_model` because we don't
-                                // have one, so we'll just skip the Rust-Lean check in this case.
-                            }
+                            // while we're here, might as well also check that the
+                            // counterexample is valid -- it's a negligible amount
+                            // more computational work compared to everything we've
+                            // already done.
+                            // Since this is a counterexample to Implies, we expect
+                            // Allow on the LHS and Deny on the RHS
+                            assert_eq!(reproduce(&rust_cex, &policyset1), Decision::Allow);
+                            assert_eq!(reproduce(&rust_cex, &policyset2), Decision::Deny);
                         }
-                        // while we're here, might as well also check that the
-                        // counterexample is valid -- it's a negligible amount
-                        // more computational work compared to everything we've
-                        // already done.
-                        // Since this is a counterexample to Implies, we expect
-                        // Allow on the LHS and Deny on the RHS
-                        assert_eq!(reproduce(&rust_cex, &policyset1), Decision::Allow);
-                        assert_eq!(reproduce(&rust_cex, &policyset2), Decision::Deny);
+                        Err(CexError::Timeout) => {
+                            solver_guard.restart().await;
+                        }
+                        Err(_) => {}
                     }
                 });
             }

--- a/cedar-drt/fuzz/fuzz_targets/symcc-cex-pbt.rs
+++ b/cedar-drt/fuzz/fuzz_targets/symcc-cex-pbt.rs
@@ -18,7 +18,7 @@
 use cedar_drt::logger::initialize_log;
 use cedar_drt_inner::{
     fuzz_target,
-    symcc::{RUNTIME, SinglePolicyFuzzTargetInput, get_cex, get_solver, reproduce},
+    symcc::{CexError, RUNTIME, SinglePolicyFuzzTargetInput, get_cex, get_solver, reproduce},
 };
 use cedar_policy::Decision;
 use cedar_policy_symcc::CompiledPolicySet;
@@ -32,19 +32,37 @@ fuzz_target!(|input: SinglePolicyFuzzTargetInput<128>| {
             // also note that we do the compilation (and reproduction) while _not_ holding the `get_solver()` lock
             if let Ok(cps) = CompiledPolicySet::compile(&policyset, &req_env, &schema) {
                 RUNTIME.block_on(async {
-                    if let Some(cex) = get_cex(get_solver().await.symcc.check_always_allows_with_counterexample_opt(&cps)).await {
-                        assert_eq!(
-                            reproduce(&cex, &policyset),
-                            Decision::Deny,
-                            "Rust SymCC counterexample for AlwaysAllows was expected to produce Deny but did not"
-                        );
+                    let mut solver_guard = get_solver().await;
+                    match get_cex(solver_guard.symcc.check_always_allows_with_counterexample_opt(&cps)).await {
+                        Ok(cex) => {
+                            drop(solver_guard);
+                            assert_eq!(
+                                reproduce(&cex, &policyset),
+                                Decision::Deny,
+                                "Rust SymCC counterexample for AlwaysAllows was expected to produce Deny but did not"
+                            );
+                        }
+                        Err(CexError::Timeout) => {
+                            solver_guard.restart().await;
+                            drop(solver_guard);
+                        }
+                        Err(_) => { drop(solver_guard); }
                     }
-                    if let Some(cex) = get_cex(get_solver().await.symcc.check_always_denies_with_counterexample_opt(&cps)).await {
-                        assert_eq!(
-                            reproduce(&cex, &policyset),
-                            Decision::Allow,
-                            "Rust SymCC counterexample for AlwaysDenies was expected to produce Allow but did not"
-                        );
+                    let mut solver_guard = get_solver().await;
+                    match get_cex(solver_guard.symcc.check_always_denies_with_counterexample_opt(&cps)).await {
+                        Ok(cex) => {
+                            drop(solver_guard);
+                            assert_eq!(
+                                reproduce(&cex, &policyset),
+                                Decision::Allow,
+                                "Rust SymCC counterexample for AlwaysDenies was expected to produce Allow but did not"
+                            );
+                        }
+                        Err(CexError::Timeout) => {
+                            solver_guard.restart().await;
+                            drop(solver_guard);
+                        }
+                        Err(_) => { drop(solver_guard); }
                     }
                 });
             }

--- a/cedar-drt/fuzz/src/symcc.rs
+++ b/cedar-drt/fuzz/src/symcc.rs
@@ -483,6 +483,15 @@ pub struct SymCCWithUsageLimit {
 
 impl SymCCWithUsageLimit {
     const SOLVER_USAGE_LIMIT: usize = 10_000;
+
+    /// Kill the solver process and start new one. Automatically called after
+    /// `SOLVER_USAGE_LIMIT` calls, but can also be called manually if the
+    /// solver is in a bad state.
+    pub async fn restart(&mut self) {
+        let _ = self.symcc.solver_mut().solver.clean_up().await;
+        self.symcc = new_symcc();
+        self.usage_count = 0;
+    }
 }
 
 fn new_symcc() -> CedarSymCompiler<WrappedLocalSolver> {
@@ -502,9 +511,7 @@ pub async fn get_solver() -> MutexGuard<'static, SymCCWithUsageLimit> {
     let mut guard = SOLVER.lock().await;
     guard.usage_count += 1;
     if guard.usage_count >= SymCCWithUsageLimit::SOLVER_USAGE_LIMIT {
-        let _ = guard.symcc.solver_mut().solver.clean_up().await;
-        guard.symcc = new_symcc();
-        guard.usage_count = 0;
+        guard.restart().await;
     }
     guard
 }
@@ -512,18 +519,30 @@ pub async fn get_solver() -> MutexGuard<'static, SymCCWithUsageLimit> {
 /// Solver timeout used for `get_cex()`
 const TIMEOUT_DUR: Duration = Duration::from_secs(300);
 
+pub enum CexError {
+    /// Successfully executed, but no counterexample because the property holds
+    NoCex,
+    /// Known benign error that fuzz testing should ignore
+    Benign,
+    /// Solver time out. This is expected on some inputs, but fuzz target need
+    /// to handle this by restarting the solver process.
+    Timeout,
+}
+
 /// Run the given future (producing `Result<Option<Env>>`), and return the
 /// counterexample if one was successfully generated.
 ///
-/// Panics on unexpected errors. Ignores certain expected errors, returning
-/// `None`. Also returns `None` if the property holds and there is no
-/// counterexample.
+/// Panics on unexpected errors. Expected errors, timeouts, and successful queries
+/// which do not produce a counter example are forwarded as `Err` results.
+/// These should not generally cause a fuzz target to fail. Callers should
+/// handle timeouts by restarting the solver process if they intend to make any
+/// subsequent queries.
 pub async fn get_cex(
     f: impl Future<Output = cedar_policy_symcc::err::Result<Option<Env>>>,
-) -> Option<Env> {
+) -> Result<Env, CexError> {
     match timeout(TIMEOUT_DUR, f).await {
-        Ok(Ok(None)) => None, // successfully executed, no counterexample because the property holds
-        Ok(Ok(Some(cex))) => Some(cex),
+        Ok(Ok(None)) => Err(CexError::NoCex), // successfully executed, no counterexample because the property holds
+        Ok(Ok(Some(cex))) => Ok(cex),
         Err(err) => {
             // Exceeded timeout for solver. Skip this and continue testing, it
             // should still be reported as a slow-unit since out solver timeout
@@ -532,14 +551,14 @@ pub async fn get_cex(
                 "found a slow unit (solver took more than {secs:.2} sec) probably worth investigating: {err}",
                 secs = TIMEOUT_DUR.as_secs_f32()
             );
-            None
+            Err(CexError::Timeout)
         }
         Ok(Err(Error::SolverError(err))) => panic!("solver failed: {err}"),
         Ok(Err(Error::EncodeError(EncodeError::EncodeStringFailed(_))))
         | Ok(Err(Error::EncodeError(EncodeError::EncodePatternFailed(_)))) => {
             // Encoding errors are benign -- SMTLIB doesn't support full unicode
             // but our generators generate full unicode
-            None
+            Err(CexError::Benign)
         }
         Ok(Err(err)) => panic!("{err}"), // other errors are unexpected
     }


### PR DESCRIPTION
Follow up to https://github.com/cedar-policy/cedar-spec/pull/925 to possibly fix an issue found in nightly testing.

We got a timeout failure on an input that runs quickly locally. Current guess is that the solver process was still blocking on a prior slow query, so we need to restart it after any timeout.

