### PR TITLE
Model and proofs for batched authorization

### DIFF
--- a/cedar-drt/fuzz/fuzz_targets/batched-evaluation-drt.rs
+++ b/cedar-drt/fuzz/fuzz_targets/batched-evaluation-drt.rs
@@ -19,7 +19,7 @@ use cedar_drt::logger::initialize_log;
 use cedar_drt_inner::{abac::FuzzTargetInput, fuzz_target};
 
 use cedar_lean_ffi::CedarLeanFfi;
-use cedar_policy::{Policy, PolicySet, Schema, TestEntityLoader};
+use cedar_policy::{Schema, TestEntityLoader};
 
 // This target tests a property that batched evaluation, if succeeds, should
 // produce the same authorization decision based on the Lean model output
@@ -28,9 +28,7 @@ fuzz_target!(|input: FuzzTargetInput<true>| {
     initialize_log();
 
     if let Ok(schema) = Schema::try_from(input.schema) {
-        let policy = Policy::from(input.policy);
-        let mut policyset = PolicySet::new();
-        policyset.add(policy.clone()).unwrap();
+        let policyset = input.policy.into_policy_set();
         let mut loader = TestEntityLoader::new(&input.entities);
         log::debug!("policy: {policyset}");
         let iteration = (FuzzTargetInput::<true>::settings().max_depth + 1) as u32;
@@ -44,9 +42,9 @@ fuzz_target!(|input: FuzzTargetInput<true>| {
             if let Ok(rust_decision) =
                 policyset.is_authorized_batched(&req, &schema, &mut loader, iteration)
             {
-                match ffi.batched_evaluation(&policy, &schema, &req, &input.entities, iteration) {
+                match ffi.batched_evaluation(&policyset, &schema, &req, &input.entities, iteration) {
                     Ok(lean_decision) => {
-                        assert_eq!(lean_decision, Some(rust_decision));
+                        assert_eq!(lean_decision.decision, Some(rust_decision));
                     }
                     Err(err) => {
                         panic!("lean failed but rust didn't: {err}");

--- a/cedar-drt/fuzz/fuzz_targets/batched-evaluation-drt.rs
+++ b/cedar-drt/fuzz/fuzz_targets/batched-evaluation-drt.rs
@@ -44,7 +44,7 @@ fuzz_target!(|input: FuzzTargetInput<true>| {
             if let Ok(rust_decision) =
                 policyset.is_authorized_batched(&req, &schema, &mut loader, iteration)
             {
-                match ffi.batched_evaluation(&policyset, &schema, &req, &input.entities, iteration)
+                match ffi.batched_authorization(&policyset, &schema, &req, &input.entities, iteration)
                 {
                     Ok(lean_decision) => {
                         assert_eq!(lean_decision.decision, Some(rust_decision));

--- a/cedar-drt/fuzz/fuzz_targets/batched-evaluation-drt.rs
+++ b/cedar-drt/fuzz/fuzz_targets/batched-evaluation-drt.rs
@@ -44,7 +44,8 @@ fuzz_target!(|input: FuzzTargetInput<true>| {
             if let Ok(rust_decision) =
                 policyset.is_authorized_batched(&req, &schema, &mut loader, iteration)
             {
-                match ffi.batched_evaluation(&policyset, &schema, &req, &input.entities, iteration) {
+                match ffi.batched_evaluation(&policyset, &schema, &req, &input.entities, iteration)
+                {
                     Ok(lean_decision) => {
                         assert_eq!(lean_decision.decision, Some(rust_decision));
                     }

--- a/cedar-drt/fuzz/fuzz_targets/batched-evaluation-drt.rs
+++ b/cedar-drt/fuzz/fuzz_targets/batched-evaluation-drt.rs
@@ -19,7 +19,7 @@ use cedar_drt::logger::initialize_log;
 use cedar_drt_inner::{abac::FuzzTargetInput, fuzz_target};
 
 use cedar_lean_ffi::CedarLeanFfi;
-use cedar_policy::{Schema, TestEntityLoader};
+use cedar_policy::{Policy, PolicySet, Schema, TestEntityLoader};
 
 // This target tests a property that batched evaluation, if succeeds, should
 // produce the same authorization decision based on the Lean model output
@@ -28,7 +28,9 @@ fuzz_target!(|input: FuzzTargetInput<true>| {
     initialize_log();
 
     if let Ok(schema) = Schema::try_from(input.schema) {
-        let policyset = input.policy.into_policy_set();
+        let policy = Policy::from(input.policy);
+        let mut policyset = PolicySet::new();
+        policyset.add(policy).unwrap();
         let mut loader = TestEntityLoader::new(&input.entities);
         log::debug!("policy: {policyset}");
         let iteration = (FuzzTargetInput::<true>::settings().max_depth + 1) as u32;

--- a/cedar-drt/fuzz/fuzz_targets/batched-evaluation-drt.rs
+++ b/cedar-drt/fuzz/fuzz_targets/batched-evaluation-drt.rs
@@ -44,8 +44,13 @@ fuzz_target!(|input: FuzzTargetInput<true>| {
             if let Ok(rust_decision) =
                 policyset.is_authorized_batched(&req, &schema, &mut loader, iteration)
             {
-                match ffi.batched_authorization(&policyset, &schema, &req, &input.entities, iteration)
-                {
+                match ffi.batched_authorization(
+                    &policyset,
+                    &schema,
+                    &req,
+                    &input.entities,
+                    iteration,
+                ) {
                     Ok(lean_decision) => {
                         assert_eq!(lean_decision.decision, Some(rust_decision));
                     }

--- a/cedar-lean-ffi/protobuf_schema/Messages.proto
+++ b/cedar-lean-ffi/protobuf_schema/Messages.proto
@@ -332,8 +332,8 @@ message PartialAuthorizationRequest {
     PartialEntities entities = 4;
 }
 
-// Batched evaluation request
-message BatchedEvaluationRequest {
+// Batched authorization request
+message BatchedAuthorizationRequest {
     cedar_policy_core.PolicySet policies = 1;
     cedar_policy_validator.Schema schema = 2;
     cedar_policy_core.Request request = 3;

--- a/cedar-lean-ffi/src/datatypes.rs
+++ b/cedar-lean-ffi/src/datatypes.rs
@@ -46,8 +46,8 @@ pub(crate) enum ResultDef<T> {
 }
 
 impl<T> ResultDef<T> {
-    pub fn to_result(def: ResultDef<T>) -> Result<T, String> {
-        match def {
+    pub fn to_result(self) -> Result<T, String> {
+        match self {
             ResultDef::Ok(t) => Ok(t),
             ResultDef::Error(s) => Err(s),
         }
@@ -58,6 +58,15 @@ impl<T> ResultDef<T> {
 pub(crate) struct TimedDef<T> {
     pub(crate) data: T,
     pub(crate) duration: u128,
+}
+
+impl<T> TimedDef<T> {
+    pub fn to_timed_result(self) -> TimedResult<T> {
+        TimedResult {
+            result: self.data,
+            duration: self.duration,
+        }
+    }
 }
 
 /// Authorization Response
@@ -182,6 +191,16 @@ impl<T> TimedResult<T> {
             result: f(self.result),
             duration: self.duration,
         }
+    }
+
+    pub(crate) fn transform_m<U, F, E>(self, f: F) -> Result<TimedResult<U>, E>
+    where
+        F: FnOnce(T) -> Result<U, E>,
+    {
+        Ok(TimedResult {
+            result: f(self.result)?,
+            duration: self.duration,
+        })
     }
 }
 

--- a/cedar-lean-ffi/src/lean_ffi.rs
+++ b/cedar-lean-ffi/src/lean_ffi.rs
@@ -23,7 +23,7 @@ mod tpe;
 
 use crate::datatypes::{
     AuthorizationResponse, AuthorizationResponseInner, Env, ResultDef, Term, TimedDef, TimedResult,
-    ValidationResponse,
+    TpeResponse, TpeResponseInner, ValidationResponse,
 };
 use crate::err::FfiError;
 use crate::lean_object::{
@@ -33,7 +33,7 @@ use crate::lean_object::{
 use crate::messages::*;
 
 use cedar_policy::{
-    Decision, Effect, Entities, Expression, Policy, PolicySet, Request, RequestEnv, Schema,
+    Entities, Expression, Policy, PolicySet, Request, RequestEnv, Schema,
     ValidationMode,
 };
 use lean_sys::{
@@ -1225,15 +1225,12 @@ impl CedarLeanFfi {
     /// Calls the lean backend to perform batched evaluation on a single policy
     pub fn batched_evaluation_timed(
         &self,
-        policy: &Policy,
+        policyset: &PolicySet,
         schema: &Schema,
         request: &Request,
         entities: &Entities,
         iteration: u32,
-    ) -> Result<TimedResult<Option<Decision>>, FfiError> {
-        // We have to construct a policy set because we don't have protobuf encoding of policy yet
-        let policyset = PolicySet::from_policies(std::iter::once(policy.clone()))
-            .expect("policy set construction should succeed");
+    ) -> Result<TimedResult<TpeResponse>, FfiError> {
         let response = unsafe {
             call_lean_ffi_takes_protobuf(
                 batchedEvaluateFFI,
@@ -1242,27 +1239,26 @@ impl CedarLeanFfi {
                 ),
             )
         };
-        match response.as_borrowed().deserialize_into()? {
-            ResultDef::Ok(res) => Ok(TimedResult::from_def(res).transform(|b: Option<bool>| {
-                match (b, policy.effect()) {
-                    (Some(true), Effect::Permit) => Some(Decision::Allow),
-                    (Some(_), _) | (None, Effect::Forbid) => Some(Decision::Deny),
-                    // We can't make any conclusions for this case
-                    (None, Effect::Permit) => None,
-                }
-            })),
-            ResultDef::Error(s) => Err(FfiError::LeanBackendError(s)),
-        }
+        println!("{:?}", response);
+        response
+            .as_borrowed()
+            .deserialize_into::<ResultDef<TimedDef<ResultDef<TpeResponseInner>>>>()?
+            .to_result()
+            .map_err(FfiError::LeanBackendError)?
+            .to_timed_result()
+            .transform_m(ResultDef::to_result)
+            .map_err(FfiError::LeanBackendError)?
+            .transform_m(TpeResponse::from_inner)
     }
 
     pub fn batched_evaluation(
         &self,
-        policy: &Policy,
+        policy: &PolicySet,
         schema: &Schema,
         request: &Request,
         entities: &Entities,
         iteration: u32,
-    ) -> Result<Option<Decision>, FfiError> {
+    ) -> Result<TpeResponse, FfiError> {
         Ok(self
             .batched_evaluation_timed(policy, schema, request, entities, iteration)?
             .take_result())
@@ -2204,7 +2200,7 @@ mod test {
         "#,
         )
         .expect("valid schema");
-        let policy = Policy::from_str(
+        let policy = PolicySet::from_str(
             r#"
         // Rule 1a: organization-level access
 permit (
@@ -2317,10 +2313,10 @@ when
         )
         .expect("valid request");
         let ffi = CedarLeanFfi::new();
-        assert_matches!(
-            ffi.batched_evaluation(&policy, &schema, &request, &entities, 3),
-            Ok(Some(cedar_policy::Decision::Allow))
-        );
+        let response = ffi
+            .batched_evaluation(&policy, &schema, &request, &entities, 3)
+            .unwrap();
+        assert_eq!(response.decision, Some(cedar_policy::Decision::Allow));
     }
 
     #[test]

--- a/cedar-lean-ffi/src/lean_ffi.rs
+++ b/cedar-lean-ffi/src/lean_ffi.rs
@@ -33,8 +33,7 @@ use crate::lean_object::{
 use crate::messages::*;
 
 use cedar_policy::{
-    Entities, Expression, Policy, PolicySet, Request, RequestEnv, Schema,
-    ValidationMode,
+    Entities, Expression, Policy, PolicySet, Request, RequestEnv, Schema, ValidationMode,
 };
 use lean_sys::{
     lean_dec, lean_dec_ref, lean_finalize_thread, lean_initialize_runtime_module_locked,

--- a/cedar-lean-ffi/src/lean_ffi.rs
+++ b/cedar-lean-ffi/src/lean_ffi.rs
@@ -1239,7 +1239,6 @@ impl CedarLeanFfi {
                 ),
             )
         };
-        println!("{:?}", response);
         response
             .as_borrowed()
             .deserialize_into::<ResultDef<TimedDef<ResultDef<TpeResponseInner>>>>()?

--- a/cedar-lean-ffi/src/lean_ffi.rs
+++ b/cedar-lean-ffi/src/lean_ffi.rs
@@ -277,7 +277,7 @@ unsafe extern "C" {
         req: *mut lean_object,
     ) -> *mut lean_object;
 
-    fn batchedEvaluateFFI(req: *mut lean_object) -> *mut lean_object;
+    fn batchedAuthorizationFFI(req: *mut lean_object) -> *mut lean_object;
 
     fn isAuthorizedPartial(req: *mut lean_object) -> *mut lean_object;
 
@@ -1221,8 +1221,8 @@ impl CedarLeanFfi {
         Ok(self.validate_request_timed(schema, request)?.take_result())
     }
 
-    /// Calls the lean backend to perform batched evaluation on a single policy
-    pub fn batched_evaluation_timed(
+    /// Calls the lean backend to perform batched authorization
+    pub fn batched_authorization_timed(
         &self,
         policyset: &PolicySet,
         schema: &Schema,
@@ -1232,7 +1232,7 @@ impl CedarLeanFfi {
     ) -> Result<TimedResult<TpeResponse>, FfiError> {
         let response = unsafe {
             call_lean_ffi_takes_protobuf(
-                batchedEvaluateFFI,
+                batchedAuthorizationFFI,
                 &proto::BatchedEvaluationRequest::new(
                     &policyset, schema, request, entities, iteration,
                 ),
@@ -1249,7 +1249,7 @@ impl CedarLeanFfi {
             .transform_m(TpeResponse::from_inner)
     }
 
-    pub fn batched_evaluation(
+    pub fn batched_authorization(
         &self,
         policy: &PolicySet,
         schema: &Schema,
@@ -1258,7 +1258,7 @@ impl CedarLeanFfi {
         iteration: u32,
     ) -> Result<TpeResponse, FfiError> {
         Ok(self
-            .batched_evaluation_timed(policy, schema, request, entities, iteration)?
+            .batched_authorization_timed(policy, schema, request, entities, iteration)?
             .take_result())
     }
 
@@ -2312,7 +2312,7 @@ when
         .expect("valid request");
         let ffi = CedarLeanFfi::new();
         let response = ffi
-            .batched_evaluation(&policy, &schema, &request, &entities, 3)
+            .batched_authorization(&policy, &schema, &request, &entities, 3)
             .unwrap();
         assert_eq!(response.decision, Some(cedar_policy::Decision::Allow));
     }

--- a/cedar-lean-ffi/src/lean_ffi.rs
+++ b/cedar-lean-ffi/src/lean_ffi.rs
@@ -1233,7 +1233,7 @@ impl CedarLeanFfi {
         let response = unsafe {
             call_lean_ffi_takes_protobuf(
                 batchedAuthorizationFFI,
-                &proto::BatchedEvaluationRequest::new(
+                &proto::BatchedAuthorizationRequest::new(
                     &policyset, schema, request, entities, iteration,
                 ),
             )

--- a/cedar-lean-ffi/src/messages.rs
+++ b/cedar-lean-ffi/src/messages.rs
@@ -723,7 +723,7 @@ impl proto::CheckAssertsRequest {
     }
 }
 
-impl proto::BatchedEvaluationRequest {
+impl proto::BatchedAuthorizationRequest {
     pub(crate) fn new(
         policies: &PolicySet,
         schema: &Schema,

--- a/cedar-lean/Cedar/TPE/Authorizer.lean
+++ b/cedar-lean/Cedar/TPE/Authorizer.lean
@@ -94,10 +94,13 @@ structure Response where
 
 def isAuthorized (schema : Schema) (policies : List Policy) (req : PartialRequest) (es : PartialEntities) : Except Error Response :=
   do
-    let residualPolicies ← policies.mapM (λ p => do
-      pure ⟨p.id, p.effect, ← evaluatePolicy schema p req es⟩)
+    let residualPolicies ← evaluatePolicies schema policies req es
     pure (isAuthorizedFromResiduals residualPolicies)
   where
+    evaluatePolicies (schema : Schema) (policies : List Policy) (req : PartialRequest) (es : PartialEntities) : Except Error (List ResidualPolicy) :=
+      policies.mapM (λ p => do
+        pure ⟨p.id, p.effect, ← evaluatePolicy schema p req es⟩)
+
     satisfiedPolicies (effect : Effect) (policies : List ResidualPolicy) : Set PolicyID :=
       Set.make (policies.filterMap (ResidualPolicy.satisfiedWithEffect effect))
 

--- a/cedar-lean/Cedar/TPE/Authorizer.lean
+++ b/cedar-lean/Cedar/TPE/Authorizer.lean
@@ -92,15 +92,40 @@ structure Response where
 
   residuals : List ResidualPolicy
 
-def isAuthorized (schema : Schema) (policies : List Policy) (req : PartialRequest) (es : PartialEntities) : Except Error Response :=
-  do
-    let residualPolicies ← evaluatePolicies schema policies req es
-    pure (isAuthorizedFromResiduals residualPolicies)
-  where
-    evaluatePolicies (schema : Schema) (policies : List Policy) (req : PartialRequest) (es : PartialEntities) : Except Error (List ResidualPolicy) :=
-      policies.mapM (λ p => do
-        pure ⟨p.id, p.effect, ← evaluatePolicy schema p req es⟩)
+/-- Compute an authorization decision (if possible) from a list of partially
+    evaluated policies. Also used for batched evaluation.  -/
+def isAuthorizedFromResiduals (residuals : List ResidualPolicy) : Response :=
+  let satisfiedForbids := satisfiedPolicies .forbid residuals
+  let falseForbids := falsePolicies .forbid residuals
+  let errorForbids := errorPolicies .forbid residuals
+  let residualForbids := residualPolicies .forbid residuals
 
+  let satisfiedPermits := satisfiedPolicies .permit residuals
+  let falsePermits := falsePolicies .permit residuals
+  let errorPermits := errorPolicies .permit residuals
+  let residualPermits := residualPolicies .permit residuals
+
+  let decision :=
+    match (!satisfiedForbids.isEmpty, !satisfiedPermits.isEmpty, !residualPermits.isEmpty, !residualForbids.isEmpty) with
+    | (true,  _,     _,     _)    => some Decision.deny
+    | (_,     false, false, _)    => some Decision.deny
+    | (false, _,     _,    true)  => none
+    | (false, false, true, false) => none
+    | (false, true,  _,    false) => some .allow
+
+  {
+    decision,
+    satisfiedPermits,
+    falsePermits,
+    errorPermits,
+    residualPermits,
+    satisfiedForbids,
+    falseForbids,
+    errorForbids,
+    residualForbids
+    residuals
+  }
+  where
     satisfiedPolicies (effect : Effect) (policies : List ResidualPolicy) : Set PolicyID :=
       Set.make (policies.filterMap (ResidualPolicy.satisfiedWithEffect effect))
 
@@ -113,37 +138,14 @@ def isAuthorized (schema : Schema) (policies : List Policy) (req : PartialReques
     falsePolicies (effect : Effect) (policies : List ResidualPolicy) : Set PolicyID :=
       Set.make (policies.filterMap (ResidualPolicy.falseWithEffect effect))
 
-    isAuthorizedFromResiduals (residuals : List ResidualPolicy) : Response :=
-      let satisfiedForbids := satisfiedPolicies .forbid residuals
-      let falseForbids := falsePolicies .forbid residuals
-      let errorForbids := errorPolicies .forbid residuals
-      let residualForbids := residualPolicies .forbid residuals
-
-      let satisfiedPermits := satisfiedPolicies .permit residuals
-      let falsePermits := falsePolicies .permit residuals
-      let errorPermits := errorPolicies .permit residuals
-      let residualPermits := residualPolicies .permit residuals
-
-      let decision :=
-        match (!satisfiedForbids.isEmpty, !satisfiedPermits.isEmpty, !residualPermits.isEmpty, !residualForbids.isEmpty) with
-        | (true,  _,     _,     _)    => some Decision.deny
-        | (_,     false, false, _)    => some Decision.deny
-        | (false, _,     _,    true)  => none
-        | (false, false, true, false) => none
-        | (false, true,  _,    false) => some .allow
-
-      {
-        decision,
-        satisfiedPermits,
-        falsePermits,
-        errorPermits,
-        residualPermits,
-        satisfiedForbids,
-        falseForbids,
-        errorForbids,
-        residualForbids
-        residuals
-      }
+def isAuthorized (schema : Schema) (policies : List Policy) (req : PartialRequest) (es : PartialEntities) : Except Error Response :=
+  do
+    let residualPolicies ← evaluatePolicies schema policies req es
+    pure (isAuthorizedFromResiduals residualPolicies)
+  where
+    evaluatePolicies (schema : Schema) (policies : List Policy) (req : PartialRequest) (es : PartialEntities) : Except Error (List ResidualPolicy) :=
+      policies.mapM (λ p => do
+        pure ⟨p.id, p.effect, ← evaluatePolicy schema p req es⟩)
 
 /--
 Take a partial authorization Response and fully evaluate it using a concrete

--- a/cedar-lean/Cedar/TPE/BatchedEvaluator.lean
+++ b/cedar-lean/Cedar/TPE/BatchedEvaluator.lean
@@ -82,7 +82,7 @@ def batchedAuthorizeLoop
   (store : PartialEntities) (n : Nat)
   : Response
 :=
-  let resp := isAuthorized.isAuthorizedFromResiduals residuals
+  let resp := isAuthorizedFromResiduals residuals
   if resp.decision.isSome then
     resp
   else match n with

--- a/cedar-lean/Cedar/TPE/BatchedEvaluator.lean
+++ b/cedar-lean/Cedar/TPE/BatchedEvaluator.lean
@@ -75,10 +75,7 @@ def batchedEvaluate
   batchedEvaluateLoop residual req loader Map.empty iters
 
 /--
-The batched evaluation loop for authorization over a list of policies.
-  1. Asks for any new entities referenced by the residual
-  2. Partially evaluates now that new entities are loaded
-  3. Exits if a value has been found or it hits the maximum iteration limit
+The batched authorization loop for authorization over a list of policies.
 -/
 def batchedAuthorizeLoop
   (residuals : List ResidualPolicy) (req : Request) (loader : EntityLoader)
@@ -100,10 +97,9 @@ def batchedAuthorizeLoop
       batchedAuthorizeLoop residuals req loader newStore n
 
 /--
-Evaluate a cedar expression using an EntityLoader
-instead of a full Entities store.
-Performs a maximum of `iter` number of calls to `loader`,
-but may perform fewer when a value is found.
+Evaluate an authorization request using an EntityLoader instead of a full Entities store.
+
+Performs a maximum of `iter` number of calls to `loader`, but may perform fewer when an authorization decisions is reached.
 -/
 def batchedAuthorize
   (schema : Schema)
@@ -114,7 +110,6 @@ def batchedAuthorize
   : Except Error Response := do
   let residualPolicies ← policies.mapM (λ p => do
     pure ⟨p.id, p.effect, ← evaluatePolicy schema p req.asPartialRequest Map.empty⟩)
-  -- start the batched authorization loop
   pure (batchedAuthorizeLoop residualPolicies req loader Map.empty iters)
 
 /--

--- a/cedar-lean/Cedar/TPE/BatchedEvaluator.lean
+++ b/cedar-lean/Cedar/TPE/BatchedEvaluator.lean
@@ -99,7 +99,7 @@ def batchedAuthorizeLoop
 /--
 Evaluate an authorization request using an EntityLoader instead of a full Entities store.
 
-Performs a maximum of `iter` number of calls to `loader`, but may perform fewer when an authorization decisions is reached.
+Performs a maximum of `iter` number of calls to `loader`, but may perform fewer when an authorization decision is reached early.
 -/
 def batchedAuthorize
   (schema : Schema)

--- a/cedar-lean/Cedar/TPE/BatchedEvaluator.lean
+++ b/cedar-lean/Cedar/TPE/BatchedEvaluator.lean
@@ -17,6 +17,7 @@
 
 import Cedar.Spec
 import Cedar.Data
+import Cedar.TPE.Authorizer
 import Cedar.TPE.Residual
 import Cedar.TPE.Evaluator
 import Cedar.TPE.Input
@@ -37,12 +38,12 @@ See `EntityLoader.WellBehaved` for a formal definition.
 abbrev EntityLoader := Set EntityUID → Map EntityUID MaybeEntityData
 
 /--
-The batched evaluation loop
+The batched evaluation loop for a single residual expression.
   1. Asks for any new entities referenced by the residual
   2. Partially evaluates now that new entities are loaded
   3. Exits if a value has been found or it hits the maximum iteration limit
 -/
-def batchedEvalLoop
+def batchedEvaluateLoop
   (residual : Residual)
   (req : Request)
   (loader : EntityLoader)
@@ -56,11 +57,10 @@ def batchedEvalLoop
 
     match Cedar.TPE.evaluate residual req.asPartialRequest newStore with
     | .val v _ty => .val v _ty
-    | newRes => batchedEvalLoop newRes req loader newStore n
-
+    | newRes => batchedEvaluateLoop newRes req loader newStore n
 
 /--
-Evaluate a cedar expression using an EntityLoader
+Evaluate a single cedar expression using an EntityLoader
 instead of a full Entities store.
 Performs a maximum of `iter` number of calls to `loader`,
 but may perform fewer when a value is found.
@@ -72,8 +72,50 @@ def batchedEvaluate
   (iters : Nat)
   : Residual :=
   let residual := Cedar.TPE.evaluate x.toResidual req.asPartialRequest Map.empty
-  -- start the batched evaluation loop
-  batchedEvalLoop residual req loader Map.empty iters
+  batchedEvaluateLoop residual req loader Map.empty iters
+
+/--
+The batched evaluation loop for authorization over a list of policies.
+  1. Asks for any new entities referenced by the residual
+  2. Partially evaluates now that new entities are loaded
+  3. Exits if a value has been found or it hits the maximum iteration limit
+-/
+def batchedAuthorizeLoop
+  (residuals : List ResidualPolicy) (req : Request) (loader : EntityLoader)
+  (store : PartialEntities) (n : Nat)
+  : Response
+:=
+  let resp := isAuthorized.isAuthorizedFromResiduals residuals
+  if resp.decision.isSome then
+    resp
+  else match n with
+    | 0 => resp
+    | n + 1 =>
+      let toLoad := residuals.mapUnion (λ rp : ResidualPolicy => rp.residual.allLiteralUIDs)|>.filter (λ uid => (store.find? uid).isNone)
+      let newEntities := ((loader toLoad).mapOnValues MaybeEntityData.asPartial)
+      let newStore := newEntities ++ store
+
+      let residuals : List ResidualPolicy := residuals.map λ rp =>
+        ⟨rp.id, rp.effect, Cedar.TPE.evaluate rp.residual req.asPartialRequest newStore⟩
+      batchedAuthorizeLoop residuals req loader newStore n
+
+/--
+Evaluate a cedar expression using an EntityLoader
+instead of a full Entities store.
+Performs a maximum of `iter` number of calls to `loader`,
+but may perform fewer when a value is found.
+-/
+def batchedAuthorize
+  (schema : Schema)
+  (policies : List Policy)
+  (req : Request)
+  (loader : EntityLoader)
+  (iters : Nat)
+  : Except Error Response := do
+  let residualPolicies ← policies.mapM (λ p => do
+    pure ⟨p.id, p.effect, ← evaluatePolicy schema p req.asPartialRequest Map.empty⟩)
+  -- start the batched authorization loop
+  pure (batchedAuthorizeLoop residualPolicies req loader Map.empty iters)
 
 /--
 Create an entity loader for a given entity store.

--- a/cedar-lean/Cedar/TPE/Input.lean
+++ b/cedar-lean/Cedar/TPE/Input.lean
@@ -121,7 +121,7 @@ where
     let (uid, _) := p
     match es.find? uid with
     | .some entry₁ => actionEntityIsValid uid entry₁
-    | _            => false
+    | _            => true
 
 def requestAndEntitiesIsValid (env : TypeEnv) (req : PartialRequest) (es : PartialEntities) : Bool :=
   requestIsValid env req && entitiesIsValid env es

--- a/cedar-lean/Cedar/Thm/BatchedEvaluator.lean
+++ b/cedar-lean/Cedar/Thm/BatchedEvaluator.lean
@@ -1,13 +1,5 @@
-import Cedar.TPE.Input
-import Cedar.TPE.BatchedEvaluator
-import Cedar.Spec
-import Cedar.Validation
-import Cedar.Thm.Validation
-import Cedar.Thm.TPE
-
-/-!
-This file defines theorems related to the batched evaluator
--/
+import Cedar.Thm.BatchedEvaluator.Evaluate
+import Cedar.Thm.BatchedEvaluator.Authorize
 
 namespace Cedar.Thm
 
@@ -16,129 +8,6 @@ open Cedar.Spec
 open Cedar.Validation
 open Cedar.Thm
 open Cedar.Data
-
-
-/-- A well behaved entity loader
-1. Loads all the requested entities, returning none for missing
-entities
-2. Refines the backing entity store
-
-The first condition is required for convergence of
-batched evaluation, which has not been proven. It is unused
-in the code base at the moment.
--/
-abbrev EntityLoader.WellBehaved (store: Entities) (loader: EntityLoader) : Prop :=
-  ∀ s, s ⊆ (loader s).keys ∧
-       EntitiesRefine store ((loader s).mapOnValues MaybeEntityData.asPartial)
-
-theorem as_partial_request_refines {req : Request} :
-  RequestRefines req req.asPartialRequest := by
-  simp only [Request.asPartialRequest, RequestRefines, PartialEntityUID.asEntityUID, Option.map_some]
-  constructor
-  · apply PartialIsValid.some
-    rfl
-  constructor
-  · trivial
-  constructor
-  · apply PartialIsValid.some
-    rfl
-  constructor
-  · apply PartialIsValid.some
-    rfl
-  constructor <;> trivial
-
-theorem any_refines_empty_entities :
-  EntitiesRefine es Data.Map.empty := by
-  simp only [EntitiesRefine, Data.Map.empty, Data.Map.find?, Map.toList]
-  intro a e₂ h₁
-  contradiction
-
--- Helper lemma for map append refinement
-theorem entities_refine_append (es : Entities) (m1 m2 : PartialEntities) :
-  EntitiesRefine es m1 → EntitiesRefine es m2 → EntitiesRefine es (m2 ++ m1) := by
-  intro h1 h2
-  unfold EntitiesRefine
-  intro a e₂ h_find
-  rw [Map.find?_append] at h_find
-  cases h_case : m2.find? a with
-  | some e₂' =>
-    have h_eq : e₂ = e₂' := by
-      rw [h_case] at h_find
-      simp only [Option.some_or, Option.some.injEq] at h_find
-      rw [h_find]
-    rw [h_eq]
-    exact h2 a e₂' h_case
-  | none =>
-    have h_find1 : m1.find? a = some e₂ := by
-      rw [h_case] at h_find
-      simp only [Option.none_or] at h_find
-      rw [h_find]
-    exact h1 a e₂ h_find1
-
-
-theorem direct_request_and_entities_refine (req : Request) (es : Entities) :
-  RequestAndEntitiesRefine req es req.asPartialRequest es.asPartial := by
-  constructor
-  · exact as_partial_request_refines
-  · unfold EntitiesRefine Entities.asPartial
-    intro uid data₂ h_find
-    have h_mapOnValues := Map.find?_mapOnValues_some' EntityData.asPartial h_find
-    obtain ⟨data₁, h_find₁, h_eq⟩ := h_mapOnValues
-    exists data₁
-    exact ⟨h_find₁,
-           by rw [h_eq]; apply PartialIsValid.some; rfl,
-           by rw [h_eq]; apply PartialIsValid.some; rfl,
-           by rw [h_eq]; apply PartialIsValid.some; rfl⟩
-
-theorem batched_eval_loop_eq_evaluate
-  {x : Residual}
-  {req : Request}
-  (es : Entities)
-  {current_store : PartialEntities}
-  {env : TypeEnv} :
-  EntityLoader.WellBehaved es loader →
-  Residual.WellTyped env x →
-  RequestAndEntitiesRefine req es req.asPartialRequest current_store →
-  InstanceOfWellFormedEnvironment req es env →
-  (Residual.evaluate (batchedEvalLoop x req loader current_store iters) req es).toOption = (Residual.evaluate x req es).toOption := by
-  intro h₀ h₁ h₂ h₃
-  unfold batchedEvalLoop
-  split
-  case h_1 => simp only
-  case h_2 iters n=>
-    let toLoad := (Set.filter (fun uid => (Map.find? current_store uid).isNone) x.allLiteralUIDs)
-    let newEntities := ((loader toLoad).mapOnValues MaybeEntityData.asPartial)
-    let newStore := newEntities ++ current_store
-
-    have h₀₂ := h₀
-    specialize h₀₂ toLoad
-    obtain ⟨h₄, h₅⟩ := h₀₂
-
-    have h₆ : RequestAndEntitiesRefine req es req.asPartialRequest newStore := by
-      unfold RequestAndEntitiesRefine
-      constructor
-      · exact as_partial_request_refines
-      · apply entities_refine_append
-        · unfold RequestAndEntitiesRefine at h₂
-          exact h₂.right
-        · apply h₅
-    let newRes := TPE.evaluate x req.asPartialRequest newStore
-    have h₇ : (Residual.evaluate newRes req es).toOption = (Residual.evaluate x req es).toOption := by
-      subst newRes
-      rw [← partial_evaluate_is_sound h₁ h₃ h₆]
-
-    simp only
-    split
-    case h_1 h₆ =>
-      rw [← h₆]
-      subst toLoad newStore newRes
-      exact h₇
-    case h_2 =>
-      subst toLoad newStore newRes
-      have h₈ := (partial_eval_preserves_well_typed h₃ h₆ h₁)
-
-      rw [batched_eval_loop_eq_evaluate es h₀ h₈ h₆ h₃]
-      exact h₇
 
 /--
 The main correctness theorem for batched evaluation:
@@ -158,8 +27,7 @@ theorem batched_eval_eq_evaluate
   intro h₁ h₂ h₃
   have h₄ := (direct_request_and_entities_refine req es)
 
-  let first_partial := (TPE.evaluate x.toResidual req.asPartialRequest (Entities.asPartial (Data.Map.mk [])))
-  let h₅ : Residual.WellTyped env (TypedExpr.toResidual x) := by {
+  have h₅ : Residual.WellTyped env (TypedExpr.toResidual x) := by {
     apply conversion_preserves_typedness
     exact h₂
   }
@@ -168,8 +36,7 @@ theorem batched_eval_eq_evaluate
 
   have h₆ : Residual.WellTyped env (TPE.evaluate x.toResidual req.asPartialRequest Map.empty) := by
     apply partial_eval_preserves_well_typed h₃ _ h₅
-    . unfold RequestAndEntitiesRefine
-      constructor
+    . constructor
       . apply as_partial_request_refines
       . apply any_refines_empty_entities
   have h₇: RequestAndEntitiesRefine req es req.asPartialRequest Map.empty := by
@@ -177,8 +44,35 @@ theorem batched_eval_eq_evaluate
     . apply as_partial_request_refines
     . apply any_refines_empty_entities
 
-  rw [batched_eval_loop_eq_evaluate es h₁ h₆ h₇ h₃]
+  rw [batched_evaluate_loop_eq_evaluate es h₁ h₆ h₇ h₃]
   rw [←partial_evaluate_is_sound h₅ h₃ h₇]
   rw [←partial_evaluate_is_sound h₅ h₃ h₄]
 
-end Cedar.Thm
+/--
+The main correctness theorem for batched authorization:
+If the batched authorizer reaches a definitive decision, that decision
+agrees with the concrete authorizer.
+-/
+theorem batched_authorize_decision_agrees
+  {schema : Schema} {policies : List Policy} {req : Request}
+  {es : Entities} {response : TPE.Response} {d : Decision} :
+  EntityLoader.WellBehaved es loader →
+  batchedAuthorize schema policies req loader iters = .ok response →
+  isValidAndConsistent schema req es req.asPartialRequest Map.empty = .ok () →
+  response.decision = some d →
+  (Spec.isAuthorized req es policies).decision = d
+:= by
+  intro h_loader h_batched h_valid h_dec
+  simp only [batchedAuthorize] at h_batched
+  cases h_mapM : policies.mapM (λ p =>
+    ResidualPolicy.mk p.id p.effect <$> evaluatePolicy schema p req.asPartialRequest Map.empty) with
+  | error e => simp [h_mapM, bind_pure_comp] at h_batched
+  | ok residualPolicies =>
+    simp only [bind_pure_comp, h_mapM, Except.map_ok, Except.ok.injEq] at h_batched
+    subst h_batched
+    rw [List.mapM_ok_iff_forall₂] at h_mapM
+    have h_ref : RequestAndEntitiesRefine req es req.asPartialRequest Map.empty :=
+      ⟨as_partial_request_refines, any_refines_empty_entities⟩
+    have ⟨env, h_schema_env, h_wf⟩ := isValidAndConsistent_env h_valid
+    have h_sound := evaluatePolicies_equiv_and_well_typed h_mapM h_valid h_schema_env h_wf h_ref
+    exact batched_authorize_loop_decision_agrees es h_loader h_sound h_ref h_wf h_dec

--- a/cedar-lean/Cedar/Thm/BatchedEvaluator.lean
+++ b/cedar-lean/Cedar/Thm/BatchedEvaluator.lean
@@ -52,18 +52,23 @@ theorem batched_eval_eq_evaluate
 The main correctness theorem for batched authorization:
 If the batched authorizer reaches a definitive decision, that decision
 agrees with the concrete authorizer.
+
+Request well-typedness is inferred from `batchedAuthorize` succeeding (which
+internally checks `requestAndEntitiesIsValid`). Entity and schema
+well-typedness are stated in terms of the boolean validation functions
+`schema.validateWellFormed` and `validateEntities`.
 -/
 theorem batched_authorize_decision_eq_authorize
   {schema : Schema} {policies : List Policy} {req : Request}
-  {es : Entities} {response : TPE.Response} {d : Decision} {env : TypeEnv} :
+  {es : Entities} {response : TPE.Response} {d : Decision} :
   EntityLoader.WellBehaved es loader →
   batchedAuthorize schema policies req loader iters = .ok response →
-  schema.environment? req.asPartialRequest.principal.ty req.asPartialRequest.resource.ty req.asPartialRequest.action = .some env →
-  InstanceOfWellFormedEnvironment req es env →
+  schema.validateWellFormed = .ok () →
+  validateEntities schema es = .ok () →
   response.decision = some d →
   (Spec.isAuthorized req es policies).decision = d
 := by
-  intro h_loader h_batched h_schema_env h_wf h_dec
+  intro h_loader h_batched h_schema_wf h_entities h_dec
   simp only [batchedAuthorize] at h_batched
   cases h_mapM : policies.mapM (λ p =>
     ResidualPolicy.mk p.id p.effect <$> evaluatePolicy schema p req.asPartialRequest Map.empty) with
@@ -74,5 +79,18 @@ theorem batched_authorize_decision_eq_authorize
     rw [List.mapM_ok_iff_forall₂] at h_mapM
     have h_ref : RequestAndEntitiesRefine req es req.asPartialRequest Map.empty :=
       ⟨as_partial_request_refines, any_refines_empty_entities⟩
-    have h_sound := evaluatePolicies_equiv_and_well_typed h_mapM h_schema_env h_wf h_ref
-    exact batched_authorize_loop_decision_agrees es h_loader h_sound h_ref h_wf h_dec
+    match policies, h_mapM with
+    | [], .nil =>
+      rw [batchedAuthorizeLoop_nil_decision] at h_dec
+      exact residuals_decision_agrees .nil h_dec
+    | p :: _, .cons h_first h_rest =>
+      have h_ep_ok : ∃ r, evaluatePolicy schema p req.asPartialRequest Map.empty = .ok r := by
+        cases h_ep : evaluatePolicy schema p req.asPartialRequest Map.empty with
+        | ok r => exact ⟨r, rfl⟩
+        | error e => simp [h_ep, Except.map_error] at h_first
+      obtain ⟨r, h_ep⟩ := h_ep_ok
+      obtain ⟨env, h_schema_env, h_wf⟩ :=
+        evaluatePolicy_ok_implies_well_formed_env h_ep h_schema_wf h_entities
+      exact batched_authorize_loop_decision_agrees es h_loader
+        (evaluatePolicies_equiv_and_well_typed (.cons h_first h_rest) h_schema_env h_wf h_ref)
+        h_ref h_wf h_dec

--- a/cedar-lean/Cedar/Thm/BatchedEvaluator.lean
+++ b/cedar-lean/Cedar/Thm/BatchedEvaluator.lean
@@ -53,16 +53,15 @@ The main correctness theorem for batched authorization:
 If the batched authorizer reaches a definitive decision, that decision
 agrees with the concrete authorizer.
 -/
-theorem batched_authorize_decision_agrees
+theorem batched_authorize_decision_eq_authorize
   {schema : Schema} {policies : List Policy} {req : Request}
   {es : Entities} {response : TPE.Response} {d : Decision} :
   EntityLoader.WellBehaved es loader →
   batchedAuthorize schema policies req loader iters = .ok response →
-  isValidAndConsistent schema req es req.asPartialRequest Map.empty = .ok () →
   response.decision = some d →
   (Spec.isAuthorized req es policies).decision = d
 := by
-  intro h_loader h_batched h_valid h_dec
+  intro h_loader h_batched h_dec
   simp only [batchedAuthorize] at h_batched
   cases h_mapM : policies.mapM (λ p =>
     ResidualPolicy.mk p.id p.effect <$> evaluatePolicy schema p req.asPartialRequest Map.empty) with
@@ -73,6 +72,34 @@ theorem batched_authorize_decision_agrees
     rw [List.mapM_ok_iff_forall₂] at h_mapM
     have h_ref : RequestAndEntitiesRefine req es req.asPartialRequest Map.empty :=
       ⟨as_partial_request_refines, any_refines_empty_entities⟩
+
+    have : (Spec.isAuthorized req es policies).decision = d ∨ ∃ env,
+        schema.environment? req.asPartialRequest.principal.ty req.asPartialRequest.resource.ty req.asPartialRequest.action = .some env ∧
+        requestAndEntitiesIsValid env req.asPartialRequest Map.empty = true
+    := by
+      cases h_mapM
+      · unfold batchedAuthorizeLoop isAuthorized.isAuthorizedFromResiduals isAuthorized.satisfiedPolicies isAuthorized.residualPolicies isAuthorized.falsePolicies isAuthorized.errorPolicies at h_dec
+        simp at h_dec
+        rw [←h_dec]
+        have := default_deny req es []
+        simp [IsExplicitlyPermitted, HasSatisfiedEffect] at this
+        exact .inl this
+      · rename_i p rp ps rps _ _
+        rename_i h _
+        cases h₂ : evaluatePolicy schema p req.asPartialRequest Map.empty <;> simp [h₂] at h
+        simp [evaluatePolicy] at h₂
+        split at h₂ <;> grind
+
+    cases this ; case inl => assumption
+    rename_i henv
+    replace ⟨env, henv, henv₂⟩ := henv
+
+    have h_valid : isValidAndConsistent schema req es req.asPartialRequest Map.empty = .ok () := by
+      simp [isValidAndConsistent]
+      split
+      ·
+        sorry
+      · grind
     have ⟨env, h_schema_env, h_wf⟩ := isValidAndConsistent_env h_valid
     have h_sound := evaluatePolicies_equiv_and_well_typed h_mapM h_valid h_schema_env h_wf h_ref
     exact batched_authorize_loop_decision_agrees es h_loader h_sound h_ref h_wf h_dec

--- a/cedar-lean/Cedar/Thm/BatchedEvaluator.lean
+++ b/cedar-lean/Cedar/Thm/BatchedEvaluator.lean
@@ -55,13 +55,15 @@ agrees with the concrete authorizer.
 -/
 theorem batched_authorize_decision_eq_authorize
   {schema : Schema} {policies : List Policy} {req : Request}
-  {es : Entities} {response : TPE.Response} {d : Decision} :
+  {es : Entities} {response : TPE.Response} {d : Decision} {env : TypeEnv} :
   EntityLoader.WellBehaved es loader →
   batchedAuthorize schema policies req loader iters = .ok response →
+  schema.environment? req.asPartialRequest.principal.ty req.asPartialRequest.resource.ty req.asPartialRequest.action = .some env →
+  InstanceOfWellFormedEnvironment req es env →
   response.decision = some d →
   (Spec.isAuthorized req es policies).decision = d
 := by
-  intro h_loader h_batched h_dec
+  intro h_loader h_batched h_schema_env h_wf h_dec
   simp only [batchedAuthorize] at h_batched
   cases h_mapM : policies.mapM (λ p =>
     ResidualPolicy.mk p.id p.effect <$> evaluatePolicy schema p req.asPartialRequest Map.empty) with
@@ -72,34 +74,5 @@ theorem batched_authorize_decision_eq_authorize
     rw [List.mapM_ok_iff_forall₂] at h_mapM
     have h_ref : RequestAndEntitiesRefine req es req.asPartialRequest Map.empty :=
       ⟨as_partial_request_refines, any_refines_empty_entities⟩
-
-    have : (Spec.isAuthorized req es policies).decision = d ∨ ∃ env,
-        schema.environment? req.asPartialRequest.principal.ty req.asPartialRequest.resource.ty req.asPartialRequest.action = .some env ∧
-        requestAndEntitiesIsValid env req.asPartialRequest Map.empty = true
-    := by
-      cases h_mapM
-      · unfold batchedAuthorizeLoop isAuthorized.isAuthorizedFromResiduals isAuthorized.satisfiedPolicies isAuthorized.residualPolicies isAuthorized.falsePolicies isAuthorized.errorPolicies at h_dec
-        simp at h_dec
-        rw [←h_dec]
-        have := default_deny req es []
-        simp [IsExplicitlyPermitted, HasSatisfiedEffect] at this
-        exact .inl this
-      · rename_i p rp ps rps _ _
-        rename_i h _
-        cases h₂ : evaluatePolicy schema p req.asPartialRequest Map.empty <;> simp [h₂] at h
-        simp [evaluatePolicy] at h₂
-        split at h₂ <;> grind
-
-    cases this ; case inl => assumption
-    rename_i henv
-    replace ⟨env, henv, henv₂⟩ := henv
-
-    have h_valid : isValidAndConsistent schema req es req.asPartialRequest Map.empty = .ok () := by
-      simp [isValidAndConsistent]
-      split
-      ·
-        sorry
-      · grind
-    have ⟨env, h_schema_env, h_wf⟩ := isValidAndConsistent_env h_valid
-    have h_sound := evaluatePolicies_equiv_and_well_typed h_mapM h_valid h_schema_env h_wf h_ref
+    have h_sound := evaluatePolicies_equiv_and_well_typed h_mapM h_schema_env h_wf h_ref
     exact batched_authorize_loop_decision_agrees es h_loader h_sound h_ref h_wf h_dec

--- a/cedar-lean/Cedar/Thm/BatchedEvaluator.lean
+++ b/cedar-lean/Cedar/Thm/BatchedEvaluator.lean
@@ -1,7 +1,12 @@
+import Cedar.Thm.BatchedEvaluator.Common
 import Cedar.Thm.BatchedEvaluator.Evaluate
 import Cedar.Thm.BatchedEvaluator.Authorize
 
 namespace Cedar.Thm
+
+/-!
+This file defines the main theorems for batched authorization and evaluation.
+-/
 
 open Cedar.TPE
 open Cedar.Spec
@@ -14,7 +19,7 @@ The main correctness theorem for batched evaluation:
 Batched evaluation with an entity loader produces the same result
 as normal evaluation with the complete entity store.
 -/
-theorem batched_eval_eq_evaluate
+theorem batched_evaluate_eq_evaluate
   {x : TypedExpr}
   {req : Request}
   {es : Entities}
@@ -53,22 +58,22 @@ The main correctness theorem for batched authorization:
 If the batched authorizer reaches a definitive decision, that decision
 agrees with the concrete authorizer.
 
-Request well-typedness is inferred from `batchedAuthorize` succeeding (which
-internally checks `requestAndEntitiesIsValid`). Entity and schema
-well-typedness are stated in terms of the boolean validation functions
-`schema.validateWellFormed` and `validateEntities`.
+Request and policy well-typedness are checked by `batchedAuthorize`, so we do
+not need those as an explicit precondition. We do need entity to explicitly
+require well-typed entities because `batchedAuthorize` only has access to these
+through the entity loader.
 -/
 theorem batched_authorize_decision_eq_authorize
   {schema : Schema} {policies : List Policy} {req : Request}
   {es : Entities} {response : TPE.Response} {d : Decision} :
   EntityLoader.WellBehaved es loader →
-  batchedAuthorize schema policies req loader iters = .ok response →
   schema.validateWellFormed = .ok () →
   validateEntities schema es = .ok () →
+  batchedAuthorize schema policies req loader iters = .ok response →
   response.decision = some d →
   (Spec.isAuthorized req es policies).decision = d
 := by
-  intro h_loader h_batched h_schema_wf h_entities h_dec
+  intro h_loader h_schema_wf h_entities h_batched h_dec
   simp only [batchedAuthorize] at h_batched
   cases h_mapM : policies.mapM (λ p =>
     ResidualPolicy.mk p.id p.effect <$> evaluatePolicy schema p req.asPartialRequest Map.empty) with
@@ -77,20 +82,20 @@ theorem batched_authorize_decision_eq_authorize
     simp only [bind_pure_comp, h_mapM, Except.map_ok, Except.ok.injEq] at h_batched
     subst h_batched
     rw [List.mapM_ok_iff_forall₂] at h_mapM
-    have h_ref : RequestAndEntitiesRefine req es req.asPartialRequest Map.empty :=
-      ⟨as_partial_request_refines, any_refines_empty_entities⟩
     match policies, h_mapM with
     | [], .nil =>
-      rw [batchedAuthorizeLoop_nil_decision] at h_dec
+      replace h_dec : (isAuthorizedFromResiduals []).decision = some d := by
+        unfold batchedAuthorizeLoop at h_dec
+        simpa using h_dec
       exact residuals_decision_agrees .nil h_dec
     | p :: _, .cons h_first h_rest =>
-      have h_ep_ok : ∃ r, evaluatePolicy schema p req.asPartialRequest Map.empty = .ok r := by
-        cases h_ep : evaluatePolicy schema p req.asPartialRequest Map.empty with
-        | ok r => exact ⟨r, rfl⟩
-        | error e => simp [h_ep, Except.map_error] at h_first
-      obtain ⟨r, h_ep⟩ := h_ep_ok
+      have ⟨r, h_ep⟩ : ∃ r, evaluatePolicy schema p req.asPartialRequest Map.empty = .ok r := by
+        cases h_ep : evaluatePolicy schema p req.asPartialRequest Map.empty <;>
+          simp [h_ep] at ⊢ h_first
       obtain ⟨env, h_schema_env, h_wf⟩ :=
         evaluatePolicy_ok_implies_well_formed_env h_ep h_schema_wf h_entities
+      have h_ref : RequestAndEntitiesRefine req es req.asPartialRequest Map.empty :=
+        ⟨as_partial_request_refines, any_refines_empty_entities⟩
       exact batched_authorize_loop_decision_agrees es h_loader
         (evaluatePolicies_equiv_and_well_typed (.cons h_first h_rest) h_schema_env h_wf h_ref)
         h_ref h_wf h_dec

--- a/cedar-lean/Cedar/Thm/BatchedEvaluator/Authorize.lean
+++ b/cedar-lean/Cedar/Thm/BatchedEvaluator/Authorize.lean
@@ -20,53 +20,6 @@ open Cedar.Validation
 open Cedar.Thm
 open Cedar.Data
 
-private theorem mem_foldl_append_of_init {α β : Type} {f : β → List α} {xs : List β}
-  {init : List α} {a : α} (h : a ∈ init) :
-  a ∈ List.foldl (fun acc x => f x ++ acc) init xs
-:= by
-  induction xs generalizing init with
-  | nil => exact h
-  | cons hd tl ih => exact ih (List.mem_append_right _ h)
-
-private theorem mem_foldl_append_of_mem {α β : Type} {f : β → List α} {xs : List β}
-  {init : List α} {a : α} {x : β} (hx : x ∈ xs) (ha : a ∈ f x) :
-  a ∈ List.foldl (fun acc y => f y ++ acc) init xs
-:= by
-  induction xs generalizing init with
-  | nil => cases hx
-  | cons hd tl ih =>
-    simp only [List.foldl_cons]
-    cases hx with
-    | head => exact mem_foldl_append_of_init (List.mem_append_left _ ha)
-    | tail _ htl => exact ih htl
-
-theorem environment_some_mem_environments {schema : Schema}
-  {principal resource : EntityType} {action : EntityUID} {env : TypeEnv}
-  (h : schema.environment? principal resource action = .some env) :
-  env ∈ schema.environments
-:= by
-  simp only [Schema.environment?] at h
-  cases h_find : schema.acts.find? action <;> simp only [h_find, Option.bind_none_fun,
-    Option.bind_some_fun, reduceCtorEq] at h
-  rename_i ase
-  split at h <;> simp only [reduceCtorEq, Option.some.injEq] at h
-  rename_i hp hr
-  subst h
-  simp only [Schema.environments, List.mem_map]
-  refine ⟨{ principal, action, resource, context := ase.context }, ?_, rfl⟩
-  -- Show this RequestType is in the foldl result
-  apply mem_foldl_append_of_mem (Map.find?_mem_toList h_find)
-  -- Show it's in the inner foldl (requestTypes for this action entry)
-  -- ActionSchemaEntry.requestTypes inlines to a foldl over appliesToPrincipal
-  show { principal, action, resource, context := ase.context : RequestType } ∈
-    ase.appliesToPrincipal.toList.foldl (fun acc p =>
-      (ase.appliesToResource.toList.map (fun r =>
-        { principal := p, action, resource := r, context := ase.context })) ++ acc) []
-  apply mem_foldl_append_of_mem
-  · exact (Set.mem_elts_iff_mem_set _ _).mpr (Set.contains_prop_bool_equiv.mp hp)
-  · simp only [List.mem_map]
-    exact ⟨resource, (Set.mem_elts_iff_mem_set _ _).mpr (Set.contains_prop_bool_equiv.mp hr), rfl⟩
-
 theorem evaluatePolicy_ok_implies_env_some {schema : Schema} {p : Policy}
   {preq : PartialRequest} {pes : PartialEntities} {r : Residual} :
   evaluatePolicy schema p preq pes = .ok r →
@@ -74,9 +27,7 @@ theorem evaluatePolicy_ok_implies_env_some {schema : Schema} {p : Policy}
 := by
   intro h
   simp only [evaluatePolicy] at h
-  split at h
-  · exact ⟨_, ‹_›⟩
-  · cases h
+  split at h <;> grind
 
 private theorem requestIsValid_asPartialRequest_eq {env : TypeEnv} {req : Request} :
   requestIsValid env req.asPartialRequest = instanceOfRequestType req env
@@ -155,18 +106,6 @@ theorem residuals_equiv_preserved
      by rw [← partial_evaluate_is_sound h_wt h_wf h_ref]; exact h_eval,
      partial_eval_preserves_well_typed h_wf h_ref h_wt⟩
   ) h_sound
-
-theorem batchedAuthorizeLoop_nil_decision {req : Request} {loader : EntityLoader}
-  {store : PartialEntities} {iters : Nat} :
-  (batchedAuthorizeLoop [] req loader store iters).decision =
-  (isAuthorized.isAuthorizedFromResiduals []).decision
-:= by
-  unfold batchedAuthorizeLoop
-  simp only
-  have : (isAuthorized.isAuthorizedFromResiduals ([] : List ResidualPolicy)).decision.isSome = true := by
-    simp [isAuthorized.isAuthorizedFromResiduals, isAuthorized.satisfiedPolicies,
-      isAuthorized.falsePolicies, isAuthorized.errorPolicies, isAuthorized.residualPolicies]
-  simp [this]
 
 theorem batched_authorize_loop_decision_agrees
   {policies : List Policy} {residuals : List ResidualPolicy} {req : Request}

--- a/cedar-lean/Cedar/Thm/BatchedEvaluator/Authorize.lean
+++ b/cedar-lean/Cedar/Thm/BatchedEvaluator/Authorize.lean
@@ -90,58 +90,24 @@ theorem batched_authorize_loop_decision_agrees
       exact batched_authorize_loop_decision_agrees es h₀
         (residuals_equiv_preserved h₁ h₃ h₆) h₆ h₃ h_dec
 
-theorem isValidAndConsistent_env
-  {schema : Schema} {req : Request} {es : Entities}
-  {preq : PartialRequest} {pes : PartialEntities} :
-  isValidAndConsistent schema req es preq pes = .ok () →
-  ∃ env,
-    schema.environment? preq.principal.ty preq.resource.ty preq.action = .some env ∧
-    InstanceOfWellFormedEnvironment req es env
-:= by
-  intro h_valid
-  simp only [isValidAndConsistent] at h_valid
-  split at h_valid <;> try cases h_valid
-  rename_i env heq
-  exists env; refine ⟨heq, ?_⟩
-  rcases do_eq_ok₂ h_valid with ⟨h₁, h₂⟩
-  simp only [isValidAndConsistent.requestIsConsistent, Bool.or_eq_true, Bool.not_eq_eq_eq_not,
-    Bool.not_true, Bool.and_eq_true, decide_eq_true_eq] at h₁
-  split at h₁ <;> try cases h₁
-  rename_i h_guard; simp only [not_or, Bool.not_eq_false] at h_guard
-  simp only [isValidAndConsistent.entitiesIsConsistent, Bool.or_eq_true, Bool.not_eq_eq_eq_not,
-    Bool.not_true] at h₂
-  split at h₂ <;> try cases h₂
-  rename_i heq₄; simp only [not_or, Bool.not_eq_false] at heq₄
-  rcases heq₄ with ⟨_, heq₄⟩
-  simp only [Except.isOk, Except.toBool] at heq₄
-  split at heq₄ <;> cases heq₄; rename_i heq₄
-  simp only [bind, Except.bind, isValidAndConsistent.envIsWellFormed, Bool.not_eq_eq_eq_not,
-    Bool.not_true] at h₂
-  split at h₂ <;> try cases h₂
-  simp only [ite_eq_right_iff, reduceCtorEq, imp_false, Bool.not_eq_false] at h₂
-  simp only [Except.isOk, Except.toBool] at h₂
-  split at h₂ <;> cases h₂; rename_i heq₅
-  exact instance_of_well_formed_env heq₅ h_guard.2 heq₄
-
 theorem evaluatePolicies_equiv_and_well_typed
   {schema : Schema} {policies : List Policy} {rps : List ResidualPolicy}
   {req : Request} {es : Entities} {preq : PartialRequest}
   {pes : PartialEntities} {env : TypeEnv} :
   List.Forall₂ (λ p rp => ResidualPolicy.mk p.id p.effect <$> evaluatePolicy schema p preq pes = .ok rp) policies rps →
-  isValidAndConsistent schema req es preq pes = .ok () →
   schema.environment? preq.principal.ty preq.resource.ty preq.action = .some env →
   InstanceOfWellFormedEnvironment req es env →
   RequestAndEntitiesRefine req es preq pes →
   ResidualPoliciesEquivAndWellTyped env policies rps req es
 := by
-  intro h_mapM h_valid h_schema_env h_wf h_ref
+  intro h_mapM h_schema_env h_wf h_ref
   unfold ResidualPoliciesEquivAndWellTyped
   apply List.Forall₂.imp _ h_mapM
   intro p rp h
   cases h_ep : evaluatePolicy schema p preq pes <;> simp only [h_ep, Except.map_error, reduceCtorEq] at h
   simp only [Except.map_ok, Except.ok.injEq] at h
   subst h
-  refine ⟨rfl, rfl, (partial_evaluate_policy_is_sound h_ep h_valid).symm, ?_⟩
+  refine ⟨rfl, rfl, (partial_evaluate_policy_is_sound h_ep h_schema_env h_wf h_ref).symm, ?_⟩
   simp only [evaluatePolicy, h_schema_env, List.empty_eq] at h_ep
   split at h_ep <;> try cases h_ep
   simp only [do_ok_eq_ok, Prod.exists, exists_and_right] at h_ep

--- a/cedar-lean/Cedar/Thm/BatchedEvaluator/Authorize.lean
+++ b/cedar-lean/Cedar/Thm/BatchedEvaluator/Authorize.lean
@@ -20,6 +20,106 @@ open Cedar.Validation
 open Cedar.Thm
 open Cedar.Data
 
+private theorem mem_foldl_append_of_init {α β : Type} {f : β → List α} {xs : List β}
+  {init : List α} {a : α} (h : a ∈ init) :
+  a ∈ List.foldl (fun acc x => f x ++ acc) init xs
+:= by
+  induction xs generalizing init with
+  | nil => exact h
+  | cons hd tl ih => exact ih (List.mem_append_right _ h)
+
+private theorem mem_foldl_append_of_mem {α β : Type} {f : β → List α} {xs : List β}
+  {init : List α} {a : α} {x : β} (hx : x ∈ xs) (ha : a ∈ f x) :
+  a ∈ List.foldl (fun acc y => f y ++ acc) init xs
+:= by
+  induction xs generalizing init with
+  | nil => cases hx
+  | cons hd tl ih =>
+    simp only [List.foldl_cons]
+    cases hx with
+    | head => exact mem_foldl_append_of_init (List.mem_append_left _ ha)
+    | tail _ htl => exact ih htl
+
+theorem environment_some_mem_environments {schema : Schema}
+  {principal resource : EntityType} {action : EntityUID} {env : TypeEnv}
+  (h : schema.environment? principal resource action = .some env) :
+  env ∈ schema.environments
+:= by
+  simp only [Schema.environment?] at h
+  cases h_find : schema.acts.find? action <;> simp only [h_find, Option.bind_none_fun,
+    Option.bind_some_fun, reduceCtorEq] at h
+  rename_i ase
+  split at h <;> simp only [reduceCtorEq, Option.some.injEq] at h
+  rename_i hp hr
+  subst h
+  simp only [Schema.environments, List.mem_map]
+  refine ⟨{ principal, action, resource, context := ase.context }, ?_, rfl⟩
+  -- Show this RequestType is in the foldl result
+  apply mem_foldl_append_of_mem (Map.find?_mem_toList h_find)
+  -- Show it's in the inner foldl (requestTypes for this action entry)
+  -- ActionSchemaEntry.requestTypes inlines to a foldl over appliesToPrincipal
+  show { principal, action, resource, context := ase.context : RequestType } ∈
+    ase.appliesToPrincipal.toList.foldl (fun acc p =>
+      (ase.appliesToResource.toList.map (fun r =>
+        { principal := p, action, resource := r, context := ase.context })) ++ acc) []
+  apply mem_foldl_append_of_mem
+  · exact (Set.mem_elts_iff_mem_set _ _).mpr (Set.contains_prop_bool_equiv.mp hp)
+  · simp only [List.mem_map]
+    exact ⟨resource, (Set.mem_elts_iff_mem_set _ _).mpr (Set.contains_prop_bool_equiv.mp hr), rfl⟩
+
+theorem evaluatePolicy_ok_implies_env_some {schema : Schema} {p : Policy}
+  {preq : PartialRequest} {pes : PartialEntities} {r : Residual} :
+  evaluatePolicy schema p preq pes = .ok r →
+  ∃ env, schema.environment? preq.principal.ty preq.resource.ty preq.action = .some env
+:= by
+  intro h
+  simp only [evaluatePolicy] at h
+  split at h
+  · exact ⟨_, ‹_›⟩
+  · cases h
+
+private theorem requestIsValid_asPartialRequest_eq {env : TypeEnv} {req : Request} :
+  requestIsValid env req.asPartialRequest = instanceOfRequestType req env
+:= by
+  simp only [requestIsValid, Request.asPartialRequest, PartialEntityUID.asEntityUID,
+    partialIsValid, Option.map_some, Option.getD_some, instanceOfRequestType]
+
+theorem evaluatePolicy_ok_implies_requestMatchesEnvironment
+  {schema : Schema} {p : Policy} {req : Request} {r : Residual} :
+  evaluatePolicy schema p req.asPartialRequest Map.empty = .ok r →
+  ∀ env, schema.environment? req.asPartialRequest.principal.ty req.asPartialRequest.resource.ty req.asPartialRequest.action = .some env →
+  requestMatchesEnvironment env req
+:= by
+  intro h env h_env
+  simp only [evaluatePolicy, h_env] at h
+  split at h <;> try cases h
+  rename_i h_valid
+  simp only [requestAndEntitiesIsValid, Bool.and_eq_true] at h_valid
+  simp only [requestMatchesEnvironment, ← requestIsValid_asPartialRequest_eq]
+  exact h_valid.1
+
+/--
+If `evaluatePolicy` succeeds on a concrete request, and the schema and entities
+pass validation, then `InstanceOfWellFormedEnvironment` holds for the
+environment determined by the schema and request.
+-/
+theorem evaluatePolicy_ok_implies_well_formed_env
+  {schema : Schema} {p : Policy} {req : Request} {es : Entities} {r : Residual} :
+  evaluatePolicy schema p req.asPartialRequest Map.empty = .ok r →
+  schema.validateWellFormed = .ok () →
+  validateEntities schema es = .ok () →
+  ∃ env,
+    schema.environment? req.asPartialRequest.principal.ty req.asPartialRequest.resource.ty req.asPartialRequest.action = .some env ∧
+    InstanceOfWellFormedEnvironment req es env
+:= by
+  intro h_ep h_schema_wf h_entities
+  obtain ⟨env, h_env⟩ := evaluatePolicy_ok_implies_env_some h_ep
+  have h_mem := environment_some_mem_environments h_env
+  exact ⟨env, h_env, instance_of_well_formed_env
+    (List.forM_ok_implies_all_ok _ _ h_schema_wf _ h_mem)
+    (evaluatePolicy_ok_implies_requestMatchesEnvironment h_ep env h_env)
+    (List.forM_ok_implies_all_ok _ _ h_entities _ h_mem)⟩
+
 def ResidualPoliciesEquivAndWellTyped
   (env : TypeEnv)
   (policies : List Policy)
@@ -55,6 +155,18 @@ theorem residuals_equiv_preserved
      by rw [← partial_evaluate_is_sound h_wt h_wf h_ref]; exact h_eval,
      partial_eval_preserves_well_typed h_wf h_ref h_wt⟩
   ) h_sound
+
+theorem batchedAuthorizeLoop_nil_decision {req : Request} {loader : EntityLoader}
+  {store : PartialEntities} {iters : Nat} :
+  (batchedAuthorizeLoop [] req loader store iters).decision =
+  (isAuthorized.isAuthorizedFromResiduals []).decision
+:= by
+  unfold batchedAuthorizeLoop
+  simp only
+  have : (isAuthorized.isAuthorizedFromResiduals ([] : List ResidualPolicy)).decision.isSome = true := by
+    simp [isAuthorized.isAuthorizedFromResiduals, isAuthorized.satisfiedPolicies,
+      isAuthorized.falsePolicies, isAuthorized.errorPolicies, isAuthorized.residualPolicies]
+  simp [this]
 
 theorem batched_authorize_loop_decision_agrees
   {policies : List Policy} {residuals : List ResidualPolicy} {req : Request}

--- a/cedar-lean/Cedar/Thm/BatchedEvaluator/Authorize.lean
+++ b/cedar-lean/Cedar/Thm/BatchedEvaluator/Authorize.lean
@@ -90,9 +90,6 @@ theorem batched_authorize_loop_decision_agrees
       exact batched_authorize_loop_decision_agrees es h₀
         (residuals_equiv_preserved h₁ h₃ h₆) h₆ h₃ h_dec
 
-/--
-Extract the type environment and well-formedness proof from `isValidAndConsistent`.
--/
 theorem isValidAndConsistent_env
   {schema : Schema} {req : Request} {es : Entities}
   {preq : PartialRequest} {pes : PartialEntities} :

--- a/cedar-lean/Cedar/Thm/BatchedEvaluator/Authorize.lean
+++ b/cedar-lean/Cedar/Thm/BatchedEvaluator/Authorize.lean
@@ -1,0 +1,159 @@
+import Cedar.TPE.Input
+import Cedar.TPE.BatchedEvaluator
+import Cedar.Spec
+import Cedar.Validation
+import Cedar.Thm.Validation
+import Cedar.Thm.TPE
+import Cedar.Thm.Authorization
+import Cedar.Thm.BatchedEvaluator.Common
+
+/-!
+Soundness of batched authorization: if the batched authorizer reaches a
+definitive decision, that decision agrees with the concrete authorizer.
+-/
+
+namespace Cedar.Thm
+
+open Cedar.TPE
+open Cedar.Spec
+open Cedar.Validation
+open Cedar.Thm
+open Cedar.Data
+
+def ResidualPoliciesEquivAndWellTyped
+  (env : TypeEnv)
+  (policies : List Policy)
+  (residuals : List ResidualPolicy)
+  (req : Request)
+  (es : Entities) : Prop :=
+  List.Forall₂ (λ p rp =>
+    rp.id = p.id ∧
+    rp.effect = p.effect ∧
+    (rp.residual.evaluate req es).toOption = (Spec.evaluate p.toExpr req es).toOption ∧
+    Residual.WellTyped env rp.residual
+  ) policies residuals
+
+theorem equiv_well_typed_implies_equiv
+  (h : ResidualPoliciesEquivAndWellTyped env policies residuals req es) :
+  ResidualPoliciesEquiv policies residuals req es :=
+  List.Forall₂.imp (fun _ _ ⟨a, b, c, _⟩ => ⟨a, b, c⟩) h
+
+theorem residuals_equiv_preserved
+  {env : TypeEnv} {policies : List Policy} {residuals : List ResidualPolicy}
+  {req : Request} {es : Entities} {pes : PartialEntities}
+  (h_sound : ResidualPoliciesEquivAndWellTyped env policies residuals req es)
+  (h_wf : InstanceOfWellFormedEnvironment req es env)
+  (h_ref : RequestAndEntitiesRefine req es req.asPartialRequest pes) :
+  ResidualPoliciesEquivAndWellTyped env policies
+    (residuals.map λ rp => ⟨rp.id, rp.effect, Cedar.TPE.evaluate rp.residual req.asPartialRequest pes⟩)
+    req es
+:= by
+  unfold ResidualPoliciesEquivAndWellTyped at *
+  rw [← List.map_id policies]
+  exact List.map_preserves_forall₂ (fun p rp ⟨h_id, h_eff, h_eval, h_wt⟩ =>
+    ⟨h_id, h_eff,
+     by rw [← partial_evaluate_is_sound h_wt h_wf h_ref]; exact h_eval,
+     partial_eval_preserves_well_typed h_wf h_ref h_wt⟩
+  ) h_sound
+
+theorem batched_authorize_loop_decision_agrees
+  {policies : List Policy} {residuals : List ResidualPolicy} {req : Request}
+  (es : Entities) {current_store : PartialEntities} {env : TypeEnv} {d : Decision} :
+  EntityLoader.WellBehaved es loader →
+  ResidualPoliciesEquivAndWellTyped env policies residuals req es →
+  RequestAndEntitiesRefine req es req.asPartialRequest current_store →
+  InstanceOfWellFormedEnvironment req es env →
+  (batchedAuthorizeLoop residuals req loader current_store iters).decision = some d →
+  (Spec.isAuthorized req es policies).decision = d
+:= by
+  intro h₀ h₁ h₂ h₃ h_dec
+  unfold batchedAuthorizeLoop at h_dec
+  simp only at h_dec
+  split at h_dec
+  case isTrue =>
+    exact residuals_decision_agrees (equiv_well_typed_implies_equiv h₁) h_dec
+  case isFalse =>
+    cases iters with
+    | zero =>
+      exact residuals_decision_agrees (equiv_well_typed_implies_equiv h₁) h_dec
+    | succ n =>
+      have h₆ : RequestAndEntitiesRefine req es req.asPartialRequest
+        (((loader
+          (Set.filter (fun uid => (Map.find? current_store uid).isNone)
+            (List.mapUnion (fun rp => rp.residual.allLiteralUIDs) residuals))).mapOnValues
+            MaybeEntityData.asPartial) ++ current_store) := by
+        constructor
+        · exact as_partial_request_refines
+        · apply entities_refine_append
+          · exact h₂.right
+          · exact (h₀ _).2
+      exact batched_authorize_loop_decision_agrees es h₀
+        (residuals_equiv_preserved h₁ h₃ h₆) h₆ h₃ h_dec
+
+/--
+Extract the type environment and well-formedness proof from `isValidAndConsistent`.
+-/
+theorem isValidAndConsistent_env
+  {schema : Schema} {req : Request} {es : Entities}
+  {preq : PartialRequest} {pes : PartialEntities} :
+  isValidAndConsistent schema req es preq pes = .ok () →
+  ∃ env,
+    schema.environment? preq.principal.ty preq.resource.ty preq.action = .some env ∧
+    InstanceOfWellFormedEnvironment req es env
+:= by
+  intro h_valid
+  simp only [isValidAndConsistent] at h_valid
+  split at h_valid <;> try cases h_valid
+  rename_i env heq
+  exists env; refine ⟨heq, ?_⟩
+  rcases do_eq_ok₂ h_valid with ⟨h₁, h₂⟩
+  simp only [isValidAndConsistent.requestIsConsistent, Bool.or_eq_true, Bool.not_eq_eq_eq_not,
+    Bool.not_true, Bool.and_eq_true, decide_eq_true_eq] at h₁
+  split at h₁ <;> try cases h₁
+  rename_i h_guard; simp only [not_or, Bool.not_eq_false] at h_guard
+  simp only [isValidAndConsistent.entitiesIsConsistent, Bool.or_eq_true, Bool.not_eq_eq_eq_not,
+    Bool.not_true] at h₂
+  split at h₂ <;> try cases h₂
+  rename_i heq₄; simp only [not_or, Bool.not_eq_false] at heq₄
+  rcases heq₄ with ⟨_, heq₄⟩
+  simp only [Except.isOk, Except.toBool] at heq₄
+  split at heq₄ <;> cases heq₄; rename_i heq₄
+  simp only [bind, Except.bind, isValidAndConsistent.envIsWellFormed, Bool.not_eq_eq_eq_not,
+    Bool.not_true] at h₂
+  split at h₂ <;> try cases h₂
+  simp only [ite_eq_right_iff, reduceCtorEq, imp_false, Bool.not_eq_false] at h₂
+  simp only [Except.isOk, Except.toBool] at h₂
+  split at h₂ <;> cases h₂; rename_i heq₅
+  exact instance_of_well_formed_env heq₅ h_guard.2 heq₄
+
+theorem evaluatePolicies_equiv_and_well_typed
+  {schema : Schema} {policies : List Policy} {rps : List ResidualPolicy}
+  {req : Request} {es : Entities} {preq : PartialRequest}
+  {pes : PartialEntities} {env : TypeEnv} :
+  List.Forall₂ (λ p rp => ResidualPolicy.mk p.id p.effect <$> evaluatePolicy schema p preq pes = .ok rp) policies rps →
+  isValidAndConsistent schema req es preq pes = .ok () →
+  schema.environment? preq.principal.ty preq.resource.ty preq.action = .some env →
+  InstanceOfWellFormedEnvironment req es env →
+  RequestAndEntitiesRefine req es preq pes →
+  ResidualPoliciesEquivAndWellTyped env policies rps req es
+:= by
+  intro h_mapM h_valid h_schema_env h_wf h_ref
+  unfold ResidualPoliciesEquivAndWellTyped
+  apply List.Forall₂.imp _ h_mapM
+  intro p rp h
+  cases h_ep : evaluatePolicy schema p preq pes <;> simp only [h_ep, Except.map_error, reduceCtorEq] at h
+  simp only [Except.map_ok, Except.ok.injEq] at h
+  subst h
+  refine ⟨rfl, rfl, (partial_evaluate_policy_is_sound h_ep h_valid).symm, ?_⟩
+  simp only [evaluatePolicy, h_schema_env, List.empty_eq] at h_ep
+  split at h_ep <;> try cases h_ep
+  simp only [do_ok_eq_ok, Prod.exists, exists_and_right] at h_ep
+  rcases h_ep with ⟨_, ⟨_, h₁₁⟩, h₁₂⟩
+  simp only [Except.mapError] at h₁₁
+  split at h₁₁ <;> try cases h₁₁
+  rename_i ty _ _ heq₂
+  subst h₁₂
+  exact partial_eval_preserves_well_typed h_wf h_ref
+    (conversion_preserves_typedness (typechecked_is_well_typed_after_lifting heq₂))
+
+end Cedar.Thm

--- a/cedar-lean/Cedar/Thm/BatchedEvaluator/Common.lean
+++ b/cedar-lean/Cedar/Thm/BatchedEvaluator/Common.lean
@@ -1,0 +1,86 @@
+import Cedar.TPE.Input
+import Cedar.TPE.BatchedEvaluator
+import Cedar.Spec
+import Cedar.Thm.TPE.Input
+
+/-!
+Shared definitions and lemmas for batched evaluator theorems.
+-/
+
+namespace Cedar.Thm
+
+open Cedar.TPE
+open Cedar.Spec
+open Cedar.Data
+
+/-- A well behaved entity loader
+1. Loads all the requested entities, returning none for missing
+entities
+2. Refines the backing entity store
+
+The first condition is required for convergence of
+batched evaluation, which has not been proven. It is unused
+in the code base at the moment.
+-/
+abbrev EntityLoader.WellBehaved (store: Entities) (loader: EntityLoader) : Prop :=
+  ∀ s, s ⊆ (loader s).keys ∧
+       EntitiesRefine store ((loader s).mapOnValues MaybeEntityData.asPartial)
+
+theorem as_partial_request_refines {req : Request} :
+  RequestRefines req req.asPartialRequest := by
+  simp only [Request.asPartialRequest, RequestRefines, PartialEntityUID.asEntityUID, Option.map_some]
+  constructor
+  · apply PartialIsValid.some
+    rfl
+  constructor
+  · trivial
+  constructor
+  · apply PartialIsValid.some
+    rfl
+  constructor
+  · apply PartialIsValid.some
+    rfl
+  constructor <;> trivial
+
+theorem any_refines_empty_entities :
+  EntitiesRefine es Data.Map.empty := by
+  simp only [EntitiesRefine, Data.Map.empty, Data.Map.find?, Map.toList]
+  intro a e₂ h₁
+  contradiction
+
+theorem entities_refine_append (es : Entities) (m1 m2 : PartialEntities) :
+  EntitiesRefine es m1 → EntitiesRefine es m2 → EntitiesRefine es (m2 ++ m1) := by
+  intro h1 h2
+  unfold EntitiesRefine
+  intro a e₂ h_find
+  rw [Map.find?_append] at h_find
+  cases h_case : m2.find? a with
+  | some e₂' =>
+    have h_eq : e₂ = e₂' := by
+      rw [h_case] at h_find
+      simp only [Option.some_or, Option.some.injEq] at h_find
+      rw [h_find]
+    rw [h_eq]
+    exact h2 a e₂' h_case
+  | none =>
+    have h_find1 : m1.find? a = some e₂ := by
+      rw [h_case] at h_find
+      simp only [Option.none_or] at h_find
+      rw [h_find]
+    exact h1 a e₂ h_find1
+
+theorem direct_request_and_entities_refine (req : Request) (es : Entities) :
+  RequestAndEntitiesRefine req es req.asPartialRequest es.asPartial := by
+  constructor
+  · exact as_partial_request_refines
+  · unfold EntitiesRefine Entities.asPartial
+    intro uid data₂ h_find
+    have h_mapOnValues := Map.find?_mapOnValues_some' EntityData.asPartial h_find
+    obtain ⟨data₁, h_find₁, h_eq⟩ := h_mapOnValues
+    exists data₁
+    exact ⟨h_find₁,
+           by rw [h_eq]; apply PartialIsValid.some; rfl,
+           by rw [h_eq]; apply PartialIsValid.some; rfl,
+           by rw [h_eq]; apply PartialIsValid.some; rfl⟩
+
+end Cedar.Thm

--- a/cedar-lean/Cedar/Thm/BatchedEvaluator/Common.lean
+++ b/cedar-lean/Cedar/Thm/BatchedEvaluator/Common.lean
@@ -14,8 +14,7 @@ open Cedar.Spec
 open Cedar.Data
 
 /-- A well behaved entity loader
-1. Loads all the requested entities, returning none for missing
-entities
+1. Loads all the requested entities, returning none for missing entities
 2. Refines the backing entity store
 
 The first condition is required for convergence of

--- a/cedar-lean/Cedar/Thm/BatchedEvaluator/Evaluate.lean
+++ b/cedar-lean/Cedar/Thm/BatchedEvaluator/Evaluate.lean
@@ -1,0 +1,64 @@
+import Cedar.TPE.Input
+import Cedar.TPE.BatchedEvaluator
+import Cedar.Spec
+import Cedar.Validation
+import Cedar.Thm.Validation
+import Cedar.Thm.TPE
+import Cedar.Thm.BatchedEvaluator.Common
+
+/-!
+Soundness of batched expression evaluation: batched evaluation of a single
+well-typed residual produces the same result as direct evaluation with the
+complete entity store.
+-/
+
+namespace Cedar.Thm
+
+open Cedar.TPE
+open Cedar.Spec
+open Cedar.Validation
+open Cedar.Thm
+open Cedar.Data
+
+theorem batched_evaluate_loop_eq_evaluate
+  {x : Residual}
+  {req : Request}
+  (es : Entities)
+  {current_store : PartialEntities}
+  {env : TypeEnv} :
+  EntityLoader.WellBehaved es loader →
+  Residual.WellTyped env x →
+  RequestAndEntitiesRefine req es req.asPartialRequest current_store →
+  InstanceOfWellFormedEnvironment req es env →
+  (Residual.evaluate (batchedEvaluateLoop x req loader current_store iters) req es).toOption = (Residual.evaluate x req es).toOption := by
+  intro h₀ h₁ h₂ h₃
+  unfold batchedEvaluateLoop
+  split
+  case h_1 => simp only
+  case h_2 iters n=>
+    let toLoad := (Set.filter (fun uid => (Map.find? current_store uid).isNone) x.allLiteralUIDs)
+    let newEntities := ((loader toLoad).mapOnValues MaybeEntityData.asPartial)
+    let newStore := newEntities ++ current_store
+
+    have h₆ : RequestAndEntitiesRefine req es req.asPartialRequest newStore := by
+      constructor
+      · exact as_partial_request_refines
+      · apply entities_refine_append
+        · exact h₂.right
+        · exact (h₀ toLoad).2
+    let newRes := TPE.evaluate x req.asPartialRequest newStore
+    have h₇ : (Residual.evaluate newRes req es).toOption = (Residual.evaluate x req es).toOption := by
+      rw [← partial_evaluate_is_sound h₁ h₃ h₆]
+
+    simp only
+    split
+    case h_1 h₆ =>
+      rw [← h₆]
+      exact h₇
+    case h_2 =>
+      have h₈ := (partial_eval_preserves_well_typed h₃ h₆ h₁)
+      rw [batched_evaluate_loop_eq_evaluate es h₀ h₈ h₆ h₃]
+      exact h₇
+
+
+end Cedar.Thm

--- a/cedar-lean/Cedar/Thm/TPE.lean
+++ b/cedar-lean/Cedar/Thm/TPE.lean
@@ -70,7 +70,7 @@ theorem reauthorize_is_sound
   have h_equiv := evaluatePolicies_residuals_equiv hv h_auth₁
   have equiv_satisfied := reauthorize_satisfied_policies_equiv h_equiv
   have equiv_errors := reauthorize_error_policies_equiv h_equiv
-  simp [TPE.isAuthorized.isAuthorizedFromResiduals, Response.reauthorize, Spec.isAuthorized,
+  simp [TPE.isAuthorizedFromResiduals, Response.reauthorize, Spec.isAuthorized,
         equiv_satisfied .forbid, equiv_satisfied .permit, equiv_errors]
 
 /-- Main partial authorization soundness theorem: If partial authorization
@@ -232,7 +232,7 @@ theorem partial_authorize_satisfied_forbid_is_determining
   have h_equiv := evaluatePolicies_residuals_equiv h₂ h₃
   rename_i rps
 
-  simp only [isAuthorized.isAuthorizedFromResiduals, isAuthorized.satisfiedPolicies, Set.subset_def,
+  simp only [isAuthorizedFromResiduals, isAuthorizedFromResiduals.satisfiedPolicies, Set.subset_def,
     Set.mem_make, List.mem_filterMap, ResidualPolicy.satisfiedWithEffect,
     ResidualPolicy.satisfied, Residual.isTrue, Bool.and_eq_true, beq_iff_eq,
     Option.ite_none_right_eq_some, Option.some.injEq, forall_exists_index, and_imp]

--- a/cedar-lean/Cedar/Thm/TPE.lean
+++ b/cedar-lean/Cedar/Thm/TPE.lean
@@ -63,13 +63,13 @@ theorem reauthorize_is_sound
   intro hv h_auth
 
   simp only [TPE.isAuthorized] at h_auth
-  cases h_auth₁ : List.mapM (λ p => ResidualPolicy.mk p.id p.effect <$> evaluatePolicy schema p preq pes) policies <;> simp [h_auth₁] at h_auth
-  rename_i residuals
-  subst h_auth
+  cases h_auth₁ : isAuthorized.evaluatePolicies schema policies preq pes <;>
+    simp [h_auth₁] at h_auth
+  rw [← h_auth]
 
-  rw [List.mapM_ok_iff_forall₂] at h_auth₁
-  have equiv_satisfied := reauthorize_satisfied_policies_equiv hv h_auth₁
-  have equiv_errors := reauthorize_error_policies_equiv hv h_auth₁
+  have h_equiv := evaluatePolicies_residuals_equiv hv h_auth₁
+  have equiv_satisfied := reauthorize_satisfied_policies_equiv h_equiv
+  have equiv_errors := reauthorize_error_policies_equiv h_equiv
   simp [TPE.isAuthorized.isAuthorizedFromResiduals, Response.reauthorize, Spec.isAuthorized,
         equiv_satisfied .forbid, equiv_satisfied .permit, equiv_errors]
 
@@ -92,51 +92,10 @@ theorem partial_authorize_decision_is_sound
 := by
   intro h₁ h₂
   simp only [TPE.isAuthorized] at h₁
-
-  cases h₃ : List.mapM (λ p => ResidualPolicy.mk p.id p.effect <$> evaluatePolicy schema p preq pes) policies <;>
+  cases h₃ : isAuthorized.evaluatePolicies schema policies preq pes <;>
     simp [h₃] at h₁
-  rename_i rps
-
-  rw [List.mapM_ok_iff_forall₂] at h₃
-  simp [isAuthorized.isAuthorizedFromResiduals] at h₁
-  split at h₁ <;>
-    simp only [← h₁, reduceCtorEq, false_implies]
-  all_goals
-    intro h₅
-    simp only [Option.some.injEq] at h₅
-    subst h₅
-  -- Deny (satisfied forbid exists)
-  · have hf : ¬ (isAuthorized.satisfiedPolicies .forbid rps).isEmpty := by grind
-    have h_forbid : HasSatisfiedEffect Effect.forbid req es policies :=
-      satisfied_effect_if_non_empty_satisfied_policies h₂ h₃ hf
-
-    apply forbid_trumps_permit
-    unfold IsExplicitlyForbidden
-    exact h_forbid
-
-  -- Deny (no satisfied permits)
-  · have hp₁ : (isAuthorized.satisfiedPolicies .permit rps).isEmpty := by grind
-    have hp₂ : (isAuthorized.residualPolicies .permit rps).isEmpty := by grind
-    have h_not_permit : ¬HasSatisfiedEffect Effect.permit req es policies :=
-      no_satisfied_effect_if_empty_satisfied_and_residual_policies h₂ h₃ hp₁ hp₂
-
-    apply default_deny
-    unfold IsExplicitlyPermitted
-    exact h_not_permit
-
-  -- Allow (satisfied permit exists, no satisfied/residual forbids)
-  · have hf₁ : (isAuthorized.satisfiedPolicies .forbid rps).isEmpty := by grind
-    have hf₂ : (isAuthorized.residualPolicies .forbid rps).isEmpty := by grind
-    have h_not_forbid : ¬HasSatisfiedEffect Effect.forbid req es policies :=
-      no_satisfied_effect_if_empty_satisfied_and_residual_policies h₂ h₃ hf₁ hf₂
-
-    have hp : ¬ (isAuthorized.satisfiedPolicies .permit rps).isEmpty := by grind
-    have h_permit : HasSatisfiedEffect Effect.permit req es policies :=
-      satisfied_effect_if_non_empty_satisfied_policies h₂ h₃ hp
-
-    apply (allowed_iff_explicitly_permitted_and_not_denied _ _ _).mp
-    unfold IsExplicitlyPermitted IsExplicitlyForbidden
-    exact .intro h_permit h_not_forbid
+  rw [← h₁]
+  exact residuals_decision_agrees (evaluatePolicies_residuals_equiv h₂ h₃)
 
 /-- Trivial composition of the first two soundness theorems directly relating
 the decision of partial authorization and subsequent re-authorization.-/
@@ -175,15 +134,12 @@ theorem partial_authorize_erroring_policies_is_sound
 := by
   intro h₁ h₂
   simp only [TPE.isAuthorized] at h₁
-
-  cases h₃ : List.mapM (λ p => ResidualPolicy.mk p.id p.effect <$> evaluatePolicy schema p preq pes) policies <;>
+  cases h₃ : isAuthorized.evaluatePolicies schema policies preq pes <;>
     simp [h₃] at h₁
-  rename_i rps
-  rw [List.mapM_ok_iff_forall₂] at h₃
-  subst response
-
-  have h_err_permit := partial_authorize_error_policies_is_sound .permit h₃ h₂
-  have h_err_forbid := partial_authorize_error_policies_is_sound .forbid h₃ h₂
+  subst h₁
+  have h_equiv := evaluatePolicies_residuals_equiv h₂ h₃
+  have h_err_permit := partial_authorize_error_policies_is_sound .permit h_equiv
+  have h_err_forbid := partial_authorize_error_policies_is_sound .forbid h_equiv
   rw [Set.union_subset]
   exact .intro h_err_forbid h_err_permit
 
@@ -209,36 +165,13 @@ theorem partial_authorize_allow_determining_policies_is_sound
     grind [Spec.isAuthorized]
   simp only [Spec.isAuthorized, h_allow', Bool.not_false, Bool.and_self, ↓reduceIte]
 
-  cases h₃ : List.mapM (λ p => ResidualPolicy.mk p.id p.effect <$> evaluatePolicy schema p preq pes) policies <;>
+  cases h₃ : isAuthorized.evaluatePolicies schema policies preq pes <;>
     simp [h₃] at h₁
-  rename_i rps
-  rw [List.mapM_ok_iff_forall₂] at h₃
-  subst response
-
-  simp [isAuthorized.isAuthorizedFromResiduals, isAuthorized.satisfiedPolicies,
-    satisfiedPolicies, satisfiedWithEffect, satisfied, Bool.and_eq_true,
-    decide_eq_true_eq, Set.subset_def, Set.mem_make, List.mem_filterMap,
-    ResidualPolicy.satisfiedWithEffect, ResidualPolicy.satisfied, Residual.isTrue,
-    Option.ite_none_right_eq_some, forall_exists_index, and_imp]
-  intro pid rp hrp heff hs hpid
-  split at hs <;> try contradiction
-
-  have ⟨p, hp₁, hp₂⟩ := List.forall₂_implies_all_right h₃ rp hrp
-  cases hp₃ : evaluatePolicy schema p preq pes <;>
-   simp only [hp₃, Except.map_error, Except.map_ok, reduceCtorEq, Except.ok.injEq] at hp₂
-
-  exists p
-  and_intros
-  · exact hp₁
-  · rw [←hp₂] at heff
-    exact heff
-  · rename_i ty hr r
-    replace hr : r = .val (.prim (.bool true)) ty := by grind
-    have ha := partial_evaluate_policy_is_sound hp₃ h₂
-    simp only [hr, Residual.evaluate] at ha
-    exact to_option_right_ok' ha
-  · rw [←hp₂] at hpid
-    exact hpid
+  subst h₁
+  have h_equiv := evaluatePolicies_residuals_equiv h₂ h₃
+  exact Set.subset_trans
+    (partial_authorize_satisfied_policies_is_sound .permit h_equiv)
+    (by simp [Set.subset_def])
 
 /-- If the result of concrete authorization is `deny`, then any permit policies
 satisfied after partial authorization cannot be determining policies.  -/
@@ -293,12 +226,11 @@ theorem partial_authorize_satisfied_forbid_is_determining
 := by
   intro h₁ h₂
   simp only [TPE.isAuthorized] at h₁
-
-  cases h₃ : List.mapM (λ p => ResidualPolicy.mk p.id p.effect <$> evaluatePolicy schema p preq pes) policies <;>
-    simp only [bind_pure_comp, h₃, Except.map_ok, Except.map_error, Except.ok.injEq, reduceCtorEq] at h₁
+  cases h₃ : isAuthorized.evaluatePolicies schema policies preq pes <;>
+    simp [h₃] at h₁
+  subst h₁
+  have h_equiv := evaluatePolicies_residuals_equiv h₂ h₃
   rename_i rps
-  rw [List.mapM_ok_iff_forall₂] at h₃
-  subst response
 
   simp only [isAuthorized.isAuthorizedFromResiduals, isAuthorized.satisfiedPolicies, Set.subset_def,
     Set.mem_make, List.mem_filterMap, ResidualPolicy.satisfiedWithEffect,
@@ -306,35 +238,24 @@ theorem partial_authorize_satisfied_forbid_is_determining
     Option.ite_none_right_eq_some, Option.some.injEq, forall_exists_index, and_imp]
   intro pid rp hrp heff hs hpid
   split at hs <;> try contradiction
+  rename_i hf₅
 
-  have ⟨p, hp₁, hp₂⟩ := List.forall₂_implies_all_right h₃ rp hrp
-  cases hp₃ : evaluatePolicy schema p preq pes <;>
-    simp only [hp₃, Except.map_error, Except.map_ok, reduceCtorEq, Except.ok.injEq] at hp₂
-  rename_i ty hr r
+  have ⟨p, hp₁, h_id, h_eff, h_eval⟩ := List.forall₂_implies_all_right h_equiv rp hrp
 
   have ha : Spec.evaluate p.toExpr req es = .ok (.prim (.bool true)) := by
-    replace hr : r = .val (.prim (.bool true)) ty := by grind
-    have ha := partial_evaluate_policy_is_sound hp₃ h₂
-    simp only [hr, Residual.evaluate] at ha
-    exact to_option_right_ok' ha
+    simp only [hf₅, Residual.evaluate] at h_eval
+    exact to_option_left_ok' h_eval
 
   suffices h : pid ∈ satisfiedPolicies Effect.forbid policies req es by
     have hd : IsExplicitlyForbidden req es policies := by
-      exists p
-      and_intros <;> grind [satisfied]
-    replace hd : (Spec.isAuthorized req es policies).decision = .deny :=
-      forbid_trumps_permit _ _ _ hd
+      exists p; and_intros <;> grind [satisfied]
+    replace hd := forbid_trumps_permit _ _ _ hd
     grind [Spec.isAuthorized]
 
   simp only [satisfiedPolicies, satisfiedWithEffect, satisfied, Bool.and_eq_true, beq_iff_eq,
     decide_eq_true_eq, Set.mem_make, List.mem_filterMap, Option.ite_none_right_eq_some,
     Option.some.injEq]
-  exists p
-  and_intros
-  · exact hp₁
-  · simpa [←hp₂] using heff
-  · exact ha
-  · simpa [←hp₂] using hpid
+  exact ⟨p, hp₁, ⟨h_eff ▸ heff, ha⟩, h_id ▸ hpid⟩
 
 /-- Like `partial_authorize_satisfied_permits_not_determining_if_deny` for
 `forbid` policies, but we can prove a stronger theorem because any satisfied

--- a/cedar-lean/Cedar/Thm/TPE/Authorizer.lean
+++ b/cedar-lean/Cedar/Thm/TPE/Authorizer.lean
@@ -35,16 +35,43 @@ open Cedar.Spec
 open Cedar.Validation
 open Cedar.Thm
 
-theorem reauthorize_satisfied_policies_equiv
+def ResidualPoliciesEquiv
+  (policies : List Policy)
+  (residuals : List ResidualPolicy)
+  (req : Request)
+  (es : Entities) : Prop :=
+  List.Forall₂ (λ p rp =>
+    rp.id = p.id ∧
+    rp.effect = p.effect ∧
+    (rp.residual.evaluate req es).toOption = (Spec.evaluate p.toExpr req es).toOption
+  ) policies residuals
+
+theorem evaluatePolicies_residuals_equiv
   {schema : Schema}
   {policies : List Policy}
+  {rps : List ResidualPolicy}
   {req : Request}
   {es : Entities}
   {preq : PartialRequest}
   {pes : PartialEntities}
-  {residuals : List ResidualPolicy}
   (hv : isValidAndConsistent schema req es preq pes = Except.ok ())
-  (h_auth : List.Forall₂ (λ x y => ResidualPolicy.mk x.id x.effect <$> evaluatePolicy schema x preq pes = .ok y) policies residuals) :
+  (h : isAuthorized.evaluatePolicies schema policies preq pes = Except.ok rps) :
+  ResidualPoliciesEquiv policies rps req es
+:= by
+  simp only [isAuthorized.evaluatePolicies, bind_pure_comp, List.mapM_ok_iff_forall₂] at h
+  apply List.Forall₂.imp _ h
+  intro p rp h₂
+  cases h_ep : evaluatePolicy schema p preq pes <;> simp only [h_ep, Except.map_error, reduceCtorEq] at h₂
+  simp only [Except.map_ok, Except.ok.injEq] at h₂
+  simp only [true_and, ←h₂]
+  exact (partial_evaluate_policy_is_sound h_ep hv).symm
+
+theorem reauthorize_satisfied_policies_equiv
+  {policies : List Policy}
+  {req : Request}
+  {es : Entities}
+  {residuals : List ResidualPolicy}
+  (h_auth : ResidualPoliciesEquiv policies residuals req es) :
   ∀ effect,
     TPE.Response.reauthorize.satisfiedPolicies effect residuals req es = Spec.satisfiedPolicies effect policies req es
 := by
@@ -57,35 +84,26 @@ theorem reauthorize_satisfied_policies_equiv
   simp [Data.Set.subset_def, Data.Set.mem_make, List.mem_filterMap]
   and_intros
   · intro pid rp h₁ h₂ h₃ h₄
-    replace ⟨p, h_auth₁, h_auth₂⟩ := h_auth₁ rp h₁
-    cases h_auth₃ : evaluatePolicy schema p preq pes <;> simp [h_auth₃] at h_auth₂
-    simp only [← h_auth₂] at h₁ h₂ h₃ h₄
-    subst h₄ h₂
+    replace ⟨p, h_auth₁, h_auth₂, h_auth₃, h_auth₄⟩ := h_auth₁ rp h₁
     exists p
-    simp only [h_auth₁, true_and, and_true, satisfied, decide_eq_true_eq]
+    simp only [h_auth₁, ← h_auth₃, h₂, satisfied, decide_eq_true_eq, true_and, ← h_auth₂, h₄, and_true]
     simp only [Response.reauthorize.satisfied, decide_eq_true_eq] at h₃
-    exact to_option_right_ok (partial_evaluate_policy_is_sound h_auth₃ hv) h₃
+    rw [h₃] at h_auth₄
+    exact to_option_left_ok h_auth₄ rfl
   · intro pid p h₁ h₂ h₃ h₄
-    replace ⟨rp, h_auth₁, h_auth₂⟩ := h_auth₂ _ h₁
+    replace ⟨rp, h_auth₁, h_auth₂, h_auth₃, h_auth₄⟩ := h_auth₂ _ h₁
     exists rp
-    simp only [h_auth₁, true_and]
-    cases h_auth₃ : evaluatePolicy schema p preq pes <;> simp [h_auth₃] at h_auth₂
-    subst h_auth₂
-    simp only [h₂, Response.reauthorize.satisfied, decide_eq_true_eq, true_and, h₄, and_true]
-    rename_i r
+    simp only [h_auth₁, h_auth₃, h₂, true_and, h_auth₂, h₄, and_true, Response.reauthorize.satisfied, decide_eq_true_eq]
     simp only [satisfied, decide_eq_true_eq] at h₃
-    exact to_option_left_ok (partial_evaluate_policy_is_sound h_auth₃ hv) h₃
+    rw [h₃] at h_auth₄
+    exact to_option_right_ok h_auth₄ rfl
 
 theorem reauthorize_error_policies_equiv
-  {schema : Schema}
   {policies : List Policy}
   {req : Request}
   {es : Entities}
-  {preq : PartialRequest}
-  {pes : PartialEntities}
   {residuals : List ResidualPolicy}
-  (hv : isValidAndConsistent schema req es preq pes = Except.ok ())
-  (h_auth : List.Forall₂ (λ x y => ResidualPolicy.mk x.id x.effect <$> evaluatePolicy schema x preq pes = .ok y) policies residuals) :
+  (h_auth : ResidualPoliciesEquiv policies residuals req es) :
   TPE.Response.reauthorize.errorPolicies residuals req es = Spec.errorPolicies policies req es
 := by
   have h_auth₁ := List.forall₂_implies_all_right h_auth
@@ -96,53 +114,45 @@ theorem reauthorize_error_policies_equiv
   simp [Data.Set.subset_def, Data.Set.mem_make, List.mem_filterMap]
   and_intros
   · intro pid rp h₁ h₂ h₃
-    replace ⟨p, h_auth₁, h_auth₂⟩ := h_auth₁ rp h₁
-    cases h_auth₃ : evaluatePolicy schema p preq pes <;> simp [h_auth₃] at h_auth₂
-    simp only [←h_auth₂] at h₁ h₂ h₃
+    replace ⟨p, h_auth₁, h_auth₂, h_auth₃, h_auth₄⟩ := h_auth₁ rp h₁
     simp only [Response.reauthorize.hasError] at h₂
     split at h₂ <;> simp only [Bool.false_eq_true] at h₂
-    rename_i h₃
-    replace ⟨_, h_auth₃⟩ : ∃ e, Spec.evaluate p.toExpr req es = Except.error e := by
-      replace h_auth₃ := partial_evaluate_policy_is_sound h_auth₃ hv
-      rw [h₃] at h_auth₃
-      exact to_option_right_err h_auth₃
+    rename_i h_err
+    have ⟨_, h_spec_err⟩ : ∃ e, Spec.evaluate p.toExpr req es = Except.error e := by
+      rw [h_err] at h_auth₄
+      exact to_option_left_err h_auth₄
+    exists p
+    refine ⟨h_auth₁, ?_, h_auth₂ ▸ h₃⟩
     grind [hasError]
   · intro pid p h₁ h₂ h₃
-    replace ⟨_, _, h_auth₂⟩ := h_auth₂ _ h₁
-    cases h_auth₃ : evaluatePolicy schema p preq pes <;>
-      simp only [h_auth₃, Except.map_error, reduceCtorEq, Except.map_ok, Except.ok.injEq] at h_auth₂
-    rename_i r
-    replace ⟨_, h_auth₃⟩ : ∃ e, r.evaluate req es = Except.error e := by
-      replace h_auth₃ := partial_evaluate_policy_is_sound h_auth₃ hv
-      have ⟨_, h₃⟩ : ∃ e, Spec.evaluate p.toExpr req es = Except.error e := by
-        grind [hasError]
-      rw [h₃] at h_auth₃
-      exact to_option_left_err h_auth₃
+    replace ⟨rp, h_auth₁, h_auth₂, h_auth₃, h_auth₄⟩ := h_auth₂ _ h₁
+    exists rp
+    have ⟨_, h_spec_err⟩ : ∃ e, Spec.evaluate p.toExpr req es = Except.error e :=
+      if_hasError_then_exists_error h₂
+    have ⟨_, h_res_err⟩ : ∃ e, rp.residual.evaluate req es = Except.error e := by
+      rw [h_spec_err] at h_auth₄
+      exact to_option_right_err h_auth₄
+    refine ⟨h_auth₁, ?_, h_auth₂ ▸ h₃⟩
     grind [Response.reauthorize.hasError]
 
+
 theorem no_satisfied_effect_if_empty_satisfied_and_residual_policies
-  {schema : Schema}
   {policies : List Policy}
+  {rps : List ResidualPolicy}
   {req : Request}
   {es : Entities}
-  {preq : PartialRequest}
-  {pes : PartialEntities}
-  {rps : List ResidualPolicy}
   {effect : Effect}
-  (h₂ : isValidAndConsistent schema req es preq pes = Except.ok ())
-  (h₃ : List.Forall₂ (λ p rp => ResidualPolicy.mk p.id p.effect <$> evaluatePolicy schema p preq pes = Except.ok rp) policies rps)
+  (h₃ : ResidualPoliciesEquiv policies rps req es)
   (h_satisfied_empty : (isAuthorized.satisfiedPolicies effect rps).isEmpty)
   (h_residual_empty : (isAuthorized.residualPolicies effect rps).isEmpty) :
   ¬HasSatisfiedEffect effect req es policies
 := by
   simp [HasSatisfiedEffect, satisfied]
   intro p hp₁ hp₂ h
-  replace ⟨rp, h₅, h₄⟩ := List.forall₂_implies_all_left h₃ p hp₁
-  cases he : evaluatePolicy schema p preq pes <;> simp [he] at h₄
-  rename_i r
+  replace ⟨rp, h₅, h_id, h_eff, h_eval⟩ := List.forall₂_implies_all_left h₃ p hp₁
 
   replace ⟨_, hp⟩ :
-    ∃ ty, r = .val (.prim (.bool false)) ty ∨ r = .error ty
+    ∃ ty, rp.residual = .val (.prim (.bool false)) ty ∨ rp.residual = .error ty
   := by
     simp only [isAuthorized.satisfiedPolicies, Set.empty_iff_not_exists, Set.mem_make,
       List.mem_filterMap, ResidualPolicy.satisfiedWithEffect, ResidualPolicy.satisfied,
@@ -153,24 +163,20 @@ theorem no_satisfied_effect_if_empty_satisfied_and_residual_policies
       ResidualPolicy.hasError, Residual.isError, Option.ite_none_right_eq_some, not_exists] at h_residual_empty
     grind
 
-  have ha : r.evaluate req es = Except.ok (Value.prim (Prim.bool true)) :=
-    to_option_left_ok (partial_evaluate_policy_is_sound he h₂) h
+  have ha : rp.residual.evaluate req es = Except.ok (Value.prim (Prim.bool true)) :=
+    to_option_right_ok h_eval h
 
   cases hp
-  · rename_i hp; simp only at hp; simp [hp, Residual.evaluate] at ha
-  · rename_i hp; subst hp; simp [Residual.evaluate] at ha
+  · rename_i hp; simp [hp, Residual.evaluate] at ha
+  · rename_i hp; simp [hp, Residual.evaluate] at ha
 
 theorem satisfied_effect_if_non_empty_satisfied_policies
-  {schema : Schema}
   {policies : List Policy}
+  {rps : List ResidualPolicy}
   {req : Request}
   {es : Entities}
-  {preq : PartialRequest}
-  {pes : PartialEntities}
-  {rps : List ResidualPolicy}
   {effect : Effect}
-  (h₂ : isValidAndConsistent schema req es preq pes = Except.ok ())
-  (h₃ : List.Forall₂ (λ p rp => ResidualPolicy.mk p.id p.effect <$> evaluatePolicy schema p preq pes = Except.ok rp) policies rps)
+  (h₃ : ResidualPoliciesEquiv policies rps req es)
   (h_non_empty : ¬(isAuthorized.satisfiedPolicies effect rps).isEmpty) :
   HasSatisfiedEffect effect req es policies
 := by
@@ -178,101 +184,101 @@ theorem satisfied_effect_if_non_empty_satisfied_policies
   replace ⟨_, hf⟩ := h_non_empty
   simp [isAuthorized.satisfiedPolicies] at hf
   simp [ResidualPolicy.satisfiedWithEffect, ResidualPolicy.satisfied, Residual.isTrue] at hf
-  have ⟨rp, hf₁, ⟨ hf₂, hf₃⟩, hf₄⟩ := hf ; clear hf
+  have ⟨rp, hf₁, ⟨hf₂, hf₃⟩, hf₄⟩ := hf ; clear hf
   split at hf₃ <;> try contradiction
   rename_i hf₅
 
-  have ⟨p, hp₁, hp₂⟩ := List.forall₂_implies_all_right h₃ rp hf₁
-  cases hp₃ : evaluatePolicy schema p preq pes <;>
-   simp only [hp₃, Except.map_error, Except.map_ok, reduceCtorEq, Except.ok.injEq] at hp₂
-  subst hp₂; subst hf₅
+  have ⟨p, hp₁, h_id, h_eff, h_eval⟩ := List.forall₂_implies_all_right h₃ rp hf₁
 
   exists p
   and_intros
   · exact hp₁
-  · exact hf₂
-  · have ha := partial_evaluate_policy_is_sound hp₃ h₂
-    simp only [Residual.evaluate] at ha
-    simpa [satisfied] using to_option_right_ok' ha
+  · exact h_eff ▸ hf₂
+  · simp only [hf₅, Residual.evaluate] at h_eval
+    simpa [satisfied] using to_option_left_ok' h_eval
 
-theorem partial_authorize_error_policies_is_sound
-  {schema : Schema}
+theorem residuals_decision_agrees
   {policies : List Policy}
+  {rps : List ResidualPolicy}
   {req : Request}
   {es : Entities}
-  {preq : PartialRequest}
-  {pes : PartialEntities}
-  (effect : Effect) :
-  List.Forall₂ (λ p rp => ResidualPolicy.mk p.id p.effect <$> evaluatePolicy schema p preq pes = Except.ok rp) policies rps →
-  isValidAndConsistent schema req es preq pes = Except.ok () →
+  {d : Decision}
+  (h₃ : ResidualPoliciesEquiv policies rps req es)
+  (h_dec : (isAuthorized.isAuthorizedFromResiduals rps).decision = some d) :
+  (Spec.isAuthorized req es policies).decision = d
+:= by
+  simp [isAuthorized.isAuthorizedFromResiduals] at h_dec
+  split at h_dec <;>
+    simp only [Option.some.injEq, reduceCtorEq] at h_dec
+  all_goals subst h_dec
+  -- Deny (satisfied forbid exists)
+  · have hf : ¬ (isAuthorized.satisfiedPolicies .forbid rps).isEmpty := by grind
+    exact forbid_trumps_permit _ _ _ (satisfied_effect_if_non_empty_satisfied_policies h₃ hf)
+  -- Deny (no satisfied permits, no residual permits)
+  · have hp₁ : (isAuthorized.satisfiedPolicies .permit rps).isEmpty := by grind
+    have hp₂ : (isAuthorized.residualPolicies .permit rps).isEmpty := by grind
+    exact default_deny _ _ _ (no_satisfied_effect_if_empty_satisfied_and_residual_policies h₃ hp₁ hp₂)
+  -- Allow (no satisfied/residual forbids, satisfied permit exists)
+  · have hf₁ : (isAuthorized.satisfiedPolicies .forbid rps).isEmpty := by grind
+    have hf₂ : (isAuthorized.residualPolicies .forbid rps).isEmpty := by grind
+    have hp : ¬ (isAuthorized.satisfiedPolicies .permit rps).isEmpty := by grind
+    exact (allowed_iff_explicitly_permitted_and_not_denied _ _ _).mp
+      ⟨satisfied_effect_if_non_empty_satisfied_policies h₃ hp,
+       no_satisfied_effect_if_empty_satisfied_and_residual_policies h₃ hf₁ hf₂⟩
+
+theorem partial_authorize_error_policies_is_sound
+  {policies : List Policy}
+  {rps : List ResidualPolicy}
+  {req : Request}
+  {es : Entities}
+  (effect : Effect)
+  (h₁ : ResidualPoliciesEquiv policies rps req es) :
   isAuthorized.errorPolicies effect rps ⊆ (Spec.isAuthorized req es policies).erroringPolicies
 := by
-  intro h₁ h₂
-  have h₄ : (Spec.isAuthorized req es policies).erroringPolicies =  errorPolicies policies req es :=
+  have h₄ : (Spec.isAuthorized req es policies).erroringPolicies = errorPolicies policies req es :=
     by grind [Spec.isAuthorized]
   simp only [errorPolicies, errored, hasError] at h₄
   simp only [isAuthorized.errorPolicies, h₄, Set.subset_def, Set.mem_make, List.mem_filterMap,
-    ResidualPolicy.erroredWithEffect, Bool.and_eq_true,  Option.ite_none_right_eq_some, forall_exists_index, and_imp]
+    ResidualPolicy.erroredWithEffect, Bool.and_eq_true, Option.ite_none_right_eq_some, forall_exists_index, and_imp]
   intro pid rp hrp hef herr hpid
-
-  have ⟨p, hp₁, hp₂⟩ := List.forall₂_implies_all_right h₁ rp hrp
-  cases hp₃ : evaluatePolicy schema p preq pes <;>
-   simp only [hp₃, Except.map_error, Except.map_ok, reduceCtorEq, Except.ok.injEq] at hp₂
-
+  have ⟨p, hp₁, h_id, h_eff, h_eval⟩ := List.forall₂_implies_all_right h₁ rp hrp
   exists p
   and_intros
   · exact hp₁
   · replace ⟨_, ha⟩ : ∃ e, Spec.evaluate p.toExpr req es = .error e := by
-      rename_i r
       replace herr := isError_evaluate_err herr req es
-      simp only [← hp₂] at herr
-      have ha := partial_evaluate_policy_is_sound hp₃ h₂
-      rw [herr.choose_spec] at ha
-      exact to_option_right_err ha
+      rw [herr.choose_spec] at h_eval
+      exact to_option_left_err h_eval
     simp [ha]
-  · simpa [←hp₂] using hpid
+  · exact h_id ▸ hpid
 
 theorem partial_authorize_satisfied_policies_is_sound
-  {schema : Schema}
   {policies : List Policy}
+  {rps : List ResidualPolicy}
   {req : Request}
   {es : Entities}
-  {preq : PartialRequest}
-  {pes : PartialEntities}
-  (effect : Effect) :
-  List.Forall₂ (λ p rp => ResidualPolicy.mk p.id p.effect <$> evaluatePolicy schema p preq pes = Except.ok rp) policies rps →
-  isValidAndConsistent schema req es preq pes = Except.ok () →
+  (effect : Effect)
+  (h₁ : ResidualPoliciesEquiv policies rps req es) :
   isAuthorized.satisfiedPolicies effect rps ⊆ Spec.satisfiedPolicies effect policies req es
 := by
-  intro h₁ h₂
   simp only [isAuthorized.satisfiedPolicies, satisfiedPolicies, satisfiedWithEffect,
     Bool.and_eq_true, beq_iff_eq, Set.subset_def, Set.mem_make, List.mem_filterMap,
     ResidualPolicy.satisfiedWithEffect, ResidualPolicy.satisfied, Option.ite_none_right_eq_some,
     Option.some.injEq, forall_exists_index, and_imp]
   intro pid rp hrp hef htrue hpid
-
-  have ⟨p, hp₁, hp₂⟩ := List.forall₂_implies_all_right h₁ rp hrp
-  cases hp₃ : evaluatePolicy schema p preq pes <;>
-   simp only [hp₃, Except.map_error, Except.map_ok, reduceCtorEq, Except.ok.injEq] at hp₂
-
+  have ⟨p, hp₁, h_id, h_eff, h_eval⟩ := List.forall₂_implies_all_right h₁ rp hrp
   exists p
   and_intros
   · exact hp₁
-  · simpa [←hp₂] using hef
+  · exact h_eff ▸ hef
   · replace htrue : Spec.evaluate p.toExpr req es = .ok (.prim (.bool true)) := by
-      rename_i r
-      replace ⟨_, htrue⟩ : ∃ ty, r = .val true ty := by
-        simp only [Residual.isTrue] at htrue
-        grind
-      have ha := partial_evaluate_policy_is_sound hp₃ h₂
-      simp only [htrue, Residual.evaluate, Except.toOption] at ha
-      split at ha <;> try contradiction
-      simp only [Option.some.injEq] at ha
-      rw [←ha]
-      assumption
+      replace ⟨_, htrue⟩ : ∃ ty, rp.residual = .val true ty := by
+        simp only [Residual.isTrue] at htrue; grind
+      simp only [htrue, Residual.evaluate] at h_eval
+      exact to_option_left_ok' h_eval
     simp only [satisfied, decide_eq_true_eq]
     exact htrue
-  · simpa [←hp₂] using hpid
+  · exact h_id ▸ hpid
 
 theorem partial_authorize_satisfied_forbids_is_sound
   {schema : Schema}
@@ -287,13 +293,11 @@ theorem partial_authorize_satisfied_forbids_is_sound
 := by
   intro h₁ h₂
   simp only [TPE.isAuthorized] at h₁
-  cases h₃ : List.mapM (λ p => ResidualPolicy.mk p.id p.effect <$> evaluatePolicy schema p preq pes) policies <;>
-    simp only [bind_pure_comp, h₃, Except.map_ok, Except.map_error, Except.ok.injEq, reduceCtorEq] at h₁
-  rw [List.mapM_ok_iff_forall₂] at h₃
-  subst response
-
+  cases h₃ : isAuthorized.evaluatePolicies schema policies preq pes <;>
+    simp [h₃] at h₁
+  subst h₁
   simp only [isAuthorized.isAuthorizedFromResiduals]
-  exact partial_authorize_satisfied_policies_is_sound .forbid h₃ h₂
+  exact partial_authorize_satisfied_policies_is_sound .forbid (evaluatePolicies_residuals_equiv h₂ h₃)
 
 theorem partial_authorize_satisfied_permits_is_sound
   {schema : Schema}
@@ -308,10 +312,8 @@ theorem partial_authorize_satisfied_permits_is_sound
 := by
   intro h₁ h₂
   simp only [TPE.isAuthorized] at h₁
-  cases h₃ : List.mapM (λ p => ResidualPolicy.mk p.id p.effect <$> evaluatePolicy schema p preq pes) policies <;>
-    simp only [bind_pure_comp, h₃, Except.map_ok, Except.map_error, Except.ok.injEq, reduceCtorEq] at h₁
-  rw [List.mapM_ok_iff_forall₂] at h₃
-  subst response
-
+  cases h₃ : isAuthorized.evaluatePolicies schema policies preq pes <;>
+    simp [h₃] at h₁
+  subst h₁
   simp only [isAuthorized.isAuthorizedFromResiduals]
-  exact partial_authorize_satisfied_policies_is_sound .permit h₃ h₂
+  exact partial_authorize_satisfied_policies_is_sound .permit (evaluatePolicies_residuals_equiv h₂ h₃)

--- a/cedar-lean/Cedar/Thm/TPE/Authorizer.lean
+++ b/cedar-lean/Cedar/Thm/TPE/Authorizer.lean
@@ -178,8 +178,8 @@ theorem no_satisfied_effect_if_empty_satisfied_and_residual_policies
   {es : Entities}
   {effect : Effect}
   (h₃ : ResidualPoliciesEquiv policies rps req es)
-  (h_satisfied_empty : (isAuthorized.satisfiedPolicies effect rps).isEmpty)
-  (h_residual_empty : (isAuthorized.residualPolicies effect rps).isEmpty) :
+  (h_satisfied_empty : (isAuthorizedFromResiduals.satisfiedPolicies effect rps).isEmpty)
+  (h_residual_empty : (isAuthorizedFromResiduals.residualPolicies effect rps).isEmpty) :
   ¬HasSatisfiedEffect effect req es policies
 := by
   simp [HasSatisfiedEffect, satisfied]
@@ -189,10 +189,10 @@ theorem no_satisfied_effect_if_empty_satisfied_and_residual_policies
   replace ⟨_, hp⟩ :
     ∃ ty, rp.residual = .val (.prim (.bool false)) ty ∨ rp.residual = .error ty
   := by
-    simp only [isAuthorized.satisfiedPolicies, Set.empty_iff_not_exists, Set.mem_make,
+    simp only [isAuthorizedFromResiduals.satisfiedPolicies, Set.empty_iff_not_exists, Set.mem_make,
       List.mem_filterMap, ResidualPolicy.satisfiedWithEffect, ResidualPolicy.satisfied,
       Residual.isTrue, Option.ite_none_right_eq_some] at h_satisfied_empty
-    simp only [isAuthorized.residualPolicies, Set.empty_iff_not_exists, Set.mem_make,
+    simp only [isAuthorizedFromResiduals.residualPolicies, Set.empty_iff_not_exists, Set.mem_make,
       List.mem_filterMap, ResidualPolicy.residualWithEffect, ResidualPolicy.isResidual,
       ResidualPolicy.satisfied, Residual.isTrue, ResidualPolicy.isFalse, Residual.isFalse,
       ResidualPolicy.hasError, Residual.isError, Option.ite_none_right_eq_some, not_exists] at h_residual_empty
@@ -212,12 +212,12 @@ theorem satisfied_effect_if_non_empty_satisfied_policies
   {es : Entities}
   {effect : Effect}
   (h₃ : ResidualPoliciesEquiv policies rps req es)
-  (h_non_empty : ¬(isAuthorized.satisfiedPolicies effect rps).isEmpty) :
+  (h_non_empty : ¬(isAuthorizedFromResiduals.satisfiedPolicies effect rps).isEmpty) :
   HasSatisfiedEffect effect req es policies
 := by
   rw [Set.non_empty_iff_exists] at h_non_empty
   replace ⟨_, hf⟩ := h_non_empty
-  simp [isAuthorized.satisfiedPolicies] at hf
+  simp [isAuthorizedFromResiduals.satisfiedPolicies] at hf
   simp [ResidualPolicy.satisfiedWithEffect, ResidualPolicy.satisfied, Residual.isTrue] at hf
   have ⟨rp, hf₁, ⟨hf₂, hf₃⟩, hf₄⟩ := hf ; clear hf
   split at hf₃ <;> try contradiction
@@ -239,24 +239,24 @@ theorem residuals_decision_agrees
   {es : Entities}
   {d : Decision}
   (h₃ : ResidualPoliciesEquiv policies rps req es)
-  (h_dec : (isAuthorized.isAuthorizedFromResiduals rps).decision = some d) :
+  (h_dec : (isAuthorizedFromResiduals rps).decision = some d) :
   (Spec.isAuthorized req es policies).decision = d
 := by
-  simp [isAuthorized.isAuthorizedFromResiduals] at h_dec
+  simp [isAuthorizedFromResiduals] at h_dec
   split at h_dec <;>
     simp only [Option.some.injEq, reduceCtorEq] at h_dec
   all_goals subst h_dec
   -- Deny (satisfied forbid exists)
-  · have hf : ¬ (isAuthorized.satisfiedPolicies .forbid rps).isEmpty := by grind
+  · have hf : ¬ (isAuthorizedFromResiduals.satisfiedPolicies .forbid rps).isEmpty := by grind
     exact forbid_trumps_permit _ _ _ (satisfied_effect_if_non_empty_satisfied_policies h₃ hf)
   -- Deny (no satisfied permits, no residual permits)
-  · have hp₁ : (isAuthorized.satisfiedPolicies .permit rps).isEmpty := by grind
-    have hp₂ : (isAuthorized.residualPolicies .permit rps).isEmpty := by grind
+  · have hp₁ : (isAuthorizedFromResiduals.satisfiedPolicies .permit rps).isEmpty := by grind
+    have hp₂ : (isAuthorizedFromResiduals.residualPolicies .permit rps).isEmpty := by grind
     exact default_deny _ _ _ (no_satisfied_effect_if_empty_satisfied_and_residual_policies h₃ hp₁ hp₂)
   -- Allow (no satisfied/residual forbids, satisfied permit exists)
-  · have hf₁ : (isAuthorized.satisfiedPolicies .forbid rps).isEmpty := by grind
-    have hf₂ : (isAuthorized.residualPolicies .forbid rps).isEmpty := by grind
-    have hp : ¬ (isAuthorized.satisfiedPolicies .permit rps).isEmpty := by grind
+  · have hf₁ : (isAuthorizedFromResiduals.satisfiedPolicies .forbid rps).isEmpty := by grind
+    have hf₂ : (isAuthorizedFromResiduals.residualPolicies .forbid rps).isEmpty := by grind
+    have hp : ¬ (isAuthorizedFromResiduals.satisfiedPolicies .permit rps).isEmpty := by grind
     exact (allowed_iff_explicitly_permitted_and_not_denied _ _ _).mp
       ⟨satisfied_effect_if_non_empty_satisfied_policies h₃ hp,
        no_satisfied_effect_if_empty_satisfied_and_residual_policies h₃ hf₁ hf₂⟩
@@ -268,12 +268,12 @@ theorem partial_authorize_error_policies_is_sound
   {es : Entities}
   (effect : Effect)
   (h₁ : ResidualPoliciesEquiv policies rps req es) :
-  isAuthorized.errorPolicies effect rps ⊆ (Spec.isAuthorized req es policies).erroringPolicies
+  isAuthorizedFromResiduals.errorPolicies effect rps ⊆ (Spec.isAuthorized req es policies).erroringPolicies
 := by
   have h₄ : (Spec.isAuthorized req es policies).erroringPolicies = errorPolicies policies req es :=
     by grind [Spec.isAuthorized]
   simp only [errorPolicies, errored, hasError] at h₄
-  simp only [isAuthorized.errorPolicies, h₄, Set.subset_def, Set.mem_make, List.mem_filterMap,
+  simp only [isAuthorizedFromResiduals.errorPolicies, h₄, Set.subset_def, Set.mem_make, List.mem_filterMap,
     ResidualPolicy.erroredWithEffect, Bool.and_eq_true, Option.ite_none_right_eq_some, forall_exists_index, and_imp]
   intro pid rp hrp hef herr hpid
   have ⟨p, hp₁, h_id, h_eff, h_eval⟩ := List.forall₂_implies_all_right h₁ rp hrp
@@ -294,9 +294,9 @@ theorem partial_authorize_satisfied_policies_is_sound
   {es : Entities}
   (effect : Effect)
   (h₁ : ResidualPoliciesEquiv policies rps req es) :
-  isAuthorized.satisfiedPolicies effect rps ⊆ Spec.satisfiedPolicies effect policies req es
+  isAuthorizedFromResiduals.satisfiedPolicies effect rps ⊆ Spec.satisfiedPolicies effect policies req es
 := by
-  simp only [isAuthorized.satisfiedPolicies, satisfiedPolicies, satisfiedWithEffect,
+  simp only [isAuthorizedFromResiduals.satisfiedPolicies, satisfiedPolicies, satisfiedWithEffect,
     Bool.and_eq_true, beq_iff_eq, Set.subset_def, Set.mem_make, List.mem_filterMap,
     ResidualPolicy.satisfiedWithEffect, ResidualPolicy.satisfied, Option.ite_none_right_eq_some,
     Option.some.injEq, forall_exists_index, and_imp]
@@ -331,7 +331,7 @@ theorem partial_authorize_satisfied_forbids_is_sound
   cases h₃ : isAuthorized.evaluatePolicies schema policies preq pes <;>
     simp [h₃] at h₁
   subst h₁
-  simp only [isAuthorized.isAuthorizedFromResiduals]
+  simp only [isAuthorizedFromResiduals]
   exact partial_authorize_satisfied_policies_is_sound .forbid (evaluatePolicies_residuals_equiv h₂ h₃)
 
 theorem partial_authorize_satisfied_permits_is_sound
@@ -350,5 +350,5 @@ theorem partial_authorize_satisfied_permits_is_sound
   cases h₃ : isAuthorized.evaluatePolicies schema policies preq pes <;>
     simp [h₃] at h₁
   subst h₁
-  simp only [isAuthorized.isAuthorizedFromResiduals]
+  simp only [isAuthorizedFromResiduals]
   exact partial_authorize_satisfied_policies_is_sound .permit (evaluatePolicies_residuals_equiv h₂ h₃)

--- a/cedar-lean/Cedar/Thm/TPE/Authorizer.lean
+++ b/cedar-lean/Cedar/Thm/TPE/Authorizer.lean
@@ -46,6 +46,39 @@ def ResidualPoliciesEquiv
     (rp.residual.evaluate req es).toOption = (Spec.evaluate p.toExpr req es).toOption
   ) policies residuals
 
+theorem isValidAndConsistent_env
+  {schema : Schema} {req : Request} {es : Entities}
+  {preq : PartialRequest} {pes : PartialEntities} :
+  isValidAndConsistent schema req es preq pes = .ok () →
+  ∃ env,
+    schema.environment? preq.principal.ty preq.resource.ty preq.action = .some env ∧
+    InstanceOfWellFormedEnvironment req es env
+:= by
+  intro h_valid
+  simp only [isValidAndConsistent] at h_valid
+  split at h_valid <;> try cases h_valid
+  rename_i env heq
+  exists env; refine ⟨heq, ?_⟩
+  rcases do_eq_ok₂ h_valid with ⟨h₁, h₂⟩
+  simp only [isValidAndConsistent.requestIsConsistent, Bool.or_eq_true, Bool.not_eq_eq_eq_not,
+    Bool.not_true, Bool.and_eq_true, decide_eq_true_eq] at h₁
+  split at h₁ <;> try cases h₁
+  rename_i h_guard; simp only [not_or, Bool.not_eq_false] at h_guard
+  simp only [isValidAndConsistent.entitiesIsConsistent, Bool.or_eq_true, Bool.not_eq_eq_eq_not,
+    Bool.not_true] at h₂
+  split at h₂ <;> try cases h₂
+  rename_i heq₄; simp only [not_or, Bool.not_eq_false] at heq₄
+  rcases heq₄ with ⟨_, heq₄⟩
+  simp only [Except.isOk, Except.toBool] at heq₄
+  split at heq₄ <;> cases heq₄; rename_i heq₄
+  simp only [bind, Except.bind, isValidAndConsistent.envIsWellFormed, Bool.not_eq_eq_eq_not,
+    Bool.not_true] at h₂
+  split at h₂ <;> try cases h₂
+  simp only [ite_eq_right_iff, reduceCtorEq, imp_false, Bool.not_eq_false] at h₂
+  simp only [Except.isOk, Except.toBool] at h₂
+  split at h₂ <;> cases h₂; rename_i heq₅
+  exact instance_of_well_formed_env heq₅ h_guard.2 heq₄
+
 theorem evaluatePolicies_residuals_equiv
   {schema : Schema}
   {policies : List Policy}
@@ -58,13 +91,15 @@ theorem evaluatePolicies_residuals_equiv
   (h : isAuthorized.evaluatePolicies schema policies preq pes = Except.ok rps) :
   ResidualPoliciesEquiv policies rps req es
 := by
+  have h_ref := consistent_checks_ensure_refinement hv
+  have ⟨env, h_schema_env, h_wf⟩ := isValidAndConsistent_env hv
   simp only [isAuthorized.evaluatePolicies, bind_pure_comp, List.mapM_ok_iff_forall₂] at h
   apply List.Forall₂.imp _ h
   intro p rp h₂
   cases h_ep : evaluatePolicy schema p preq pes <;> simp only [h_ep, Except.map_error, reduceCtorEq] at h₂
   simp only [Except.map_ok, Except.ok.injEq] at h₂
   simp only [true_and, ←h₂]
-  exact (partial_evaluate_policy_is_sound h_ep hv).symm
+  exact (partial_evaluate_policy_is_sound h_ep h_schema_env h_wf h_ref).symm
 
 theorem reauthorize_satisfied_policies_equiv
   {policies : List Policy}

--- a/cedar-lean/Cedar/Thm/TPE/Policy.lean
+++ b/cedar-lean/Cedar/Thm/TPE/Policy.lean
@@ -50,58 +50,25 @@ theorem partial_evaluate_policy_is_sound
   {req : Request}
   {es : Entities}
   {preq : PartialRequest}
-  {pes : PartialEntities} :
-  evaluatePolicy schema policy preq pes = .ok residual   →
-  isValidAndConsistent schema req es preq pes = .ok () →
+  {pes : PartialEntities}
+  {env : TypeEnv} :
+  evaluatePolicy schema policy preq pes = .ok residual →
+  schema.environment? preq.principal.ty preq.resource.ty preq.action = .some env →
+  InstanceOfWellFormedEnvironment req es env →
+  RequestAndEntitiesRefine req es preq pes →
   (Spec.evaluate policy.toExpr req es).toOption = (Residual.evaluate residual req es).toOption
 := by
-  intro h₁ h₂
-  have h₃ := consistent_checks_ensure_refinement h₂
-  simp [evaluatePolicy] at h₁
-  split at h₁ <;> try cases h₁
+  intro h₁ h_schema_env h₄ h₃
+  simp [evaluatePolicy, h_schema_env] at h₁
   split at h₁ <;> try cases h₁
   simp [do_ok_eq_ok] at h₁
   rcases h₁ with ⟨_, ⟨_, h₁₁⟩, h₁₂⟩
   simp [Except.mapError] at h₁₁
   split at h₁₁ <;> try cases h₁₁
-  rename_i env heq₁ _ ty _ _ heq₂
-  simp [isValidAndConsistent] at h₂
-  split at h₂ <;> try cases h₂
-  rename_i heq₃
-  simp [heq₁] at heq₃
-  subst heq₃
-  have ⟨h₂₁, h₂₂⟩ := do_eq_ok₂ h₂
-  simp only [isValidAndConsistent.requestIsConsistent, Bool.or_eq_true, Bool.not_eq_eq_eq_not,
-    Bool.not_true, Bool.and_eq_true, decide_eq_true_eq] at h₂₁
-  split at h₂₁ <;> try cases h₂₁
-  rename_i heq₃
-  simp only [not_or, Bool.not_eq_false] at heq₃
-  rcases heq₃ with ⟨_, heq₃⟩
-  simp only [isValidAndConsistent.entitiesIsConsistent, Bool.or_eq_true, Bool.not_eq_eq_eq_not,
-    Bool.not_true] at h₂₂
-  split at h₂₂ <;> try cases h₂₂
-  rename_i heq₄
-  simp only [not_or, Bool.not_eq_false] at heq₄
-  rcases heq₄ with ⟨_, heq₄⟩
-  simp [Except.isOk, Except.toBool] at heq₄
-  split at heq₄ <;> cases heq₄
-  rename_i heq₄
-  simp only [bind, Except.bind, isValidAndConsistent.envIsWellFormed, Bool.not_eq_eq_eq_not,
-    Bool.not_true] at h₂₂
-  split at h₂₂ <;> try cases h₂₂
-  simp only [ite_eq_right_iff, reduceCtorEq, imp_false, Bool.not_eq_false] at h₂₂
-  have heq₅ := h₂₂
-  simp [Except.isOk, Except.toBool] at heq₅
-  split at heq₅ <;> cases heq₅
-  rename_i heq₅
-  have h₄ := instance_of_well_formed_env heq₅ heq₃ heq₄
+  rename_i ty _ _ heq₂
   have h₅ := typechecked_is_well_typed_after_lifting heq₂
-  let old_residual := (TypedExpr.toResidual ty.liftBoolTypes)
-
-  have h₉ : Residual.WellTyped env old_residual := by {
-    have h := conversion_preserves_typedness h₅
-    exact h
-  }
+  have h₉ : Residual.WellTyped env (TypedExpr.toResidual ty.liftBoolTypes) :=
+    conversion_preserves_typedness h₅
   have h₆ := partial_evaluate_is_sound h₉ h₄ h₃
   subst h₁₂
   have h₇ := type_of_preserves_evaluation_results (empty_capabilities_invariant req es) h₄ heq₂
@@ -113,8 +80,6 @@ theorem partial_evaluate_policy_is_sound
     rw [←h₄]
     exact substitute_action_preserves_evaluation policy.toExpr req es
   simp [h₈] at h₇
-  rw [h₇, type_lifting_preserves_expr]
-  rw [← h₆]
-  subst old_residual
+  rw [h₇, type_lifting_preserves_expr, ← h₆]
   congr
   apply conversion_preserves_evaluation

--- a/cedar-lean/Cedar/Thm/Validation/EnvironmentValidation.lean
+++ b/cedar-lean/Cedar/Thm/Validation/EnvironmentValidation.lean
@@ -522,4 +522,27 @@ theorem env_validate_well_formed_is_sound
   simp only [hwf_reqs] at hok
   exact request_type_validate_well_formed_is_sound hwf_reqs
 
+theorem environment_some_mem_environments {schema : Schema}
+  {principal resource : EntityType} {action : EntityUID} {env : TypeEnv}
+  (h : schema.environment? principal resource action = .some env) :
+  env ∈ schema.environments
+:= by
+  simp only [Schema.environment?] at h
+  cases h_find : schema.acts.find? action <;>
+    simp only [h_find, Option.bind_none_fun, Option.bind_some_fun, reduceCtorEq] at h
+  rename_i ase
+  split at h <;> simp only [reduceCtorEq, Option.some.injEq] at h
+  rename_i hp hr
+  subst h
+  simp only [Schema.environments, List.mem_map, List.mem_flatMap, TypeEnv.mk.injEq, true_and, exists_eq_right]
+  exists (action, ase)
+  and_intros
+  · exact Map.find?_mem_toList h_find
+  · show { principal, action, resource, context := ase.context : RequestType } ∈
+      (ase.appliesToPrincipal.toList.product ase.appliesToResource.toList |>.map
+        (λ (principal, resource) => {
+          principal, action, resource,
+          context := ase.context}))
+    simp [Set.toList, Set.mem_elts_iff_mem_set, ← Set.contains_prop_bool_equiv, hr, hp]
+
 end Cedar.Thm

--- a/cedar-lean/Cedar/Validation/Types.lean
+++ b/cedar-lean/Cedar/Validation/Types.lean
@@ -171,7 +171,13 @@ public structure ActionSchemaEntry where
   context : RecordType
 deriving Repr, Inhabited
 
+public def ActionSchemaEntry.entityData (action : ActionSchemaEntry) : EntityData :=
+  EntityData.mk Map.empty action.ancestors Map.empty
+
 public abbrev ActionSchema := Map EntityUID ActionSchemaEntry
+
+public def ActionSchema.asEntities (acts : ActionSchema) : Entities :=
+  acts.mapOnValues ActionSchemaEntry.entityData
 
 public def ActionSchema.actionType? (acts: ActionSchema) (ety : EntityType) : Bool :=
   acts.keys.any (EntityUID.ty · == ety)

--- a/cedar-lean/Cedar/Validation/Types.lean
+++ b/cedar-lean/Cedar/Validation/Types.lean
@@ -171,13 +171,7 @@ public structure ActionSchemaEntry where
   context : RecordType
 deriving Repr, Inhabited
 
-public def ActionSchemaEntry.entityData (action : ActionSchemaEntry) : EntityData :=
-  EntityData.mk Map.empty action.ancestors Map.empty
-
 public abbrev ActionSchema := Map EntityUID ActionSchemaEntry
-
-public def ActionSchema.asEntities (acts : ActionSchema) : Entities :=
-  acts.mapOnValues ActionSchemaEntry.entityData
 
 public def ActionSchema.actionType? (acts: ActionSchema) (ety : EntityType) : Bool :=
   acts.keys.any (EntityUID.ty · == ety)

--- a/cedar-lean/Cedar/Validation/Validator.lean
+++ b/cedar-lean/Cedar/Validation/Validator.lean
@@ -33,21 +33,18 @@ For a given action, compute the cross-product of the applicable principal and
 resource types.
 -/
 def ActionSchemaEntry.requestTypes (action : EntityUID) (entry : ActionSchemaEntry) : List RequestType :=
-  entry.appliesToPrincipal.toList.foldl (fun acc principal =>
-    let reqtys : List RequestType :=
-      entry.appliesToResource.toList.map (fun resource =>
-        {
-          principal := principal,
-          action := action,
-          resource := resource,
-          context := entry.context
-        })
-    reqtys ++ acc) ∅
+  entry.appliesToPrincipal.toList.product entry.appliesToResource.toList |>.map
+    (λ (principal, resource) => {
+      principal,
+      action,
+      resource,
+      context := entry.context
+    })
 
 /-- Return every schema-defined environment. -/
 public def Schema.environments (schema : Schema) : List TypeEnv :=
   let requestTypes : List RequestType :=
-    schema.acts.toList.foldl (fun acc (action,entry) => entry.requestTypes action ++ acc) ∅
+    schema.acts.toList.flatMap (λ (action, entry) => entry.requestTypes action)
   requestTypes.map ({
     ets := schema.ets,
     acts := schema.acts,

--- a/cedar-lean/CedarFFI/Main.lean
+++ b/cedar-lean/CedarFFI/Main.lean
@@ -804,10 +804,10 @@ Note that the time is only the encoder and _not_ policy compilation to Term
 
 /--
   `req`: binary protobuf for an `BatchedEvaluationRequest`
-  Upon success returns inputs to `batchedEvaluate`
+  Upon success returns inputs to `batchedAuthorize`
   Returns a failure if Protobuf message could not be parsed
 -/
-def parseBatchedEvaluationReq (req : ByteArray) : Except String (Schema × List Policy × Request × Entities × Nat) := do
+def parseBatchedAuthorizationReq (req : ByteArray) : Except String (Schema × List Policy × Request × Entities × Nat) := do
   let req ← (@Proto.Message.interpret? Proto.BatchedEvaluationRequest) req |>.mapError (s!"failed to parse input: {·}")
   let policySet := req.policies
   let schema := req.schema
@@ -821,9 +821,9 @@ def parseBatchedEvaluationReq (req : ByteArray) : Except String (Schema × List 
 
   returns a string containing a JSON encoding of `Timed TPE.Response`
 -/
-@[export batchedEvaluateFFI] unsafe def batchedEvaluateFFI (req : ByteArray) : String :=
+@[export batchedAuthorizationFFI] unsafe def batchedAuthorizationFFI (req : ByteArray) : String :=
   runFfiM do
-    let (schema, policies, request, entities, iteration) ← parseBatchedEvaluationReq req
+    let (schema, policies, request, entities, iteration) ← parseBatchedAuthorizationReq req
     runAndTime (λ () =>
       (batchedAuthorize schema policies request (entityLoaderFor entities) iteration).mapError
         (s!"TPE error: {repr ·}"))

--- a/cedar-lean/CedarFFI/Main.lean
+++ b/cedar-lean/CedarFFI/Main.lean
@@ -808,7 +808,7 @@ Note that the time is only the encoder and _not_ policy compilation to Term
   Returns a failure if Protobuf message could not be parsed
 -/
 def parseBatchedAuthorizationReq (req : ByteArray) : Except String (Schema × List Policy × Request × Entities × Nat) := do
-  let req ← (@Proto.Message.interpret? Proto.BatchedEvaluationRequest) req |>.mapError (s!"failed to parse input: {·}")
+  let req ← (@Proto.Message.interpret? Proto.BatchedAuthorizationRequest) req |>.mapError (s!"failed to parse input: {·}")
   let policySet := req.policies
   let schema := req.schema
   let request := req.request

--- a/cedar-lean/CedarFFI/Main.lean
+++ b/cedar-lean/CedarFFI/Main.lean
@@ -803,7 +803,7 @@ Note that the time is only the encoder and _not_ policy compilation to Term
   runFfiM $ SymCCPrimitive.matchesDisjoint.smtLib schema req
 
 /--
-  `req`: binary protobuf for an `BatchedEvaluationRequest`
+  `req`: binary protobuf for an `BatchedAuthorizationRequest`
   Upon success returns inputs to `batchedAuthorize`
   Returns a failure if Protobuf message could not be parsed
 -/
@@ -817,7 +817,7 @@ def parseBatchedAuthorizationReq (req : ByteArray) : Except String (Schema × Li
   return (schema, policySet, request, entities, iteration)
 
 /--
-  `req`: binary protobuf for a `BatchedEvaluationRequest`
+  `req`: binary protobuf for a `BatchedAuthorizationRequest`
 
   returns a string containing a JSON encoding of `Timed TPE.Response`
 -/

--- a/cedar-lean/CedarFFI/Main.lean
+++ b/cedar-lean/CedarFFI/Main.lean
@@ -805,54 +805,28 @@ Note that the time is only the encoder and _not_ policy compilation to Term
 /--
   `req`: binary protobuf for an `BatchedEvaluationRequest`
   Upon success returns inputs to `batchedEvaluate`
-  Returns a failure if
-  1.) Protobuf message could not be parsed
-  2.) Cannot derive a request environment from the request
-  3.) Request cannot be validated
-  4.) Policy cannot be validated
-  5.) Policy set contains more than one policy (a limitation at this moment)
+  Returns a failure if Protobuf message could not be parsed
 -/
-def parseBatchedEvaluationReq (req : ByteArray) : Except String (TypedExpr × Request × Entities × Nat) := do
+def parseBatchedEvaluationReq (req : ByteArray) : Except String (Schema × List Policy × Request × Entities × Nat) := do
   let req ← (@Proto.Message.interpret? Proto.BatchedEvaluationRequest) req |>.mapError (s!"failed to parse input: {·}")
   let policySet := req.policies
-  let policy ← match policySet with
-    | [policy] => .ok policy
-    | _ => .error s!"only one policy is expected"
   let schema := req.schema
   let request := req.request
   let entities := req.entities
   let iteration := req.iteration.toNat
-  let expr ← match schema.environment? request.principal.ty request.resource.ty request.action with
-    | .some env =>
-      if requestIsValid env request.asPartialRequest then do
-        let expr := substituteAction env.reqty.action policy.toExpr
-        let (te, _) ← (typeOf expr ∅ env).mapError (fun err => s!"invalid policy: {reprStr err}")
-        .ok te
-      else
-        .error s!"invalid request"
-    | .none => .error s!"invalid environment derived from request"
-  return (expr, request, entities, iteration)
+  return (schema, policySet, request, entities, iteration)
 
 /--
-  `req`: binary protobuf for an `CheckPolicySetRequest`
+  `req`: binary protobuf for a `BatchedEvaluationRequest`
 
-  returns JSON encoded of `Option Bool`
-  1.) .error err_message if there was an error in parsing `req`
-  2.) .ok {data, ..} where data is of type `Option Bool`. It is true when the
-      result residual is `.val true`; and it is false when the result residual
-      is either `.val false` or `.error _`. So we can interpret the boolean
-      value as if the policy takes effect or not
+  returns a string containing a JSON encoding of `Timed TPE.Response`
 -/
 @[export batchedEvaluateFFI] unsafe def batchedEvaluateFFI (req : ByteArray) : String :=
   runFfiM do
-    let (expr, request, entities, iteration) ← parseBatchedEvaluationReq req
-    runAndTime (λ () => match batchedEvaluate expr request (entityLoaderFor entities) iteration with
-    | .val v _ => match v.asBool with
-      | .ok b => (.some b : Option Bool)
-      | .error _ => .none
-    | .error _ => (.some false)
-    | _ => .none
-    )
+    let (schema, policies, request, entities, iteration) ← parseBatchedEvaluationReq req
+    runAndTime (λ () =>
+      (batchedAuthorize schema policies request (entityLoaderFor entities) iteration).mapError
+        (s!"TPE error: {repr ·}"))
 
 
 def parsePartialAuthzRequest (req: ByteArray): Except String (Schema × List Policy × PartialRequest × PartialEntities) := do

--- a/cedar-lean/CedarProto/TPERequest.lean
+++ b/cedar-lean/CedarProto/TPERequest.lean
@@ -31,7 +31,7 @@ open Proto
 
 namespace Cedar.Proto
 
-structure BatchedEvaluationRequest where
+structure BatchedAuthorizationRequest where
   policies : Spec.Policies
   schema : Validation.Schema
   request : Spec.Request
@@ -40,9 +40,9 @@ structure BatchedEvaluationRequest where
 deriving Inhabited
 
 
-namespace BatchedEvaluationRequest
+namespace BatchedAuthorizationRequest
 
-instance : Message BatchedEvaluationRequest where
+instance : Message BatchedAuthorizationRequest where
   parseField (t : Proto.Tag) := do
     match t.fieldNum with
     | 1 => parseFieldElement t policies (update policies)
@@ -60,7 +60,7 @@ instance : Message BatchedEvaluationRequest where
     iteration := Field.merge x.iteration y.iteration
   }
 
-end BatchedEvaluationRequest
+end BatchedAuthorizationRequest
 
 structure PartialAuthorizationRequest where
   schema: Validation.Schema


### PR DESCRIPTION
The existing Proofs only showed equivalence for evaluating a single expression, but the Rust implementation does authorization for sets of policies. This PR adds a batched authorization algorithm and proves it equivalent to concrete authorization, resolving #851

The main theorem is

```lean
theorem batched_authorize_decision_eq_authorize
  {schema : Schema} {policies : List Policy} {req : Request}
  {es : Entities} {response : TPE.Response} {d : Decision} :
  EntityLoader.WellBehaved es loader →
  schema.validateWellFormed = .ok () →
  validateEntities schema es = .ok () →
  batchedAuthorize schema policies req loader iters = .ok response →
  response.decision = some d →
  (Spec.isAuthorized req es policies).decision = d
```