### PR TITLE
Generate templates in fuzz targets

### DIFF
--- a/cedar-drt/fuzz/fuzz_targets/abac-type-directed.rs
+++ b/cedar-drt/fuzz/fuzz_targets/abac-type-directed.rs
@@ -24,7 +24,7 @@ use cedar_drt::{
 use cedar_drt_inner::{abac::FuzzTargetInput, fuzz_target};
 
 use cedar_lean_ffi::CedarLeanFfi;
-use cedar_policy::{Authorizer, Policy, PolicyId, PolicySet, SchemaFragment};
+use cedar_policy::{Authorizer, PolicyId, PolicySet, SchemaFragment};
 use cedar_testing::cedar_test_impl::time_function;
 
 use log::{debug, info};
@@ -34,9 +34,7 @@ use std::convert::TryFrom;
 fuzz_target!(|input: FuzzTargetInput<true>| {
     initialize_log();
     let lean_engine = CedarLeanFfi::new();
-    let mut policyset = PolicySet::new();
-    let policy: Policy = input.policy.into();
-    policyset.add(policy.clone()).unwrap();
+    let policyset = input.policy.0.clone().into_policy_set();
     debug!("Schema: {}\n", input.schema.schemafile_string());
     debug!("Policies: {policyset}\n");
     debug!("Entities: {}\n", input.entities.as_ref());
@@ -61,7 +59,10 @@ fuzz_target!(|input: FuzzTargetInput<true>| {
         // When the corpus is re-parsed, the policy will be given id "policy0".
         // Recreate the policy set and compute responses here to account for this.
         let mut policyset = PolicySet::new();
-        let policy = policy.new_id(PolicyId::new("policy0"));
+        let policy = input
+            .policy
+            .link_to_static()
+            .new_id(PolicyId::new("policy0"));
         policyset.add(policy).unwrap();
         let responses = requests
             .iter()

--- a/cedar-drt/fuzz/fuzz_targets/abac.rs
+++ b/cedar-drt/fuzz/fuzz_targets/abac.rs
@@ -24,7 +24,7 @@ use cedar_drt::{
 use cedar_drt_inner::{abac::FuzzTargetInput, fuzz_target};
 
 use cedar_lean_ffi::CedarLeanFfi;
-use cedar_policy::{Authorizer, Policy, PolicyId, PolicySet, Request, SchemaFragment};
+use cedar_policy::{Authorizer, PolicyId, PolicySet, Request, SchemaFragment};
 
 use cedar_testing::cedar_test_impl::time_function;
 
@@ -34,9 +34,7 @@ use std::convert::TryFrom;
 // Simple fuzzing of ABAC hierarchy/policy/requests without respect to types.
 fuzz_target!(|input: FuzzTargetInput<false>| {
     initialize_log();
-    let mut policyset = PolicySet::new();
-    let policy = Policy::from(input.policy);
-    policyset.add(policy.clone()).unwrap();
+    let policyset = input.policy.0.clone().into_policy_set();
     debug!("Policies: {policyset}");
     debug!("Entities: {}", input.entities.as_ref());
     let requests = input
@@ -57,7 +55,11 @@ fuzz_target!(|input: FuzzTargetInput<false>| {
         // When the corpus is re-parsed, the policy will be given id "policy0".
         // Recreate the policy set and compute responses here to account for this.
         let mut policyset = PolicySet::new();
-        let policy = policy.new_id(PolicyId::new("policy0"));
+        // Corpus tests don't support linked policies, so we have to convert to static.
+        let policy = input
+            .policy
+            .link_to_static()
+            .new_id(PolicyId::new("policy0"));
         policyset.add(policy).unwrap();
         let responses = requests
             .iter()

--- a/cedar-drt/fuzz/fuzz_targets/batched-evaluation-drt.rs
+++ b/cedar-drt/fuzz/fuzz_targets/batched-evaluation-drt.rs
@@ -19,8 +19,8 @@ use cedar_drt::logger::initialize_log;
 use cedar_drt_inner::{abac::FuzzTargetInput, fuzz_target};
 
 use cedar_lean_ffi::CedarLeanFfi;
-use cedar_policy::{Policy, PolicySet, Schema, TestEntityLoader};
-use cedar_policy_generators::{abac::ABACPolicy, policy::GeneratedPolicy};
+use cedar_policy::{Schema, TestEntityLoader};
+use cedar_policy_core::batched_evaluator::err::BatchedEvalError;
 
 // This target tests a property that batched evaluation, if succeeds, should
 // produce the same authorization decision based on the Lean model output
@@ -29,15 +29,7 @@ fuzz_target!(|input: FuzzTargetInput<true>| {
     initialize_log();
 
     if let Ok(schema) = Schema::try_from(input.schema) {
-        let ABACPolicy(GeneratedPolicy::Static(policy)) = input.policy else {
-            panic!(
-                "batched-evaluation-drt needs #932 to support linked policies\n{:?}",
-                input.policy
-            )
-        };
-        let policy = Policy::from(policy);
-        let mut policyset = PolicySet::new();
-        policyset.add(policy).unwrap();
+        let policyset = input.policy.into_policy_set();
         let mut loader = TestEntityLoader::new(&input.entities);
         log::debug!("policy: {policyset}");
         let iteration = (FuzzTargetInput::<true>::settings().max_depth + 1) as u32;
@@ -45,26 +37,26 @@ fuzz_target!(|input: FuzzTargetInput<true>| {
         for req in input.requests {
             let req = req.into();
             log::debug!("req: {req}");
-            // We need to start with an `Ok` result of Rust because the
-            // validation DRT property is if Rust validations, then Lean also
-            // does. `is_authorized_batched` validates policies/request/entities
-            if let Ok(rust_decision) =
-                policyset.is_authorized_batched(&req, &schema, &mut loader, iteration)
-            {
-                match ffi.batched_authorization(
-                    &policyset,
-                    &schema,
-                    &req,
-                    &input.entities,
-                    iteration,
-                ) {
-                    Ok(lean_decision) => {
-                        assert_eq!(lean_decision.decision, Some(rust_decision));
-                    }
-                    Err(err) => {
-                        panic!("lean failed but rust didn't: {err}");
-                    }
+            let rust_decision =
+                match policyset.is_authorized_batched(&req, &schema, &mut loader, iteration) {
+                    Ok(decision) => Ok(Some(decision)),
+                    Err(BatchedEvalError::InsufficientIterations(_)) => Ok(None),
+                    Err(e) => Err(e),
+                };
+
+            let lean_decision =
+                ffi.batched_authorization(&policyset, &schema, &req, &input.entities, iteration);
+            match (rust_decision, lean_decision) {
+                (Ok(rust_decision), Ok(lean_decision)) => {
+                    assert_eq!(rust_decision, lean_decision.decision);
                 }
+                (Ok(rust_decision), Err(lean_err)) => {
+                    panic!("Rust reached decisions {rust_decision:?} but lean errored: {lean_err}")
+                }
+                (Err(rust_err), Ok(lean_decision)) => {
+                    panic!("Lean reached decisions {lean_decision:?} but rust errored: {rust_err}")
+                }
+                (Err(_), Err(_)) => {}
             }
         }
     }

--- a/cedar-drt/fuzz/fuzz_targets/batched-evaluation-drt.rs
+++ b/cedar-drt/fuzz/fuzz_targets/batched-evaluation-drt.rs
@@ -20,6 +20,7 @@ use cedar_drt_inner::{abac::FuzzTargetInput, fuzz_target};
 
 use cedar_lean_ffi::CedarLeanFfi;
 use cedar_policy::{Policy, PolicySet, Schema, TestEntityLoader};
+use cedar_policy_generators::{abac::ABACPolicy, policy::GeneratedPolicy};
 
 // This target tests a property that batched evaluation, if succeeds, should
 // produce the same authorization decision based on the Lean model output
@@ -28,7 +29,13 @@ fuzz_target!(|input: FuzzTargetInput<true>| {
     initialize_log();
 
     if let Ok(schema) = Schema::try_from(input.schema) {
-        let policy = Policy::from(input.policy);
+        let ABACPolicy(GeneratedPolicy::Static(policy)) = input.policy else {
+            panic!(
+                "batched-evaluation-drt needs #932 to support linked policies\n{:?}",
+                input.policy
+            )
+        };
+        let policy = Policy::from(policy);
         let mut policyset = PolicySet::new();
         policyset.add(policy).unwrap();
         let mut loader = TestEntityLoader::new(&input.entities);

--- a/cedar-drt/fuzz/fuzz_targets/batched-evaluation-pbt.rs
+++ b/cedar-drt/fuzz/fuzz_targets/batched-evaluation-pbt.rs
@@ -18,7 +18,7 @@
 use cedar_drt::logger::initialize_log;
 use cedar_drt_inner::{abac::FuzzTargetInput, fuzz_target};
 
-use cedar_policy::{Authorizer, Policy, PolicySet, Schema, TestEntityLoader};
+use cedar_policy::{Authorizer, Schema, TestEntityLoader};
 
 use cedar_policy_core::batched_evaluator::err::BatchedEvalError;
 
@@ -29,9 +29,7 @@ fuzz_target!(|input: FuzzTargetInput<true>| {
     initialize_log();
 
     if let Ok(schema) = Schema::try_from(input.schema) {
-        let policy = Policy::from(input.policy);
-        let mut policyset = PolicySet::new();
-        policyset.add(policy.clone()).unwrap();
+        let policyset = input.policy.into_policy_set();
         let mut loader = TestEntityLoader::new(&input.entities);
         log::debug!("policy: {policyset}");
         let iteration = (FuzzTargetInput::<true>::settings().max_depth + 1) as u32;

--- a/cedar-drt/fuzz/fuzz_targets/entity-slicing-drt-type-directed.rs
+++ b/cedar-drt/fuzz/fuzz_targets/entity-slicing-drt-type-directed.rs
@@ -20,8 +20,7 @@ use cedar_drt::logger::initialize_log;
 use cedar_drt_inner::{abac::FuzzTargetInput, fuzz_target};
 
 use cedar_policy::{
-    Authorizer, Entities, EntityManifestError, Policy, PolicySet, Request, Schema, Validator,
-    compute_entity_manifest,
+    Authorizer, Entities, EntityManifestError, Request, Schema, Validator, compute_entity_manifest,
 };
 
 use log::debug;
@@ -32,9 +31,7 @@ fuzz_target!(|input: FuzzTargetInput<true>| {
     initialize_log();
     if let Ok(schema) = Schema::try_from(input.schema) {
         debug!("Schema: {:?}", schema);
-        let mut policyset = PolicySet::new();
-        let policy: Policy = input.policy.into();
-        policyset.add(policy.clone()).unwrap();
+        let policyset = input.policy.into_policy_set();
         let manifest = match compute_entity_manifest(&Validator::new(schema), &policyset) {
             Ok(manifest) => manifest,
             Err(

--- a/cedar-drt/fuzz/fuzz_targets/formatter.rs
+++ b/cedar-drt/fuzz/fuzz_targets/formatter.rs
@@ -20,13 +20,15 @@ use cedar_drt::check_policy_equivalence;
 use cedar_drt::logger::initialize_log;
 use cedar_drt_inner::fuzz_target;
 
+use cedar_policy::Policy;
 use cedar_policy_core::ast::{StaticPolicy, Template};
 use cedar_policy_core::parser::{self, parse_policy};
 use cedar_policy_formatter::token::{Comment, Token, WrappedToken};
 use cedar_policy_formatter::{Config, policies_str_to_pretty};
+use cedar_policy_generators::abac::StaticABACPolicy;
 use cedar_policy_generators::schema_gen::SchemaGen;
 use cedar_policy_generators::{
-    abac::ABACPolicy, hierarchy::HierarchyGenerator, schema::Schema, settings::ABACSettings,
+    hierarchy::HierarchyGenerator, schema::Schema, settings::ABACSettings,
 };
 use libfuzzer_sys::arbitrary::{self, Arbitrary, Unstructured};
 use log::debug;
@@ -41,7 +43,7 @@ use uuid::Builder;
 #[derive(Debug, Clone)]
 struct FuzzTargetInput {
     // the generated policy
-    policy: ABACPolicy,
+    policy: StaticABACPolicy,
     // seed to generate random UUIDs
     seed: u64,
 }
@@ -57,7 +59,7 @@ impl<'a> Arbitrary<'a> for FuzzTargetInput {
     fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
         let schema: Schema = Schema::arbitrary(SETTINGS.clone(), u)?;
         let hierarchy = schema.arbitrary_hierarchy(u)?;
-        let policy = schema.arbitrary_policy(&hierarchy, u)?;
+        let policy = schema.arbitrary_static_policy(&hierarchy, u)?;
         let seed = u.arbitrary()?;
         Ok(Self { policy, seed })
     }
@@ -102,13 +104,18 @@ fn attach_comment(p: &str, uuids: &mut Vec<String>, seed: u64) -> String {
 
 // round-tripping of a policy
 // i.e., print a policy to string, format it, and parse it back
-fn round_trip(p: &StaticPolicy, seed: u64) -> Result<StaticPolicy, Box<parser::err::ParseErrors>> {
+fn round_trip(p: &Policy, seed: u64) -> Result<StaticPolicy, Box<parser::err::ParseErrors>> {
     let config = Config {
         indent_width: 2,
         line_width: 80,
     };
     let mut uuids = Vec::new();
-    let commented = attach_comment(&p.to_string(), &mut uuids, seed);
+    let commented = attach_comment(
+        &p.to_cedar()
+            .expect("`to_cedar` should never fail on static policy"),
+        &mut uuids,
+        seed,
+    );
     let formatted_policy_str =
         &policies_str_to_pretty(&commented, &config).expect("pretty-printing should not fail");
     // check if pretty-printing drops any comment
@@ -144,8 +151,7 @@ fn round_trip(p: &StaticPolicy, seed: u64) -> Result<StaticPolicy, Box<parser::e
 fuzz_target!(|input: FuzzTargetInput| {
     initialize_log();
     let seed = input.seed;
-    let p: StaticPolicy = input.policy.into();
-    let (t, _) = Template::link_static_policy(p.clone());
+    let p: Policy = input.policy.into_static_policy();
 
     debug!("Starting policy: {:?}", p);
     // round-tripping over it should preserve syntactical equivalence.
@@ -153,12 +159,8 @@ fuzz_target!(|input: FuzzTargetInput| {
     // get ids from policy text
     match round_trip(&p, seed) {
         Ok(roundtripped) => {
-            assert!(
-                t.slots().collect::<Vec<_>>().is_empty(),
-                "\nold template slots should be empty\n"
-            );
             check_policy_equivalence(
-                &Into::<Arc<Template>>::into(p),
+                p.as_ref().template(),
                 &Into::<Arc<Template>>::into(roundtripped),
             );
         }

--- a/cedar-drt/fuzz/fuzz_targets/level-validation-drt.rs
+++ b/cedar-drt/fuzz/fuzz_targets/level-validation-drt.rs
@@ -19,7 +19,7 @@ use cedar_drt::tests::run_level_val_test;
 use cedar_drt_inner::fuzz_target;
 
 use cedar_lean_ffi::CedarLeanFfi;
-use cedar_policy::{Policy, PolicySet, Schema, ValidationMode};
+use cedar_policy::{Schema, ValidationMode};
 
 use cedar_policy_generators::{
     abac::ABACPolicy, hierarchy::HierarchyGenerator, schema, schema_gen::SchemaGen,
@@ -73,14 +73,10 @@ fuzz_target!(|input: FuzzTargetInput| {
     let def_impl = CedarLeanFfi::new();
 
     if let Ok(schema) = Schema::try_from(input.schema) {
-        let policy = Policy::from(input.policy);
-        let mut policyset = PolicySet::new();
-        policyset.add(policy).unwrap();
-
         run_level_val_test(
             &def_impl,
             schema,
-            &policyset,
+            &input.policy.into_policy_set(),
             ValidationMode::Strict,
             input.level as i32,
         );

--- a/cedar-drt/fuzz/fuzz_targets/protobuf-roundtrip.rs
+++ b/cedar-drt/fuzz/fuzz_targets/protobuf-roundtrip.rs
@@ -19,7 +19,7 @@
 use cedar_drt_inner::roundtrip_entities;
 use cedar_drt_inner::{fuzz_target, schemas::Equiv};
 
-use cedar_policy::{Entities, Entity, Policy, PolicySet, Request, Schema, proto};
+use cedar_policy::{Entities, Entity, PolicySet, Request, Schema, proto};
 
 use cedar_policy_generators::schema_gen::SchemaGen;
 use libfuzzer_sys::arbitrary::{self, MaxRecursionReached};
@@ -81,9 +81,7 @@ impl<'a> Arbitrary<'a> for FuzzTargetInput {
 }
 
 fuzz_target!(|input: FuzzTargetInput| {
-    let policy = Policy::from(input.policy);
-    let mut policies = PolicySet::new();
-    policies.add(policy).expect("Failed to add policy");
+    let policies = input.policy.into_policy_set();
     let request = Request::from(input.request);
 
     roundtrip_policies(policies);

--- a/cedar-drt/fuzz/fuzz_targets/rbac.rs
+++ b/cedar-drt/fuzz/fuzz_targets/rbac.rs
@@ -30,7 +30,7 @@ use cedar_policy_core::{ast, extensions::Extensions};
 use cedar_policy_generators::{
     err::Result,
     hierarchy::{AttributesMode, HierarchyGenerator, HierarchyGeneratorMode},
-    policy::GeneratedLinkedPolicy,
+    policy::GeneratedLink,
     rbac::{RBACHierarchy, RBACPolicy, RBACRequest},
 };
 
@@ -63,7 +63,7 @@ pub enum PolicyGroup {
     StaticPolicy(RBACPolicy),
     TemplateWithLinks {
         template: RBACPolicy,
-        links: Vec<GeneratedLinkedPolicy>,
+        links: Vec<GeneratedLink>,
     },
 }
 
@@ -119,7 +119,7 @@ impl PolicyGroup {
         )?;
         if policy.has_slots() {
             let links = arbitrary_vec(u, Some(1), Some(4), |l_idx, u| {
-                GeneratedLinkedPolicy::arbitrary(
+                GeneratedLink::arbitrary_for_hierarchy(
                     ast::PolicyID::from_string(format!("t{}_l{}", pg_idx, l_idx)),
                     &policy,
                     hierarchy,

--- a/cedar-drt/fuzz/fuzz_targets/roundtrip.rs
+++ b/cedar-drt/fuzz/fuzz_targets/roundtrip.rs
@@ -19,12 +19,14 @@
 use cedar_drt::{check_policy_equivalence, logger::initialize_log};
 use cedar_drt_inner::fuzz_target;
 
-use cedar_policy_core::ast::{self, StaticPolicy, Template};
+use cedar_policy::Policy;
+use cedar_policy_core::ast::{StaticPolicy, Template};
 use cedar_policy_core::est;
 use cedar_policy_core::parser::{self, parse_policy};
+use cedar_policy_generators::abac::StaticABACPolicy;
 use cedar_policy_generators::schema_gen::SchemaGen;
 use cedar_policy_generators::{
-    abac::ABACPolicy, hierarchy::HierarchyGenerator, schema::Schema, settings::ABACSettings,
+    hierarchy::HierarchyGenerator, schema::Schema, settings::ABACSettings,
 };
 use libfuzzer_sys::arbitrary::{self, Arbitrary, Unstructured};
 use log::debug;
@@ -34,7 +36,7 @@ use std::sync::Arc;
 #[derive(Debug, Clone)]
 struct FuzzTargetInput {
     // the generated policy
-    policy: ABACPolicy,
+    policy: StaticABACPolicy,
 }
 
 // settings for this fuzz target
@@ -49,7 +51,7 @@ impl<'a> Arbitrary<'a> for FuzzTargetInput {
     fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
         let schema: Schema = Schema::arbitrary(SETTINGS.clone(), u)?;
         let hierarchy = schema.arbitrary_hierarchy(u)?;
-        let policy = schema.arbitrary_policy(&hierarchy, u)?;
+        let policy = schema.arbitrary_static_policy(&hierarchy, u)?;
         Ok(Self { policy })
     }
 
@@ -67,8 +69,8 @@ impl<'a> Arbitrary<'a> for FuzzTargetInput {
 // AST --> text --> CST --> AST
 // Print a policy to a string and parse it back using the standard AST parser.
 // Panics if parsing fails.
-fn round_trip_ast(p: &StaticPolicy) -> StaticPolicy {
-    parse_policy(None, &p.to_string()).unwrap_or_else(|err| {
+fn round_trip_ast(p: &Policy) -> StaticPolicy {
+    parse_policy(None, &p.to_cedar().unwrap()).unwrap_or_else(|err| {
         panic!(
             "Failed to round-trip AST: {:?}\nPretty printed form: {}\nParse error: {:?}\n",
             p, p, err
@@ -78,9 +80,9 @@ fn round_trip_ast(p: &StaticPolicy) -> StaticPolicy {
 
 // AST --> EST --> json --> EST --> AST
 // Print a policy to a JSON string and parse it back. Panics if any step fails.
-fn round_trip_json(p: StaticPolicy) -> StaticPolicy {
+fn round_trip_json(p: &Policy) -> StaticPolicy {
     // convert to json
-    let est = est::Policy::from(ast::Policy::from(p));
+    let est = est::Policy::from(p.as_ref().clone());
     let json = serde_json::to_value(est).expect("failed to convert EST to JSON");
     // read back
     let est: est::Policy = serde_json::from_value(json).expect("failed to parse EST from JSON");
@@ -95,13 +97,14 @@ fn round_trip_json(p: StaticPolicy) -> StaticPolicy {
 // AST --> text --> CST --> EST --> json --> EST --> AST
 // Print a policy to a string, parse it back using the EST parser, convert to JSON,
 // and then parse back to an AST. Panics if any step fails.
-fn round_trip_est(p: &StaticPolicy) -> StaticPolicy {
-    let est = parser::parse_policy_or_template_to_est(&p.to_string()).unwrap_or_else(|err| {
-        panic!(
-            "Failed to round-trip EST: {:?}\nPretty printed form: {}\nParse error: {:?}\n",
-            p, p, err
-        )
-    });
+fn round_trip_est(p: &Policy) -> StaticPolicy {
+    let est =
+        parser::parse_policy_or_template_to_est(&p.to_cedar().unwrap()).unwrap_or_else(|err| {
+            panic!(
+                "Failed to round-trip EST: {:?}\nPretty printed form: {}\nParse error: {:?}\n",
+                p, p, err
+            )
+        });
     let json = serde_json::to_value(est).unwrap_or_else(|err| {
         panic!(
             "Failed to convert EST to JSON: {:?}\nParse error: {:?}\n",
@@ -119,28 +122,19 @@ fn round_trip_est(p: &StaticPolicy) -> StaticPolicy {
 
 fuzz_target!(|input: FuzzTargetInput| {
     initialize_log();
-    let p: StaticPolicy = input.policy.into();
+    let p: Policy = input.policy.into_static_policy();
 
     debug!("Running on policy: {:?}", p);
 
     // AST --> text --> CST --> AST
     let np = round_trip_ast(&p);
-    check_policy_equivalence(
-        &Into::<Arc<Template>>::into(p.clone()),
-        &Into::<Arc<Template>>::into(np),
-    );
+    check_policy_equivalence(p.as_ref().template(), &Into::<Arc<Template>>::into(np));
 
     // AST --> EST --> json --> EST --> AST
-    let np = round_trip_json(p.clone());
-    check_policy_equivalence(
-        &Into::<Arc<Template>>::into(p.clone()),
-        &Into::<Arc<Template>>::into(np),
-    );
+    let np = round_trip_json(&p);
+    check_policy_equivalence(p.as_ref().template(), &Into::<Arc<Template>>::into(np));
 
     // AST --> text --> CST --> EST --> json --> EST --> AST
     let np = round_trip_est(&p);
-    check_policy_equivalence(
-        &Into::<Arc<Template>>::into(p),
-        &Into::<Arc<Template>>::into(np),
-    );
+    check_policy_equivalence(p.as_ref().template(), &Into::<Arc<Template>>::into(np));
 });

--- a/cedar-drt/fuzz/fuzz_targets/tpe-is-authorized-drt.rs
+++ b/cedar-drt/fuzz/fuzz_targets/tpe-is-authorized-drt.rs
@@ -25,7 +25,7 @@ use cedar_drt_inner::{
 };
 use cedar_lean_ffi::CedarLeanFfi;
 use cedar_policy::{
-    PartialEntities, PartialRequest, Policy, PolicyId, PolicySet, Request, Schema, Validator,
+    PartialEntities, PartialRequest, PolicyId, PolicySet, Request, Schema, Validator,
     pst::{Clause, Expr, UnaryOp},
 };
 use log::debug;
@@ -158,9 +158,7 @@ fuzz_target!(|input: TpeFuzzTargetInput| {
     if let Ok(schema) = Schema::try_from(input.abac_input.schema) {
         debug!("Schema: {schemafile_string}");
         let validator = Validator::new(schema.clone());
-        let mut policyset = PolicySet::new();
-        let policy: Policy = input.abac_input.policy.into();
-        policyset.add(policy).unwrap();
+        let policyset = input.abac_input.policy.into_policy_set();
         if passes_policyset_validation(&validator, &policyset) {
             let ffi = CedarLeanFfi::new();
             for (request, partial_request) in input

--- a/cedar-drt/fuzz/fuzz_targets/tpe-pbt.rs
+++ b/cedar-drt/fuzz/fuzz_targets/tpe-pbt.rs
@@ -20,7 +20,7 @@ use cedar_drt_inner::{
     fuzz_target,
     tpe::{TpeFuzzTargetInput, passes_policyset_validation, passes_request_validation},
 };
-use cedar_policy::{Authorizer, Entities, Policy, PolicySet, Request, Schema, Validator};
+use cedar_policy::{Authorizer, Entities, PolicySet, Request, Schema, Validator};
 use log::debug;
 use std::convert::TryFrom;
 
@@ -49,9 +49,7 @@ fuzz_target!(|input: TpeFuzzTargetInput| {
     if let Ok(schema) = Schema::try_from(input.abac_input.schema) {
         debug!("Schema: {schemafile_string}");
         let validator = Validator::new(schema.clone());
-        let mut policyset = PolicySet::new();
-        let policy: Policy = input.abac_input.policy.into();
-        policyset.add(policy.clone()).unwrap();
+        let policyset = input.abac_input.policy.into_policy_set();
         let passes_strict = passes_policyset_validation(&validator, &policyset);
         if passes_strict {
             let partial_entities = input.partial_entities;

--- a/cedar-drt/fuzz/fuzz_targets/tpe-query-action-pbt.rs
+++ b/cedar-drt/fuzz/fuzz_targets/tpe-query-action-pbt.rs
@@ -18,7 +18,7 @@
 use cedar_drt::logger::initialize_log;
 use cedar_drt_inner::{abac, fuzz_target, tpe::entities_to_partial_entities};
 use cedar_policy::{
-    ActionQueryRequest, Decision, EntityId, PartialEntities, PartialEntityUid, PolicySet, Request,
+    ActionQueryRequest, Decision, EntityId, PartialEntities, PartialEntityUid, Request,
     ValidationMode, Validator,
 };
 use cedar_policy_generators::abac::ABACRequest;
@@ -99,8 +99,7 @@ impl<'a> Arbitrary<'a> for FuzzTargetInput {
 fuzz_target!(|input: FuzzTargetInput| {
     initialize_log();
 
-    let mut policyset = PolicySet::new();
-    policyset.add(input.abac_input.policy.into()).unwrap();
+    let policyset = input.abac_input.policy.into_policy_set();
 
     let cedar_schema = cedar_policy::Schema::try_from(input.abac_input.schema.clone()).unwrap();
 

--- a/cedar-drt/fuzz/fuzz_targets/tpe-query-principal-pbt.rs
+++ b/cedar-drt/fuzz/fuzz_targets/tpe-query-principal-pbt.rs
@@ -17,13 +17,12 @@
 #![no_main]
 use cedar_drt_inner::{abac::FuzzTargetInput, fuzz_target};
 
-use cedar_policy::{PolicySet, PrincipalQueryRequest, Request, Validator};
+use cedar_policy::{PrincipalQueryRequest, Request, Validator};
 
 use std::{collections::BTreeSet, convert::TryFrom};
 
 fuzz_target!(|input: FuzzTargetInput<true>| {
-    let mut policyset = PolicySet::new();
-    policyset.add(input.policy.into()).unwrap();
+    let policyset = input.policy.into_policy_set();
     let cedar_schema = cedar_policy::Schema::try_from(input.schema.clone()).unwrap();
 
     let validator = Validator::new(cedar_schema);

--- a/cedar-drt/fuzz/fuzz_targets/tpe-query-resource-pbt.rs
+++ b/cedar-drt/fuzz/fuzz_targets/tpe-query-resource-pbt.rs
@@ -17,13 +17,12 @@
 #![no_main]
 use cedar_drt_inner::{abac::FuzzTargetInput, fuzz_target};
 
-use cedar_policy::{PolicySet, Request, ResourceQueryRequest, Validator};
+use cedar_policy::{Request, ResourceQueryRequest, Validator};
 
 use std::{collections::BTreeSet, convert::TryFrom};
 
 fuzz_target!(|input: FuzzTargetInput<true>| {
-    let mut policyset = PolicySet::new();
-    policyset.add(input.policy.into()).unwrap();
+    let policyset = input.policy.into_policy_set();
     let cedar_schema = cedar_policy::Schema::try_from(input.schema.clone()).unwrap();
 
     let validator = Validator::new(cedar_schema);

--- a/cedar-drt/fuzz/fuzz_targets/validation-pbt-type-directed.rs
+++ b/cedar-drt/fuzz/fuzz_targets/validation-pbt-type-directed.rs
@@ -20,8 +20,8 @@ use cedar_drt::logger::initialize_log;
 use cedar_drt_inner::{abac::FuzzTargetInput, fuzz_target};
 
 use cedar_policy::{
-    AuthorizationError, Authorizer, EvaluationError, Policy, PolicySet, Request, Schema,
-    ValidationMode, Validator,
+    AuthorizationError, Authorizer, EvaluationError, PolicySet, Request, Schema, ValidationMode,
+    Validator,
 };
 
 use log::debug;
@@ -40,9 +40,7 @@ fuzz_target!(|input: FuzzTargetInput<true>| {
     if let Ok(schema) = Schema::try_from(input.schema) {
         debug!("Schema: {:?}", schema);
         let validator = Validator::new(schema);
-        let mut policyset = PolicySet::new();
-        let policy: Policy = input.policy.into();
-        policyset.add(policy.clone()).unwrap();
+        let policyset = input.policy.into_policy_set();
         let passes_strict = passes_validation(&validator, &policyset, ValidationMode::Strict);
         let passes_permissive =
             passes_validation(&validator, &policyset, ValidationMode::Permissive);

--- a/cedar-drt/fuzz/fuzz_targets/validation-pbt.rs
+++ b/cedar-drt/fuzz/fuzz_targets/validation-pbt.rs
@@ -19,8 +19,8 @@ use cedar_drt::logger::initialize_log;
 use cedar_drt_inner::{abac::FuzzTargetInput, fuzz_target};
 
 use cedar_policy::{
-    AuthorizationError, Authorizer, EvaluationError, Policy, PolicySet, Request, Schema,
-    ValidationMode, Validator,
+    AuthorizationError, Authorizer, EvaluationError, PolicySet, Request, Schema, ValidationMode,
+    Validator,
 };
 
 use itertools::Itertools;
@@ -40,9 +40,7 @@ fuzz_target!(|input: FuzzTargetInput<false>| {
     if let Ok(schema) = Schema::try_from(input.schema) {
         debug!("Schema: {:?}", schema);
         let validator = Validator::new(schema.clone());
-        let mut policyset = PolicySet::new();
-        let policy: Policy = input.policy.into();
-        policyset.add(policy.clone()).unwrap();
+        let policyset = input.policy.into_policy_set();
         let passes_strict = passes_validation(&validator, &policyset, ValidationMode::Strict);
         let passes_permissive =
             passes_validation(&validator, &policyset, ValidationMode::Permissive);

--- a/cedar-drt/fuzz/src/symcc.rs
+++ b/cedar-drt/fuzz/src/symcc.rs
@@ -18,7 +18,7 @@ use cedar_lean_ffi::{CedarLeanFfi, FfiError, LeanSchema};
 use cedar_policy::{Authorizer, Policy, PolicySet, RequestEnv, Schema};
 use cedar_policy_core::ast::PolicyID;
 use cedar_policy_generators::{
-    abac::ABACPolicy,
+    abac::StaticABACPolicy,
     accum, r#gen as weighted_generate, gen_inner,
     hierarchy::{Hierarchy, HierarchyGenerator},
     schema,
@@ -184,21 +184,24 @@ pub struct SinglePolicyFuzzTargetInput<const MAX_REQUEST_ENVS: MaxRequestEnvs> {
     /// generated schema
     schema: schema::Schema,
     /// generated policy
-    policy: ABACPolicy,
+    policy: StaticABACPolicy,
 }
 
 impl<const MAX_REQUEST_ENVS: MaxRequestEnvs> SinglePolicyFuzzTargetInput<MAX_REQUEST_ENVS> {
     /// Get the `cedar_policy::Schema` and `cedar_policy::Policy` that were generated
     pub fn into_inputs(self) -> Result<(Schema, Policy), cedar_policy::SchemaError> {
-        Ok((Schema::try_from(self.schema)?, self.policy.into()))
+        Ok((
+            Schema::try_from(self.schema)?,
+            self.policy.into_static_policy(),
+        ))
     }
 
     /// Get the `cedar_policy::Schema` and singleton `cedar_policy::PolicySet` that were generated
     pub fn into_inputs_as_pset(self) -> Result<(Schema, PolicySet), cedar_policy::SchemaError> {
-        let mut pset = PolicySet::new();
-        pset.add(self.policy.into())
-            .expect("creating a singleton policyset should not fail");
-        Ok((Schema::try_from(self.schema)?, pset))
+        Ok((
+            Schema::try_from(self.schema)?,
+            self.policy.into_policy_set(),
+        ))
     }
 }
 
@@ -208,7 +211,7 @@ impl<'a, const MAX_REQUEST_ENVS: MaxRequestEnvs> Arbitrary<'a>
     fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
         let schema = schema::Schema::arbitrary(settings(MAX_REQUEST_ENVS), u)?;
         let hierarchy = schema.arbitrary_hierarchy(u)?;
-        let policy = schema.arbitrary_policy(&hierarchy, u)?;
+        let policy = schema.arbitrary_static_policy(&hierarchy, u)?;
 
         Ok(Self { schema, policy })
     }
@@ -227,7 +230,7 @@ fn arbitrary_policies(
     schema: &schema::Schema,
     hierarchy: &Hierarchy,
     u: &mut Unstructured<'_>,
-) -> arbitrary::Result<Vec<ABACPolicy>> {
+) -> arbitrary::Result<Vec<StaticABACPolicy>> {
     let len = weighted_generate!(u,
         1 => 0, // very rarely, try the empty-policyset case
         0 => 1, // other targets cover the single-policy case
@@ -241,9 +244,9 @@ fn arbitrary_policies(
         4 => 9,
         2 => 10
     );
-    let mut policies: Vec<ABACPolicy> = Vec::with_capacity(len);
+    let mut policies: Vec<StaticABACPolicy> = Vec::with_capacity(len);
     for _ in 0..len {
-        policies.push(schema.arbitrary_policy(&hierarchy, u)?);
+        policies.push(schema.arbitrary_static_policy(&hierarchy, u)?);
     }
     // we want to ensure that the policies all have unique IDs.
     // this will be a list of policy IDs that we have seen (and will ensure there are no duplicates of)
@@ -282,7 +285,7 @@ pub struct SinglePolicySetFuzzTargetInput<const MAX_REQUEST_ENVS: MaxRequestEnvs
     /// generated schema
     schema: schema::Schema,
     /// generated policyset
-    pset: Vec<ABACPolicy>,
+    pset: Vec<StaticABACPolicy>,
 }
 
 impl<const MAX_REQUEST_ENVS: MaxRequestEnvs> SinglePolicySetFuzzTargetInput<MAX_REQUEST_ENVS> {
@@ -290,7 +293,7 @@ impl<const MAX_REQUEST_ENVS: MaxRequestEnvs> SinglePolicySetFuzzTargetInput<MAX_
     pub fn into_inputs(self) -> Result<(Schema, PolicySet), cedar_policy::SchemaError> {
         Ok((
             Schema::try_from(self.schema)?,
-            PolicySet::from_policies(self.pset.into_iter().map(Into::into))
+            PolicySet::from_policies(self.pset.into_iter().map(|p| p.into_static_policy()))
                 .expect("creating a policyset from the generated policies should not fail"),
         ))
     }
@@ -325,9 +328,9 @@ pub struct TwoPolicyFuzzTargetInput<const MAX_REQUEST_ENVS: MaxRequestEnvs> {
     /// generated schema
     schema: schema::Schema,
     /// generated policy
-    policy1: ABACPolicy,
+    policy1: StaticABACPolicy,
     /// generated policy
-    policy2: ABACPolicy,
+    policy2: StaticABACPolicy,
 }
 
 impl<const MAX_REQUEST_ENVS: MaxRequestEnvs> TwoPolicyFuzzTargetInput<MAX_REQUEST_ENVS> {
@@ -335,8 +338,8 @@ impl<const MAX_REQUEST_ENVS: MaxRequestEnvs> TwoPolicyFuzzTargetInput<MAX_REQUES
     pub fn into_inputs(self) -> Result<(Schema, Policy, Policy), cedar_policy::SchemaError> {
         Ok((
             Schema::try_from(self.schema)?,
-            self.policy1.into(),
-            self.policy2.into(),
+            self.policy1.into_static_policy(),
+            self.policy2.into_static_policy(),
         ))
     }
 
@@ -346,11 +349,11 @@ impl<const MAX_REQUEST_ENVS: MaxRequestEnvs> TwoPolicyFuzzTargetInput<MAX_REQUES
     ) -> Result<(Schema, PolicySet, PolicySet), cedar_policy::SchemaError> {
         let mut pset1 = PolicySet::new();
         pset1
-            .add(self.policy1.into())
+            .add(self.policy1.into_static_policy())
             .expect("creating a singleton policyset should not fail");
         let mut pset2 = PolicySet::new();
         pset2
-            .add(self.policy2.into())
+            .add(self.policy2.into_static_policy())
             .expect("creating a singleton policyset should not fail");
         Ok((Schema::try_from(self.schema)?, pset1, pset2))
     }
@@ -362,8 +365,8 @@ impl<'a, const MAX_REQUEST_ENVS: MaxRequestEnvs> Arbitrary<'a>
     fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
         let schema = schema::Schema::arbitrary(settings(MAX_REQUEST_ENVS), u)?;
         let hierarchy = schema.arbitrary_hierarchy(u)?;
-        let policy1 = schema.arbitrary_policy(&hierarchy, u)?;
-        let policy2 = schema.arbitrary_policy(&hierarchy, u)?;
+        let policy1 = schema.arbitrary_static_policy(&hierarchy, u)?;
+        let policy2 = schema.arbitrary_static_policy(&hierarchy, u)?;
 
         Ok(Self {
             schema,
@@ -390,9 +393,9 @@ pub struct TwoPolicySetFuzzTargetInput<const MAX_REQUEST_ENVS: MaxRequestEnvs> {
     /// generated schema
     schema: schema::Schema,
     /// generated policyset
-    pset1: Vec<ABACPolicy>,
+    pset1: Vec<StaticABACPolicy>,
     /// generated policyset
-    pset2: Vec<ABACPolicy>,
+    pset2: Vec<StaticABACPolicy>,
 }
 
 impl<const MAX_REQUEST_ENVS: MaxRequestEnvs> TwoPolicySetFuzzTargetInput<MAX_REQUEST_ENVS> {
@@ -400,9 +403,9 @@ impl<const MAX_REQUEST_ENVS: MaxRequestEnvs> TwoPolicySetFuzzTargetInput<MAX_REQ
     pub fn into_inputs(self) -> Result<(Schema, PolicySet, PolicySet), cedar_policy::SchemaError> {
         Ok((
             Schema::try_from(self.schema)?,
-            PolicySet::from_policies(self.pset1.into_iter().map(Into::into))
+            PolicySet::from_policies(self.pset1.into_iter().map(|p| p.into_static_policy()))
                 .expect("creating a policyset from the generated policies should not fail"),
-            PolicySet::from_policies(self.pset2.into_iter().map(Into::into))
+            PolicySet::from_policies(self.pset2.into_iter().map(|p| p.into_static_policy()))
                 .expect("creating a policyset from the generated policies should not fail"),
         ))
     }

--- a/cedar-drt/fuzz/src/validation_drt.rs
+++ b/cedar-drt/fuzz/src/validation_drt.rs
@@ -20,7 +20,7 @@ use cedar_drt::{
 };
 
 use cedar_lean_ffi::CedarLeanFfi;
-use cedar_policy::{Policy, PolicySet, Schema, ValidationMode};
+use cedar_policy::{Schema, ValidationMode};
 
 use cedar_policy_generators::{
     abac::ABACPolicy, hierarchy::HierarchyGenerator, schema, schema_gen::SchemaGen,
@@ -80,9 +80,7 @@ pub fn fuzz_target<const TYPE_DIRECTED: bool>(input: FuzzTargetInput<TYPE_DIRECT
         debug!("Schema: {:?}", schema);
 
         // generate a policy
-        let mut policyset = PolicySet::new();
-        let policy: Policy = input.policy.into();
-        policyset.add(policy).unwrap();
+        let policyset = input.policy.into_policy_set();
         debug!("Policies: {policyset}");
 
         // run the policy through both validators and compare the result

--- a/cedar-policy-generators/src/abac.rs
+++ b/cedar-policy-generators/src/abac.rs
@@ -885,7 +885,7 @@ impl ABACPolicy {
     pub fn link_to_static(self) -> cedar_policy::Policy {
         match self.0 {
             GeneratedPolicy::Static(p) => p.into(),
-            GeneratedPolicy::Link { template, link } => template.link_to_static(link).into(),
+            GeneratedPolicy::Linked { template, link } => template.link_to_static(link).into(),
         }
     }
 }

--- a/cedar-policy-generators/src/abac.rs
+++ b/cedar-policy-generators/src/abac.rs
@@ -15,17 +15,16 @@
  */
 
 use crate::err::{while_doing, Error, Result};
-use crate::policy::GeneratedPolicy;
+use crate::policy::{GeneratedPolicy, GeneratedTemplate};
 use crate::request::Request;
 use crate::settings::*;
 use crate::size_hint_utils::size_hint_for_choose;
 use crate::{accum, gen, gen_inner, uniform};
 use arbitrary::{Arbitrary, Unstructured};
-use ast::{EntityUID, Name, RestrictedExpr, StaticPolicy};
+use ast::{EntityUID, Name, RestrictedExpr};
 use cedar_policy_core::ast::{self, EntityType};
 use cedar_policy_core::extensions;
 use indexmap::IndexMap;
-use serde::Serialize;
 use smol_str::{SmolStr, ToSmolStr};
 use std::cell::RefCell;
 use std::collections::BTreeMap;
@@ -865,40 +864,49 @@ impl From<AttrValue> for RestrictedExpr {
     }
 }
 
-/// Represents an ABAC policy, i.e., fully general
-#[derive(Debug, Clone, Serialize)]
-#[serde(transparent)]
+/// Represents an ABAC policy, i.e., having arbitrary conditions in `when` and `unless` clauses.
+#[derive(Debug, Clone)]
 pub struct ABACPolicy(pub GeneratedPolicy);
 
-impl std::fmt::Display for ABACPolicy {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0)
+impl ABACPolicy {
+    /// Get a `PolicySet` containing either a single static policy or a template and template linked policy.
+    #[cfg(feature = "cedar-policy")]
+    pub fn into_policy_set(self) -> cedar_policy::PolicySet {
+        self.0.into_policy_set()
+    }
+
+    /// Get this policy as a static policy, substituting template slots for
+    /// their linked values if necessary.
+    ///
+    /// If you want to generate a static policy, you should prefer using
+    /// `StaticABACPolicy`. This functions is intended for serializing linked
+    /// policies to the corpus test JSON format, which doesn't support links.
+    #[cfg(feature = "cedar-policy")]
+    pub fn link_to_static(self) -> cedar_policy::Policy {
+        match self.0 {
+            GeneratedPolicy::Static(p) => p.into(),
+            GeneratedPolicy::Link { template, link } => template.link_to_static(link).into(),
+        }
     }
 }
 
-impl Deref for ABACPolicy {
-    type Target = GeneratedPolicy;
-    fn deref(&self) -> &GeneratedPolicy {
-        &self.0
-    }
-}
+/// Represents an static ABAC policy. This is an `ABACPolicy` which we know does not have any slots
+#[derive(Debug, Clone)]
+pub struct StaticABACPolicy(pub GeneratedTemplate);
 
-impl DerefMut for ABACPolicy {
-    fn deref_mut(&mut self) -> &mut GeneratedPolicy {
-        &mut self.0
+impl StaticABACPolicy {
+    /// Get a `PolicySet` containing a single static policy
+    #[cfg(feature = "cedar-policy")]
+    pub fn into_policy_set(self) -> cedar_policy::PolicySet {
+        let mut ps = cedar_policy::PolicySet::new();
+        ps.add(self.into_static_policy()).unwrap();
+        ps
     }
-}
 
-impl From<ABACPolicy> for StaticPolicy {
-    fn from(abac: ABACPolicy) -> StaticPolicy {
-        abac.0.into()
-    }
-}
-
-#[cfg(feature = "cedar-policy")]
-impl From<ABACPolicy> for cedar_policy::Policy {
-    fn from(abac: ABACPolicy) -> cedar_policy::Policy {
-        StaticPolicy::from(abac).into()
+    /// Get this as  a static policy.
+    #[cfg(feature = "cedar-policy")]
+    pub fn into_static_policy(self) -> cedar_policy::Policy {
+        self.0.into()
     }
 }
 

--- a/cedar-policy-generators/src/abac.rs
+++ b/cedar-policy-generators/src/abac.rs
@@ -879,7 +879,7 @@ impl ABACPolicy {
     /// their linked values if necessary.
     ///
     /// If you want to generate a static policy, you should prefer using
-    /// `StaticABACPolicy`. This functions is intended for serializing linked
+    /// `StaticABACPolicy`. This function is intended for serializing linked
     /// policies to the corpus test JSON format, which doesn't support links.
     #[cfg(feature = "cedar-policy")]
     pub fn link_to_static(self) -> cedar_policy::Policy {
@@ -890,7 +890,7 @@ impl ABACPolicy {
     }
 }
 
-/// Represents an static ABAC policy. This is an `ABACPolicy` which we know does not have any slots
+/// Represents a static ABAC policy. This is an `ABACPolicy` which we know does not have any slots
 #[derive(Debug, Clone)]
 pub struct StaticABACPolicy(pub GeneratedTemplate);
 

--- a/cedar-policy-generators/src/policy.rs
+++ b/cedar-policy-generators/src/policy.rs
@@ -66,10 +66,7 @@ impl GeneratedPolicy {
             u,
         )?;
         if template.has_slots() {
-            let link_id = match fixed_id_opt {
-                Some(pid) => PolicyID::from_smolstr(format_smolstr!("link_{}", pid)),
-                None => PolicyID::from_string("l"),
-            };
+            let link_id = PolicyID::from_smolstr(format_smolstr!("link_{}", template.id()));
             let link = GeneratedLinkedPolicy::arbitrary(link_id, &template, hierarchy, u)?;
             Ok(GeneratedPolicy::Link { template, link })
         } else {

--- a/cedar-policy-generators/src/policy.rs
+++ b/cedar-policy-generators/src/policy.rs
@@ -653,7 +653,8 @@ impl GeneratedLink {
         )
     }
 
-    /// Generate
+    /// Generate a `GeneratedLink` using the provided generators for principal
+    /// and resource slot values.
     pub fn arbitrary(
         id: PolicyID,
         template: &GeneratedTemplate,

--- a/cedar-policy-generators/src/policy.rs
+++ b/cedar-policy-generators/src/policy.rs
@@ -37,11 +37,11 @@ pub enum GeneratedPolicy {
     /// Generated static policy. The `GeneratedTemplate` will not have any slots
     Static(GeneratedTemplate),
     /// Generated linked policy
-    Link {
+    Linked {
         /// Generated template which will have at least one slot
         template: GeneratedTemplate,
         /// Bindings for slots in `template`
-        link: GeneratedLinkedPolicy,
+        link: GeneratedLink,
     },
 }
 
@@ -49,6 +49,10 @@ impl GeneratedPolicy {
     /// Generate an arbitrary policy, either static or linked.
     ///
     /// If `allow_slots` is `false`, then this will always be a static policy.
+    ///
+    /// Even though this function accept a `schema` argument. It *does not* use
+    /// that schema to generate well typed policies. If you want type-directed
+    /// generation, use [`SchemaGen::arbitrary_policy`] instead.
     pub fn arbitrary_for_hierarchy(
         fixed_id_opt: Option<PolicyID>,
         schema: Option<&Schema>,
@@ -67,8 +71,8 @@ impl GeneratedPolicy {
         )?;
         if template.has_slots() {
             let link_id = PolicyID::from_smolstr(format_smolstr!("link_{}", template.id()));
-            let link = GeneratedLinkedPolicy::arbitrary(link_id, &template, hierarchy, u)?;
-            Ok(GeneratedPolicy::Link { template, link })
+            let link = GeneratedLink::arbitrary_for_hierarchy(link_id, &template, hierarchy, u)?;
+            Ok(GeneratedPolicy::Linked { template, link })
         } else {
             Ok(GeneratedPolicy::Static(template))
         }
@@ -82,7 +86,7 @@ impl GeneratedPolicy {
             GeneratedPolicy::Static(generated_template) => {
                 ps.add(generated_template.into()).unwrap();
             }
-            GeneratedPolicy::Link { template, link } => {
+            GeneratedPolicy::Linked { template, link } => {
                 let t: cedar_policy::Template = template.into();
                 let tid = t.id().clone();
                 ps.add_template(t).unwrap();
@@ -104,7 +108,7 @@ impl GeneratedPolicy {
     pub fn id(&self) -> &PolicyID {
         match self {
             GeneratedPolicy::Static(generated_template) => &generated_template.id,
-            GeneratedPolicy::Link { link, .. } => &link.id,
+            GeneratedPolicy::Linked { link, .. } => &link.id,
         }
     }
 
@@ -112,7 +116,7 @@ impl GeneratedPolicy {
     pub fn set_id(&mut self, id: PolicyID) {
         match self {
             GeneratedPolicy::Static(generated_template) => generated_template.set_id(id),
-            GeneratedPolicy::Link { link, .. } => {
+            GeneratedPolicy::Linked { link, .. } => {
                 link.id = id;
             }
         }
@@ -244,7 +248,7 @@ impl GeneratedTemplate {
     /// directly if you do not want templates. This is intended for obtaining a
     /// static representation of a template, primarily for corpus test
     /// serialization.
-    pub fn link_to_static(self, link: GeneratedLinkedPolicy) -> Self {
+    pub fn link_to_static(self, link: GeneratedLink) -> Self {
         Self {
             principal_constraint: self.principal_constraint.link_to_static(link.principal),
             resource_constraint: self.resource_constraint.link_to_static(link.resource),
@@ -623,7 +627,7 @@ impl ActionConstraint {
 
 /// Data structure representing a generated linked policy
 #[derive(Debug, Clone, Serialize)]
-pub struct GeneratedLinkedPolicy {
+pub struct GeneratedLink {
     /// ID of the linked policy
     pub id: PolicyID,
     /// ID of the template it's linked to
@@ -632,35 +636,48 @@ pub struct GeneratedLinkedPolicy {
     resource: Option<EntityUID>,
 }
 
-impl GeneratedLinkedPolicy {
-    fn arbitrary_slot_value(
-        prc: &PrincipalOrResourceConstraint,
-        hierarchy: &Hierarchy,
-        u: &mut Unstructured<'_>,
-    ) -> Result<Option<EntityUID>> {
-        if prc.has_slot() {
-            Ok(Some(hierarchy.arbitrary_uid(u)?))
-        } else {
-            Ok(None)
-        }
-    }
-
-    /// Generate an arbitrary `GeneratedLinkedPolicy` from the given template
-    pub fn arbitrary(
+impl GeneratedLink {
+    /// Generate an arbitrary `GeneratedLink` from the given template
+    pub fn arbitrary_for_hierarchy(
         id: PolicyID,
         template: &GeneratedTemplate,
         hierarchy: &Hierarchy,
         u: &mut Unstructured<'_>,
     ) -> Result<Self> {
+        Self::arbitrary(
+            id,
+            template,
+            |u| hierarchy.arbitrary_uid(u),
+            |u| hierarchy.arbitrary_uid(u),
+            u,
+        )
+    }
+
+    /// Generate
+    pub fn arbitrary(
+        id: PolicyID,
+        template: &GeneratedTemplate,
+        gen_principal_link: impl FnOnce(&mut Unstructured<'_>) -> Result<EntityUID>,
+        gen_resource_link: impl FnOnce(&mut Unstructured<'_>) -> Result<EntityUID>,
+        u: &mut Unstructured<'_>,
+    ) -> Result<Self> {
         Ok(Self {
             id,
             template_id: template.id.clone(),
-            principal: Self::arbitrary_slot_value(&template.principal_constraint, hierarchy, u)?,
-            resource: Self::arbitrary_slot_value(&template.resource_constraint, hierarchy, u)?,
+            principal: template
+                .principal_constraint
+                .has_slot()
+                .then(|| gen_principal_link(u))
+                .transpose()?,
+            resource: template
+                .resource_constraint
+                .has_slot()
+                .then(|| gen_resource_link(u))
+                .transpose()?,
         })
     }
 
-    /// Add this `GeneratedLinkedPolicy` to the given `PolicySet`
+    /// Add this `GeneratedLink` to the given `PolicySet`
     pub fn add_to_policyset(self, policyset: &mut PolicySet) {
         let mut vals = IndexMap::new();
         if let Some(principal_uid) = self.principal {
@@ -675,7 +692,7 @@ impl GeneratedLinkedPolicy {
     }
 
     #[cfg(feature = "cedar-policy")]
-    /// Add this `GeneratedLinkedPolicy` to the given `cedar_policy::PolicySet`
+    /// Add this `GeneratedLink` to the given `cedar_policy::PolicySet`
     pub fn add_to_api_policyset(self, policyset: &mut cedar_policy::PolicySet) {
         let mut vals = HashMap::new();
         if let Some(principal_uid) = self.principal {

--- a/cedar-policy-generators/src/policy.rs
+++ b/cedar-policy-generators/src/policy.rs
@@ -26,19 +26,106 @@ use cedar_policy_core::ast::{
 use cedar_policy_core::{ast, est};
 use indexmap::IndexMap;
 use serde::Serialize;
+use smol_str::format_smolstr;
 use std::collections::HashMap;
 use std::fmt::Display;
 use std::sync::Arc;
 
+/// A generated static or linked policy.
+#[derive(Debug, Clone)]
+pub enum GeneratedPolicy {
+    /// Generated static policy. The `GeneratedTemplate` will not have any slots
+    Static(GeneratedTemplate),
+    /// Generated linked policy
+    Link {
+        /// Generated template which will have at least one slot
+        template: GeneratedTemplate,
+        /// Bindings for slots in `template`
+        link: GeneratedLinkedPolicy,
+    },
+}
+
+impl GeneratedPolicy {
+    /// Generate an arbitrary policy, either static or linked.
+    ///
+    /// If `allow_slots` is `false`, then this will always be a static policy.
+    pub fn arbitrary_for_hierarchy(
+        fixed_id_opt: Option<PolicyID>,
+        schema: Option<&Schema>,
+        hierarchy: &Hierarchy,
+        allow_slots: bool,
+        abac_constraints: Expr,
+        u: &mut Unstructured<'_>,
+    ) -> arbitrary::Result<Self> {
+        let template = GeneratedTemplate::arbitrary_for_hierarchy(
+            fixed_id_opt.clone(),
+            schema,
+            hierarchy,
+            allow_slots,
+            abac_constraints,
+            u,
+        )?;
+        if template.has_slots() {
+            let link_id = match fixed_id_opt {
+                Some(pid) => PolicyID::from_smolstr(format_smolstr!("link_{}", pid)),
+                None => PolicyID::from_string("l"),
+            };
+            let link = GeneratedLinkedPolicy::arbitrary(link_id, &template, hierarchy, u)?;
+            Ok(GeneratedPolicy::Link { template, link })
+        } else {
+            Ok(GeneratedPolicy::Static(template))
+        }
+    }
+
+    /// Get a `PolicySet` containing either a single static policy or a template and template linked policy.
+    #[cfg(feature = "cedar-policy")]
+    pub fn into_policy_set(self) -> cedar_policy::PolicySet {
+        let mut ps = cedar_policy::PolicySet::new();
+        match self {
+            GeneratedPolicy::Static(generated_template) => {
+                ps.add(generated_template.into()).unwrap();
+            }
+            GeneratedPolicy::Link { template, link } => {
+                let t: cedar_policy::Template = template.into();
+                let tid = t.id().clone();
+                ps.add_template(t).unwrap();
+                let mut slot_env = HashMap::new();
+                if let Some(p_link) = link.principal {
+                    slot_env.insert(cedar_policy::SlotId::principal(), p_link.into());
+                }
+                if let Some(r_link) = link.resource {
+                    slot_env.insert(cedar_policy::SlotId::resource(), r_link.into());
+                }
+                ps.link(tid, cedar_policy::PolicyId::new(link.id), slot_env)
+                    .unwrap();
+            }
+        }
+        ps
+    }
+
+    /// Get the `PolicyID` of the policy
+    pub fn id(&self) -> &PolicyID {
+        match self {
+            GeneratedPolicy::Static(generated_template) => &generated_template.id,
+            GeneratedPolicy::Link { link, .. } => &link.id,
+        }
+    }
+
+    /// Change the `PolicyID` of the policy
+    pub fn set_id(&mut self, id: PolicyID) {
+        match self {
+            GeneratedPolicy::Static(generated_template) => generated_template.set_id(id),
+            GeneratedPolicy::Link { link, .. } => {
+                link.id = id;
+            }
+        }
+    }
+}
+
 /// Data structure representing a generated policy (or template)
 #[derive(Clone, Serialize)]
-// `GeneratedPolicy` is now a bit of a misnomer: it may have slots depending on
-// how it is generated, e.g., the `allow_slots` parameter to
-// `arbitrary_for_hierarchy()`. But as of this writing, it feels like renaming
-// `GeneratedPolicy` to something like `GeneratedTemplate` seems unduly
-// disruptive.
 #[serde(into = "est::Policy")]
-pub struct GeneratedPolicy {
+pub struct GeneratedTemplate {
     id: PolicyID,
     annotations: cedar_policy_core::est::Annotations,
     effect: Effect,
@@ -48,8 +135,8 @@ pub struct GeneratedPolicy {
     abac_constraints: Expr,
 }
 
-impl GeneratedPolicy {
-    /// Create a new `GeneratedPolicy` with these fields
+impl GeneratedTemplate {
+    /// Create a new `GeneratedTemplate` with these fields
     pub fn new(
         id: PolicyID,
         annotations: cedar_policy_core::est::Annotations,
@@ -70,7 +157,7 @@ impl GeneratedPolicy {
         }
     }
 
-    /// Generate an arbitrary `GeneratedPolicy`
+    /// Generate an arbitrary `GeneratedTemplate`
     pub fn arbitrary_for_hierarchy(
         fixed_id_opt: Option<PolicyID>,
         schema: Option<&Schema>,
@@ -153,10 +240,24 @@ impl GeneratedPolicy {
             policyset.add_static(self.into()).unwrap();
         }
     }
+
+    /// Substitute bindings in `link` for slots in this template to obtain a static policy.
+    ///
+    /// You should generally prefer generating slot-free static policies
+    /// directly if you do not want templates. This is intended for obtaining a
+    /// static representation of a template, primarily for corpus test
+    /// serialization.
+    pub fn link_to_static(self, link: GeneratedLinkedPolicy) -> Self {
+        Self {
+            principal_constraint: self.principal_constraint.link_to_static(link.principal),
+            resource_constraint: self.resource_constraint.link_to_static(link.resource),
+            ..self
+        }
+    }
 }
 
-impl From<GeneratedPolicy> for StaticPolicy {
-    fn from(gen: GeneratedPolicy) -> StaticPolicy {
+impl From<GeneratedTemplate> for StaticPolicy {
+    fn from(gen: GeneratedTemplate) -> StaticPolicy {
         StaticPolicy::new(
             gen.id,
             None,
@@ -167,12 +268,12 @@ impl From<GeneratedPolicy> for StaticPolicy {
             gen.resource_constraint.into(),
             Some(gen.abac_constraints),
         )
-        .unwrap() // Will panic if the GeneratedPolicy contains a slot.
+        .unwrap() // Will panic if the GeneratedTemplate contains a slot.
     }
 }
 
-impl From<GeneratedPolicy> for Template {
-    fn from(gen: GeneratedPolicy) -> Template {
+impl From<GeneratedTemplate> for Template {
+    fn from(gen: GeneratedTemplate) -> Template {
         Template::new(
             gen.id,
             None,
@@ -186,8 +287,8 @@ impl From<GeneratedPolicy> for Template {
     }
 }
 
-impl From<GeneratedPolicy> for est::Policy {
-    fn from(gp: GeneratedPolicy) -> est::Policy {
+impl From<GeneratedTemplate> for est::Policy {
+    fn from(gp: GeneratedTemplate) -> est::Policy {
         let sp: StaticPolicy = gp.into();
         let p: Policy = sp.into();
         p.into()
@@ -195,27 +296,27 @@ impl From<GeneratedPolicy> for est::Policy {
 }
 
 #[cfg(feature = "cedar-policy")]
-impl From<GeneratedPolicy> for cedar_policy::Policy {
-    fn from(gp: GeneratedPolicy) -> Self {
+impl From<GeneratedTemplate> for cedar_policy::Policy {
+    fn from(gp: GeneratedTemplate) -> Self {
         StaticPolicy::from(gp).into()
     }
 }
 
 #[cfg(feature = "cedar-policy")]
-impl From<GeneratedPolicy> for cedar_policy::Template {
-    fn from(gp: GeneratedPolicy) -> Self {
+impl From<GeneratedTemplate> for cedar_policy::Template {
+    fn from(gp: GeneratedTemplate) -> Self {
         Template::from(gp).into()
     }
 }
 
-impl From<GeneratedPolicy> for String {
-    fn from(g: GeneratedPolicy) -> String {
+impl From<GeneratedTemplate> for String {
+    fn from(g: GeneratedTemplate) -> String {
         let t = Template::from(g);
         t.to_string()
     }
 }
 
-impl Display for GeneratedPolicy {
+impl Display for GeneratedTemplate {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let t: Template = self.clone().into();
         write!(f, "{t}")
@@ -223,7 +324,7 @@ impl Display for GeneratedPolicy {
 }
 
 // Use `Display` implentation for `Debug` so we see Cedar policy syntax in fuzz target error reports.
-impl std::fmt::Debug for GeneratedPolicy {
+impl std::fmt::Debug for GeneratedTemplate {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{self}")
     }
@@ -261,6 +362,35 @@ impl PrincipalOrResourceConstraint {
             PrincipalOrResourceConstraint::IsType(_) => false,
             PrincipalOrResourceConstraint::IsTypeIn(_, _) => false,
             PrincipalOrResourceConstraint::IsTypeInSlot(_) => true,
+        }
+    }
+
+    fn link_to_static(self, binding: Option<EntityUID>) -> Self {
+        match self {
+            constraint @ (PrincipalOrResourceConstraint::NoConstraint
+            | PrincipalOrResourceConstraint::Eq(_)
+            | PrincipalOrResourceConstraint::In(_)
+            | PrincipalOrResourceConstraint::IsType(_)
+            | PrincipalOrResourceConstraint::IsTypeIn(_, _)) => {
+                assert!(
+                    binding.is_none(),
+                    "unexpected binding for constraint without slot"
+                );
+                constraint
+            }
+
+            PrincipalOrResourceConstraint::EqSlot => PrincipalOrResourceConstraint::Eq(
+                binding.expect("missing slot binding for constraint with slot"),
+            ),
+            PrincipalOrResourceConstraint::InSlot => PrincipalOrResourceConstraint::In(
+                binding.expect("missing slot binding for constraint with slot"),
+            ),
+            PrincipalOrResourceConstraint::IsTypeInSlot(entity_type) => {
+                PrincipalOrResourceConstraint::IsTypeIn(
+                    entity_type,
+                    binding.expect("missing slot binding for constraint with slot"),
+                )
+            }
         }
     }
 }
@@ -521,7 +651,7 @@ impl GeneratedLinkedPolicy {
     /// Generate an arbitrary `GeneratedLinkedPolicy` from the given template
     pub fn arbitrary(
         id: PolicyID,
-        template: &GeneratedPolicy,
+        template: &GeneratedTemplate,
         hierarchy: &Hierarchy,
         u: &mut Unstructured<'_>,
     ) -> Result<Self> {

--- a/cedar-policy-generators/src/policy_set.rs
+++ b/cedar-policy-generators/src/policy_set.rs
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 use crate::hierarchy::Hierarchy;
-use crate::policy::GeneratedPolicy;
+use crate::policy::GeneratedTemplate;
 use crate::schema::Schema;
+use crate::schema_gen::SchemaGen;
 use arbitrary::Unstructured;
 use cedar_policy_core::ast;
 use cedar_policy_core::ast::PolicyID;
@@ -30,7 +31,7 @@ const MAX_LENGTH: usize = 6;
 
 /// Data structure representing a set of generated templates and static policies.
 #[derive(Debug, Clone, Serialize)]
-pub struct GeneratedPolicySet(Vec<GeneratedPolicy>);
+pub struct GeneratedPolicySet(Vec<GeneratedTemplate>);
 
 impl GeneratedPolicySet {
     /// Generate an arbitrary [`GeneratedPolicySet`]
@@ -41,13 +42,13 @@ impl GeneratedPolicySet {
     ) -> arbitrary::Result<Self> {
         let mut ids: HashSet<PolicyID> = HashSet::new();
         let len = u.int_in_range(MIN_LENGTH..=MAX_LENGTH)?;
-        let mut policies: Vec<GeneratedPolicy> = Vec::with_capacity(len);
+        let mut policies: Vec<GeneratedTemplate> = Vec::with_capacity(len);
         for _ in 0..len {
             let id: PolicyID = u.arbitrary()?;
             // Skip duplicate IDs
             if ids.insert(id.clone()) {
                 let abac_constraints = schema.arbitrary_abac_constraints(hierarchy, u)?;
-                let policy = GeneratedPolicy::arbitrary_for_hierarchy(
+                let policy = GeneratedTemplate::arbitrary_for_hierarchy(
                     Some(id),
                     Some(schema),
                     hierarchy,

--- a/cedar-policy-generators/src/rbac.rs
+++ b/cedar-policy-generators/src/rbac.rs
@@ -15,7 +15,7 @@
  */
 
 use crate::hierarchy::Hierarchy;
-use crate::policy::GeneratedPolicy;
+use crate::policy::GeneratedTemplate;
 use crate::request::Request;
 use arbitrary::{self, Unstructured};
 use ast::{Entity, Expr, PolicyID, StaticPolicy, Template};
@@ -158,17 +158,17 @@ impl From<RBACEntity> for cedar_policy::Entity {
 /// Represents an RBAC policy, ie, with no `when` or `unless` clauses
 #[derive(Debug, Clone, Serialize)]
 #[serde(transparent)]
-pub struct RBACPolicy(pub GeneratedPolicy);
+pub struct RBACPolicy(pub GeneratedTemplate);
 
 impl Deref for RBACPolicy {
-    type Target = GeneratedPolicy;
-    fn deref(&self) -> &GeneratedPolicy {
+    type Target = GeneratedTemplate;
+    fn deref(&self) -> &GeneratedTemplate {
         &self.0
     }
 }
 
 impl DerefMut for RBACPolicy {
-    fn deref_mut(&mut self) -> &mut GeneratedPolicy {
+    fn deref_mut(&mut self) -> &mut GeneratedTemplate {
         &mut self.0
     }
 }
@@ -207,7 +207,7 @@ impl RBACPolicy {
         allow_slots: bool,
         u: &mut Unstructured<'_>,
     ) -> arbitrary::Result<Self> {
-        Ok(Self(GeneratedPolicy::arbitrary_for_hierarchy(
+        Ok(Self(GeneratedTemplate::arbitrary_for_hierarchy(
             fixed_id_opt,
             None,
             hierarchy,
@@ -223,7 +223,7 @@ impl RBACPolicy {
         allow_slots: bool,
         depth: usize,
     ) -> (usize, Option<usize>) {
-        GeneratedPolicy::arbitrary_for_hierarchy_size_hint(have_fixed_id, allow_slots, depth)
+        GeneratedTemplate::arbitrary_for_hierarchy_size_hint(have_fixed_id, allow_slots, depth)
     }
 }
 

--- a/cedar-policy-generators/src/schema.rs
+++ b/cedar-policy-generators/src/schema.rs
@@ -1469,7 +1469,7 @@ impl Schema {
         })
     }
 
-    /// Size hint for [`Self::arbitrary_abac_constraints()`].
+    /// Size hint for [`SchemaGen::arbitrary_abac_constraints`].
     pub fn arbitrary_abac_constraints_size_hint(_depth: usize) -> (usize, Option<usize>) {
         // not sure how to count the arbitrary_loop() call
         (1, None)

--- a/cedar-policy-generators/src/schema.rs
+++ b/cedar-policy-generators/src/schema.rs
@@ -15,15 +15,12 @@
  */
 
 use crate::abac::{
-    ABACPolicy, ABACRequest, AvailableExtensionFunctions, ConstantPool, QualifiedType, Type,
-    UnknownPool,
+    ABACRequest, AvailableExtensionFunctions, ConstantPool, QualifiedType, Type, UnknownPool,
 };
 use crate::err::{while_doing, Error, Result};
 use crate::expr::ExprGenerator;
 use crate::hierarchy::Hierarchy;
-use crate::policy::GeneratedPolicy;
 use crate::request::Request;
-use crate::schema_gen::SchemaGen;
 use crate::settings::ABACSettings;
 use crate::size_hint_utils::{size_hint_for_choose, size_hint_for_range, size_hint_for_ratio};
 use arbitrary::{self, Arbitrary, MaxRecursionReached, Unstructured};
@@ -1470,56 +1467,6 @@ impl Schema {
                 e,
             )
         })
-    }
-
-    /// get an arbitrary policy conforming to this schema
-    pub fn arbitrary_policy(
-        &self,
-        hierarchy: &Hierarchy,
-        u: &mut Unstructured<'_>,
-    ) -> Result<ABACPolicy> {
-        let id = u.arbitrary()?;
-        let effect = u.arbitrary()?;
-        let principal_constraint = self.arbitrary_principal_constraint(hierarchy, u)?;
-        let action_constraint = self.arbitrary_action_constraint(u, Some(3))?;
-        let resource_constraint = self.arbitrary_resource_constraint(hierarchy, u)?;
-        let conjunction = self.arbitrary_abac_constraints(hierarchy, u)?;
-        Ok(ABACPolicy(GeneratedPolicy::new(
-            id,
-            u.arbitrary()?,
-            effect,
-            principal_constraint,
-            action_constraint,
-            resource_constraint,
-            conjunction,
-        )))
-    }
-
-    /// Generates arbitrary non-scope constraints
-    pub fn arbitrary_abac_constraints(
-        &self,
-        hierarchy: &Hierarchy,
-        u: &mut Unstructured<'_>,
-    ) -> Result<ast::Expr> {
-        let mut abac_constraints = Vec::new();
-        let mut exprgenerator = self.exprgenerator(Some(hierarchy));
-        u.arbitrary_loop(Some(0), Some(self.settings.max_depth as u32), |u| {
-            if self.settings.match_types {
-                abac_constraints.push(exprgenerator.generate_expr_for_type(
-                    &Type::bool(),
-                    self.settings.max_depth,
-                    u,
-                )?);
-            } else {
-                abac_constraints.push(exprgenerator.generate_expr(self.settings.max_depth, u)?);
-            }
-            Ok(std::ops::ControlFlow::Continue(()))
-        })?;
-        let mut conjunction = ast::Expr::val(true);
-        for constraint in abac_constraints {
-            conjunction = ast::Expr::and(conjunction, constraint);
-        }
-        Ok(conjunction)
     }
 
     /// Size hint for [`Self::arbitrary_abac_constraints()`].

--- a/cedar-policy-generators/src/schema_gen.rs
+++ b/cedar-policy-generators/src/schema_gen.rs
@@ -9,7 +9,7 @@ use crate::{
     expr::ExprGenerator,
     hierarchy::{Hierarchy, HierarchyGenerator, HierarchyGeneratorMode, NumEntities},
     policy::{
-        ActionConstraint, GeneratedLinkedPolicy, GeneratedPolicy, GeneratedTemplate,
+        ActionConstraint, GeneratedLink, GeneratedPolicy, GeneratedTemplate,
         PrincipalOrResourceConstraint,
     },
     request::Request,
@@ -146,8 +146,20 @@ pub trait SchemaGen: std::fmt::Debug {
         let template = self.arbitrary_template(hierarchy, true, u)?;
         let policy = if template.has_slots() {
             let link_id = PolicyID::from_smolstr(format_smolstr!("link_{}", template.id()));
-            let link = GeneratedLinkedPolicy::arbitrary(link_id, &template, hierarchy, u)?;
-            GeneratedPolicy::Link { template, link }
+            let link = GeneratedLink::arbitrary(
+                link_id,
+                &template,
+                |u| {
+                    self.exprgenerator(Some(hierarchy))
+                        .arbitrary_principal_uid(u)
+                },
+                |u| {
+                    self.exprgenerator(Some(hierarchy))
+                        .arbitrary_resource_uid(u)
+                },
+                u,
+            )?;
+            GeneratedPolicy::Linked { template, link }
         } else {
             GeneratedPolicy::Static(template)
         };

--- a/cedar-policy-generators/src/schema_gen.rs
+++ b/cedar-policy-generators/src/schema_gen.rs
@@ -155,7 +155,7 @@ pub trait SchemaGen: std::fmt::Debug {
     }
     /// Get an arbitrary unlinked template conforming to this schema.
     ///
-    /// If `with_slots` is false, then the template will not have any slots and
+    /// If `allow_slots` is false, then the template will not have any slots and
     /// can be used to construct a static policy (though you should prefer
     /// calling `arbitrary_static_policy` directly).
     fn arbitrary_template(

--- a/cedar-policy-generators/src/schema_gen.rs
+++ b/cedar-policy-generators/src/schema_gen.rs
@@ -3,12 +3,15 @@ use std::collections::BTreeMap;
 use crate::{
     abac::{
         self, ABACPolicy, ABACRequest, AvailableExtensionFunctions, ConstantPool, QualifiedType,
-        UnknownPool,
+        StaticABACPolicy, UnknownPool,
     },
     err::{while_doing, Error, Result},
     expr::ExprGenerator,
     hierarchy::{Hierarchy, HierarchyGenerator, HierarchyGeneratorMode, NumEntities},
-    policy::{ActionConstraint, GeneratedPolicy, PrincipalOrResourceConstraint},
+    policy::{
+        ActionConstraint, GeneratedLinkedPolicy, GeneratedPolicy, GeneratedTemplate,
+        PrincipalOrResourceConstraint,
+    },
     request::Request,
     schema::Schema,
     settings::ABACSettings,
@@ -16,7 +19,7 @@ use crate::{
 };
 use arbitrary::Unstructured;
 use cedar_policy_core::{
-    ast::{self, Eid, EntityType},
+    ast::{self, Eid, EntityType, EntityUID, PolicyID},
     extensions::Extensions,
     validator::{
         types::{self, OpenTag},
@@ -25,7 +28,7 @@ use cedar_policy_core::{
 };
 use indexmap::IndexMap;
 use nonempty::NonEmpty;
-use smol_str::SmolStr;
+use smol_str::{format_smolstr, SmolStr};
 
 impl From<types::Type> for abac::Type {
     fn from(ty: types::Type) -> Self {
@@ -71,7 +74,7 @@ impl From<types::Type> for abac::Type {
 /// A trait that specifies what methods other generators expect from a schema
 pub trait SchemaGen: std::fmt::Debug {
     /// Gen all entity types
-    fn entity_types(&self) -> Box<dyn Iterator<Item = EntityType> + '_>;
+    fn entity_types(&self) -> Box<dyn ExactSizeIterator<Item = EntityType> + '_>;
     /// Get an arbitrary entity type
     fn arbitrary_entity_type(&self, u: &mut Unstructured<'_>) -> Result<EntityType>;
     /// Get an arbitrary attribute
@@ -124,19 +127,51 @@ pub trait SchemaGen: std::fmt::Debug {
     fn type_generator<'s>(&'s self) -> TypeGenerator<'s>;
     /// Get an arbitrary Hierarchy conforming to the schema.
     fn arbitrary_hierarchy(&self, u: &mut Unstructured<'_>) -> Result<Hierarchy>;
-    /// get an arbitrary policy conforming to this schema
+    /// get an arbitrary static policy conforming to this schema
+    fn arbitrary_static_policy(
+        &self,
+        hierarchy: &Hierarchy,
+        u: &mut Unstructured<'_>,
+    ) -> Result<StaticABACPolicy> {
+        Ok(StaticABACPolicy(
+            self.arbitrary_template(hierarchy, false, u)?,
+        ))
+    }
+    /// get an arbitrary static or linked policy conforming to this schema
     fn arbitrary_policy(
         &self,
         hierarchy: &Hierarchy,
         u: &mut Unstructured<'_>,
     ) -> Result<ABACPolicy> {
+        let template = self.arbitrary_template(hierarchy, true, u)?;
+        let policy = if template.has_slots() {
+            let link_id = PolicyID::from_smolstr(format_smolstr!("link_{}", template.id()));
+            let link = GeneratedLinkedPolicy::arbitrary(link_id, &template, hierarchy, u)?;
+            GeneratedPolicy::Link { template, link }
+        } else {
+            GeneratedPolicy::Static(template)
+        };
+        Ok(ABACPolicy(policy))
+    }
+    /// Get an arbitrary unlinked template conforming to this schema.
+    ///
+    /// If `with_slots` is false, then the template will not have any slots and
+    /// can be used to construct a static policy (though you should prefer
+    /// calling `arbitrary_static_policy` directly).
+    fn arbitrary_template(
+        &self,
+        hierarchy: &Hierarchy,
+        allow_slots: bool,
+        u: &mut Unstructured<'_>,
+    ) -> Result<GeneratedTemplate> {
         let id = u.arbitrary()?;
         let effect = u.arbitrary()?;
-        let principal_constraint = self.arbitrary_principal_constraint(hierarchy, u)?;
+        let principal_constraint =
+            self.arbitrary_principal_constraint(hierarchy, allow_slots, u)?;
         let action_constraint = self.arbitrary_action_constraint(u, Some(3))?;
-        let resource_constraint = self.arbitrary_resource_constraint(hierarchy, u)?;
+        let resource_constraint = self.arbitrary_resource_constraint(hierarchy, allow_slots, u)?;
         let conjunction = self.arbitrary_abac_constraints(hierarchy, u)?;
-        Ok(ABACPolicy(GeneratedPolicy::new(
+        Ok(GeneratedTemplate::new(
             id,
             u.arbitrary()?,
             effect,
@@ -144,31 +179,20 @@ pub trait SchemaGen: std::fmt::Debug {
             action_constraint,
             resource_constraint,
             conjunction,
-        )))
+        ))
     }
     /// Generate an arbitrary principal constraint
     fn arbitrary_principal_constraint(
         &self,
         hierarchy: &Hierarchy,
+        allow_slots: bool,
         u: &mut Unstructured<'_>,
     ) -> Result<PrincipalOrResourceConstraint> {
-        // 20% of the time, NoConstraint
-        if u.ratio(1, 5)? {
-            Ok(PrincipalOrResourceConstraint::NoConstraint)
-        } else {
-            // 32% Eq, 16% In, 16% Is, 16% IsIn
-            let uid = self
-                .exprgenerator(Some(hierarchy))
-                .arbitrary_principal_uid(u)?;
-            let entity_types: Vec<_> = self.entity_types().collect();
-            let ety = u.choose(&entity_types)?.clone();
-            gen!(u,
-                2 => Ok(PrincipalOrResourceConstraint::Eq(uid)),
-                1 => Ok(PrincipalOrResourceConstraint::In(uid)),
-                1 => Ok(PrincipalOrResourceConstraint::IsType(ety)),
-                1 => Ok(PrincipalOrResourceConstraint::IsTypeIn(ety, uid))
-            )
-        }
+        let choose_uid = |u: &mut Unstructured<'_>| {
+            self.exprgenerator(Some(hierarchy))
+                .arbitrary_principal_uid(u)
+        };
+        self.arbitrary_principal_or_resource_constraint(&choose_uid, allow_slots, u)
     }
     /// Generates an arbitrary action constraint.
     fn arbitrary_action_constraint(
@@ -201,24 +225,45 @@ pub trait SchemaGen: std::fmt::Debug {
     fn arbitrary_resource_constraint(
         &self,
         hierarchy: &Hierarchy,
+        allow_slots: bool,
+        u: &mut Unstructured<'_>,
+    ) -> Result<PrincipalOrResourceConstraint> {
+        let choose_uid = |u: &mut Unstructured<'_>| {
+            self.exprgenerator(Some(hierarchy))
+                .arbitrary_resource_uid(u)
+        };
+        self.arbitrary_principal_or_resource_constraint(&choose_uid, allow_slots, u)
+    }
+    /// Generate an arbitrary principal or resource constraint with entity uids drawn from `uid_gen`
+    fn arbitrary_principal_or_resource_constraint(
+        &self,
+        uid_gen: &dyn Fn(&mut Unstructured<'_>) -> Result<EntityUID>,
+        allow_slots: bool,
         u: &mut Unstructured<'_>,
     ) -> Result<PrincipalOrResourceConstraint> {
         // 20% of the time, NoConstraint
         if u.ratio(1, 5)? {
             Ok(PrincipalOrResourceConstraint::NoConstraint)
         } else {
-            // 32% Eq, 16% In, 16% Is, 16% IsIn
-            let uid = self
-                .exprgenerator(Some(hierarchy))
-                .arbitrary_resource_uid(u)?;
-            let entity_types: Vec<_> = self.entity_types().collect();
-            let ety = u.choose(&entity_types)?.clone();
-            gen!(u,
-                2 => Ok(PrincipalOrResourceConstraint::Eq(uid)),
-                1 => Ok(PrincipalOrResourceConstraint::In(uid)),
-                1 => Ok(PrincipalOrResourceConstraint::IsType(ety)),
-                1 => Ok(PrincipalOrResourceConstraint::IsTypeIn(ety, uid))
-            )
+            let choose_ety = |u: &mut Unstructured<'_>| u.choose_iter(self.entity_types());
+            // If slots are allowed, then generate a slot 50% of the time.
+            if allow_slots && u.ratio(1, 2)? {
+                // 40% Eq, 40% In or IsIn.
+                // Don't generate `Is` on its own because it can't have a slot.
+                gen!(u,
+                    2 => Ok(PrincipalOrResourceConstraint::EqSlot),
+                    1 => Ok(PrincipalOrResourceConstraint::InSlot),
+                    1 => Ok(PrincipalOrResourceConstraint::IsTypeInSlot(choose_ety(u)?))
+                )
+            } else {
+                // 32% Eq, 16% In, 16% Is, 16% IsIn
+                gen!(u,
+                    2 => Ok(PrincipalOrResourceConstraint::Eq(uid_gen(u)?)),
+                    1 => Ok(PrincipalOrResourceConstraint::In(uid_gen(u)?)),
+                    1 => Ok(PrincipalOrResourceConstraint::IsType(choose_ety(u)?)),
+                    1 => Ok(PrincipalOrResourceConstraint::IsTypeIn(choose_ety(u)?, uid_gen(u)?))
+                )
+            }
         }
     }
     /// Generates arbitrary non-scope constraints
@@ -404,7 +449,7 @@ impl SchemaGen for ValidatorSchema<'_> {
                 cedar_policy_core::validator::ValidatorEntityTypeKind::Standard(_) => None,
             })
     }
-    fn entity_types(&self) -> Box<dyn Iterator<Item = EntityType> + '_> {
+    fn entity_types(&self) -> Box<dyn ExactSizeIterator<Item = EntityType> + '_> {
         Box::new(self.entity_types.clone().into_iter())
     }
     fn allowed_parent_typenames(
@@ -570,7 +615,7 @@ impl SchemaGen for Schema {
     fn get_uid_enum_choices(&self, ty: &ast::EntityType) -> Option<&NonEmpty<Eid>> {
         self.get_uid_enum_choices(ty)
     }
-    fn entity_types(&self) -> Box<dyn Iterator<Item = EntityType> + '_> {
+    fn entity_types(&self) -> Box<dyn ExactSizeIterator<Item = EntityType> + '_> {
         Box::new(self.entity_types.clone().into_iter())
     }
     fn allowed_parent_typenames(


### PR DESCRIPTION
Enhances policy generation to generate template linked policies instead of only generating static policies. Impacts a lot of fuzz targets. I've run a few targets locally to check that it works (links are generated, and it doesn't immediately crash), but this touches a lot of targets, so we might see something go wrong on the first nightly test run.

On the lean side, the bindings for template slots get substituted before evaluation. For Rust side, we construct a policy set containing a single template with a single link against that template. Most targets were already written using a `PolicySet` containing a single policy, so this didn't require major changes to fuzz targets.

Some fuzz targets still generate only static policies. This includes all symcc targets (the symcc implementations does not support links) and some formatting/roundtrip targets (can't support links if they go through cedar policy text, but should be extended to fuzz unlinked templates)  

Fixes #36 

