### PR TITLE
Add fuzz target using abstract policies to test TPE authorization

### DIFF
--- a/cedar-drt/fuzz/Cargo.toml
+++ b/cedar-drt/fuzz/Cargo.toml
@@ -233,6 +233,12 @@ test = false
 doc = false
 
 [[bin]]
+name = "tpe-is-authorized-abstract-drt"
+path = "fuzz_targets/tpe-is-authorized-abstract-drt.rs"
+test = false
+doc = false
+
+[[bin]]
 name = "tpe-pbt"
 path = "fuzz_targets/tpe-pbt.rs"
 test = false

--- a/cedar-drt/fuzz/fuzz_targets/tpe-is-authorized-abstract-drt.rs
+++ b/cedar-drt/fuzz/fuzz_targets/tpe-is-authorized-abstract-drt.rs
@@ -5,8 +5,7 @@ use std::sync::LazyLock;
 use cedar_drt_inner::tpe::test_tpe_is_authorized_equiv;
 use cedar_lean_ffi::CedarLeanFfi;
 use cedar_policy::{
-    PartialEntities, PartialEntityUid, PartialRequest, Policy, PolicyId, PolicySet,
-    Schema,
+    PartialEntities, PartialEntityUid, PartialRequest, Policy, PolicyId, PolicySet, Schema,
 };
 use libfuzzer_sys::{
     arbitrary::{self, Arbitrary},
@@ -62,7 +61,7 @@ mod concrete_policies {
     pub static PERMIT_RESIDUAL: LazyLock<Policy> = LazyLock::new(|| {
         Policy::parse(
             None,
-            "permit(principal, action, resource) when {{ principal.is_admin };",
+            "permit(principal, action, resource) when { principal.is_admin };",
         )
         .expect("should be a valid policy")
     });
@@ -91,7 +90,7 @@ mod concrete_policies {
     pub static FORBID_RESIDUAL: LazyLock<Policy> = LazyLock::new(|| {
         Policy::parse(
             None,
-            "forbid(principal, action, resource) when {{ principal.is_admin };",
+            "forbid(principal, action, resource) when { principal.is_admin };",
         )
         .expect("should be a valid policy")
     });

--- a/cedar-drt/fuzz/fuzz_targets/tpe-is-authorized-abstract-drt.rs
+++ b/cedar-drt/fuzz/fuzz_targets/tpe-is-authorized-abstract-drt.rs
@@ -1,0 +1,155 @@
+#![no_main]
+
+use std::sync::LazyLock;
+
+use cedar_drt_inner::tpe::test_tpe_is_authorized_equiv;
+use cedar_lean_ffi::CedarLeanFfi;
+use cedar_policy::{
+    PartialEntities, PartialEntityUid, PartialRequest, Policy, PolicyId, PolicySet,
+    Schema,
+};
+use libfuzzer_sys::{
+    arbitrary::{self, Arbitrary},
+    fuzz_target,
+};
+use smol_str::format_smolstr;
+
+#[derive(Arbitrary, Debug, PartialEq, Eq, Clone)]
+enum AbstractPolicy {
+    /// Permit policy that evaluates 'true'
+    PermitTrue,
+    /// Permit policy that evaluates 'false'
+    PermitFalse,
+    /// Permit policy that errors
+    PermitError,
+    /// Permit policy that leaves a residual
+    PermitResidual,
+    /// Forbid policy that evaluates 'true'
+    ForbidTrue,
+    /// Forbid policy that evaluates 'false'
+    ForbidFalse,
+    /// Forbid policy that evaluates 'error'
+    ForbidError,
+    /// Forbid policy that leaves a residual
+    ForbidResidual,
+}
+
+mod concrete_policies {
+    use cedar_policy::Policy;
+    use std::sync::LazyLock;
+
+    pub static PERMIT_TRUE: LazyLock<Policy> = LazyLock::new(|| {
+        Policy::parse(None, "permit(principal, action, resource);")
+            .expect("should be a valid policy")
+    });
+
+    pub static PERMIT_FALSE: LazyLock<Policy> = LazyLock::new(|| {
+        Policy::parse(None, "permit(principal, action, resource) when { 1 == 0 };")
+            .expect("should be a valid policy")
+    });
+
+    pub static PERMIT_ERROR: LazyLock<Policy> = LazyLock::new(|| {
+        Policy::parse(
+            None,
+            &format!(
+                "permit(principal, action, resource) when {{ ({} + 1) == 0 }};",
+                i64::MAX
+            ),
+        )
+        .expect("should be a valid policy")
+    });
+
+    pub static PERMIT_RESIDUAL: LazyLock<Policy> = LazyLock::new(|| {
+        Policy::parse(
+            None,
+            "permit(principal, action, resource) when {{ principal.is_admin };",
+        )
+        .expect("should be a valid policy")
+    });
+
+    pub static FORBID_TRUE: LazyLock<Policy> = LazyLock::new(|| {
+        Policy::parse(None, "forbid(principal, action, resource);")
+            .expect("should be a valid policy")
+    });
+
+    pub static FORBID_FALSE: LazyLock<Policy> = LazyLock::new(|| {
+        Policy::parse(None, "forbid(principal, action, resource) when { 1 == 0 };")
+            .expect("should be a valid policy")
+    });
+
+    pub static FORBID_ERROR: LazyLock<Policy> = LazyLock::new(|| {
+        Policy::parse(
+            None,
+            &format!(
+                "forbid(principal, action, resource) when {{ ({} + 1) == 0 }};",
+                i64::MAX
+            ),
+        )
+        .expect("should be a valid policy")
+    });
+
+    pub static FORBID_RESIDUAL: LazyLock<Policy> = LazyLock::new(|| {
+        Policy::parse(
+            None,
+            "forbid(principal, action, resource) when {{ principal.is_admin };",
+        )
+        .expect("should be a valid policy")
+    });
+}
+
+impl AbstractPolicy {
+    /// Convert the `AbstractPolicy` into a `Policy` with the given `id`
+    fn into_policy(self, id: PolicyId) -> Policy {
+        match self {
+            AbstractPolicy::PermitTrue => concrete_policies::PERMIT_TRUE.new_id(id),
+            AbstractPolicy::PermitFalse => concrete_policies::PERMIT_FALSE.new_id(id),
+            AbstractPolicy::PermitError => concrete_policies::PERMIT_ERROR.new_id(id),
+            AbstractPolicy::PermitResidual => concrete_policies::PERMIT_RESIDUAL.new_id(id),
+            AbstractPolicy::ForbidTrue => concrete_policies::FORBID_TRUE.new_id(id),
+            AbstractPolicy::ForbidFalse => concrete_policies::FORBID_FALSE.new_id(id),
+            AbstractPolicy::ForbidError => concrete_policies::FORBID_ERROR.new_id(id),
+            AbstractPolicy::ForbidResidual => concrete_policies::FORBID_RESIDUAL.new_id(id),
+        }
+    }
+}
+
+#[derive(Arbitrary, Debug)]
+pub struct AbstractAuthorizerInput {
+    policies: Vec<AbstractPolicy>,
+}
+
+static SCHEMA: LazyLock<Schema> = LazyLock::new(|| {
+    Schema::from_cedarschema_str("entity E; action A appliesTo {principal: E, resource: E};")
+        .unwrap()
+        .0
+});
+
+static REQUEST: LazyLock<PartialRequest> = LazyLock::new(|| {
+    PartialRequest::new(
+        PartialEntityUid::from_concrete("E::\"0\"".parse().unwrap()),
+        "Action::\"A\"".parse().expect("should be valid"),
+        PartialEntityUid::from_concrete("E::\"1\"".parse().unwrap()),
+        None,
+        &SCHEMA,
+    )
+    .unwrap()
+});
+
+fuzz_target!(|input: AbstractAuthorizerInput| {
+    let policyset = PolicySet::from_policies(
+        input
+            .policies
+            .into_iter()
+            .enumerate()
+            .map(|(idx, p)| p.into_policy(PolicyId::new(format_smolstr!("p{idx}")))),
+    )
+    .unwrap();
+    let ffi = CedarLeanFfi::new();
+    test_tpe_is_authorized_equiv(
+        &ffi,
+        &SCHEMA,
+        &policyset,
+        &REQUEST,
+        &PartialEntities::empty(),
+    );
+});

--- a/cedar-drt/fuzz/fuzz_targets/tpe-is-authorized-drt.rs
+++ b/cedar-drt/fuzz/fuzz_targets/tpe-is-authorized-drt.rs
@@ -21,136 +21,15 @@
 use cedar_drt::logger::initialize_log;
 use cedar_drt_inner::{
     fuzz_target,
-    tpe::{TpeFuzzTargetInput, passes_policyset_validation, passes_request_validation},
+    tpe::{
+        TpeFuzzTargetInput, passes_policyset_validation, passes_request_validation,
+        test_tpe_is_authorized_equiv,
+    },
 };
 use cedar_lean_ffi::CedarLeanFfi;
-use cedar_policy::{
-    PartialEntities, PartialRequest, Policy, PolicyId, PolicySet, Request, Schema, Validator,
-    pst::{Clause, Expr, UnaryOp},
-};
+use cedar_policy::{Policy, PolicySet, Request, Schema, Validator};
 use log::debug;
 use std::convert::TryFrom;
-use std::{collections::HashSet, sync::Arc};
-
-/// Compare Rust and Lean TPE outputs for a single partial request.
-fn test_tpe_is_authorized_equiv(
-    ffi: &CedarLeanFfi,
-    schema: &Schema,
-    policies: &PolicySet,
-    partial_request: &PartialRequest,
-    partial_entities: &PartialEntities,
-) {
-    // Run Rust TPE
-    let maybe_rust_resp = policies.tpe(partial_request, partial_entities, schema);
-
-    // Run Lean TPE
-    let maybe_lean_resp =
-        ffi.is_authorized_partial(policies, partial_request, partial_entities, schema);
-
-    let (rust_resp, lean_resp) = match (maybe_rust_resp, maybe_lean_resp) {
-        (Ok(r), Ok(l)) => (r, l),
-        (Err(_), Err(_)) => return,
-        (Ok(r), Err(e)) => panic!(
-            "Got Lean TPE error, but Rust returned response.\nRust: {:?}\n, Lean: {}",
-            r, e
-        ),
-        (Err(e), Ok(l)) => panic!(
-            "Got Rust TPE error, but Lean returned response.\nRust: {}\n, Lean: {:?}",
-            e, l
-        ),
-    };
-
-    let rust_inner = rust_resp.as_ref();
-
-    // Compare decisions
-    assert_eq!(
-        rust_inner.decision(),
-        lean_resp.decision,
-        "TPE decision mismatch"
-    );
-
-    // Compare policy categorizations (comparing sets of policy IDs)
-    let to_set =
-        |iter: Box<dyn Iterator<Item = &cedar_policy_core::tpe::response::ResidualPolicy> + '_>| {
-            iter.map(|p| PolicyId::new(p.get_policy_id().as_ref()))
-                .collect::<HashSet<PolicyId>>()
-        };
-    // The satisified forbids/permits match.
-    assert_eq!(
-        to_set(Box::new(rust_inner.satisfied_permits())),
-        lean_resp.satisfied_permits,
-        "satisfied_permits mismatch"
-    );
-    assert_eq!(
-        to_set(Box::new(rust_inner.satisfied_forbids())),
-        lean_resp.satisfied_forbids,
-        "satisfied_forbids mismatch"
-    );
-    // Rust only returns false_permits, which should be the union of the
-    // false_permits and error_permits of the Lean side.
-    assert_eq!(
-        to_set(Box::new(rust_inner.false_permits())),
-        &lean_resp.false_permits | &lean_resp.error_permits,
-        "rust false_permits mismatch with false permits union error permits"
-    );
-    // Same for the false_forbids and error_forbids. The Rust side puts the policy ID
-    // in false_forbids for all Effect::Forbid policies that result in false or error.
-    assert_eq!(
-        to_set(Box::new(rust_inner.false_forbids())),
-        &lean_resp.false_forbids | &lean_resp.error_forbids,
-        "rust false_forbids mismatch with false forbids union error forbids"
-    );
-    // The policies with residuals match on both sides.
-    assert_eq!(
-        to_set(Box::new(rust_inner.residual_permits())),
-        lean_resp.residual_permits,
-        "residual_permits mismatch"
-    );
-    assert_eq!(
-        to_set(Box::new(rust_inner.residual_forbids())),
-        lean_resp.residual_forbids,
-        "residual_forbids mismatch"
-    );
-
-    // Compare residual expressions by policy ID via PST
-    let rust_residual_map: std::collections::HashMap<String, Expr> = rust_resp
-        .residual_policies()
-        .map(|rp| {
-            let id: String = rp.id().to_string();
-            let pst = rp
-                .to_pst()
-                .expect("policy->pst conversion should succeeed for residuals");
-            // Residual should only have one clause
-            let clause = match pst.body().clauses().as_slice() {
-                [Clause::When(x)] => x.clone(),
-                [Clause::Unless(x)] => Arc::new(Expr::UnaryOp {
-                    op: UnaryOp::Not,
-                    expr: x.clone(),
-                }),
-                _ => panic!(""),
-            };
-            (id, Arc::unwrap_or_clone(clause))
-        })
-        .collect();
-
-    for lean_rp in &lean_resp.residuals {
-        let lean_pst = Expr::try_from(lean_rp.residual.clone())
-            .expect("lean residual->pst conversion should succeed");
-        let id_str = lean_rp.id.to_string();
-        let rust_pst = rust_residual_map.get(&id_str).unwrap_or_else(|| {
-            panic!(
-                "Lean returned residual for policy {id_str:?} but Rust did not.\n\
-                 Rust residual IDs: {:?}",
-                rust_residual_map.keys().collect::<Vec<_>>()
-            )
-        });
-        assert_eq!(
-            rust_pst, &lean_pst,
-            "Residual expression mismatch for policy {id_str:?}\n\
-             Rust PST: {rust_pst:?}\nLean PST: {lean_pst:?}"
-        );
-    }
-}
 
 fuzz_target!(|input: TpeFuzzTargetInput| {
     initialize_log();

--- a/cedar-drt/fuzz/src/tpe.rs
+++ b/cedar-drt/fuzz/src/tpe.rs
@@ -16,9 +16,11 @@
 
 //! Test utilities for type-directed partial evaluation fuzz targets
 
+use cedar_lean_ffi::CedarLeanFfi;
+use cedar_policy::pst::{Clause, Expr, UnaryOp};
 use cedar_policy::{
     Entity, EntityId, EntityUid, PartialEntities, PartialEntity, PartialEntityUid, PartialRequest,
-    PolicySet, Request, Schema, Validator,
+    PolicyId, PolicySet, Request, Schema, Validator,
 };
 use cedar_policy_core::ast::{self, Value};
 use cedar_policy_generators::abac::ABACRequest;
@@ -26,6 +28,7 @@ use libfuzzer_sys::arbitrary::{self, Arbitrary, Unstructured};
 use ref_cast::RefCast;
 use std::collections::{BTreeMap, HashSet};
 use std::convert::TryFrom;
+use std::sync::Arc;
 
 use crate::abac;
 
@@ -190,4 +193,124 @@ pub fn passes_request_validation(validator: &Validator, request: &Request) -> bo
         Some(validator.schema()),
     )
     .is_ok()
+}
+
+/// Compare Rust and Lean TPE outputs for a single partial request.
+pub fn test_tpe_is_authorized_equiv(
+    ffi: &CedarLeanFfi,
+    schema: &Schema,
+    policies: &PolicySet,
+    partial_request: &PartialRequest,
+    partial_entities: &PartialEntities,
+) {
+    // Run Rust TPE
+    let maybe_rust_resp = policies.tpe(partial_request, partial_entities, schema);
+
+    // Run Lean TPE
+    let maybe_lean_resp =
+        ffi.is_authorized_partial(policies, partial_request, partial_entities, schema);
+
+    let (rust_resp, lean_resp) = match (maybe_rust_resp, maybe_lean_resp) {
+        (Ok(r), Ok(l)) => (r, l),
+        (Err(_), Err(_)) => return,
+        (Ok(r), Err(e)) => panic!(
+            "Got Lean TPE error, but Rust returned response.\nRust: {:?}\n, Lean: {}",
+            r, e
+        ),
+        (Err(e), Ok(l)) => panic!(
+            "Got Rust TPE error, but Lean returned response.\nRust: {}\n, Lean: {:?}",
+            e, l
+        ),
+    };
+
+    let rust_inner = rust_resp.as_ref();
+
+    // Compare decisions
+    assert_eq!(
+        rust_inner.decision(),
+        lean_resp.decision,
+        "TPE decision mismatch"
+    );
+
+    // Compare policy categorizations (comparing sets of policy IDs)
+    let to_set =
+        |iter: Box<dyn Iterator<Item = &cedar_policy_core::tpe::response::ResidualPolicy> + '_>| {
+            iter.map(|p| PolicyId::new(p.get_policy_id().as_ref()))
+                .collect::<HashSet<PolicyId>>()
+        };
+    // The satisfied forbids/permits match.
+    assert_eq!(
+        to_set(Box::new(rust_inner.satisfied_permits())),
+        lean_resp.satisfied_permits,
+        "satisfied_permits mismatch"
+    );
+    assert_eq!(
+        to_set(Box::new(rust_inner.satisfied_forbids())),
+        lean_resp.satisfied_forbids,
+        "satisfied_forbids mismatch"
+    );
+    // Rust only returns false_permits, which should be the union of the
+    // false_permits and error_permits of the Lean side.
+    assert_eq!(
+        to_set(Box::new(rust_inner.false_permits())),
+        &lean_resp.false_permits | &lean_resp.error_permits,
+        "rust false_permits mismatch with false permits union error permits"
+    );
+    // Same for the false_forbids and error_forbids. The Rust side puts the policy ID
+    // in false_forbids for all Effect::Forbid policies that result in false or error.
+    assert_eq!(
+        to_set(Box::new(rust_inner.false_forbids())),
+        &lean_resp.false_forbids | &lean_resp.error_forbids,
+        "rust false_forbids mismatch with false forbids union error forbids"
+    );
+    // The policies with residuals match on both sides.
+    assert_eq!(
+        to_set(Box::new(rust_inner.residual_permits())),
+        lean_resp.residual_permits,
+        "residual_permits mismatch"
+    );
+    assert_eq!(
+        to_set(Box::new(rust_inner.residual_forbids())),
+        lean_resp.residual_forbids,
+        "residual_forbids mismatch"
+    );
+
+    // Compare residual expressions by policy ID via PST
+    let rust_residual_map: std::collections::HashMap<String, Expr> = rust_resp
+        .residual_policies()
+        .map(|rp| {
+            let id: String = rp.id().to_string();
+            let pst = rp
+                .to_pst()
+                .expect("policy->pst conversion should succeeed for residuals");
+            // Residual should only have one clause
+            let clause = match pst.body().clauses().as_slice() {
+                [Clause::When(x)] => x.clone(),
+                [Clause::Unless(x)] => Arc::new(Expr::UnaryOp {
+                    op: UnaryOp::Not,
+                    expr: x.clone(),
+                }),
+                _ => panic!(""),
+            };
+            (id, Arc::unwrap_or_clone(clause))
+        })
+        .collect();
+
+    for lean_rp in &lean_resp.residuals {
+        let lean_pst = Expr::try_from(lean_rp.residual.clone())
+            .expect("lean residual->pst conversion should succeed");
+        let id_str = lean_rp.id.to_string();
+        let rust_pst = rust_residual_map.get(&id_str).unwrap_or_else(|| {
+            panic!(
+                "Lean returned residual for policy {id_str:?} but Rust did not.\n\
+                 Rust residual IDs: {:?}",
+                rust_residual_map.keys().collect::<Vec<_>>()
+            )
+        });
+        assert_eq!(
+            rust_pst, &lean_pst,
+            "Residual expression mismatch for policy {id_str:?}\n\
+             Rust PST: {rust_pst:?}\nLean PST: {lean_pst:?}"
+        );
+    }
 }


### PR DESCRIPTION
Adds a new fuzz target in the style of [rbac-authorizer](https://github.com/cedar-policy/cedar-spec/blob/main/cedar-drt/fuzz/fuzz_targets/rbac-authorizer.rs) to specifically test TPE authorization algorithm.