### PR TITLE
fix for recursion limit reached in DRT code

### DIFF
--- a/cedar-drt/Cargo.toml
+++ b/cedar-drt/Cargo.toml
@@ -8,14 +8,20 @@ publish = false
 libfuzzer-sys = "0.4"
 cedar-lean-ffi = { path = "../cedar-lean-ffi", version = "4.4.0" }
 cedar-policy = "4.4.0"
-cedar-policy-core = { version = "4.4.0", features = ["arbitrary", "entity-manifest", "tpe"] }
+cedar-policy-core = { version = "4.4.0", features = [
+    "arbitrary",
+    "entity-manifest",
+    "tpe",
+] }
 cedar-policy-formatter = "4.4.0"
 cedar-testing = { path = "../cedar/cedar-testing", version = "4.4.0" }
-cedar-policy-generators = { path = "../cedar-policy-generators", version = "4.0.0", features = ["cedar-policy"] }
+cedar-policy-generators = { path = "../cedar-policy-generators", version = "4.0.0", features = [
+    "cedar-policy",
+] }
 env_logger = "0.11"
 log = "0.4"
 miette = "7.1.0"
-serde_json = "1.0.140"
+serde_json = { version = "1.0", features = ["unbounded_depth"] }
 similar-asserts = "1.5.0"
 smol_str = { version = "0.3", features = ["serde"] }
 indexmap = { version = "2.12.0", features = ["serde"] }

--- a/cedar-drt/fuzz/fuzz_targets/convert-policy-cedar-to-json.rs
+++ b/cedar-drt/fuzz/fuzz_targets/convert-policy-cedar-to-json.rs
@@ -65,7 +65,13 @@ fuzz_target!(|src: String| {
                     })
                     .and_then(|est: est::PolicySet| {
                         // EST -> AST
-                        est.try_into().map_err(|e| ESTParseError::from(Box::new(e)))
+                        // Disable serde_json's default recursion limit (128) because
+                        // chained attribute access (e.g. a.b.c["d"]["e"]) produces
+                        // deeply nested JSON in the EST format.
+                        let mut deserializer = serde_json::Deserializer::from_str(&json);
+                        deserializer.disable_recursion_limit();
+                        est::PolicySet::deserialize(&mut deserializer)
+                            .map_err(|e| ESTParseError::from(Box::new(e)))
                     });
 
                 match ast_from_est_result {


### PR DESCRIPTION
`serde_json`'s recursion limit is easily reached in the DRT code. This is one easy solution, but it might cause stack overflow instead of recursion limit exceeded. 


