### PR TITLE
Check that entity-types/enums/actions exists pre-TPE validation

### DIFF
--- a/cedar-lean/Cedar/TPE/Evaluator.lean
+++ b/cedar-lean/Cedar/TPE/Evaluator.lean
@@ -249,6 +249,7 @@ def evaluatePolicy (schema : Schema)
       if requestAndEntitiesIsValid env req es
       then
         do
+          checkEntities schema p.toExpr|>.mapError .invalidPolicy
           let expr := substituteAction env.reqty.action p.toExpr
           let (te, _) ← (typeOf expr ∅ env).mapError Error.invalidPolicy
           .ok (evaluate te.liftBoolTypes.toResidual req es)

--- a/cedar-lean/Cedar/Thm/BatchedEvaluator/Authorize.lean
+++ b/cedar-lean/Cedar/Thm/BatchedEvaluator/Authorize.lean
@@ -161,7 +161,9 @@ theorem evaluatePolicies_equiv_and_well_typed
   refine ⟨rfl, rfl, (partial_evaluate_policy_is_sound h_ep h_schema_env h_wf h_ref).symm, ?_⟩
   simp only [evaluatePolicy, h_schema_env, List.empty_eq] at h_ep
   split at h_ep <;> try cases h_ep
-  simp only [do_ok_eq_ok, Prod.exists, exists_and_right] at h_ep
+  cases hcheck : Except.mapError Error.invalidPolicy (checkEntities schema p.toExpr) <;>
+    simp only [hcheck, Except.bind_err, reduceCtorEq] at h_ep
+  simp only [Except.bind_ok, do_ok_eq_ok, Prod.exists, exists_and_right] at h_ep
   rcases h_ep with ⟨_, ⟨_, h₁₁⟩, h₁₂⟩
   simp only [Except.mapError] at h₁₁
   split at h₁₁ <;> try cases h₁₁

--- a/cedar-lean/Cedar/Thm/TPE/Policy.lean
+++ b/cedar-lean/Cedar/Thm/TPE/Policy.lean
@@ -61,6 +61,8 @@ theorem partial_evaluate_policy_is_sound
   intro h₁ h_schema_env h₄ h₃
   simp [evaluatePolicy, h_schema_env] at h₁
   split at h₁ <;> try cases h₁
+  cases hcheck : Except.mapError Error.invalidPolicy (checkEntities schema policy.toExpr) <;>
+    simp only [hcheck, Except.bind_err, reduceCtorEq] at h₁
   simp [do_ok_eq_ok] at h₁
   rcases h₁ with ⟨_, ⟨_, h₁₁⟩, h₁₂⟩
   simp [Except.mapError] at h₁₁


### PR DESCRIPTION
This matches the behavior implemented in Rust. Found in differential test for batched eval

*Issue #, if available:*

*Description of changes:*


