### PR TITLE
fuzz targets for protobuf decode shall not panic

### DIFF
--- a/cedar-drt/fuzz/Cargo.toml
+++ b/cedar-drt/fuzz/Cargo.toml
@@ -197,6 +197,48 @@ test = false
 doc = false
 
 [[bin]]
+name = "protobuf-decode-bytes-entity"
+path = "fuzz_targets/protobuf-decode/protobuf-decode-bytes-entity.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "protobuf-decode-bytes-entities"
+path = "fuzz_targets/protobuf-decode/protobuf-decode-bytes-entities.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "protobuf-decode-bytes-expression"
+path = "fuzz_targets/protobuf-decode/protobuf-decode-bytes-expression.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "protobuf-decode-bytes-policyset"
+path = "fuzz_targets/protobuf-decode/protobuf-decode-bytes-policyset.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "protobuf-decode-bytes-request"
+path = "fuzz_targets/protobuf-decode/protobuf-decode-bytes-request.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "protobuf-decode-bytes-schema"
+path = "fuzz_targets/protobuf-decode/protobuf-decode-bytes-schema.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "protobuf-decode-bytes-template"
+path = "fuzz_targets/protobuf-decode/protobuf-decode-bytes-template.rs"
+test = false
+doc = false
+
+[[bin]]
 name = "entity-validation"
 path = "fuzz_targets/entity-validation.rs"
 test = false

--- a/cedar-drt/fuzz/fuzz_targets/protobuf-decode/protobuf-decode-bytes-entities.rs
+++ b/cedar-drt/fuzz/fuzz_targets/protobuf-decode/protobuf-decode-bytes-entities.rs
@@ -1,0 +1,28 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#![no_main]
+
+use cedar_drt_inner::fuzz_target;
+
+use cedar_policy::Entities;
+use cedar_policy::proto::traits::Protobuf;
+
+// Feed arbitrary bytes into entities protobuf decoder.
+// The property under test: decode either returns Ok or Err, never panics.
+fuzz_target!(|input: &[u8]| {
+    let _ = Entities::decode(input);
+});

--- a/cedar-drt/fuzz/fuzz_targets/protobuf-decode/protobuf-decode-bytes-entity.rs
+++ b/cedar-drt/fuzz/fuzz_targets/protobuf-decode/protobuf-decode-bytes-entity.rs
@@ -1,0 +1,28 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#![no_main]
+
+use cedar_drt_inner::fuzz_target;
+
+use cedar_policy::Entity;
+use cedar_policy::proto::traits::Protobuf;
+
+// Feed arbitrary bytes into entity protobuf decoder.
+// The property under test: decode either returns Ok or Err, never panics.
+fuzz_target!(|input: &[u8]| {
+    let _ = Entity::decode(input);
+});

--- a/cedar-drt/fuzz/fuzz_targets/protobuf-decode/protobuf-decode-bytes-expression.rs
+++ b/cedar-drt/fuzz/fuzz_targets/protobuf-decode/protobuf-decode-bytes-expression.rs
@@ -1,0 +1,28 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#![no_main]
+
+use cedar_drt_inner::fuzz_target;
+
+use cedar_policy::Expression;
+use cedar_policy::proto::traits::Protobuf;
+
+// Feed arbitrary bytes into Expression protobuf decoder.
+// The property under test: decode either returns Ok or Err, never panics.
+fuzz_target!(|input: &[u8]| {
+    let _ = Expression::decode(input);
+});

--- a/cedar-drt/fuzz/fuzz_targets/protobuf-decode/protobuf-decode-bytes-policyset.rs
+++ b/cedar-drt/fuzz/fuzz_targets/protobuf-decode/protobuf-decode-bytes-policyset.rs
@@ -1,0 +1,28 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#![no_main]
+
+use cedar_drt_inner::fuzz_target;
+
+use cedar_policy::PolicySet;
+use cedar_policy::proto::traits::Protobuf;
+
+// Feed arbitrary bytes into PolicySet protobuf decoder.
+// The property under test: decode either returns Ok or Err, never panics.
+fuzz_target!(|input: &[u8]| {
+    let _ = PolicySet::decode(input);
+});

--- a/cedar-drt/fuzz/fuzz_targets/protobuf-decode/protobuf-decode-bytes-request.rs
+++ b/cedar-drt/fuzz/fuzz_targets/protobuf-decode/protobuf-decode-bytes-request.rs
@@ -1,0 +1,28 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#![no_main]
+
+use cedar_drt_inner::fuzz_target;
+
+use cedar_policy::Request;
+use cedar_policy::proto::traits::Protobuf;
+
+// Feed arbitrary bytes into each protobuf decoder.
+// The property under test: decode either returns Ok or Err, never panics.
+fuzz_target!(|input: &[u8]| {
+    let _ = Request::decode(input);
+});

--- a/cedar-drt/fuzz/fuzz_targets/protobuf-decode/protobuf-decode-bytes-schema.rs
+++ b/cedar-drt/fuzz/fuzz_targets/protobuf-decode/protobuf-decode-bytes-schema.rs
@@ -1,0 +1,28 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#![no_main]
+
+use cedar_drt_inner::fuzz_target;
+
+use cedar_policy::Schema;
+use cedar_policy::proto::traits::Protobuf;
+
+// Feed arbitrary bytes into Schema protobuf decoder.
+// The property under test: decode either returns Ok or Err, never panics.
+fuzz_target!(|input: &[u8]| {
+    let _ = Schema::decode(input);
+});

--- a/cedar-drt/fuzz/fuzz_targets/protobuf-decode/protobuf-decode-bytes-template.rs
+++ b/cedar-drt/fuzz/fuzz_targets/protobuf-decode/protobuf-decode-bytes-template.rs
@@ -1,0 +1,28 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#![no_main]
+
+use cedar_drt_inner::fuzz_target;
+
+use cedar_policy::Template;
+use cedar_policy::proto::traits::Protobuf;
+
+// Feed arbitrary bytes into Template protobuf decoder.
+// The property under test: decode either returns Ok or Err, never panics.
+fuzz_target!(|input: &[u8]| {
+    let _ = Template::decode(input);
+});

--- a/cedar-drt/fuzz/fuzz_targets/protobuf-roundtrip.rs
+++ b/cedar-drt/fuzz/fuzz_targets/protobuf-roundtrip.rs
@@ -105,7 +105,7 @@ fn roundtrip_entities(entities: Entities) {
     let buf = entities_proto.encode_to_vec();
     let roundtriped_proto = proto::models::Entities::decode(&buf[..])
         .expect("Failed to deserialize Entities from proto");
-    let roundtripped = Entities::from(roundtriped_proto);
+    let roundtripped = Entities::try_from(roundtriped_proto).unwrap();
     roundtrip_entities::pretty_assert_entities_deep_eq(&entities, &roundtripped);
 }
 
@@ -114,7 +114,7 @@ fn roundtrip_request(request: Request) {
     let buf = request_proto.encode_to_vec();
     let roundtriped_proto =
         proto::models::Request::decode(&buf[..]).expect("Failed to deserialize Request from proto");
-    let roundtripped = Request::from(roundtriped_proto);
+    let roundtripped = Request::try_from(roundtriped_proto).unwrap();
     assert_eq!(
         request.principal().map(|p| p.id()),
         roundtripped.principal().map(|p| p.id())
@@ -138,6 +138,6 @@ fn roundtrip_schema(schema: Schema) {
     let buf = schema_proto.encode_to_vec();
     let roundtriped_proto =
         proto::models::Schema::decode(&buf[..]).expect("Failed to deserialize Schema from proto");
-    let roundtripped = Schema::from(roundtriped_proto);
+    let roundtripped = Schema::try_from(roundtriped_proto).unwrap();
     Equiv::equiv(schema.as_ref(), roundtripped.as_ref()).unwrap();
 }

--- a/cedar-lean-ffi/src/messages.rs
+++ b/cedar-lean-ffi/src/messages.rs
@@ -992,8 +992,8 @@ mod test {
 
         let rt_policyset = PolicySet::try_from(authorization_proto.policies.unwrap())
             .expect("Failed to round-trip policies");
-        let rt_entities = Entities::from(authorization_proto.entities.unwrap());
-        let rt_request = Request::from(authorization_proto.request.unwrap());
+        let rt_entities = Entities::try_from(authorization_proto.entities.unwrap()).unwrap();
+        let rt_request = Request::try_from(authorization_proto.request.unwrap()).unwrap();
 
         assert_eq!(policyset, rt_policyset);
         assert_eq!(entities, rt_entities);
@@ -1060,7 +1060,7 @@ mod test {
 
         let rt_pset = PolicySet::try_from(validation_request_proto.policies.unwrap())
             .expect("Failed to roundtrip PolicySet");
-        let rt_schema = Schema::from(validation_request_proto.schema.unwrap());
+        let rt_schema = Schema::try_from(validation_request_proto.schema.unwrap()).unwrap();
 
         assert_eq!(policyset, rt_pset);
 
@@ -1097,7 +1097,7 @@ mod test {
 
         let rt_pset = PolicySet::try_from(validation_request_proto.policies.unwrap())
             .expect("Failed to roundtrip PolicySet");
-        let rt_schema = Schema::from(validation_request_proto.schema.unwrap());
+        let rt_schema = Schema::try_from(validation_request_proto.schema.unwrap()).unwrap();
 
         assert_eq!(policyset, rt_pset);
 
@@ -1129,8 +1129,8 @@ mod test {
                 .expect("Failed to decode protobuf entity validation request");
         assert_eq!(validation_request_pre_proto, validation_request_proto);
 
-        let rt_schema = Schema::from(validation_request_proto.schema.unwrap());
-        let rt_entities = Entities::from(validation_request_proto.entities.unwrap());
+        let rt_schema = Schema::try_from(validation_request_proto.schema.unwrap()).unwrap();
+        let rt_entities = Entities::try_from(validation_request_proto.entities.unwrap()).unwrap();
 
         // Need to collect into a collection that is either unordered or is first sorted
         assert_eq!(
@@ -1165,8 +1165,8 @@ mod test {
                 .expect("Failed to decode protobuf request validation request");
         assert_eq!(validation_request_pre_proto, validation_request_proto);
 
-        let rt_schema = Schema::from(validation_request_proto.schema.unwrap());
-        let rt_request = Request::from(validation_request_proto.request.unwrap());
+        let rt_schema = Schema::try_from(validation_request_proto.schema.unwrap()).unwrap();
+        let rt_request = Request::try_from(validation_request_proto.request.unwrap()).unwrap();
 
         // Need to collect into a collection that is either unordered or is first sorted
         assert_eq!(


### PR DESCRIPTION
This is the companion PR of https://github.com/cedar-policy/cedar/pull/2331 

Adds a few smoke tests on protobuf decoding: it shouldn't panic given random bytes.


