### PR TITLE
Add workaround for stricter template link validation in Rust

### DIFF
--- a/cedar-drt/src/tests.rs
+++ b/cedar-drt/src/tests.rs
@@ -230,6 +230,11 @@ fn compare_validation_results(
                 // if the validation comparison mode is `AgreeOnAll`.
                 match comparison_mode {
                     ValidationComparisonMode::AgreeOnAll => {
+                        // Workaround for known discrepancy where Rust is more strict when typechecking linked policies.
+                        // https://github.com/cedar-policy/cedar-spec/issues/945
+                        if policies.num_of_templates() != 0 {
+                            return;
+                        }
                         assert!(
                             !definitional_res.validation_passed(),
                             "Mismatch for Policies:\n{}\nSchema:\n{:?}\ncedar-policy response:\n{:?}\nTest engine response: {:?}\n",


### PR DESCRIPTION
See https://github.com/cedar-policy/cedar-spec/issues/945 for details

I'd like to update the Lean model and proof, but it's not trivial, so this is the easier way to ensure we're at least testing for soundness properly in the short term. 