### PR TITLE
minor changes for json integration tests

### DIFF
--- a/cedar-drt/src/dump.rs
+++ b/cedar-drt/src/dump.rs
@@ -114,7 +114,9 @@ pub fn dump(
     let testcase = JsonTest {
         schema: schema_filename.display().to_string(),
         policies: policies_filename.display().to_string(),
+        policy_format: Default::default(),
         entities: entities_filename.display().to_string(),
+        schema_format: Default::default(),
         should_validate,
         requests: requests.clone(),
     };


### PR DESCRIPTION
Small changes following up on https://github.com/cedar-policy/cedar/pull/2334 (allowing json inputs for policies and schemas in integration tests).


