### PR TITLE
fix model to match change in #2343

### DIFF
--- a/cedar-lean/Cedar/SymCC/ExtFun.lean
+++ b/cedar-lean/Cedar/SymCC/ExtFun.lean
@@ -96,9 +96,8 @@ def inRange (range : Term → Term × Term) (t₁ t₂ : Term) : Term :=
   (and (bvule r₁.2 r₂.2) (bvule r₂.1 r₁.1))
 
 def inRangeV (isIp : Term → Term) (range : Term → Term × Term) (t₁ t₂ : Term) : Term :=
-  (and
-    (and (isIp t₁) (isIp t₂))
-    (inRange range t₁ t₂))
+  (and (isIp t₁)
+    (and (isIp t₂) (inRange range t₁ t₂)))
 
 public def isInRange (t₁ t₂ : Term) : Term :=
   (or

--- a/cedar-lean/Cedar/Thm/SymCC/Compiler/Call.lean
+++ b/cedar-lean/Cedar/Thm/SymCC/Compiler/Call.lean
@@ -496,12 +496,12 @@ private theorem interpret_ipaddr_inRangeV {εs : SymEntities} {I : Interpretatio
   (IPAddr.inRangeV isIp rangeV t₁ t₂).interpret I =
   IPAddr.inRangeV isIp rangeV (t₁.interpret I) (t₂.interpret I)
 := by
-  have hw₃ := wf_and hw₁.left hw₂.left hw₁.right hw₂.right
-  have hw₄ := wf_ipaddr_inRange hr₁ hr₂
+  have hw₃ := wf_ipaddr_inRange hr₁ hr₂
+  have hw₄ := wf_and hw₂.left hw₃.left hw₂.right hw₃.right
   simp only [IPAddr.inRangeV]
   rw [
-    interpret_and hI hw₃.left hw₄.left hw₃.right hw₄.right,
-    interpret_and hI hw₁.left hw₂.left hw₁.right hw₂.right,
+    interpret_and hI hw₁.left hw₄.left hw₁.right hw₄.right,
+    interpret_and hI hw₂.left hw₃.left hw₂.right hw₃.right,
     hi₁, hi₂]
   have hlit₁ := interpret_term_wfl hI hw₁.left
   have hlit₂ := interpret_term_wfl hI hw₂.left

--- a/cedar-lean/Cedar/Thm/SymCC/Term/WF.lean
+++ b/cedar-lean/Cedar/Thm/SymCC/Term/WF.lean
@@ -1784,9 +1784,9 @@ public theorem wf_ipaddr_inRangeV {εs : SymEntities} {w : Nat} {isIp : Term →
   (IPAddr.inRangeV isIp rangeV t₁ t₂).typeOf = .bool
 := by
   simp only [IPAddr.inRangeV]
-  have h₅ := wf_and h₃.left h₄.left h₃.right h₄.right
-  have h₆ := wf_ipaddr_inRange h₁ h₂
-  exact wf_and h₅.left h₆.left h₅.right h₆.right
+  have h₅ := wf_ipaddr_inRange h₁ h₂
+  have h₆ := wf_and h₄.left h₅.left h₄.right h₅.right
+  exact wf_and h₃.left h₆.left h₃.right h₆.right
 
 public theorem wf_ipaddr_isInRange {εs : SymEntities} {t₁ t₂ : Term}
   (h₁ : t₁.WellFormed εs ∧ t₁.typeOf = .ext .ipAddr)


### PR DESCRIPTION
Changes how the `and` is associated in the `isInRangeV` to match changes brought by https://github.com/cedar-policy/cedar/pull/2343 (changes for the variadic case impact the term shape of the non-variadic case).
