### PR TITLE
Rename Map.make_mem_list_mem to mem_make_mem_list

### DIFF
--- a/cedar-lean/Cedar/Thm/Data/Map.lean
+++ b/cedar-lean/Cedar/Thm/Data/Map.lean
@@ -304,7 +304,7 @@ public theorem make_singleton [LT α] [DecidableLT α] [StrictLT α] (k : α) (v
 
   For a limited converse, see `mem_list_mem_make` below.
 -/
-public theorem make_mem_list_mem [LT α] [StrictLT α] [DecidableLT α] {xs : List (α × β)} :
+public theorem mem_make_mem_list [LT α] [StrictLT α] [DecidableLT α] {xs : List (α × β)} :
   x ∈ (Map.make xs).toList → x ∈ xs
 := by
   simp only [toList, make]
@@ -314,13 +314,13 @@ public theorem make_mem_list_mem [LT α] [StrictLT α] [DecidableLT α] {xs : Li
   exact h₂ h₁
 
 /--
-  Very similar to `make_mem_list_mem` above
+  Very similar to `mem_make_mem_list` above
 -/
 public theorem mem_values_make [LT α] [StrictLT α] [DecidableLT α] {xs : List (α × β)} :
   v ∈ (Map.make xs).values → v ∈ xs.map Prod.snd
 := by
-  -- despite the similarity to `make_mem_list_mem`, the proof does not currently
-  -- use `make_mem_list_mem`
+  -- despite the similarity to `mem_make_mem_list`, the proof does not currently
+  -- use `mem_make_mem_list`
   simp only [values, make]
   simp only [List.mem_map, forall_exists_index, and_imp]
   intro (k, v) h₁ h₂
@@ -332,7 +332,7 @@ public theorem mem_values_make [LT α] [StrictLT α] [DecidableLT α] {xs : List
   exact h₂ h₁
 
 /--
-  This limited converse of `make_mem_list_mem` requires that the input list is
+  This limited converse of `mem_make_mem_list` requires that the input list is
   SortedBy Prod.fst.
 -/
 public theorem mem_list_mem_make [LT α] [StrictLT α] [DecidableLT α] {xs : List (α × β)} :

--- a/cedar-lean/Cedar/Thm/SymCC/Compiler/WF.lean
+++ b/cedar-lean/Cedar/Thm/SymCC/Compiler/WF.lean
@@ -1116,7 +1116,7 @@ private theorem evaluate_record_wf {env : Env} {v : Value} {axs : List (Attr × 
   apply Value.WellFormed.record_wf _ (Map.make_wf vs)
   intro a v hv
   replace hv := Map.find?_mem_toList hv
-  replace hv := Map.make_mem_list_mem hv
+  replace hv := Map.mem_make_mem_list hv
   replace ⟨x, hx, hvs⟩ := List.mapM'_ok_implies_all_from_ok hvs (a, v) hv
   simp [bindAttr] at hvs
   simp_do_let (evaluate x.snd env.request env.entities) at hvs

--- a/cedar-lean/Cedar/Thm/SymCC/Env/Completeness.lean
+++ b/cedar-lean/Cedar/Thm/SymCC/Env/Completeness.lean
@@ -50,7 +50,7 @@ private theorem sym_entities_is_valid_entity_uid_implies_entity_uid_wf
   split at huid
   · rename_i δ hfind
     have := Map.find?_mem_toList hfind
-    have := Map.make_mem_list_mem this
+    have := Map.mem_make_mem_list this
     have := List.mem_append.mp this
     cases this with
     | inl hmem =>
@@ -849,7 +849,7 @@ private theorem ofEnv_entity_completeness_standard
     ] at hfind_ancUF
     have ⟨f, hfind_f, _⟩ := Map.find?_mapOnValues_some' _ hfind_ancUF
     have := Map.find?_mem_toList hfind_f
-    have := Map.make_mem_list_mem this
+    have := Map.mem_make_mem_list this
     have ⟨ancTy, hfind_ancTy, hancTy⟩ := List.mem_map.mp this
     simp only [Prod.mk.injEq] at hancTy
     simp only [hancTy.1] at hfind_ancTy
@@ -1006,7 +1006,7 @@ private theorem ofEnv_entity_completeness_action
       have ⟨ancUF, hfind_ancUF, ⟨anc_ts, happ_ancUF, hmem_anc_ts⟩⟩ := hanc₁ anc hmem_data_anc
       simp only [hδ, hδ', SymEntityData.ofActionType, SymEntityData.interpret] at hfind_ancUF
       have ⟨ancUDF, hfind_ancUDF, hancUDF⟩ := Map.find?_mapOnValues_some' _ hfind_ancUF
-      have := Map.make_mem_list_mem (Map.find?_mem_toList hfind_ancUDF)
+      have := Map.mem_make_mem_list (Map.find?_mem_toList hfind_ancUDF)
       have ⟨ancTy, hmem_ancTy, hancTy⟩ := List.mem_map.mp this
       simp only [Prod.mk.injEq] at hancTy
       replace hmem_ancTy := List.mem_eraseDups_implies_mem hmem_ancTy
@@ -1016,7 +1016,7 @@ private theorem ofEnv_entity_completeness_action
       simp only [hancUDF, Factory.app, Term.isLiteral, ↓reduceIte] at happ_ancUF
       split at happ_ancUF
       · rename_i ts' hts'
-        have := Map.make_mem_list_mem (Map.find?_mem_toList hts')
+        have := Map.mem_make_mem_list (Map.find?_mem_toList hts')
         have ⟨⟨act'', entry''⟩, hmem_act''_entry'', hact''_entry''⟩ := List.mem_filterMap.mp this
         simp only [bind, Option.bind] at hact''_entry''
         split at hact''_entry''
@@ -1120,7 +1120,7 @@ private theorem ofEnv_entity_completeness
   -- Exists a `SymEntityData` before interpretation
   have ⟨δ', hfind_δ', hδ'⟩ := Map.find?_mapOnValues_some' _ hfind_δ
   have := Map.find?_mem_toList hfind_δ'
-  have := Map.make_mem_list_mem this
+  have := Map.mem_make_mem_list this
   have := List.mem_append.mp this
   cases this with
   -- Ordinary entity

--- a/cedar-lean/Cedar/Thm/SymCC/Env/Soundness.lean
+++ b/cedar-lean/Cedar/Thm/SymCC/Env/Soundness.lean
@@ -666,7 +666,7 @@ private theorem env_symbolize?_same_entity_data_standard
     ]
     have ⟨uuf, huuf, hancUF⟩ := Map.find?_mapOnValues_some' _ hancUF
     have := (Map.in_list_iff_find?_some (Map.make_wf _)).mpr huuf
-    have := Map.make_mem_list_mem this
+    have := Map.mem_make_mem_list this
     have ⟨_, hmem_ancTy, heq⟩ := List.mem_map.mp this
     simp only [Prod.mk.injEq] at heq
     replace huuf := heq.2
@@ -978,7 +978,7 @@ private theorem env_symbolize?_same_entities_action
       simp only [Map.find?_mapOnValues, Option.map_eq_some_iff] at hancUF
       have ⟨ancUF', hancUF', heq_ancUF⟩ := hancUF
       have := Map.find?_mem_toList hancUF'
-      have := Map.make_mem_list_mem this
+      have := Map.mem_make_mem_list this
       have ⟨_, _, h⟩ := List.mem_map.mp this
       simp only [Prod.mk.injEq] at h
       simp only [h.1, true_and] at h
@@ -1068,7 +1068,7 @@ private theorem defaultLitWithDefaultEid_wf
             simp [←hmembers] at this
         -- `eids` should not be empty
         simp only [SymEnv.ofEnv, SymEntities.ofSchema] at hfind_δ
-        have := Map.make_mem_list_mem (Map.find?_mem_toList hfind_δ)
+        have := Map.mem_make_mem_list (Map.find?_mem_toList hfind_δ)
         have := List.mem_append.mp this
         cases this with
         | inl hmem_ets =>
@@ -1267,7 +1267,7 @@ private theorem env_symbolize?_attrs_wf
   -- Well-formed `UDF.table`
   · simp only
     intros tᵢ tₒ hmem
-    have hmem := Map.make_mem_list_mem hmem
+    have hmem := Map.mem_make_mem_list hmem
     have ⟨⟨uid, data⟩, hmem_uid_data, hio⟩ := List.mem_filterMap.mp hmem
     have hfind_uid_data := (Map.in_list_iff_find?_some hwf_entities.1).mp hmem_uid_data
     have ⟨hwf_attrs, _⟩ := hwf_entities.2 uid data hfind_uid_data
@@ -1349,7 +1349,7 @@ private theorem env_symbolize?_tags_wf
       -- Well-formed `UDF.table`
       · simp only
         intros tᵢ tₒ hmem
-        have hmem := Map.make_mem_list_mem hmem
+        have hmem := Map.mem_make_mem_list hmem
         have ⟨⟨uid, data⟩, hmem_uid_data, hio⟩ := List.mem_filterMap.mp hmem
         have hfind_uid_data := (Map.in_list_iff_find?_some hwf_entities.1).mp hmem_uid_data
         have ⟨hwf_attrs, _⟩ := hwf_entities.2 uid data hfind_uid_data
@@ -1408,7 +1408,7 @@ private theorem env_symbolize?_tags_wf
         exact Map.make_wf _
       · simp only
         intros tᵢ tₒ hmem
-        have hmem := Map.make_mem_list_mem hmem
+        have hmem := Map.mem_make_mem_list hmem
         have ⟨l, hmem_l, hmem⟩ := List.mem_flatten.mp hmem
         have ⟨⟨uid, data⟩, hmem_uid_data, hl⟩ := List.mem_filterMap.mp hmem_l
         simp only [Option.bind_eq_bind, Option.ite_none_right_eq_some] at hl
@@ -1508,7 +1508,7 @@ private theorem env_symbolize?_ancs_wf
     exact Map.make_wf _
   · simp only
     intros tᵢ tₒ hmem
-    have hmem := Map.make_mem_list_mem hmem
+    have hmem := Map.mem_make_mem_list hmem
     have ⟨⟨uid, data⟩, hmem_uid_data, hio⟩ := List.mem_filterMap.mp hmem
     have hfind_uid_data := (Map.in_list_iff_find?_some hwf_entities.1).mp hmem_uid_data
     have ⟨_, _, hwf_ancs, _⟩ := hwf_entities.2 uid data hfind_uid_data

--- a/cedar-lean/Cedar/Thm/SymCC/Env/ofEnv.lean
+++ b/cedar-lean/Cedar/Thm/SymCC/Env/ofEnv.lean
@@ -655,7 +655,7 @@ theorem ofStandardEntityType_is_wf
   · intros anc_ty sym_anc_f hfind_anc
     have := Map.find?_mem_toList hfind_anc
     simp only [Map.toList] at this
-    have := Map.make_mem_list_mem this
+    have := Map.mem_make_mem_list this
     have ⟨anc_ty', hmem_anc', heq_anc'⟩ := List.mem_map.mp this
     simp only [Prod.mk.injEq] at heq_anc'
     simp only [heq_anc'.1] at hmem_anc'
@@ -800,7 +800,7 @@ theorem ofActionType_ancsUDF_is_wf
   ]
   have := Map.find?_mem_toList hanc
   simp only [Map.toList] at this
-  have := Map.make_mem_list_mem this
+  have := Map.mem_make_mem_list this
   have ⟨anc_ty', hmem_anc', heq_anc'⟩ := List.mem_map.mp this
   simp only [Prod.mk.injEq] at heq_anc'
   simp only [heq_anc'.1] at hmem_anc'
@@ -828,7 +828,7 @@ theorem ofActionType_ancsUDF_is_wf
   · simp only [Map.make_wf]
   · -- WF of the ancestor UDF
     intros tᵢ tₒ hmem
-    have := Map.make_mem_list_mem hmem
+    have := Map.mem_make_mem_list hmem
     have ⟨act_entry, hact_entry, hsym⟩ := List.mem_filterMap.mp this
     simp [bind, Option.bind] at hsym
     split at hsym
@@ -978,7 +978,7 @@ theorem ofActionType_is_wf
   · intros anc sym_anc_f hfind_anc
     have := Map.find?_mem_toList hfind_anc
     simp only [Map.toList] at this
-    have := Map.make_mem_list_mem this
+    have := Map.mem_make_mem_list this
     have ⟨anc_ty', hmem_anc', heq_anc'⟩ := List.mem_map.mp this
     simp only [Prod.mk.injEq] at heq_anc'
     simp only [heq_anc'.1] at hmem_anc'
@@ -1005,7 +1005,7 @@ theorem ofEnv_entities_is_wf
   · intros ety data hfind
     have := Map.find?_mem_toList hfind
     simp only at this
-    have := Map.make_mem_list_mem this
+    have := Map.mem_make_mem_list this
     have := List.mem_append.mp this
     -- Reduce to either `ofEntityType_is_wf` or `ofActionType_is_wf`
     cases this with
@@ -1368,7 +1368,7 @@ theorem ofEnv_entities_find?_some
       Γ.acts)
 := by
   have := Map.find?_mem_toList hfind
-  have := Map.make_mem_list_mem this
+  have := Map.mem_make_mem_list this
   have := List.mem_append.mp this
   cases this with
   | inl hmem_ets =>
@@ -1451,7 +1451,7 @@ theorem in_ancsUDF_implies_in_ancestors
     split at hmem
     · rename_i heq
       have := Map.find?_mem_toList heq
-      have := Map.make_mem_list_mem this
+      have := Map.mem_make_mem_list this
       have ⟨entry, hmem_entry, heq_entry⟩ := List.mem_filterMap.mp this
       simp only [bind, Option.bind] at heq_entry
       split at heq_entry
@@ -1529,7 +1529,7 @@ theorem ofEnv_entities_is_acyclic
   intros uid δ udf hfind_uid_ty hfind_udf_ancs huid_cyclic
   simp only [SymEnv.ofEnv, SymEntities.ofSchema] at hfind_uid_ty
   have := Map.find?_mem_toList hfind_uid_ty
-  have := Map.make_mem_list_mem this
+  have := Map.mem_make_mem_list this
   have := List.mem_append.mp this
   cases this with
   | inl hmem_ets =>
@@ -1545,7 +1545,7 @@ theorem ofEnv_entities_is_acyclic
     split at hfind_udf_ancs
     · simp only at hfind_udf_ancs
       have := Map.find?_mem_toList hfind_udf_ancs
-      have := Map.make_mem_list_mem this
+      have := Map.mem_make_mem_list this
       have ⟨_, _, h⟩ := List.mem_map.mp this
       simp [
         Prod.mk.injEq,
@@ -1557,7 +1557,7 @@ theorem ofEnv_entities_is_acyclic
     simp only [Prod.mk.injEq, SymEntityData.ofActionType] at hsym_act
     simp only [←hsym_act.2] at hfind_udf_ancs
     have := Map.find?_mem_toList hfind_udf_ancs
-    have := Map.make_mem_list_mem this
+    have := Map.mem_make_mem_list this
     have ⟨ancTy, hmem_ancTy, hudf⟩ := List.mem_map.mp this
     have := List.mem_eraseDups_implies_mem hmem_ancTy
     have ⟨⟨anc, entry⟩, hmem_anc, heq_anc⟩ := List.mem_map.mp this
@@ -1601,7 +1601,7 @@ theorem ofEnv_entities_is_transitive
   any_goals
     have ⟨⟨ety, f_anc⟩, hmem_ety_f_anc, hmem_uid₁⟩ := (List.mem_mapUnion_iff_mem_exists _).mp huid_anc₂
     simp only [SymEntityData.ofStandardEntityType ] at hmem_ety_f_anc
-    have := Map.make_mem_list_mem hmem_ety_f_anc
+    have := Map.mem_make_mem_list hmem_ety_f_anc
     replace ⟨ancTy, hmem_ancTy, heq_ancTy⟩ := List.mem_map.mp this
     simp only [Prod.mk.injEq] at heq_ancTy
     simp only [
@@ -1614,7 +1614,7 @@ theorem ofEnv_entities_is_transitive
   -- Case: `uid₁`: standard; `uid₂`: action
   · have ⟨⟨ety, f_anc⟩, hmem_ety_f_anc, hmem_uid₂⟩ := (List.mem_mapUnion_iff_mem_exists _).mp hanc
     simp only [SymEntityData.ofStandardEntityType ] at hmem_ety_f_anc
-    have := Map.make_mem_list_mem hmem_ety_f_anc
+    have := Map.mem_make_mem_list hmem_ety_f_anc
     replace ⟨ancTy, hmem_ancTy, heq_ancTy⟩ := List.mem_map.mp this
     simp only [Prod.mk.injEq] at heq_ancTy
     simp only [
@@ -1627,7 +1627,7 @@ theorem ofEnv_entities_is_transitive
   -- Case: `uid₁`: action; `uid₂`: action
   · have ⟨⟨ety₁, f_anc₁⟩, hmem_ety_f_anc₁, hmem_uid₁⟩ := (List.mem_mapUnion_iff_mem_exists _).mp hanc
     have ⟨⟨ety₂, f_anc₂⟩, hmem_ety_f_anc₂, hmem_uid₂⟩ := (List.mem_mapUnion_iff_mem_exists _).mp huid_anc₂
-    have := Map.make_mem_list_mem hmem_ety_f_anc₁
+    have := Map.mem_make_mem_list hmem_ety_f_anc₁
     replace ⟨ancTy₁, hmem_ancTy₁, heq_ancTy₁⟩ := List.mem_map.mp this
     simp only [Prod.mk.injEq] at heq_ancTy₁
     simp only [
@@ -1646,7 +1646,7 @@ theorem ofEnv_entities_is_transitive
       simp only [←heq.2] at hmem_uid₁
       exact hmem_uid₁
     simp only [heq_ety₁] at hmem_uid₁
-    have := Map.make_mem_list_mem hmem_ety_f_anc₂
+    have := Map.mem_make_mem_list hmem_ety_f_anc₂
     replace ⟨ancTy₂, hmem_ancTy₂, heq_ancTy₂⟩ := List.mem_map.mp this
     simp only [Prod.mk.injEq] at heq_ancTy₂
     simp only [
@@ -1721,7 +1721,7 @@ theorem ofEnv_entities_is_partitioned
         ]
         intros ancTy f hfind_f
         have := Map.find?_mem_toList hfind_f
-        replace := Map.make_mem_list_mem this
+        replace := Map.mem_make_mem_list this
         have ⟨ancTy', hmem_ancTy', heq_ancTy'⟩ := List.mem_map.mp this
         simp only [Prod.mk.injEq] at heq_ancTy'
         simp only [
@@ -1751,7 +1751,7 @@ theorem ofEnv_entities_is_partitioned
       ]
       intros ancTy f hfind_f
       have := Map.find?_mem_toList hfind_f
-      replace := Map.make_mem_list_mem this
+      replace := Map.mem_make_mem_list this
       have ⟨ancTy', hmem_ancTy', heq_ancTy'⟩ := List.mem_map.mp this
       simp only [Prod.mk.injEq] at heq_ancTy'
       simp only [
@@ -1785,7 +1785,7 @@ theorem ofEnv_entities_is_partitioned
     · have hancs_std_only := wf_env_implies_ancestors_of_standard_ety_is_standard hwf hfind_entry₁ ety₂
       simp only [SymEntityData.ofStandardEntityType] at hanc
       have := Map.find?_mem_toList hanc
-      replace := Map.make_mem_list_mem this
+      replace := Map.mem_make_mem_list this
       have ⟨ancTy, hmem_ancTy, heq_ancTy⟩ := List.mem_map.mp this
       simp only [Prod.mk.injEq] at heq_ancTy
       simp only [heq_ancTy.1] at hmem_ancTy
@@ -1795,7 +1795,7 @@ theorem ofEnv_entities_is_partitioned
     · have hancs_std_only := wf_env_implies_ancestors_of_standard_ety_is_standard hwf hfind_entry₁ ety₂
       simp only [SymEntityData.ofStandardEntityType] at hanc
       have := Map.find?_mem_toList hanc
-      replace := Map.make_mem_list_mem this
+      replace := Map.mem_make_mem_list this
       have ⟨ancTy, hmem_ancTy, heq_ancTy⟩ := List.mem_map.mp this
       simp only [Prod.mk.injEq] at heq_ancTy
       simp only [heq_ancTy.1] at hmem_ancTy
@@ -1805,7 +1805,7 @@ theorem ofEnv_entities_is_partitioned
       contradiction
     -- entry₁: action; entry₂: standard
     · have := Map.find?_mem_toList hanc
-      replace := Map.make_mem_list_mem this
+      replace := Map.mem_make_mem_list this
       have ⟨ancTy, hmem_ancTy, heq_ancTy⟩ := List.mem_map.mp this
       simp only [Prod.mk.injEq] at heq_ancTy
       have := List.mem_eraseDups_implies_mem hmem_ancTy

--- a/cedar-lean/Cedar/Thm/SymCC/Term/UDF.lean
+++ b/cedar-lean/Cedar/Thm/SymCC/Term/UDF.lean
@@ -74,7 +74,7 @@ theorem map_make_filterMap_find?_none
 := by
   apply Map.all_absent_find?_none
   intros v hmem_k'_v
-  have := Map.make_mem_list_mem hmem_k'_v
+  have := Map.mem_make_mem_list hmem_k'_v
   have ⟨(k'', v''), hmem_kv, hfkv⟩ := List.mem_filterMap.mp this
   have heq_k'' := hf (k'', v'')
   simp only [

--- a/cedar-lean/Cedar/Thm/SymCC/Term/WF.lean
+++ b/cedar-lean/Cedar/Thm/SymCC/Term/WF.lean
@@ -630,7 +630,7 @@ public theorem wf_recordOf {εs : SymEntities} {ats : List (Attr × Term)}
   simp only [recordOf]
   apply Term.WellFormed.record_wf _ (Map.make_wf ats)
   intro a t ht
-  replace ht := Map.make_mem_list_mem ht
+  replace ht := Map.mem_make_mem_list ht
   exact h₁ a t ht
 
 public theorem wf_recordOf_map {εs : SymEntities} {f : Term → Term} {ats : List (Attr × Term)}

--- a/cedar-lean/Cedar/Thm/Validation/Levels/CheckLevel.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Levels/CheckLevel.lean
@@ -154,7 +154,7 @@ theorem entity_access_at_level_succ {path} {tx : TypedExpr} {env : TypeEnv} {n n
     · assumption
     · rename_i path hf _ hl
       have : sizeOf tx < sizeOf attrs := by
-        have h₁ := List.sizeOf_lt_of_mem ∘ Map.make_mem_list_mem ∘ Map.find?_mem_toList $ hf
+        have h₁ := List.sizeOf_lt_of_mem ∘ Map.mem_make_mem_list ∘ Map.find?_mem_toList $ hf
         rw [Prod.mk.sizeOf_spec ha tx] at h₁
         omega
       exact entity_access_at_level_succ hl
@@ -291,7 +291,7 @@ theorem entity_access_level_spec {tx : TypedExpr} {env : TypeEnv} {n nmax : Nat}
           subst tx
           and_intros
           · have : sizeOf tx' < 1 + sizeOf atxs := by
-              replace h₁ := List.sizeOf_lt_of_mem ∘ Map.make_mem_list_mem ∘ Map.find?_mem_toList $ h₁
+              replace h₁ := List.sizeOf_lt_of_mem ∘ Map.mem_make_mem_list ∘ Map.find?_mem_toList $ h₁
               rw [Prod.mk.sizeOf_spec _ tx'] at h₁
               omega
             have ih := @entity_access_level_spec tx'
@@ -319,7 +319,7 @@ theorem entity_access_level_spec {tx : TypedExpr} {env : TypeEnv} {n nmax : Nat}
           · assumption
           · rename_i a _ tx hf
             have : sizeOf tx < 1 + sizeOf atxs := by
-              replace h₁ := List.sizeOf_lt_of_mem ∘ Map.make_mem_list_mem ∘ Map.find?_mem_toList $ hf
+              replace h₁ := List.sizeOf_lt_of_mem ∘ Map.mem_make_mem_list ∘ Map.find?_mem_toList $ hf
               rw [Prod.mk.sizeOf_spec _ tx] at h₁
               omega
             have ih := @entity_access_level_spec tx

--- a/cedar-lean/Cedar/Thm/Validation/Slice/Reachable.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Slice/Reachable.lean
@@ -206,7 +206,7 @@ theorem checked_eval_entity_reachable {e : Expr} {n nmax: Nat} {c c' : Capabilit
     have ih : ∀ a x, (Map.make rxs).find? a = some x → CheckedEvalEntityReachable x := by
       intros a x hfx
       have : sizeOf x < sizeOf (Expr.record rxs) := by
-        replace he := Map.make_mem_list_mem (Map.find?_mem_toList hfx)
+        replace he := Map.mem_make_mem_list (Map.find?_mem_toList hfx)
         have h₁ := List.sizeOf_lt_of_mem he
         rw [Prod.mk.sizeOf_spec a x] at h₁
         simp only [Expr.record.sizeOf_spec, gt_iff_lt]

--- a/cedar-lean/Cedar/Thm/WellTyped/Expr/WF.lean
+++ b/cedar-lean/Cedar/Thm/WellTyped/Expr/WF.lean
@@ -142,7 +142,7 @@ theorem well_typed_implies_wf_type
     · intros attr qty hattr
       have := (Map.in_list_iff_find?_some hwf_rty).mpr hattr
       simp only [hrty] at this
-      have := Map.make_mem_list_mem this
+      have := Map.mem_make_mem_list this
       simp only [List.mem_map, Prod.mk.injEq, Prod.exists] at this
       have ⟨attr, tx, htx, heq_attr, hqty⟩ := this
       have := hwt_attrs attr tx htx

--- a/cedar-lean/Cedar/Validation/Levels.lean
+++ b/cedar-lean/Cedar/Validation/Levels.lean
@@ -78,7 +78,7 @@ public def TypedExpr.checkEntityAccessLevel (tx : TypedExpr) (env : TypeEnv) (n 
     match h₁ : (Map.make axs).find? a with
     | some tx' =>
       have : sizeOf tx' < sizeOf axs := by
-        replace h₁ := List.sizeOf_lt_of_mem ∘ Map.make_mem_list_mem ∘ Map.find?_mem_toList $ h₁
+        replace h₁ := List.sizeOf_lt_of_mem ∘ Map.mem_make_mem_list ∘ Map.find?_mem_toList $ h₁
         rw [Prod.mk.sizeOf_spec a tx'] at h₁
         omega
       tx'.checkEntityAccessLevel env n nmax path &&


### PR DESCRIPTION
  Addresses one item from #298:

  > Rename `make_mem_list_mem` because `mem` comes first in the statement of the
   theorem.

  The forward direction
  x ∈ (Map.make xs).toList → x ∈ xs
  is renamed to `mem_make_mem_list`, mirroring the existing converse
  `mem_list_mem_make` (which carries the LHS pattern first).