### PR TITLE
Promote simp_do_let to shared Cedar.Thm.Tactics module

### DIFF
--- a/cedar-lean/Cedar/Thm.lean
+++ b/cedar-lean/Cedar/Thm.lean
@@ -15,6 +15,7 @@
 -/
 
 import Cedar.Thm.Data
+import Cedar.Thm.Tactics
 import Cedar.Thm.Authorization
 import Cedar.Thm.PolicySlice
 import Cedar.Thm.SymCC.Opt

--- a/cedar-lean/Cedar/Thm/Tactics.lean
+++ b/cedar-lean/Cedar/Thm/Tactics.lean
@@ -16,21 +16,24 @@
 
 module
 
-public import Cedar.Thm.Tactics
-import Cedar.Thm.SymCC.Data
-public meta import Lean.Meta.Tactic.Clear
+public import Cedar.Thm.Data.Control
+public import Lean.Elab.Tactic.Basic
 
 /-!
-This file contains basic utility tactics specific to symbolic compilation.
-General-purpose tactics live in `Cedar.Thm.Tactics`.
+This file contains general-purpose proof tactics that are shared across
+the Cedar theorems and not tied to any specific subsystem.
 --/
 
 namespace Cedar.Thm
 
-open Lean Elab Meta Tactic in
-elab "clean_i" : tactic => liftMetaTactic fun mvarId => mvarId.withContext do
-  let mut toClear := #[]
-  for localDecl in (← getLCtx) do
-    if localDecl.userName.hasMacroScopes then
-      toClear := toClear.push localDecl.fvarId
-  return [← mvarId.tryClearMany toClear]
+/--
+This tactic simplifies assumptions of the form `do (let x ← expr ...)` by
+performing a `cases` and `simp` on `expr`.
+-/
+syntax "simp_do_let" term (" at " ident)? : tactic
+
+macro_rules
+| `(tactic| simp_do_let $e $[at $h:ident]?) =>
+  `(tactic|
+    cases h' : $e <;>
+    simp only [h', Except.bind_err, Except.bind_ok, reduceCtorEq] $[at $h:ident]?)

--- a/cedar-lean/Cedar/Thm/Validation/Slice/Reachable/BinaryApp.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Slice/Reachable/BinaryApp.lean
@@ -23,6 +23,7 @@ import Cedar.Thm.Data.MapUnion
 import Cedar.Thm.Validation.Levels.CheckLevel
 
 import Cedar.Thm.Validation.Slice.Reachable.Basic
+import Cedar.Thm.Tactics
 
 namespace Cedar.Thm
 
@@ -64,8 +65,10 @@ theorem checked_eval_entity_reachable_get_tag {e₁ e₂: Expr} {n : Nat} {c c' 
   ReachableIn entities request.sliceEUIDs euid (n + 1)
 := by
   simp only [evaluate] at he
-  cases he₁ : evaluate e₁ request entities <;> simp only [he₁, Except.bind_err, Except.bind_ok, reduceCtorEq] at he
-  cases he₂ : evaluate e₂ request entities <;> simp only [he₂, Except.bind_err, Except.bind_ok, reduceCtorEq] at he
+  simp_do_let (evaluate e₁ request entities) at he
+  rename_i he₁
+  simp_do_let (evaluate e₂ request entities) at he
+  rename_i he₂
   simp only [apply₂] at he
   split at he <;> try contradiction
   rename_i euid' _ _
@@ -75,7 +78,8 @@ theorem checked_eval_entity_reachable_get_tag {e₁ e₂: Expr} {n : Nat} {c c' 
   cases hl
   rename_i hl₁ hl₂
   simp only [getTag] at he
-  cases he₃ : entities.tags euid' <;> simp only [he₃, Except.bind_ok, Except.bind_err, reduceCtorEq] at he
+  simp_do_let (entities.tags euid') at he
+  rename_i he₃
   simp only [Map.findOrErr] at he
   split at he <;> simp only [reduceCtorEq, Except.ok.injEq] at he
   subst he
@@ -95,8 +99,10 @@ theorem binary_op_not_euid_via_path {op : BinaryOp} {e₁ e₂: Expr} {entities 
 := by
   intro ha
   simp only [evaluate] at he
-  cases he₁ : evaluate e₁ request entities <;> simp only [he₁, Except.bind_err, Except.bind_ok, reduceCtorEq] at he
-  cases he₂ : evaluate e₂ request entities <;> simp only [he₂, Except.bind_err, Except.bind_ok, reduceCtorEq] at he
+  simp_do_let (evaluate e₁ request entities) at he
+  rename_i he₁
+  simp_do_let (evaluate e₂ request entities) at he
+  rename_i he₂
   simp only [apply₂, intOrErr, inₛ, hasTag] at he
   split at he <;> try split at he
   all_goals first


### PR DESCRIPTION
  Addresses #279 along the line suggested by @john-h-kastner-aws in the issue
  thread:

  > `simp_do_let` is in main and used by the symcc proofs.  We could adopt in
  the rest of our proofs.

  This is intentionally **not** the path that the closed #311 ("Introduce
  `csimp` tactic") took.  @emina's objection on that PR was that a generic `simp
   only` wrapper does not abstract a specific pattern; her stated rule of thumb
  is that custom tactics should either (a) abstract a specific repeating
  pattern, or (b) be general-purpose decision procedures.  `simp_do_let` clears
  bar (a): it captures the exact `cases h : e <;> simp only [h, Except.bind_err,
   Except.bind_ok, reduceCtorEq]` shape that recurs throughout the proofs.

  ## Changes

  - New file `cedar-lean/Cedar/Thm/Tactics.lean` containing only the
  `simp_do_let` macro and its imports (`Cedar.Thm.Data.Control` for the
  `Except.bind_*` lemmas, plus `Lean.Elab.Tactic.Basic`).
  - `cedar-lean/Cedar/Thm/SymCC/Tactics.lean` `public import`s the new module,
  so existing symcc call sites continue to compile unchanged.  The
  symcc-specific `clean_i` tactic stays where it is.
  - `cedar-lean/Cedar/Thm/Validation/Slice/Reachable/BinaryApp.lean` adopts
  `simp_do_let` at five exact-match sites.

  ## Adoption pattern note (for follow-up PRs)

  When replacing `cases hN : e <;> simp only [hN, Except.bind_err,
  Except.bind_ok, reduceCtorEq] at h` with `simp_do_let e at h`, the macro's
  `cases h' : e` uses a hygienic identifier rather than `hN`.  So the surviving
  branch has one more anonymous hypothesis than the original `cases hN :` form,
  which can silently shift any downstream `rename_i name1 _ _` pattern.  The
  right idiom is to always pair the macro with `rename_i hN` immediately after,
  even when `hN` is not referenced downstream, so the named/anonymous balance
  matches the original.  All five BinaryApp sites in this PR follow that idiom.

