### PR TITLE
fuzz targets testing protobuf & other formats validation agreement

### DIFF
--- a/cedar-drt/fuzz/Cargo.toml
+++ b/cedar-drt/fuzz/Cargo.toml
@@ -258,6 +258,18 @@ test = false
 doc = false
 
 [[bin]]
+name = "protobuf-decode-gen-expression"
+path = "fuzz_targets/protobuf-decode/protobuf-decode-gen-expression.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "protobuf-decode-gen-request"
+path = "fuzz_targets/protobuf-decode/protobuf-decode-gen-request.rs"
+test = false
+doc = false
+
+[[bin]]
 name = "protobuf-decode-gen-template"
 path = "fuzz_targets/protobuf-decode/protobuf-decode-gen-template.rs"
 test = false

--- a/cedar-drt/fuzz/Cargo.toml
+++ b/cedar-drt/fuzz/Cargo.toml
@@ -240,6 +240,30 @@ test = false
 doc = false
 
 [[bin]]
+name = "protobuf-decode-gen-policyset"
+path = "fuzz_targets/protobuf-decode/protobuf-decode-gen-policyset.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "protobuf-decode-gen-entity"
+path = "fuzz_targets/protobuf-decode/protobuf-decode-gen-entity.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "protobuf-decode-gen-entities"
+path = "fuzz_targets/protobuf-decode/protobuf-decode-gen-entities.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "protobuf-decode-gen-template"
+path = "fuzz_targets/protobuf-decode/protobuf-decode-gen-template.rs"
+test = false
+doc = false
+
+[[bin]]
 name = "entity-validation"
 path = "fuzz_targets/entity-validation.rs"
 test = false

--- a/cedar-drt/fuzz/fuzz_targets/protobuf-decode/protobuf-decode-bytes-entities.rs
+++ b/cedar-drt/fuzz/fuzz_targets/protobuf-decode/protobuf-decode-bytes-entities.rs
@@ -18,11 +18,15 @@
 
 use cedar_drt_inner::fuzz_target;
 
+use cedar_drt_inner::props::entities_to_json_roundtrips;
 use cedar_policy::Entities;
 use cedar_policy::proto::traits::Protobuf;
 
 // Feed arbitrary bytes into entities protobuf decoder.
 // The property under test: decode either returns Ok or Err, never panics.
 fuzz_target!(|input: &[u8]| {
-    let _ = Entities::decode(input);
+    match Entities::decode(input) {
+        Ok(es) => entities_to_json_roundtrips(es),
+        Err(_) => (), // we expect errors here
+    }
 });

--- a/cedar-drt/fuzz/fuzz_targets/protobuf-decode/protobuf-decode-bytes-entity.rs
+++ b/cedar-drt/fuzz/fuzz_targets/protobuf-decode/protobuf-decode-bytes-entity.rs
@@ -18,11 +18,15 @@
 
 use cedar_drt_inner::fuzz_target;
 
+use cedar_drt_inner::props::entity_to_json_roundtrips;
 use cedar_policy::Entity;
 use cedar_policy::proto::traits::Protobuf;
 
 // Feed arbitrary bytes into entity protobuf decoder.
 // The property under test: decode either returns Ok or Err, never panics.
 fuzz_target!(|input: &[u8]| {
-    let _ = Entity::decode(input);
+    match Entity::decode(input) {
+        Ok(e) => entity_to_json_roundtrips(e),
+        Err(_) => (), // error is fine here
+    }
 });

--- a/cedar-drt/fuzz/fuzz_targets/protobuf-decode/protobuf-decode-bytes-expression.rs
+++ b/cedar-drt/fuzz/fuzz_targets/protobuf-decode/protobuf-decode-bytes-expression.rs
@@ -18,11 +18,15 @@
 
 use cedar_drt_inner::fuzz_target;
 
+use cedar_drt_inner::props::expression_to_cedar_parses;
 use cedar_policy::Expression;
 use cedar_policy::proto::traits::Protobuf;
 
 // Feed arbitrary bytes into Expression protobuf decoder.
 // The property under test: decode either returns Ok or Err, never panics.
 fuzz_target!(|input: &[u8]| {
-    let _ = Expression::decode(input);
+    match Expression::decode(input) {
+        Ok(e) => expression_to_cedar_parses(e.into()),
+        Err(_) => (), // errors are expected here
+    }
 });

--- a/cedar-drt/fuzz/fuzz_targets/protobuf-decode/protobuf-decode-bytes-policyset.rs
+++ b/cedar-drt/fuzz/fuzz_targets/protobuf-decode/protobuf-decode-bytes-policyset.rs
@@ -18,11 +18,18 @@
 
 use cedar_drt_inner::fuzz_target;
 
+use cedar_drt_inner::props::{policyset_to_cedar_parses, policyset_to_json_deserializes};
 use cedar_policy::PolicySet;
 use cedar_policy::proto::traits::Protobuf;
 
 // Feed arbitrary bytes into PolicySet protobuf decoder.
 // The property under test: decode either returns Ok or Err, never panics.
 fuzz_target!(|input: &[u8]| {
-    let _ = PolicySet::decode(input);
+    match PolicySet::decode(input) {
+        Ok(ps) => {
+            let _ = policyset_to_cedar_parses(ps.clone());
+            let _ = policyset_to_json_deserializes(ps);
+        }
+        Err(_) => (), // error is fine here
+    }
 });

--- a/cedar-drt/fuzz/fuzz_targets/protobuf-decode/protobuf-decode-bytes-request.rs
+++ b/cedar-drt/fuzz/fuzz_targets/protobuf-decode/protobuf-decode-bytes-request.rs
@@ -18,11 +18,15 @@
 
 use cedar_drt_inner::fuzz_target;
 
+use cedar_drt_inner::props::request_context_to_cedar_parses;
 use cedar_policy::Request;
 use cedar_policy::proto::traits::Protobuf;
 
 // Feed arbitrary bytes into each protobuf decoder.
 // The property under test: decode either returns Ok or Err, never panics.
 fuzz_target!(|input: &[u8]| {
-    let _ = Request::decode(input);
+    match Request::decode(input) {
+        Ok(r) => request_context_to_cedar_parses(r),
+        Err(_) => (), // we expect errors here
+    }
 });

--- a/cedar-drt/fuzz/fuzz_targets/protobuf-decode/protobuf-decode-bytes-template.rs
+++ b/cedar-drt/fuzz/fuzz_targets/protobuf-decode/protobuf-decode-bytes-template.rs
@@ -18,11 +18,15 @@
 
 use cedar_drt_inner::fuzz_target;
 
+use cedar_drt_inner::props::template_to_cedar_parses;
 use cedar_policy::Template;
 use cedar_policy::proto::traits::Protobuf;
 
 // Feed arbitrary bytes into Template protobuf decoder.
 // The property under test: decode either returns Ok or Err, never panics.
 fuzz_target!(|input: &[u8]| {
-    let _ = Template::decode(input);
+    match Template::decode(input) {
+        Ok(t) => template_to_cedar_parses(t),
+        Err(_) => (), // errors are expeccted to happen
+    }
 });

--- a/cedar-drt/fuzz/fuzz_targets/protobuf-decode/protobuf-decode-gen-entities.rs
+++ b/cedar-drt/fuzz/fuzz_targets/protobuf-decode/protobuf-decode-gen-entities.rs
@@ -1,0 +1,81 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#![no_main]
+
+use cedar_drt_inner::fuzz_target;
+use cedar_drt_inner::proto_gen;
+
+use cedar_policy::Entities;
+use cedar_policy::proto::models;
+use prost::Message;
+
+use libfuzzer_sys::arbitrary::{self, Arbitrary, Unstructured};
+
+#[derive(Debug, Clone)]
+struct ProtoEntitiesInput {
+    entities: models::Entities,
+}
+
+impl<'a> Arbitrary<'a> for ProtoEntitiesInput {
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        let g = proto_gen::ModelGenerator::arbitrary(u)?;
+        Ok(Self {
+            entities: g.arbitrary_model_entities(u)?,
+        })
+    }
+}
+
+// This fuzz target checks that the validation of entity sets on the protobuf decode path is the
+// same as on the JSON parsing path.
+//
+// Generate a proto Entities → encode to bytes → decode → convert to domain →
+// serialize to JSON → re-parse from JSON.
+// Property: if decode+conversion succeeds, JSON serialization and re-parsing must also succeed.
+fuzz_target!(|input: ProtoEntitiesInput| {
+    // Encode the generated proto model to bytes. Should not fail since it is the encoding of
+    // a models::Entities.
+    let buf = input.entities.encode_to_vec();
+
+    // Decode from bytes.
+    let decoded =
+        models::Entities::decode(&buf[..]).expect("Decoding an encoded models::Entities failed");
+
+    // Convert proto model → domain type.
+    // This is expected to fail for many inputs.
+    let entities = match Entities::try_from(decoded) {
+        Ok(e) => e,
+        Err(_) => return,
+    };
+
+    // Serialize to JSON
+    let json = entities.to_json_value().unwrap_or_else(|e| {
+        panic!(
+            "Entities accepted from proto could not be serialized to JSON.\n\
+             Proto input: {:?}\nError: {e}",
+            input.entities
+        )
+    });
+
+    // Re-parse from JSON; this shouldn't fail
+    let _reparsed = Entities::from_json_value(json.clone(), None).unwrap_or_else(|e| {
+        panic!(
+            "JSON from proto-accepted entities failed to re-parse.\n\
+             Proto input: {:?}\nJSON: {json}\nParse error: {e}",
+            input.entities
+        )
+    });
+});

--- a/cedar-drt/fuzz/fuzz_targets/protobuf-decode/protobuf-decode-gen-entities.rs
+++ b/cedar-drt/fuzz/fuzz_targets/protobuf-decode/protobuf-decode-gen-entities.rs
@@ -17,6 +17,7 @@
 #![no_main]
 
 use cedar_drt_inner::fuzz_target;
+use cedar_drt_inner::props::entities_to_json_roundtrips;
 use cedar_drt_inner::proto_gen;
 
 use cedar_policy::Entities;
@@ -60,22 +61,7 @@ fuzz_target!(|input: ProtoEntitiesInput| {
         Ok(e) => e,
         Err(_) => return,
     };
-
-    // Serialize to JSON
-    let json = entities.to_json_value().unwrap_or_else(|e| {
-        panic!(
-            "Entities accepted from proto could not be serialized to JSON.\n\
-             Proto input: {:?}\nError: {e}",
-            input.entities
-        )
-    });
-
-    // Re-parse from JSON; this shouldn't fail
-    let _reparsed = Entities::from_json_value(json.clone(), None).unwrap_or_else(|e| {
-        panic!(
-            "JSON from proto-accepted entities failed to re-parse.\n\
-             Proto input: {:?}\nJSON: {json}\nParse error: {e}",
-            input.entities
-        )
-    });
+    // Once we have some `Entities`, then it should roundtrip through JSON. We test that validation
+    // in the JSON deserialization is not stronger than in Proto decoding.
+    entities_to_json_roundtrips(entities);
 });

--- a/cedar-drt/fuzz/fuzz_targets/protobuf-decode/protobuf-decode-gen-entity.rs
+++ b/cedar-drt/fuzz/fuzz_targets/protobuf-decode/protobuf-decode-gen-entity.rs
@@ -1,0 +1,76 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#![no_main]
+
+use cedar_drt_inner::fuzz_target;
+use cedar_drt_inner::proto_gen::ProtoEntityInput;
+
+use cedar_policy::proto::models;
+use cedar_policy::{Entities, Entity};
+use prost::Message;
+
+// This tests that validation when decoding protobufs for an entity is the same as validation
+// when deserializing from JSON.
+//
+// Generates a proto Entity → encode to bytes → decode → convert to domain →
+// serialize to JSON → re-parse from JSON.
+// Property: if decode+conversion succeeds, JSON serialization and re-parsing must also succeed.
+fuzz_target!(|input: ProtoEntityInput| {
+    // Encode the generated proto model to bytes
+    let buf = input.entity.encode_to_vec();
+
+    // Decode from bytes
+    let decoded = models::Entity::decode(&buf[..])
+        .expect("Failed to decode proto Entity that was just encoded.");
+
+    // Convert proto model → domain type
+    // If it doesn't fail here, then all subsequent steps should not fail.
+    let entity = match Entity::try_from(decoded) {
+        Ok(e) => e,
+        Err(_) => return,
+    };
+
+    // Wrap in Entities for JSON serialization
+    let entities = Entities::from_entities([entity.clone()], None)
+        .expect("Failed to create Entities from single entity");
+
+    // Serialize to JSON
+    let json = entities.to_json_value().unwrap_or_else(|e| {
+        panic!(
+            "Entity accepted from proto could not be serialized to JSON.\n\
+             Proto input: {:?}\nError: {e}",
+            input.entity
+        )
+    });
+
+    // Re-parse from JSON
+    let reparsed = Entities::from_json_value(json.clone(), None).unwrap_or_else(|e| {
+        panic!(
+            "JSON from proto-accepted entity failed to re-parse.\n\
+             Proto input: {:?}\nJSON: {json}\nParse error: {e}",
+            input.entity
+        )
+    });
+
+    // Verify the entity survived
+    assert!(
+        reparsed.get(&entity.uid()).is_some(),
+        "Entity UID {:?} not found after JSON roundtrip.\nProto input: {:?}",
+        entity.uid(),
+        input.entity
+    );
+});

--- a/cedar-drt/fuzz/fuzz_targets/protobuf-decode/protobuf-decode-gen-entity.rs
+++ b/cedar-drt/fuzz/fuzz_targets/protobuf-decode/protobuf-decode-gen-entity.rs
@@ -19,8 +19,9 @@
 use cedar_drt_inner::fuzz_target;
 use cedar_drt_inner::proto_gen::ProtoEntityInput;
 
+use cedar_drt_inner::props::entity_to_json_roundtrips;
+use cedar_policy::Entity;
 use cedar_policy::proto::models;
-use cedar_policy::{Entities, Entity};
 use prost::Message;
 
 // This tests that validation when decoding protobufs for an entity is the same as validation
@@ -43,34 +44,7 @@ fuzz_target!(|input: ProtoEntityInput| {
         Ok(e) => e,
         Err(_) => return,
     };
-
-    // Wrap in Entities for JSON serialization
-    let entities = Entities::from_entities([entity.clone()], None)
-        .expect("Failed to create Entities from single entity");
-
-    // Serialize to JSON
-    let json = entities.to_json_value().unwrap_or_else(|e| {
-        panic!(
-            "Entity accepted from proto could not be serialized to JSON.\n\
-             Proto input: {:?}\nError: {e}",
-            input.entity
-        )
-    });
-
-    // Re-parse from JSON
-    let reparsed = Entities::from_json_value(json.clone(), None).unwrap_or_else(|e| {
-        panic!(
-            "JSON from proto-accepted entity failed to re-parse.\n\
-             Proto input: {:?}\nJSON: {json}\nParse error: {e}",
-            input.entity
-        )
-    });
-
-    // Verify the entity survived
-    assert!(
-        reparsed.get(&entity.uid()).is_some(),
-        "Entity UID {:?} not found after JSON roundtrip.\nProto input: {:?}",
-        entity.uid(),
-        input.entity
-    );
+    // Once we have an `Entity` it should roundtrip through JSON. We test that validation in the
+    // JSON deserialization is not stronger than in Proto decoding.
+    entity_to_json_roundtrips(entity);
 });

--- a/cedar-drt/fuzz/fuzz_targets/protobuf-decode/protobuf-decode-gen-expression.rs
+++ b/cedar-drt/fuzz/fuzz_targets/protobuf-decode/protobuf-decode-gen-expression.rs
@@ -1,0 +1,50 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#![no_main]
+
+use cedar_drt_inner::fuzz_target;
+use cedar_drt_inner::proto_gen::ProtoExprInput;
+
+use cedar_drt_inner::props::expression_to_cedar_parses;
+use cedar_policy::Expression;
+use cedar_policy::proto::models;
+use prost::Message;
+
+// This tests that validation when decoding protobufs for an expression is the same as validation
+// when parsing Cedar.
+//
+// Generates a proto Expr → encode to bytes → decode → convert to domain →
+// serialize to Cedar → re-parse from Cedar.
+// Property: if decode+conversion succeeds, Cedar printing and re-parsing must also succeed.
+fuzz_target!(|input: ProtoExprInput| {
+    // Encode the generated proto model to bytes
+    let buf = input.expr.encode_to_vec();
+
+    // Decode from bytes
+    let decoded =
+        models::Expr::decode(&buf[..]).expect("Failed to decode proto Expr that was just encoded.");
+
+    // Convert proto model → domain type
+    // If it doesn't fail here, then all subsequent steps should not fail.
+    let expression = match Expression::try_from(decoded) {
+        Ok(e) => e,
+        Err(_) => return,
+    };
+    // Once we have an `Expression` it should roundtrip through Cedar.
+    // We test that validation when parsing Cedar is not stronger than when decoding Protobuf.
+    expression_to_cedar_parses(expression);
+});

--- a/cedar-drt/fuzz/fuzz_targets/protobuf-decode/protobuf-decode-gen-policyset.rs
+++ b/cedar-drt/fuzz/fuzz_targets/protobuf-decode/protobuf-decode-gen-policyset.rs
@@ -1,0 +1,65 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#![no_main]
+
+use cedar_drt_inner::fuzz_target;
+use cedar_drt_inner::proto_gen::ProtoPolicySetInput;
+
+use cedar_policy::PolicySet;
+use cedar_policy::proto::models;
+use prost::Message;
+
+// This fuzz target checks that the validation of policy sets on the protobuf decode path is the
+// same as on the Cedar text parsing path.
+//
+// Generate a proto PolicySet → encode to bytes → decode → convert to domain →
+// print to Cedar text → re-parse.
+// Property: if decode+conversion succeeds, printing and re-parsing must also succeed.
+fuzz_target!(|input: ProtoPolicySetInput| {
+    // Encode the generated proto model to bytes
+    let buf = input.policy_set.encode_to_vec();
+
+    // Decode from bytes (as a real client would). Should not fail since it is the encoding of
+    // a models::PolicySet.
+    let decoded =
+        models::PolicySet::decode(&buf[..]).expect("Decoding an encoded models::PolicySet failed");
+
+    // Convert proto model → domain type
+    // This is expected to fail
+    let policy_set = match PolicySet::try_from(decoded) {
+        Ok(ps) => ps,
+        Err(_) => return,
+    };
+
+    // Print the whole policy set to Cedar text
+    let cedar_text = policy_set.to_cedar().unwrap_or_else(|| {
+        panic!(
+            "PolicySet accepted from proto could not be printed to Cedar.\n\
+             Proto input: {:?}",
+            input.policy_set
+        )
+    });
+
+    // Re-parse the Cedar text; this should succeed
+    let _: PolicySet = cedar_text.parse().unwrap_or_else(|e| {
+        panic!(
+            "Cedar text from proto-accepted PolicySet failed to re-parse.\n\
+             Proto input: {:?}\nCedar text: {cedar_text}\nParse error: {e}",
+            input.policy_set
+        )
+    });
+});

--- a/cedar-drt/fuzz/fuzz_targets/protobuf-decode/protobuf-decode-gen-policyset.rs
+++ b/cedar-drt/fuzz/fuzz_targets/protobuf-decode/protobuf-decode-gen-policyset.rs
@@ -17,6 +17,7 @@
 #![no_main]
 
 use cedar_drt_inner::fuzz_target;
+use cedar_drt_inner::props::policyset_to_cedar_parses;
 use cedar_drt_inner::proto_gen::ProtoPolicySetInput;
 
 use cedar_policy::PolicySet;
@@ -44,22 +45,8 @@ fuzz_target!(|input: ProtoPolicySetInput| {
         Ok(ps) => ps,
         Err(_) => return,
     };
-
-    // Print the whole policy set to Cedar text
-    let cedar_text = policy_set.to_cedar().unwrap_or_else(|| {
-        panic!(
-            "PolicySet accepted from proto could not be printed to Cedar.\n\
-             Proto input: {:?}",
-            input.policy_set
-        )
-    });
-
-    // Re-parse the Cedar text; this should succeed
-    let _: PolicySet = cedar_text.parse().unwrap_or_else(|e| {
-        panic!(
-            "Cedar text from proto-accepted PolicySet failed to re-parse.\n\
-             Proto input: {:?}\nCedar text: {cedar_text}\nParse error: {e}",
-            input.policy_set
-        )
-    });
+    // Once we have a PolicySet, printing and parsing it back should succeed.
+    // We are testing that validation through the Cedar text parsing path is not stronger than the
+    // validation in proto.
+    policyset_to_cedar_parses(policy_set);
 });

--- a/cedar-drt/fuzz/fuzz_targets/protobuf-decode/protobuf-decode-gen-request.rs
+++ b/cedar-drt/fuzz/fuzz_targets/protobuf-decode/protobuf-decode-gen-request.rs
@@ -1,0 +1,51 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#![no_main]
+
+use cedar_drt_inner::fuzz_target;
+use cedar_drt_inner::proto_gen::ProtoRequestInput;
+
+use cedar_drt_inner::props::request_context_to_cedar_parses;
+use cedar_policy::Request;
+use cedar_policy::proto::models;
+use prost::Message;
+
+// This tests that validation when decoding protobufs for a request is the same as validation
+// when parsing Cedar restricted expressions.
+//
+// Generates a proto Request → encode to bytes → decode → convert to domain →
+// print context values to Cedar → re-parse from Cedar.
+// Property: if decode+conversion succeeds, Cedar printing and re-parsing of context values
+// must also succeed.
+fuzz_target!(|input: ProtoRequestInput| {
+    // Encode the generated proto model to bytes
+    let buf = input.request.encode_to_vec();
+
+    // Decode from bytes
+    let decoded = models::Request::decode(&buf[..])
+        .expect("Failed to decode proto Request that was just encoded.");
+
+    // Convert proto model → domain type
+    // If it doesn't fail here, then all subsequent steps should not fail.
+    let request = match Request::try_from(decoded) {
+        Ok(r) => r,
+        Err(_) => return,
+    };
+    // Once we have a `Request`, its context values should roundtrip through Cedar text.
+    // We test that validation when parsing Cedar is not stronger than when decoding Protobuf.
+    request_context_to_cedar_parses(request);
+});

--- a/cedar-drt/fuzz/fuzz_targets/protobuf-decode/protobuf-decode-gen-template.rs
+++ b/cedar-drt/fuzz/fuzz_targets/protobuf-decode/protobuf-decode-gen-template.rs
@@ -1,0 +1,72 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#![no_main]
+
+use cedar_drt_inner::fuzz_target;
+use cedar_drt_inner::proto_gen::ModelGenerator;
+
+use cedar_policy::Template;
+use cedar_policy::proto::models;
+use prost::Message;
+
+use libfuzzer_sys::arbitrary::{self, Arbitrary, Unstructured};
+
+/// Fuzz input: a directly-generated protobuf TemplateBody (no slots).
+#[derive(Debug, Clone)]
+struct ProtoTemplateInput {
+    template: models::TemplateBody,
+}
+
+impl<'a> Arbitrary<'a> for ProtoTemplateInput {
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        let g = ModelGenerator::arbitrary(u)?;
+        Ok(Self {
+            template: g.arbitrary_model_template_body(u, false)?,
+        })
+    }
+}
+
+// Generate a proto TemplateBody → encode to bytes → decode → convert to domain →
+// print to Cedar text → re-parse.
+// Property: if decode+conversion succeeds, printing and re-parsing must also succeed.
+fuzz_target!(|input: ProtoTemplateInput| {
+    // Encode the generated proto model to bytes
+    let buf = input.template.encode_to_vec();
+
+    // Decode from bytes
+    let decoded = models::TemplateBody::decode(&buf[..])
+        .expect("Decoding an encoded models::Template failed.");
+
+    // Convert proto model → domain type
+    // We expect this to fail, but when this doesn't faill all subsequent steps should pass.
+    let template = match Template::try_from(decoded) {
+        Ok(t) => t,
+        Err(_) => return,
+    };
+
+    // Print to Cedar text
+    let cedar_text = template.to_cedar();
+
+    // Re-parse (templates parse as part of a policy set)
+    let _: cedar_policy::PolicySet = cedar_text.parse().unwrap_or_else(|e| {
+        panic!(
+            "Template accepted from proto could not be re-parsed from Cedar text.\n\
+             Proto input: {:?}\nCedar text: {cedar_text}\nParse error: {e}",
+            input.template
+        )
+    });
+});

--- a/cedar-drt/fuzz/fuzz_targets/protobuf-decode/protobuf-decode-gen-template.rs
+++ b/cedar-drt/fuzz/fuzz_targets/protobuf-decode/protobuf-decode-gen-template.rs
@@ -16,8 +16,8 @@
 
 #![no_main]
 
-use cedar_drt_inner::fuzz_target;
 use cedar_drt_inner::proto_gen::ModelGenerator;
+use cedar_drt_inner::{fuzz_target, props::template_to_cedar_parses};
 
 use cedar_policy::Template;
 use cedar_policy::proto::models;
@@ -57,16 +57,7 @@ fuzz_target!(|input: ProtoTemplateInput| {
         Ok(t) => t,
         Err(_) => return,
     };
-
-    // Print to Cedar text
-    let cedar_text = template.to_cedar();
-
-    // Re-parse (templates parse as part of a policy set)
-    let _: cedar_policy::PolicySet = cedar_text.parse().unwrap_or_else(|e| {
-        panic!(
-            "Template accepted from proto could not be re-parsed from Cedar text.\n\
-             Proto input: {:?}\nCedar text: {cedar_text}\nParse error: {e}",
-            input.template
-        )
-    });
+    // Once we have a template, it should parse again through a Cedar roundtrip: we test that
+    // validation in the Cedar parser is not stronger than validation in protobuf.
+    template_to_cedar_parses(template);
 });

--- a/cedar-drt/fuzz/fuzz_targets/pst-policyset-json-roundtrip.rs
+++ b/cedar-drt/fuzz/fuzz_targets/pst-policyset-json-roundtrip.rs
@@ -17,7 +17,10 @@
 #![no_main]
 
 use cedar_drt::logger::initialize_log;
-use cedar_drt_inner::{fuzz_target, pst_equiv, pst_gen::PolicySetFuzzTargetInput};
+use cedar_drt_inner::{
+    fuzz_target, props::policyset_to_json_deserializes, pst_equiv,
+    pst_gen::PolicySetFuzzTargetInput,
+};
 
 use cedar_policy::PolicySet;
 use log::debug;
@@ -34,13 +37,9 @@ fuzz_target!(|input: PolicySetFuzzTargetInput| {
     let policy_set = PolicySet::from_pst(pst_set.clone())
         .unwrap_or_else(|e| panic!("Failed to create PolicySet from PST.\nError: {:?}", e));
 
-    // PolicySet -> JSON
-    let policy_set_json = policy_set
-        .to_json()
-        .unwrap_or_else(|e| panic!("Failed to get JSON from PolicySet:\nError: {:?}", e));
-    // JSON -> PolicySet
-    let policy_set_2 = PolicySet::from_json_value(policy_set_json)
-        .unwrap_or_else(|e| panic!("Failed to get PolicySet from JSON:\nError: {:?}", e));
+    // PolicySet -> JSON -> PolicySet
+    let policy_set_2 = policyset_to_json_deserializes(policy_set);
+
     // PolicySet -> PST
     let pst_set_2 = policy_set_2
         .to_pst()

--- a/cedar-drt/fuzz/fuzz_targets/pst-policyset-text-roundtrip.rs
+++ b/cedar-drt/fuzz/fuzz_targets/pst-policyset-text-roundtrip.rs
@@ -17,11 +17,12 @@
 #![no_main]
 
 use cedar_drt::logger::initialize_log;
-use cedar_drt_inner::{fuzz_target, pst_equiv, pst_gen::PolicySetFuzzTargetInput};
+use cedar_drt_inner::{
+    fuzz_target, props::policyset_to_cedar_parses, pst_equiv, pst_gen::PolicySetFuzzTargetInput,
+};
 
-use cedar_policy::{EntityUid, Policy, PolicySet, SlotId, Template};
+use cedar_policy::PolicySet;
 use log::debug;
-use std::collections::HashMap;
 
 // PST PolicySet -> from_pst -> deconstruct to text -> reconstruct -> to_pst -> compare
 // Tests round-tripping through text, with policy/template and link management.
@@ -36,62 +37,7 @@ fuzz_target!(|input: PolicySetFuzzTargetInput| {
         .unwrap_or_else(|e| panic!("Failed to create PolicySet from PST.\nError: {:?}", e));
 
     // Deconstruct and reconstruct via text
-    let mut reconstructed = PolicySet::new();
-
-    // Templates: print each to text, parse back with original ID, add to new set
-    for template in policy_set.templates() {
-        let id = template.id().clone();
-        let text = template.to_string();
-        let parsed = Template::parse(Some(id), &text).unwrap_or_else(|e| {
-            panic!(
-                "Failed to parse template from text:\n{}\nError: {:?}",
-                text, e
-            )
-        });
-        reconstructed
-            .add_template(parsed)
-            .unwrap_or_else(|e| panic!("Failed to add template: {:?}", e));
-    }
-
-    // Static policies: print each to text, parse back with original ID
-    // Linked policies: skip (we'll re-link below)
-    for policy in policy_set.policies() {
-        if policy.template_id().is_some() {
-            continue; // linked policy, will re-link
-        }
-        let id = policy.id().clone();
-        let text = policy.to_string();
-        let parsed = Policy::parse(Some(id), &text).unwrap_or_else(|e| {
-            panic!(
-                "Failed to parse policy from text:\n{}\nError: {:?}",
-                text, e
-            )
-        });
-        reconstructed
-            .add(parsed)
-            .unwrap_or_else(|e| panic!("Failed to add policy: {:?}", e));
-    }
-
-    // Re-link templates using original link info
-    for link in &pst_set.template_links {
-        let vals: HashMap<SlotId, EntityUid> = link
-            .values
-            .iter()
-            .map(|(k, v)| {
-                (
-                    (*k).into(),
-                    cedar_policy_core::ast::EntityUID::from(v.clone()).into(),
-                )
-            })
-            .collect();
-        reconstructed
-            .link(
-                link.template_id.clone().into(),
-                link.new_id.clone().into(),
-                vals,
-            )
-            .unwrap_or_else(|e| panic!("Failed to link template: {:?}", e));
-    }
+    let reconstructed = policyset_to_cedar_parses(policy_set);
 
     // Reconstructed to PST using to_pst, should maintain ids
     let roundtripped = reconstructed

--- a/cedar-drt/fuzz/src/lib.rs
+++ b/cedar-drt/fuzz/src/lib.rs
@@ -17,6 +17,7 @@
 pub use libfuzzer_sys::fuzz_target;
 
 pub mod abac;
+pub mod props;
 pub mod proto_gen;
 pub mod pst_equiv;
 pub mod pst_gen;

--- a/cedar-drt/fuzz/src/lib.rs
+++ b/cedar-drt/fuzz/src/lib.rs
@@ -17,6 +17,7 @@
 pub use libfuzzer_sys::fuzz_target;
 
 pub mod abac;
+pub mod proto_gen;
 pub mod pst_equiv;
 pub mod pst_gen;
 pub mod roundtrip_entities;

--- a/cedar-drt/fuzz/src/props.rs
+++ b/cedar-drt/fuzz/src/props.rs
@@ -25,7 +25,7 @@ use cedar_policy::{
 /// The [`Entity`] gets converted to a singleton [`Entities`].
 pub fn entity_to_json_roundtrips(original: Entity) {
     // Wrap in Entities for JSON serialization
-    let entities = Entities::from_entities([original.clone()], None)
+    let entities = Entities::from_entities([original], None)
         .expect("Failed to create Entities from single entity");
     entities_to_json_roundtrips(entities);
 }

--- a/cedar-drt/fuzz/src/props.rs
+++ b/cedar-drt/fuzz/src/props.rs
@@ -1,0 +1,117 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! This module contains properties that API-level entities should satisfy.
+
+use crate::roundtrip_entities::pretty_assert_entities_deep_eq;
+use cedar_policy::{Entities, Entity, Policy, PolicySet, Template};
+
+/// An [`Entity`] should roundrtrip through serialization with json and then deserialization.
+/// The [`Entity`] gets converted to a singleton [`Entities`].
+pub fn entity_to_json_roundtrips(original: Entity) {
+    // Wrap in Entities for JSON serialization
+    let entities = Entities::from_entities([original.clone()], None)
+        .expect("Failed to create Entities from single entity");
+    entities_to_json_roundtrips(entities);
+}
+
+/// An [`Entities`] should roundtrip through serialization with json and then deserialization.
+pub fn entities_to_json_roundtrips(original: Entities) {
+    // Serialize to JSON
+    let json = original.to_json_value().unwrap_or_else(|e| {
+        panic!(
+            "Entities could not be serialized to JSON.\n\
+             Original: {:?}\nError: {e}",
+            e
+        )
+    });
+
+    // Re-parse from JSON
+    let roundtripped = Entities::from_json_value(json.clone(), None).unwrap_or_else(|e| {
+        panic!(
+            "JSON from Entities failed to re-parse.\n\
+             Original: {:?}\nJSON: {json}\nParse error: {e}",
+            e
+        )
+    });
+
+    pretty_assert_entities_deep_eq(&original, &roundtripped);
+}
+
+/// A [`Template`] should print to Cedar and parse again. This function panic for inputs where
+/// it does not.
+pub fn template_to_cedar_parses(original: Template) {
+    // Print to Cedar text
+    let cedar_text = original.to_cedar();
+
+    // Re-parse (templates parse as part of a policy set)
+    let _: cedar_policy::PolicySet = cedar_text.parse().unwrap_or_else(|e| {
+        panic!(
+            "This cedar_policy::Template cannot be printed and parsed:\n{:?}\nParse error: {e}",
+            original
+        )
+    });
+}
+
+/// A [`PolicySet`] should print to Cedar and parse again. This function panics for inputs where
+/// it does not.
+/// This also returns the [`PolicySet`] reconstructed by printing and parsing.
+pub fn policyset_to_cedar_parses(original: PolicySet) -> PolicySet {
+    let mut reconstructed = PolicySet::new();
+
+    // Templates: print each to text, parse back with original ID
+    for template in original.templates() {
+        let id = template.id().clone();
+        let text = template.to_string();
+        let parsed = Template::parse(Some(id.clone()), &text).unwrap_or_else(|e| {
+            panic!("Failed to parse template from text:\n{text}\nError: {e:?}")
+        });
+        reconstructed
+            .add_template(parsed)
+            .unwrap_or_else(|e| panic!("Failed to add template {id}: {e:?}"));
+    }
+
+    // Static policies: print each to text, parse back with original ID
+    // Linked policies: re-link from template
+    for policy in original.policies() {
+        if let (Some(template_id), Some(links)) = (policy.template_id(), policy.template_links()) {
+            reconstructed
+                .link(template_id.clone(), policy.id().clone(), links)
+                .unwrap_or_else(|e| panic!("Failed to link template {template_id}: {e:?}"));
+        } else {
+            let id = policy.id().clone();
+            let text = policy.to_string();
+            let parsed = Policy::parse(Some(id.clone()), &text).unwrap_or_else(|e| {
+                panic!("Failed to parse policy from text:\n{text}\nError: {e:?}")
+            });
+            reconstructed
+                .add(parsed)
+                .unwrap_or_else(|e| panic!("Failed to add policy {id}: {e:?}"));
+        }
+    }
+    reconstructed
+}
+
+/// A [`PolicySet`] should serialize to JSON and deserialize again. This function panics for
+/// inputs where it does not.
+pub fn policyset_to_json_deserializes(original: PolicySet) -> PolicySet {
+    let json = original
+        .to_json()
+        .unwrap_or_else(|e| panic!("PolicySet could not be serialized to JSON.\nError: {e:?}"));
+    PolicySet::from_json_value(json.clone()).unwrap_or_else(|e| {
+        panic!("JSON from PolicySet failed to deserialize.\nJSON: {json}\nError: {e:?}")
+    })
+}

--- a/cedar-drt/fuzz/src/props.rs
+++ b/cedar-drt/fuzz/src/props.rs
@@ -17,7 +17,9 @@
 //! This module contains properties that API-level entities should satisfy.
 
 use crate::roundtrip_entities::pretty_assert_entities_deep_eq;
-use cedar_policy::{Entities, Entity, Policy, PolicySet, Template};
+use cedar_policy::{
+    Entities, Entity, Expression, Policy, PolicySet, Request, RestrictedExpression, Template,
+};
 
 /// An [`Entity`] should roundrtrip through serialization with json and then deserialization.
 /// The [`Entity`] gets converted to a singleton [`Entities`].
@@ -49,6 +51,19 @@ pub fn entities_to_json_roundtrips(original: Entities) {
     });
 
     pretty_assert_entities_deep_eq(&original, &roundtripped);
+}
+
+pub fn expression_to_cedar_parses(original: Expression) {
+    // Print to cedar text, wrapped in a policy body
+    let cedar_text = original.to_string();
+
+    // Re-parse as a policy
+    let _: Expression = cedar_text.parse().unwrap_or_else(|e| {
+        panic!(
+            "This Expression cannot be printed and parsed:\n{:?}\nParse error: {e}",
+            original
+        )
+    });
 }
 
 /// A [`Template`] should print to Cedar and parse again. This function panic for inputs where
@@ -103,6 +118,22 @@ pub fn policyset_to_cedar_parses(original: PolicySet) -> PolicySet {
         }
     }
     reconstructed
+}
+
+/// A [`Request`]'s context values should each print to Cedar and re-parse. This tests that
+/// protobuf decoding validation is not weaker than Cedar text parsing for context expressions.
+pub fn request_context_to_cedar_parses(request: Request) {
+    if let Some(context) = request.context() {
+        for (key, value) in context.clone() {
+            let text = value.as_ref().to_string();
+            let _: RestrictedExpression = text.parse().unwrap_or_else(|e| {
+                panic!(
+                    "Context value for key `{key}` cannot be printed and parsed:\n\
+                     {value:?}\nParse error: {e}"
+                )
+            });
+        }
+    }
 }
 
 /// A [`PolicySet`] should serialize to JSON and deserialize again. This function panics for

--- a/cedar-drt/fuzz/src/proto_gen.rs
+++ b/cedar-drt/fuzz/src/proto_gen.rs
@@ -664,3 +664,33 @@ impl<'a> Arbitrary<'a> for ProtoEntityInput {
         })
     }
 }
+
+/// Fuzz input: a protobuf Entity model.
+#[derive(Debug, Clone)]
+pub struct ProtoExprInput {
+    pub expr: models::Expr,
+}
+
+impl<'a> Arbitrary<'a> for ProtoExprInput {
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        let g = ModelGenerator::arbitrary(u)?;
+        Ok(Self {
+            expr: g.arbitrary_model_expr(u, g.max_expr_depth)?,
+        })
+    }
+}
+
+/// Fuzz input: a protobuf Request model.
+#[derive(Debug, Clone)]
+pub struct ProtoRequestInput {
+    pub request: models::Request,
+}
+
+impl<'a> Arbitrary<'a> for ProtoRequestInput {
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        let g = ModelGenerator::arbitrary(u)?;
+        Ok(Self {
+            request: g.arbitrary_model_request(u)?,
+        })
+    }
+}

--- a/cedar-drt/fuzz/src/proto_gen.rs
+++ b/cedar-drt/fuzz/src/proto_gen.rs
@@ -1,0 +1,666 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! Generators that directly produce `proto::models::*` types.
+//!
+//! The goal is to generate protobuf messages that are "semi-valid" — they use
+//! valid Cedar identifiers and structurally sound messages, but may exercise
+//! edge cases in the proto→domain conversion that the domain→proto path never
+//! produces.
+
+use cedar_policy::proto::models;
+use cedar_policy_core::ast;
+use libfuzzer_sys::arbitrary::{self, Arbitrary, Unstructured};
+
+/// Pool of extension function names.
+const EXT_FNS: &[(&[&str], &str)] = &[
+    (&[], "ip"),
+    (&[], "decimal"),
+    (&[], "datetime"),
+    (&[], "duration"),
+];
+
+/// Configuration and generator for proto model types.
+#[derive(Debug, Clone)]
+pub struct ModelGenerator {
+    /// Maximum depth for expression trees.
+    pub max_expr_depth: usize,
+    /// Maximum depth for schema type trees.
+    pub max_type_depth: usize,
+    /// Maximum number of templates in a policy set.
+    pub max_templates: usize,
+    /// Maximum number of entity declarations in a schema.
+    pub max_entity_decls: usize,
+    /// Maximum number of action declarations in a schema.
+    pub max_action_decls: usize,
+    /// Maximum number of entities in an entity set.
+    pub max_entities: usize,
+    /// Maximum number of attributes/context entries per item.
+    pub max_attrs: usize,
+    /// Maximum namespace path length.
+    pub max_namespace_depth: usize,
+    /// Range for literal integer values.
+    pub int_min: i64,
+    pub int_max: i64,
+    /// Maximum number of elements in a set/like-pattern.
+    pub max_list_elems: usize,
+    /// Maximum number of ancestors per entity.
+    pub max_ancestors: usize,
+    /// Maximum number of annotations per template.
+    pub max_annotations: usize,
+    /// Pool of identifiers to pick from (increases collision chance).
+    /// If empty, always generates fresh identifiers.
+    pub ident_pool: Vec<String>,
+    /// Pool of string constants (for EIDs, string literals).
+    /// If empty, always generates fresh strings.
+    pub string_pool: Vec<String>,
+    /// Pool of integer constants.
+    /// If empty, generates from int_min..=int_max.
+    pub int_pool: Vec<i64>,
+}
+
+impl Default for ModelGenerator {
+    fn default() -> Self {
+        Self {
+            max_expr_depth: 3,
+            max_type_depth: 2,
+            max_templates: 4,
+            max_entity_decls: 4,
+            max_action_decls: 3,
+            max_entities: 5,
+            max_attrs: 3,
+            max_namespace_depth: 2,
+            int_min: -1000,
+            int_max: 1000,
+            max_list_elems: 4,
+            max_ancestors: 3,
+            max_annotations: 2,
+            ident_pool: Vec::new(),
+            string_pool: Vec::new(),
+            int_pool: Vec::new(),
+        }
+    }
+}
+
+impl ModelGenerator {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Create a `ModelGenerator` with pools populated from arbitrary data.
+    /// This gives the fuzzer control over pool contents while ensuring
+    /// value reuse across the generated model.
+    pub fn arbitrary(u: &mut Unstructured<'_>) -> arbitrary::Result<Self> {
+        let ident_pool: Vec<String> = (0..u.int_in_range(2..=8)?)
+            .map(|_| {
+                let id: ast::UnreservedId = u.arbitrary()?;
+                Ok(id.to_string())
+            })
+            .collect::<arbitrary::Result<Vec<_>>>()?;
+        let string_pool: Vec<String> = (0..u.int_in_range(2..=6)?)
+            .map(|_| u.arbitrary())
+            .collect::<arbitrary::Result<Vec<_>>>()?;
+        let int_pool: Vec<i64> = (0..u.int_in_range(2..=6)?)
+            .map(|_| u.arbitrary())
+            .collect::<arbitrary::Result<Vec<_>>>()?;
+        Ok(Self {
+            ident_pool,
+            string_pool,
+            int_pool,
+            ..Self::default()
+        })
+    }
+
+    /// Pick an identifier from the pool, or generate a fresh one.
+    fn pick_ident<'a>(&self, u: &mut Unstructured<'a>) -> arbitrary::Result<String> {
+        if !self.ident_pool.is_empty() && u.ratio(3, 4)? {
+            Ok(u.choose(&self.ident_pool)?.clone())
+        } else {
+            let id: ast::UnreservedId = u.arbitrary()?;
+            Ok(id.to_string())
+        }
+    }
+
+    /// Pick a string from the pool, or generate a fresh one.
+    fn pick_string<'a>(&self, u: &mut Unstructured<'a>) -> arbitrary::Result<String> {
+        if !self.string_pool.is_empty() && u.ratio(3, 4)? {
+            Ok(u.choose(&self.string_pool)?.clone())
+        } else {
+            u.arbitrary()
+        }
+    }
+
+    /// Pick an integer from the pool, or generate one in range.
+    fn pick_int<'a>(&self, u: &mut Unstructured<'a>) -> arbitrary::Result<i64> {
+        if !self.int_pool.is_empty() && u.ratio(3, 4)? {
+            Ok(*u.choose(&self.int_pool)?)
+        } else {
+            u.int_in_range(self.int_min..=self.int_max)
+        }
+    }
+
+    pub fn arbitrary_model_name<'a>(
+        &self,
+        u: &mut Unstructured<'a>,
+    ) -> arbitrary::Result<models::Name> {
+        let id = self.pick_ident(u)?;
+        let path_len: usize = u.int_in_range(0..=self.max_namespace_depth)?;
+        let mut path = Vec::with_capacity(path_len);
+        for _ in 0..path_len {
+            path.push(self.pick_ident(u)?);
+        }
+        Ok(models::Name { id, path })
+    }
+
+    pub fn arbitrary_model_entity_uid<'a>(
+        &self,
+        u: &mut Unstructured<'a>,
+    ) -> arbitrary::Result<models::EntityUid> {
+        let ty = Some(self.arbitrary_model_name(u)?);
+        let eid = self.pick_string(u)?;
+        Ok(models::EntityUid { ty, eid })
+    }
+
+    pub fn arbitrary_model_expr<'a>(
+        &self,
+        u: &mut Unstructured<'a>,
+        max_depth: usize,
+    ) -> arbitrary::Result<models::Expr> {
+        use models::expr;
+
+        if max_depth == 0 {
+            let choice: u8 = u.int_in_range(0..=4)?;
+            let expr_kind = match choice {
+                0 => expr::ExprKind::Lit(expr::Literal {
+                    lit: Some(expr::literal::Lit::B(u.arbitrary()?)),
+                }),
+                1 => expr::ExprKind::Lit(expr::Literal {
+                    lit: Some(expr::literal::Lit::I(self.pick_int(u)?)),
+                }),
+                2 => expr::ExprKind::Lit(expr::Literal {
+                    lit: Some(expr::literal::Lit::S(self.pick_string(u)?)),
+                }),
+                3 => expr::ExprKind::Lit(expr::Literal {
+                    lit: Some(expr::literal::Lit::Euid(
+                        self.arbitrary_model_entity_uid(u)?,
+                    )),
+                }),
+                _ => expr::ExprKind::Var(u.int_in_range(0..=3)?),
+            };
+            return Ok(models::Expr {
+                expr_kind: Some(expr_kind),
+            });
+        }
+
+        let choice: u8 = u.int_in_range(0..=14)?;
+        let d = max_depth - 1;
+        let expr_kind = match choice {
+            0 => {
+                let lit_choice: u8 = u.int_in_range(0..=3)?;
+                let lit = match lit_choice {
+                    0 => expr::literal::Lit::B(u.arbitrary()?),
+                    1 => expr::literal::Lit::I(self.pick_int(u)?),
+                    2 => expr::literal::Lit::S(self.pick_string(u)?),
+                    _ => expr::literal::Lit::Euid(self.arbitrary_model_entity_uid(u)?),
+                };
+                expr::ExprKind::Lit(expr::Literal { lit: Some(lit) })
+            }
+            1 => expr::ExprKind::Var(u.int_in_range(0..=3)?),
+            2 => expr::ExprKind::Slot(u.int_in_range(0..=1)?),
+            3 => expr::ExprKind::If(Box::new(expr::If {
+                test_expr: Some(Box::new(self.arbitrary_model_expr(u, d)?)),
+                then_expr: Some(Box::new(self.arbitrary_model_expr(u, d)?)),
+                else_expr: Some(Box::new(self.arbitrary_model_expr(u, d)?)),
+            })),
+            4 => expr::ExprKind::And(Box::new(expr::And {
+                left: Some(Box::new(self.arbitrary_model_expr(u, d)?)),
+                right: Some(Box::new(self.arbitrary_model_expr(u, d)?)),
+            })),
+            5 => expr::ExprKind::Or(Box::new(expr::Or {
+                left: Some(Box::new(self.arbitrary_model_expr(u, d)?)),
+                right: Some(Box::new(self.arbitrary_model_expr(u, d)?)),
+            })),
+            6 => expr::ExprKind::UApp(Box::new(expr::UnaryApp {
+                op: u.int_in_range(0..=2)?,
+                expr: Some(Box::new(self.arbitrary_model_expr(u, d)?)),
+            })),
+            7 => expr::ExprKind::BApp(Box::new(expr::BinaryApp {
+                op: u.int_in_range(0..=11)?,
+                left: Some(Box::new(self.arbitrary_model_expr(u, d)?)),
+                right: Some(Box::new(self.arbitrary_model_expr(u, d)?)),
+            })),
+            8 => {
+                let (path, id) = u.choose(EXT_FNS)?;
+                let num_args: usize = u.int_in_range(1..=self.max_list_elems)?;
+                let args = (0..num_args)
+                    .map(|_| self.arbitrary_model_expr(u, d))
+                    .collect::<arbitrary::Result<Vec<_>>>()?;
+                expr::ExprKind::ExtApp(expr::ExtensionFunctionApp {
+                    fn_name: Some(models::Name {
+                        id: id.to_string(),
+                        path: path.iter().map(|s| s.to_string()).collect(),
+                    }),
+                    args,
+                })
+            }
+            9 => expr::ExprKind::GetAttr(Box::new(expr::GetAttr {
+                expr: Some(Box::new(self.arbitrary_model_expr(u, d)?)),
+                attr: self.pick_ident(u)?,
+            })),
+            10 => expr::ExprKind::HasAttr(Box::new(expr::HasAttr {
+                expr: Some(Box::new(self.arbitrary_model_expr(u, d)?)),
+                attr: self.pick_ident(u)?,
+            })),
+            11 => {
+                let num_elems: usize = u.int_in_range(0..=self.max_list_elems)?;
+                let pattern = (0..num_elems)
+                    .map(|_| {
+                        let is_wildcard: bool = u.arbitrary()?;
+                        let data = if is_wildcard {
+                            Some(expr::like::pattern_elem::Data::Wildcard(0))
+                        } else {
+                            Some(expr::like::pattern_elem::Data::C(self.pick_string(u)?))
+                        };
+                        Ok(expr::like::PatternElem { data })
+                    })
+                    .collect::<arbitrary::Result<Vec<_>>>()?;
+                expr::ExprKind::Like(Box::new(expr::Like {
+                    expr: Some(Box::new(self.arbitrary_model_expr(u, d)?)),
+                    pattern,
+                }))
+            }
+            12 => expr::ExprKind::Is(Box::new(expr::Is {
+                expr: Some(Box::new(self.arbitrary_model_expr(u, d)?)),
+                entity_type: Some(self.arbitrary_model_name(u)?),
+            })),
+            13 => {
+                let num_elems: usize = u.int_in_range(0..=self.max_list_elems)?;
+                let elements = (0..num_elems)
+                    .map(|_| self.arbitrary_model_expr(u, d))
+                    .collect::<arbitrary::Result<Vec<_>>>()?;
+                expr::ExprKind::Set(expr::Set { elements })
+            }
+            _ => {
+                let num_items: usize = u.int_in_range(0..=self.max_attrs)?;
+                let items = (0..num_items)
+                    .map(|_| Ok((self.pick_ident(u)?, self.arbitrary_model_expr(u, d)?)))
+                    .collect::<arbitrary::Result<std::collections::HashMap<_, _>>>()?;
+                expr::ExprKind::Record(expr::Record { items })
+            }
+        };
+        Ok(models::Expr {
+            expr_kind: Some(expr_kind),
+        })
+    }
+
+    pub fn arbitrary_model_entity_reference<'a>(
+        &self,
+        u: &mut Unstructured<'a>,
+        allow_slot: bool,
+    ) -> arbitrary::Result<models::EntityReference> {
+        use models::entity_reference;
+        let data = if allow_slot && u.ratio(1, 4)? {
+            Some(entity_reference::Data::Slot(0))
+        } else {
+            Some(entity_reference::Data::Euid(
+                self.arbitrary_model_entity_uid(u)?,
+            ))
+        };
+        Ok(models::EntityReference { data })
+    }
+
+    pub fn arbitrary_model_principal_or_resource_constraint<'a>(
+        &self,
+        u: &mut Unstructured<'a>,
+        allow_slot: bool,
+    ) -> arbitrary::Result<models::PrincipalOrResourceConstraint> {
+        use models::principal_or_resource_constraint::*;
+        let choice: u8 = u.int_in_range(0..=4)?;
+        let data = match choice {
+            0 => Data::Any(0),
+            1 => Data::In(InMessage {
+                er: Some(self.arbitrary_model_entity_reference(u, allow_slot)?),
+            }),
+            2 => Data::Eq(EqMessage {
+                er: Some(self.arbitrary_model_entity_reference(u, allow_slot)?),
+            }),
+            3 => Data::Is(IsMessage {
+                entity_type: Some(self.arbitrary_model_name(u)?),
+            }),
+            _ => Data::IsIn(IsInMessage {
+                er: Some(self.arbitrary_model_entity_reference(u, allow_slot)?),
+                entity_type: Some(self.arbitrary_model_name(u)?),
+            }),
+        };
+        Ok(models::PrincipalOrResourceConstraint { data: Some(data) })
+    }
+
+    pub fn arbitrary_model_action_constraint<'a>(
+        &self,
+        u: &mut Unstructured<'a>,
+    ) -> arbitrary::Result<models::ActionConstraint> {
+        use models::action_constraint::*;
+        let choice: u8 = u.int_in_range(0..=2)?;
+        let data = match choice {
+            0 => Data::Any(0),
+            1 => {
+                let num: usize = u.int_in_range(1..=self.max_list_elems)?;
+                let euids = (0..num)
+                    .map(|_| self.arbitrary_model_entity_uid(u))
+                    .collect::<arbitrary::Result<Vec<_>>>()?;
+                Data::In(InMessage { euids })
+            }
+            _ => Data::Eq(EqMessage {
+                euid: Some(self.arbitrary_model_entity_uid(u)?),
+            }),
+        };
+        Ok(models::ActionConstraint { data: Some(data) })
+    }
+
+    pub fn arbitrary_model_template_body<'a>(
+        &self,
+        u: &mut Unstructured<'a>,
+        allow_slots: bool,
+    ) -> arbitrary::Result<models::TemplateBody> {
+        let id = format!("policy{}", u.int_in_range(0..=99)?);
+        let num_annotations: usize = u.int_in_range(0..=self.max_annotations)?;
+        let annotations = (0..num_annotations)
+            .map(|_| Ok((self.pick_ident(u)?, self.pick_ident(u)?)))
+            .collect::<arbitrary::Result<std::collections::HashMap<_, _>>>()?;
+        let effect = u.int_in_range(0..=1)?;
+        let principal_constraint =
+            Some(self.arbitrary_model_principal_or_resource_constraint(u, allow_slots)?);
+        let action_constraint = Some(self.arbitrary_model_action_constraint(u)?);
+        let resource_constraint =
+            Some(self.arbitrary_model_principal_or_resource_constraint(u, allow_slots)?);
+        let non_scope_constraints = Some(self.arbitrary_model_expr(u, self.max_expr_depth)?);
+
+        Ok(models::TemplateBody {
+            id,
+            annotations,
+            effect,
+            principal_constraint,
+            action_constraint,
+            resource_constraint,
+            non_scope_constraints,
+        })
+    }
+
+    pub fn arbitrary_model_policy_link<'a>(
+        &self,
+        u: &mut Unstructured<'a>,
+        template_id: &str,
+        is_template_link: bool,
+    ) -> arbitrary::Result<models::Policy> {
+        let link_id = if is_template_link {
+            Some(format!("link{}", u.int_in_range(0..=99)?))
+        } else {
+            None
+        };
+        Ok(models::Policy {
+            template_id: template_id.to_string(),
+            link_id,
+            is_template_link,
+            principal_euid: Some(self.arbitrary_model_entity_uid(u)?),
+            resource_euid: Some(self.arbitrary_model_entity_uid(u)?),
+        })
+    }
+
+    pub fn arbitrary_model_policy_set<'a>(
+        &self,
+        u: &mut Unstructured<'a>,
+    ) -> arbitrary::Result<models::PolicySet> {
+        let num_templates: usize = u.int_in_range(1..=self.max_templates)?;
+        let mut templates = Vec::with_capacity(num_templates);
+        let mut links = Vec::new();
+
+        for _ in 0..num_templates {
+            let has_slots: bool = u.arbitrary()?;
+            let template = self.arbitrary_model_template_body(u, has_slots)?;
+            let tid = template.id.clone();
+            templates.push(template);
+
+            if has_slots {
+                links.push(self.arbitrary_model_policy_link(u, &tid, true)?);
+            } else {
+                links.push(self.arbitrary_model_policy_link(u, &tid, false)?);
+            }
+        }
+
+        Ok(models::PolicySet { templates, links })
+    }
+
+    pub fn arbitrary_model_request<'a>(
+        &self,
+        u: &mut Unstructured<'a>,
+    ) -> arbitrary::Result<models::Request> {
+        let num_context: usize = u.int_in_range(0..=self.max_attrs)?;
+        let context = (0..num_context)
+            .map(|_| {
+                Ok((
+                    self.pick_ident(u)?,
+                    self.arbitrary_model_expr(u, self.max_expr_depth)?,
+                ))
+            })
+            .collect::<arbitrary::Result<std::collections::HashMap<_, _>>>()?;
+        Ok(models::Request {
+            principal: Some(self.arbitrary_model_entity_uid(u)?),
+            action: Some(self.arbitrary_model_entity_uid(u)?),
+            resource: Some(self.arbitrary_model_entity_uid(u)?),
+            context,
+        })
+    }
+
+    pub fn arbitrary_model_entity<'a>(
+        &self,
+        u: &mut Unstructured<'a>,
+    ) -> arbitrary::Result<models::Entity> {
+        let num_attrs: usize = u.int_in_range(0..=self.max_attrs)?;
+        let attrs = (0..num_attrs)
+            .map(|_| Ok((self.pick_ident(u)?, self.arbitrary_model_expr(u, 1)?)))
+            .collect::<arbitrary::Result<std::collections::HashMap<_, _>>>()?;
+        let num_ancestors: usize = u.int_in_range(0..=self.max_ancestors)?;
+        let ancestors = (0..num_ancestors)
+            .map(|_| self.arbitrary_model_entity_uid(u))
+            .collect::<arbitrary::Result<Vec<_>>>()?;
+        let num_tags: usize = u.int_in_range(0..=self.max_attrs)?;
+        let tags = (0..num_tags)
+            .map(|_| Ok((self.pick_ident(u)?, self.arbitrary_model_expr(u, 1)?)))
+            .collect::<arbitrary::Result<std::collections::HashMap<_, _>>>()?;
+        Ok(models::Entity {
+            uid: Some(self.arbitrary_model_entity_uid(u)?),
+            attrs,
+            ancestors,
+            tags,
+        })
+    }
+
+    pub fn arbitrary_model_entities<'a>(
+        &self,
+        u: &mut Unstructured<'a>,
+    ) -> arbitrary::Result<models::Entities> {
+        let num: usize = u.int_in_range(0..=self.max_entities)?;
+        let entities = (0..num)
+            .map(|_| self.arbitrary_model_entity(u))
+            .collect::<arbitrary::Result<Vec<_>>>()?;
+        Ok(models::Entities { entities })
+    }
+
+    pub fn arbitrary_model_type<'a>(
+        &self,
+        u: &mut Unstructured<'a>,
+        max_depth: usize,
+    ) -> arbitrary::Result<models::Type> {
+        use models::r#type;
+        if max_depth == 0 {
+            let prim = u.int_in_range(0..=2)?;
+            return Ok(models::Type {
+                data: Some(r#type::Data::Prim(prim)),
+            });
+        }
+        let choice: u8 = u.int_in_range(0..=4)?;
+        let data = match choice {
+            0 => r#type::Data::Prim(u.int_in_range(0..=2)?),
+            1 => r#type::Data::SetElem(Box::new(self.arbitrary_model_type(u, max_depth - 1)?)),
+            2 => r#type::Data::Entity(self.arbitrary_model_name(u)?),
+            3 => {
+                let num_attrs: usize = u.int_in_range(0..=self.max_attrs)?;
+                let attrs = (0..num_attrs)
+                    .map(|_| {
+                        Ok((
+                            self.pick_ident(u)?,
+                            models::AttributeType {
+                                attr_type: Some(self.arbitrary_model_type(u, max_depth - 1)?),
+                                is_required: u.arbitrary()?,
+                            },
+                        ))
+                    })
+                    .collect::<arbitrary::Result<std::collections::HashMap<_, _>>>()?;
+                r#type::Data::Record(r#type::Record { attrs })
+            }
+            _ => r#type::Data::Ext(self.arbitrary_model_name(u)?),
+        };
+        Ok(models::Type { data: Some(data) })
+    }
+
+    pub fn arbitrary_model_schema<'a>(
+        &self,
+        u: &mut Unstructured<'a>,
+    ) -> arbitrary::Result<models::Schema> {
+        let num_entity_decls: usize = u.int_in_range(1..=self.max_entity_decls)?;
+        let entity_decls = (0..num_entity_decls)
+            .map(|_| {
+                let num_attrs: usize = u.int_in_range(0..=self.max_attrs)?;
+                let attributes = (0..num_attrs)
+                    .map(|_| {
+                        Ok((
+                            self.pick_ident(u)?,
+                            models::AttributeType {
+                                attr_type: Some(self.arbitrary_model_type(u, self.max_type_depth)?),
+                                is_required: u.arbitrary()?,
+                            },
+                        ))
+                    })
+                    .collect::<arbitrary::Result<std::collections::HashMap<_, _>>>()?;
+                let num_descendants: usize = u.int_in_range(0..=2)?;
+                let descendants = (0..num_descendants)
+                    .map(|_| self.arbitrary_model_name(u))
+                    .collect::<arbitrary::Result<Vec<_>>>()?;
+                let tags = if u.ratio(1, 3)? {
+                    Some(self.arbitrary_model_type(u, 1)?)
+                } else {
+                    None
+                };
+                Ok(models::EntityDecl {
+                    name: Some(self.arbitrary_model_name(u)?),
+                    descendants,
+                    attributes,
+                    tags,
+                    enum_choices: vec![],
+                })
+            })
+            .collect::<arbitrary::Result<Vec<_>>>()?;
+
+        let num_action_decls: usize = u.int_in_range(1..=self.max_action_decls)?;
+        let action_decls = (0..num_action_decls)
+            .map(|_| {
+                let num_context: usize = u.int_in_range(0..=2)?;
+                let context = (0..num_context)
+                    .map(|_| {
+                        Ok((
+                            self.pick_ident(u)?,
+                            models::AttributeType {
+                                attr_type: Some(self.arbitrary_model_type(u, self.max_type_depth)?),
+                                is_required: u.arbitrary()?,
+                            },
+                        ))
+                    })
+                    .collect::<arbitrary::Result<std::collections::HashMap<_, _>>>()?;
+                let num_principal_types: usize = u.int_in_range(1..=2)?;
+                let principal_types = (0..num_principal_types)
+                    .map(|_| self.arbitrary_model_name(u))
+                    .collect::<arbitrary::Result<Vec<_>>>()?;
+                let num_resource_types: usize = u.int_in_range(1..=2)?;
+                let resource_types = (0..num_resource_types)
+                    .map(|_| self.arbitrary_model_name(u))
+                    .collect::<arbitrary::Result<Vec<_>>>()?;
+                let num_descendants: usize = u.int_in_range(0..=2)?;
+                let descendants = (0..num_descendants)
+                    .map(|_| self.arbitrary_model_entity_uid(u))
+                    .collect::<arbitrary::Result<Vec<_>>>()?;
+                Ok(models::ActionDecl {
+                    name: Some(self.arbitrary_model_entity_uid(u)?),
+                    descendants,
+                    context,
+                    principal_types,
+                    resource_types,
+                })
+            })
+            .collect::<arbitrary::Result<Vec<_>>>()?;
+
+        Ok(models::Schema {
+            entity_decls,
+            action_decls,
+        })
+    }
+}
+
+// --- Wrapper types for use as fuzz target inputs ---
+
+/// Fuzz input: a protobuf PolicySet model.
+#[derive(Debug, Clone)]
+pub struct ProtoPolicySetInput {
+    pub policy_set: models::PolicySet,
+}
+
+impl<'a> Arbitrary<'a> for ProtoPolicySetInput {
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        let g = ModelGenerator::arbitrary(u)?;
+        Ok(Self {
+            policy_set: g.arbitrary_model_policy_set(u)?,
+        })
+    }
+}
+
+/// Fuzz input: a protobuf Schema model.
+#[derive(Debug, Clone)]
+pub struct ProtoSchemaInput {
+    pub schema: models::Schema,
+}
+
+impl<'a> Arbitrary<'a> for ProtoSchemaInput {
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        let g = ModelGenerator::arbitrary(u)?;
+        Ok(Self {
+            schema: g.arbitrary_model_schema(u)?,
+        })
+    }
+}
+
+/// Fuzz input: a protobuf Entity model.
+#[derive(Debug, Clone)]
+pub struct ProtoEntityInput {
+    pub entity: models::Entity,
+}
+
+impl<'a> Arbitrary<'a> for ProtoEntityInput {
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        let g = ModelGenerator::arbitrary(u)?;
+        Ok(Self {
+            entity: g.arbitrary_model_entity(u)?,
+        })
+    }
+}


### PR DESCRIPTION
This PR adds fuzzing targets that test that validation of inputs from decoding protobufs is the same as validation on other inputs. 
Those targets should succeed when we add validation of `models::*`. 

The matching PR in cedar/ : https://github.com/cedar-policy/cedar/pull/2372 

The next pair of PRs will deal with protobuf decoding for schemas.