### PR TITLE
Add `as` variant for `simp_do_let`

### DIFF
--- a/cedar-lean/Cedar/Thm/Authorization/Authorizer.lean
+++ b/cedar-lean/Cedar/Thm/Authorization/Authorizer.lean
@@ -233,14 +233,14 @@ theorem Except.isOk_iff_exists {x : Except ε α} :
 := by
   cases x <;> simp [Except.isOk, Except.toBool]
 
-theorem if_mapM_doesn't_fail_on_list_then_doesn't_fail_on_set [LT α] [DecidableLT α] [StrictLT α] {f : α → Except ε β} {as : List α} :
-  Except.isOk (as.mapM f) →
-  Except.isOk ((Set.elts (Set.make as)).mapM f)
+theorem if_mapM_doesn't_fail_on_list_then_doesn't_fail_on_set [LT α] [DecidableLT α] [StrictLT α] {f : α → Except ε β} {xs : List α} :
+  Except.isOk (xs.mapM f) →
+  Except.isOk ((Set.elts (Set.make xs)).mapM f)
 := by
   intro h₁
   replace ⟨bs, h₁⟩ := Except.isOk_iff_exists.mp h₁
   replace h₁ := List.mapM_ok_implies_all_ok h₁
-  cases as <;> simp at h₁
+  cases xs <;> simp at h₁
   case nil => simp [pure, Except.pure, Except.isOk, Except.toBool]
   case cons ahd atl =>
     replace ⟨⟨b, _, h₁⟩, h₂⟩ := h₁

--- a/cedar-lean/Cedar/Thm/Authorization/Evaluator.lean
+++ b/cedar-lean/Cedar/Thm/Authorization/Evaluator.lean
@@ -15,7 +15,7 @@
 -/
 
 import Cedar.Spec
-import Cedar.Thm.Data.Control
+import Cedar.Thm.Tactics
 import Cedar.Thm.Data.List
 import Cedar.Thm.Data.Map
 
@@ -250,7 +250,7 @@ theorem record_value_contains_evaluated_attrs {rxs : List (Attr × Expr)} {rvs :
     apply List.Forall₂.imp _ he₁
     intro x y h
     simp only [bindAttr] at h
-    cases hx : evaluate x.snd request entities <;> simp only [hx, Except.bind_err, Except.bind_ok, reduceCtorEq] at h
+    simp_do_let (evaluate x.snd request entities) as hx at h
     simp only [pure, Except.pure, Except.ok.injEq] at h
     simp only [←h, and_self]
   replace he₁ := List.canonicalize_preserves_forallᵥ _ _ _ he₁

--- a/cedar-lean/Cedar/Thm/BatchedEvaluator/Authorize.lean
+++ b/cedar-lean/Cedar/Thm/BatchedEvaluator/Authorize.lean
@@ -161,9 +161,8 @@ theorem evaluatePolicies_equiv_and_well_typed
   refine ⟨rfl, rfl, (partial_evaluate_policy_is_sound h_ep h_schema_env h_wf h_ref).symm, ?_⟩
   simp only [evaluatePolicy, h_schema_env, List.empty_eq] at h_ep
   split at h_ep <;> try cases h_ep
-  cases hcheck : Except.mapError Error.invalidPolicy (checkEntities schema p.toExpr) <;>
-    simp only [hcheck, Except.bind_err, reduceCtorEq] at h_ep
-  simp only [Except.bind_ok, do_ok_eq_ok, Prod.exists, exists_and_right] at h_ep
+  simp_do_let (Except.mapError Error.invalidPolicy (checkEntities schema p.toExpr)) as hcheck at h_ep
+  simp only [do_ok_eq_ok, Prod.exists, exists_and_right] at h_ep
   rcases h_ep with ⟨_, ⟨_, h₁₁⟩, h₁₂⟩
   simp only [Except.mapError] at h₁₁
   split at h₁₁ <;> try cases h₁₁

--- a/cedar-lean/Cedar/Thm/SymCC/Compiler/WF.lean
+++ b/cedar-lean/Cedar/Thm/SymCC/Compiler/WF.lean
@@ -892,8 +892,7 @@ private theorem evaluate_ite_wf {x₁ x₂ x₃ : Expr} {env : Env} {v : Value}
   replace hwf := wf_env_for_ite_implies hwf
   rw [evaluate.eq_def] at hok
   simp only [Result.as] at hok
-  cases hok₁ : evaluate x₁ env.request env.entities <;>
-  simp only [hok₁, Except.bind_err, reduceCtorEq] at hok
+  simp_do_let (evaluate x₁ env.request env.entities) as hok₁ at hok
   rename_i v₁
   simp only [Coe.coe, Value.asBool] at hok
   split at hok <;>
@@ -912,8 +911,7 @@ private theorem evaluate_and_or_wf {x₁ x₂ : Expr} {env : Env} {v : Value} {s
   Value.WellFormed env.entities v
 := by
   simp only [Result.as] at hok
-  cases hok₁ : evaluate x₁ env.request env.entities <;>
-  simp only [hok₁, Except.bind_err, reduceCtorEq] at hok
+  simp_do_let (evaluate x₁ env.request env.entities) as hok₁ at hok
   rename_i v₁
   simp only [Coe.coe, Value.asBool] at hok
   split at hok <;>

--- a/cedar-lean/Cedar/Thm/SymCC/Opt/Authorizer.lean
+++ b/cedar-lean/Cedar/Thm/SymCC/Opt/Authorizer.lean
@@ -153,8 +153,9 @@ theorem Opt.isAuthorized.correctness (ps : Policies) (εnv : SymEnv) :
   simp [Opt.isAuthorized, SymCC.isAuthorized]
   rw [Opt.satisfiedPolicies.correctness .permit]
   rw [Opt.satisfiedPolicies.correctness .forbid]
-  simp_do_let SymCC.satisfiedPolicies .forbid ps εnv ; rename_i ft hforbid
-  simp_do_let SymCC.satisfiedPolicies .permit ps εnv ; rename_i pt hpermit
+  simp_do_let SymCC.satisfiedPolicies .forbid ps εnv
+  simp_do_let SymCC.satisfiedPolicies .permit ps εnv
+  rename_i ft hforbid pt hpermit
   simp only [Except.ok.injEq, Opt.CompileResult.mk.injEq, true_and]
   simp only [footprints, List.mapUnion_filterMap, List.mapUnion_map]
   rw [List.mapUnion_union_mapUnion']

--- a/cedar-lean/Cedar/Thm/SymCC/Opt/Authorizer.lean
+++ b/cedar-lean/Cedar/Thm/SymCC/Opt/Authorizer.lean
@@ -153,9 +153,9 @@ theorem Opt.isAuthorized.correctness (ps : Policies) (εnv : SymEnv) :
   simp [Opt.isAuthorized, SymCC.isAuthorized]
   rw [Opt.satisfiedPolicies.correctness .permit]
   rw [Opt.satisfiedPolicies.correctness .forbid]
-  simp_do_let SymCC.satisfiedPolicies .forbid ps εnv
-  simp_do_let SymCC.satisfiedPolicies .permit ps εnv
-  rename_i ft hforbid pt hpermit
+  simp_do_let SymCC.satisfiedPolicies .forbid ps εnv as hforbid
+  simp_do_let SymCC.satisfiedPolicies .permit ps εnv as hpermit
+  rename_i ft pt
   simp only [Except.ok.injEq, Opt.CompileResult.mk.injEq, true_and]
   simp only [footprints, List.mapUnion_filterMap, List.mapUnion_map]
   rw [List.mapUnion_union_mapUnion']

--- a/cedar-lean/Cedar/Thm/SymCC/Opt/CompiledPolicies.lean
+++ b/cedar-lean/Cedar/Thm/SymCC/Opt/CompiledPolicies.lean
@@ -57,7 +57,7 @@ theorem intoCompiledPolicySet_correctness {p : Policy} {Γ : Validation.TypeEnv}
   simp [Opt.isAuthorized, Opt.satisfiedPolicies, Opt.compileWithEffect]
   cases p'.effect <;> simp [Factory.anyTrue, Factory.or, Factory.not, Factory.and]
   all_goals {
-    simp_do_let Opt.compile p'.toExpr (SymEnv.ofEnv Γ) ; rename_i h
+    simp_do_let Opt.compile p'.toExpr (SymEnv.ofEnv Γ) as h
     simp only [Except.ok.injEq, CompiledPolicySet.mk.injEq, true_and]
     have hwf := Opt.compile_footprint_wf h
     simp [EmptyCollection.emptyCollection, Data.Set.union_empty_right List.mapUnion_wf, Data.Set.union_empty_left List.mapUnion_wf]

--- a/cedar-lean/Cedar/Thm/SymCC/Opt/Compiler.lean
+++ b/cedar-lean/Cedar/Thm/SymCC/Opt/Compiler.lean
@@ -113,7 +113,7 @@ private theorem Opt.compileHasAttr.correctness (t₁ : Term) (attr : Attr) (εs 
   (do let term ← SymCC.compileHasAttr t₁ attr εs ; .ok { term, footprint })
 := by
   simp only [Opt.compileHasAttr, SymCC.compileHasAttr, bind_assoc]
-  simp_do_let compileAttrsOf t₁ εs ; rename_i h₁
+  simp_do_let compileAttrsOf t₁ εs as h₁
   split <;> rename_i h <;> simp [h]
   split <;> rename_i h <;> simp [h]
 
@@ -697,7 +697,7 @@ private theorem both_lists_ok_then_elts_correspond {xs : List Expr} {εnv : SymE
   case cons hd tl =>
     simp [List.mapM_cons, Functor.map, Except.map] at h₁ h₂
     rw [ih _ (by simp)] at h₁
-    simp_do_let SymCC.compile hd εnv at h₁ ; rename_i hhd
+    simp_do_let SymCC.compile hd εnv as hhd at h₁
     case ok t =>
     simp [hhd] at h₂
     split at h₁ <;> simp at h₁
@@ -734,7 +734,7 @@ private theorem both_lists_pairs_ok_then_elts_correspond {xs : List (Attr × Exp
   case cons hd tl =>
     simp [List.mapM_cons, Functor.map, Except.map] at h₁ h₂
     rw [ih _ (by simp)] at h₁
-    simp_do_let compile hd.snd εnv at h₁ ; rename_i hhd
+    simp_do_let compile hd.snd εnv as hhd at h₁
     case ok t =>
     simp [hhd] at h₂
     split at h₁ <;> simp at h₁
@@ -955,8 +955,8 @@ theorem Opt.compile.correctness.set (ls : List Expr) (εnv : SymEnv) :
   simp [Opt.compile, SymCC.compile, footprint]
   rw [List.mapM₁_eq_mapM (Opt.compile · εnv), List.mapM₁_eq_mapM (SymCC.compile · εnv)]
   rw [List.mapUnion₁_eq_mapUnion (footprint · εnv)]
-  simp_do_let ls.mapM (Opt.compile · εnv) <;> rename_i hmap₁
-  <;> simp_do_let ls.mapM (SymCC.compile · εnv) <;> rename_i hmap₂
+  simp_do_let ls.mapM (Opt.compile · εnv) as hmap₁
+  <;> simp_do_let ls.mapM (SymCC.compile · εnv) as hmap₂
   case error.error e₁ e₂ =>
     simp only [Except.error.injEq]
     apply both_lists_error_then_errors_same hmap₁ hmap₂
@@ -1006,8 +1006,8 @@ theorem Opt.compile.correctness.record (m : List (Attr × Expr)) (εnv : SymEnv)
   simp only [List.mapM₂_eq_mapM (λ x => do Except.ok (x.fst, ← Opt.compile x.snd εnv)) m]
   simp only [List.mapM₂_eq_mapM (λ x => do Except.ok (x.fst, ← SymCC.compile x.snd εnv)) m]
   rw [List.mapUnion₂_eq_mapUnion (λ x => footprint x.snd εnv)]
-  simp_do_let m.mapM (m := SymCC.Result) _ <;> rename_i hmap₁
-  <;> simp_do_let m.mapM (m := SymCC.Result) _ <;> rename_i hmap₂
+  simp_do_let m.mapM (m := SymCC.Result) _ as hmap₁
+  <;> simp_do_let m.mapM (m := SymCC.Result) _ as hmap₂
   case error.error e₁ e₂ =>
     simp only [Except.error.injEq]
     apply both_lists_pairs_error_then_errors_same hmap₁ hmap₂
@@ -1059,8 +1059,8 @@ theorem Opt.compile.correctness.call (xfn : ExtFun) (args : List Expr) (εnv : S
   simp [Opt.compile, SymCC.compile, footprint]
   rw [List.mapM₁_eq_mapM (Opt.compile · εnv), List.mapM₁_eq_mapM (SymCC.compile · εnv)]
   rw [List.mapUnion₁_eq_mapUnion (footprint · εnv)]
-  simp_do_let args.mapM (Opt.compile · εnv) <;> rename_i hmap₁
-  <;> simp_do_let args.mapM (SymCC.compile · εnv) <;> rename_i hmap₂
+  simp_do_let args.mapM (Opt.compile · εnv) as hmap₁
+  <;> simp_do_let args.mapM (SymCC.compile · εnv) as hmap₂
   case error.error e₁ e₂ =>
     simp only [Except.error.injEq]
     apply both_lists_error_then_errors_same hmap₁ hmap₂

--- a/cedar-lean/Cedar/Thm/Tactics.lean
+++ b/cedar-lean/Cedar/Thm/Tactics.lean
@@ -29,11 +29,15 @@ namespace Cedar.Thm
 /--
 This tactic simplifies assumptions of the form `do (let x ← expr ...)` by
 performing a `cases` and `simp` on `expr`.
+
+Optionally, `as h` names the case-analysis hypothesis (avoiding a subsequent `rename_i`).
 -/
-syntax "simp_do_let" term (" at " ident)? : tactic
+syntax "simp_do_let" term (" as " ident)? (" at " ident)? : tactic
 
 macro_rules
-| `(tactic| simp_do_let $e $[at $h:ident]?) =>
-  `(tactic|
-    cases h' : $e <;>
-    simp only [h', Except.bind_err, Except.bind_ok, reduceCtorEq] $[at $h:ident]?)
+| `(tactic| simp_do_let $e as $h:ident $[at $loc:ident]?) =>
+  `(tactic| cases $h:ident : $e <;>
+    simp only [$h:ident, Except.bind_err, Except.bind_ok, reduceCtorEq] $[at $loc:ident]?)
+| `(tactic| simp_do_let $e $[at $loc:ident]?) =>
+  `(tactic| cases h' : $e <;>
+    simp only [h', Except.bind_err, Except.bind_ok, reduceCtorEq] $[at $loc:ident]?)

--- a/cedar-lean/Cedar/Thm/Validation.lean
+++ b/cedar-lean/Cedar/Thm/Validation.lean
@@ -66,8 +66,7 @@ theorem validation_is_sound (policies : Policies) (schema : Schema) (request : R
     apply typecheck_policy_with_environments_is_sound policy schema request entities h₁
     subst h₃
     simp only [List.forM_eq_forM, List.forM_cons] at h₀
-    cases h₄ : (typecheckPolicyWithEnvironments typecheckPolicy h' schema) <;>
-    simp only [h₄, Except.bind_err, reduceCtorEq] at h₀
+    simp_do_let (typecheckPolicyWithEnvironments typecheckPolicy h' schema) as h₄ at h₀
     case ok _ =>
       rw [List.mem_cons] at pin
       cases pin with

--- a/cedar-lean/Cedar/Thm/Validation/Levels.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Levels.lean
@@ -134,9 +134,8 @@ theorem typecheck_policy_at_level_with_environments_is_sound {p : Policy} {schem
 := by
   replace htl : ∀ x ∈ schema.environments, ∃ tx, typecheckPolicyWithLevel p n x = .ok tx := by
     simp only [typecheckPolicyWithEnvironments, Except.mapError] at htl
-    cases hes : checkEntities schema p.toExpr <;> simp only [hes, Except.bind_err, Except.bind_ok, reduceCtorEq] at htl
-    cases htl₁ : List.mapM (typecheckPolicyWithLevel p n) schema.environments <;>
-    simp only [htl₁, Except.bind_err, reduceCtorEq] at htl
+    simp_do_let (checkEntities schema p.toExpr) as hes at htl
+    simp_do_let (List.mapM (typecheckPolicyWithLevel p n) schema.environments) as htl₁ at htl
     replace htl₁ := List.forall₂_implies_all_left ∘ List.mapM_ok_iff_forall₂.mp $ htl₁
     intro env he
     specialize htl₁ env he

--- a/cedar-lean/Cedar/Thm/Validation/Levels/BinaryApp.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Levels/BinaryApp.lean
@@ -79,8 +79,8 @@ theorem level_based_slicing_is_sound_binary_app {op : BinaryOp} {e₁ e₂ : Exp
     have hl₁' := entity_access_at_level_then_at_level hl₁
     specialize ihe₁ hc hr htx₁ hl₁'
     rw [←ihe₁]
-    cases he₁ : evaluate e₁ request entities <;> simp only [Except.bind_ok, Except.bind_err]
-    cases he₂ : evaluate e₂ request entities <;> simp only [Except.bind_ok, Except.bind_err]
+    simp_do_let (evaluate e₁ request entities) as he₁
+    simp_do_let (evaluate e₂ request entities) as he₂
     rename_i v₁ v₂
     cases v₁ <;> cases v₂ <;> simp only [apply₂]
     rename_i p₁ p₂
@@ -94,8 +94,8 @@ theorem level_based_slicing_is_sound_binary_app {op : BinaryOp} {e₁ e₂ : Exp
     have hl₁' := entity_access_at_level_then_at_level hl₁
     specialize ihe₁ hc hr htx₁ hl₁'
     rw [←ihe₁]
-    cases he₁ : evaluate e₁ request entities <;> simp only [Except.bind_ok, Except.bind_err]
-    cases he₂ : evaluate e₂ request entities <;> simp only [Except.bind_ok, Except.bind_err]
+    simp_do_let (evaluate e₁ request entities) as he₁
+    simp_do_let (evaluate e₂ request entities) as he₂
     rename_i v₁ v₂
     cases v₁ <;> cases v₂ <;> simp only [apply₂]
     case prim =>

--- a/cedar-lean/Cedar/Thm/Validation/Slice/Reachable.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Slice/Reachable.lean
@@ -81,8 +81,8 @@ theorem or_not_euid_via_path {e₁ e₂: Expr} {entities : Entities} {path : Lis
 := by
   intro ha
   simp only [evaluate] at he
-  cases he₁ : Result.as Bool (evaluate e₁ request entities) <;>
-    simp only [he₁, bind_pure_comp, Except.bind_err, Except.bind_ok, reduceCtorEq] at he
+  simp_do_let Result.as Bool (evaluate e₁ request entities) as he₁ at he
+  simp only [bind_pure_comp] at he
   split at he
   · simp only [Except.ok.injEq] at he
     subst he ; cases ha
@@ -96,8 +96,8 @@ theorem unary_not_euid_via_path {op : UnaryOp} {e₁ : Expr} {entities : Entitie
 := by
   intro ha
   simp only [evaluate] at he
-  cases he₁ : evaluate e₁ request entities <;>
-    simp only [he₁, intOrErr, apply₁, Except.bind_err, Except.bind_ok, reduceCtorEq] at he
+  simp_do_let evaluate e₁ request entities as he₁ at he
+  simp only [intOrErr, apply₁] at he
   (split at he <;> try split at he) <;>
   try simp only [reduceCtorEq] at he
   all_goals

--- a/cedar-lean/Cedar/Thm/Validation/Slice/Reachable/BinaryApp.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Slice/Reachable/BinaryApp.lean
@@ -65,10 +65,8 @@ theorem checked_eval_entity_reachable_get_tag {e₁ e₂: Expr} {n : Nat} {c c' 
   ReachableIn entities request.sliceEUIDs euid (n + 1)
 := by
   simp only [evaluate] at he
-  simp_do_let (evaluate e₁ request entities) at he
-  rename_i he₁
-  simp_do_let (evaluate e₂ request entities) at he
-  rename_i he₂
+  simp_do_let (evaluate e₁ request entities) as he₁ at he
+  simp_do_let (evaluate e₂ request entities) as he₂ at he
   simp only [apply₂] at he
   split at he <;> try contradiction
   rename_i euid' _ _
@@ -78,8 +76,7 @@ theorem checked_eval_entity_reachable_get_tag {e₁ e₂: Expr} {n : Nat} {c c' 
   cases hl
   rename_i hl₁ hl₂
   simp only [getTag] at he
-  simp_do_let (entities.tags euid') at he
-  rename_i he₃
+  simp_do_let (entities.tags euid') as he₃ at he
   simp only [Map.findOrErr] at he
   split at he <;> simp only [reduceCtorEq, Except.ok.injEq] at he
   subst he
@@ -99,10 +96,8 @@ theorem binary_op_not_euid_via_path {op : BinaryOp} {e₁ e₂: Expr} {entities 
 := by
   intro ha
   simp only [evaluate] at he
-  simp_do_let (evaluate e₁ request entities) at he
-  rename_i he₁
-  simp_do_let (evaluate e₂ request entities) at he
-  rename_i he₂
+  simp_do_let (evaluate e₁ request entities) as he₁ at he
+  simp_do_let (evaluate e₂ request entities) as he₂ at he
   simp only [apply₂, intOrErr, inₛ, hasTag] at he
   split at he <;> try split at he
   all_goals first

--- a/cedar-lean/Cedar/Thm/Validation/Slice/Reachable/BinaryApp.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Slice/Reachable/BinaryApp.lean
@@ -106,7 +106,8 @@ theorem binary_op_not_euid_via_path {op : BinaryOp} {e₁ e₂: Expr} {entities 
     rw [←he] at ha
     cases ha
   | rename_i vs
-    cases he₃ : Set.mapOrErr Value.asEntityUID vs Error.typeError <;> simp only [he₃, Except.bind_err, Except.bind_ok, reduceCtorEq, Except.ok.injEq] at he
+    simp_do_let Set.mapOrErr Value.asEntityUID vs Error.typeError  as he₃ at he
+    simp only [Except.ok.injEq] at he
     rw [←he] at ha
     cases ha
 

--- a/cedar-lean/Cedar/Thm/Validation/Slice/Reachable/GetAttr.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Slice/Reachable/GetAttr.lean
@@ -66,7 +66,7 @@ theorem checked_eval_entity_reachable_get_attr {e : Expr} {n : Nat} {c c' : Capa
   ReachableIn entities request.sliceEUIDs euid (n + 1)
 := by
   simp only [evaluate] at he
-  cases he₁ : evaluate e request entities <;> simp only [he₁, Except.bind_err, reduceCtorEq] at he
+  simp_do_let (evaluate e request entities) as he₁ at he
   have ⟨ hc', tx', c₁', ht', htx, h₂ ⟩ := type_of_getAttr_inversion ht
   rw [htx] at hl
   have ⟨ hgc, v, he', hi ⟩ := type_of_is_sound hc hr ht'
@@ -85,10 +85,10 @@ theorem checked_eval_entity_reachable_get_attr {e : Expr} {n : Nat} {c c' : Capa
       exact he'
     subst hv
 
-    simp only [getAttr, attrsOf, Except.bind_ok] at he
-    cases he₂ : entities.attrs euid' <;> simp only [he₂, Except.bind_err, reduceCtorEq] at he
+    simp only [getAttr, attrsOf] at he
+    simp_do_let (entities.attrs euid') as he₂ at he
     rename_i attrs
-    simp only [Map.findOrErr, Except.bind_ok] at he
+    simp only [Map.findOrErr] at he
     split at he <;> simp only [reduceCtorEq, Except.ok.injEq] at he
     subst he
     rename_i v hv

--- a/cedar-lean/Cedar/Thm/Validation/Slice/Reachable/IfThenElse.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Slice/Reachable/IfThenElse.lean
@@ -50,7 +50,7 @@ theorem checked_eval_entity_reachable_ite {e₁ e₂ e₃: Expr} {n : Nat} {c c'
   rename_i hl₁ hl₂ hl₃
 
   simp only [evaluate] at he
-  cases he₁' : Result.as Bool (evaluate e₁ request entities) <;> simp only [he₁', Except.bind_err, Except.bind_ok, reduceCtorEq] at he
+  simp_do_let (Result.as Bool (evaluate e₁ request entities)) as he₁' at he
   rename_i b
   replace he₁' : evaluate e₁ request entities = .ok (.prim (.bool b)) := by
     simp only [Result.as, Coe.coe, Value.asBool] at he₁'

--- a/cedar-lean/Cedar/Thm/Validation/Typechecker/Basic.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Typechecker/Basic.lean
@@ -16,7 +16,7 @@
 
 import Cedar.Spec
 import Cedar.Validation
-import Cedar.Thm.Data.Control
+import Cedar.Thm.Tactics
 import Cedar.Thm.Validation.Typechecker.Types
 import Cedar.Thm.WellTyped.Expr.WF
 

--- a/cedar-lean/Cedar/Thm/Validation/Typechecker/BinaryApp.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Typechecker/BinaryApp.lean
@@ -43,8 +43,8 @@ theorem type_of_binaryApp_inversion {op₂ : BinaryOp} {x₁ x₂ : Expr} {c c' 
     ∃ ty, tx = .binaryApp op₂ tx₁ tx₂ ty
 := by
   simp only [typeOf] at htx
-  cases htx₁ : typeOf x₁ c env <;> simp only [htx₁, Except.bind_err, reduceCtorEq] at htx
-  cases htx₂ : typeOf x₂ c env <;> simp only [htx₂, Except.bind_err, Except.bind_ok, reduceCtorEq] at htx
+  simp_do_let (typeOf x₁ c env) as htx₁ at htx
+  simp_do_let (typeOf x₂ c env) as htx₂ at htx
   rename_i r₁ r₂
   simp [typeOfBinaryApp, typeOfEq, ifLubThenBool, typeOfGetTag, typeOfHasTag, ok, err] at htx
   (split at htx <;> try split at htx <;> try split at htx <;> try split at htx) <;> try simp at htx

--- a/cedar-lean/Cedar/Thm/Validation/Typechecker/BinaryApp/GetTag.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Typechecker/BinaryApp/GetTag.lean
@@ -39,8 +39,8 @@ theorem type_of_getTag_inversion {x₁ x₂ : Expr} {c₁ c₂ : Capabilities} {
     (x₁, .tag x₂) ∈ c₁
 := by
   simp only [typeOf] at h₁
-  cases h₂ : typeOf x₁ c₁ env <;> simp only [h₂, Except.bind_ok, Except.bind_err, reduceCtorEq] at h₁
-  cases h₃ : typeOf x₂ c₁ env <;> simp only [h₃, Except.bind_ok, Except.bind_err, reduceCtorEq] at h₁
+  simp_do_let (typeOf x₁ c₁ env) as h₂ at h₁
+  simp_do_let (typeOf x₂ c₁ env) as h₃ at h₁
   rename_i tyc₁ tyc₂
   cases tyc₁
   cases tyc₂

--- a/cedar-lean/Cedar/Thm/Validation/Typechecker/BinaryApp/HasTag.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Typechecker/BinaryApp/HasTag.lean
@@ -34,8 +34,8 @@ theorem type_of_hasTag_inversion {x₁ x₂ : Expr} {c₁ c₂ : Capabilities} {
     typeOfHasTag ety x₁ x₂ c₁ env = .ok (ty.typeOf, c₂)
 := by
   simp only [typeOf] at h₁
-  cases h₂ : typeOf x₁ c₁ env <;> simp only [h₂, Except.bind_ok, Except.bind_err, reduceCtorEq] at h₁
-  cases h₃ : typeOf x₂ c₁ env <;> simp only [h₃, Except.bind_ok, Except.bind_err, reduceCtorEq] at h₁
+  simp_do_let (typeOf x₁ c₁ env) as h₂ at h₁
+  simp_do_let (typeOf x₂ c₁ env) as h₃ at h₁
   rename_i tyc₁ tyc₂
   cases tyc₁
   cases tyc₂

--- a/cedar-lean/Cedar/Thm/Validation/Typechecker/Call.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Typechecker/Call.lean
@@ -38,12 +38,12 @@ match xs with
   constructor
 | x :: xs => by
   simp only [List.mapM₁_eq_mapM λ x => justType (typeOf x c env), List.mapM_cons, bind_pure_comp] at htxs
-  cases htx : justType (typeOf x c env) <;> simp only [htx, Except.bind_err, reduceCtorEq] at htxs
+  simp_do_let (justType (typeOf x c env)) as htx at htxs
   simp only [justType, Except.map] at htx
   split at htx <;> simp only [reduceCtorEq, Except.ok.injEq] at htx
   subst htx
   cases htxs' : List.mapM (fun x => justType (typeOf x c env)) xs <;>
-    simp only [htxs', Except.map_error, Except.map_ok, Except.bind_ok, reduceCtorEq, Except.ok.injEq] at htxs
+    simp only [htxs', Except.map_error, Except.map_ok, reduceCtorEq, Except.ok.injEq] at htxs
   subst txs
   constructor
   · rename_i r _ _
@@ -58,7 +58,7 @@ theorem type_of_call_inversion {xs : List Expr} {c c' : Capabilities} {env : Typ
     List.Forall₂ (λ xᵢ txᵢ => ∃ cᵢ, typeOf xᵢ c env = .ok (txᵢ, cᵢ)) xs txs
 := by
   simp only [typeOf, typeOfCall] at htx
-  cases htx₁ : xs.mapM₁ fun x => justType (typeOf x.val c env) <;> simp only [htx₁, Except.bind_err, Except.bind_ok, reduceCtorEq] at htx
+  simp_do_let (xs.mapM₁ fun x => justType (typeOf x.val c env)) as htx₁ at htx
   rename_i txs
   exists txs
   and_intros
@@ -119,10 +119,9 @@ theorem type_of_call_datetime_inversion {xs : List Expr} {c c' : Capabilities} {
     (Cedar.Spec.Ext.Datetime.parse s).isSome
 := by
   simp only [typeOf] at h₁
-  cases h₂ : List.mapM₁ xs fun x => justType (typeOf x.val c env) <;>
-  simp only [h₂, Except.bind_err, reduceCtorEq] at h₁
+  simp_do_let (List.mapM₁ xs fun x => justType (typeOf x.val c env)) as h₂ at h₁
   rename_i tys
-  simp only [typeOfCall, typeOfConstructor, List.empty_eq, Except.bind_ok] at h₁
+  simp only [typeOfCall, typeOfConstructor, List.empty_eq] at h₁
   split at h₁ <;> simp [ok, err] at h₁
   rename_i s
   split at h₁ <;> simp at h₁
@@ -157,8 +156,7 @@ theorem type_of_call_duration_inversion {xs : List Expr} {c c' : Capabilities} {
     (Cedar.Spec.Ext.Datetime.duration s).isSome
 := by
   simp only [typeOf] at h₁
-  cases h₂ : List.mapM₁ xs fun x => justType (typeOf x.val c env) <;>
-  simp only [h₂, Except.bind_err, reduceCtorEq] at h₁
+  simp_do_let (List.mapM₁ xs fun x => justType (typeOf x.val c env)) as h₂ at h₁
   rename_i tys
   simp only [typeOfCall, typeOfConstructor, List.empty_eq] at h₁
   split at h₁ <;> simp [ok, err] at h₁
@@ -469,10 +467,9 @@ theorem type_of_call_toTime_inversion {xs : List Expr} {c c' : Capabilities} {en
     (typeOf x₁ c env).typeOf = .ok ((CedarType.ext .datetime), c₁)
 := by
   simp [typeOf] at h₁
-  cases h₂ : List.mapM₁ xs fun x => justType (typeOf x.val c env) <;>
-  simp only [h₂, Except.bind_err, reduceCtorEq] at h₁
+  simp_do_let (List.mapM₁ xs fun x => justType (typeOf x.val c env)) as h₂ at h₁
   rename_i tys
-  simp only [typeOfCall, List.empty_eq, Except.bind_ok] at h₁
+  simp only [typeOfCall, List.empty_eq] at h₁
   all_goals {
     split at h₁ <;> try { contradiction }
     all_goals {
@@ -528,10 +525,9 @@ theorem type_of_call_toDate_inversion {xs : List Expr} {c c' : Capabilities} {en
     (typeOf x₁ c env).typeOf = .ok ((CedarType.ext .datetime), c₁)
 := by
   simp only [typeOf] at h₁
-  cases h₂ : List.mapM₁ xs fun x => justType (typeOf x.val c env) <;>
-  simp only [h₂, Except.bind_err, reduceCtorEq] at h₁
+  simp_do_let (List.mapM₁ xs fun x => justType (typeOf x.val c env)) as h₂ at h₁
   rename_i tys
-  simp only [typeOfCall, List.empty_eq, Except.bind_ok] at h₁
+  simp only [typeOfCall, List.empty_eq] at h₁
   all_goals {
     split at h₁ <;> try { contradiction }
     all_goals {
@@ -593,10 +589,9 @@ theorem type_of_call_offset_inversion {xs : List Expr} {c c' : Capabilities} {en
     (typeOf x₂ c env).typeOf = .ok ((CedarType.ext .duration), c₂)
 := by
   simp only [typeOf] at h₁
-  cases h₂ : List.mapM₁ xs fun x => justType (typeOf x.val c env) <;>
-  simp only [h₂, Except.bind_err, reduceCtorEq] at h₁
+  simp_do_let (List.mapM₁ xs fun x => justType (typeOf x.val c env)) as h₂ at h₁
   rename_i tys
-  simp only [typeOfCall, List.empty_eq, Except.bind_ok] at h₁
+  simp only [typeOfCall, List.empty_eq] at h₁
   all_goals {
     split at h₁ <;> try { contradiction }
     all_goals {
@@ -673,10 +668,9 @@ theorem type_of_call_durationSince_inversion {xs : List Expr} {c c' : Capabiliti
     (typeOf x₂ c env).typeOf = .ok ((CedarType.ext .datetime), c₂)
 := by
   simp only [typeOf] at h₁
-  cases h₂ : List.mapM₁ xs fun x => justType (typeOf x.val c env) <;>
-  simp only [h₂, Except.bind_err, reduceCtorEq] at h₁
+  simp_do_let (List.mapM₁ xs fun x => justType (typeOf x.val c env)) as h₂ at h₁
   rename_i tys
-  simp only [typeOfCall, List.empty_eq, Except.bind_ok] at h₁
+  simp only [typeOfCall, List.empty_eq] at h₁
   all_goals {
     split at h₁ <;> try { contradiction }
     all_goals {

--- a/cedar-lean/Cedar/Thm/Validation/Typechecker/UnaryApp.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Typechecker/UnaryApp.lean
@@ -39,7 +39,8 @@ theorem type_of_unary_inversion {op : UnaryOp} {x₁ : Expr} {c₁ c₂ : Capabi
     | .like _ => ty = .bool .anyBool ∧ tx₁.typeOf = .string
     | .is ety₀  => ∃ ety₁, ty = .bool (if ety₀ = ety₁ then .tt else .ff) ∧ tx₁.typeOf = .entity ety₁
 := by
-  cases h₂ : typeOf x₁ c₁ env <;> simp only [h₂, typeOf, Except.bind_err, Except.bind_ok, reduceCtorEq] at h₁
+  simp only [typeOf] at h₁
+  simp_do_let (typeOf x₁ c₁ env) as h₂ at h₁
   rename_i res ; have ⟨ty₁, c₁'⟩ := res
   simp only [typeOfUnaryApp, Function.comp_apply] at h₁
   split at h₁ <;> try contradiction

--- a/cedar-lean/Cedar/Thm/Validation/Validator.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Validator.lean
@@ -89,7 +89,7 @@ theorem typecheck_policy_with_environments_is_sound (policy : Policy) (schema : 
 := by
   intro h₀ h₂
   simp only [typecheckPolicyWithEnvironments, Except.mapError] at h₂
-  cases h₄ : checkEntities schema policy.toExpr <;> simp only [h₄, Except.bind_err, Except.bind_ok, reduceCtorEq] at h₂
+  simp_do_let (checkEntities schema policy.toExpr) as h₄ at h₂
   cases h₃ : List.mapM (typecheckPolicy policy) schema.environments with
   | error => simp only [h₃, Except.bind_err, reduceCtorEq] at h₂
   | ok ts =>


### PR DESCRIPTION
Followup to #955 to simplify the common case where it's immediately followed by a `rename_i` 

