### PR TITLE
Extension Parser for Decimal 

### DIFF
--- a/cedar-lean/Cedar/Spec/Ext/Decimal.lean
+++ b/cedar-lean/Cedar/Spec/Ext/Decimal.lean
@@ -33,7 +33,7 @@ For instance, 10.234 is a decimal number. Its integer part is 10 and its fractio
 We restrict the number of the digits after the decimal point to 4.
 -/
 
-def DECIMAL_DIGITS : Nat := 4
+public abbrev DECIMAL_DIGITS : Nat := 4
 
 public abbrev Decimal := Int64
 

--- a/cedar-lean/Cedar/Thm/Data.lean
+++ b/cedar-lean/Cedar/Thm/Data.lean
@@ -24,3 +24,4 @@ public import Cedar.Thm.Data.LT
 public import Cedar.Thm.Data.Map
 public import Cedar.Thm.Data.Set
 public import Cedar.Thm.Data.MapUnion
+public import Cedar.Thm.Data.String

--- a/cedar-lean/Cedar/Thm/Data/String.lean
+++ b/cedar-lean/Cedar/Thm/Data/String.lean
@@ -1,0 +1,95 @@
+import Std.Data.String
+import Batteries.Data.String
+
+/-- `splitOnPPrepend` on a list with no separator produces a single segment. -/
+theorem splitOnPPrepend_none (P : α → Bool) (l acc : List α)
+    (h : ∀ x ∈ l, P x = false) :
+    List.splitOnPPrepend P l acc = [(acc.reverse ++ l)] := by
+  induction l generalizing acc with
+  | nil => rw [List.splitOnPPrepend.eq_def]; simp
+  | cons a t ih =>
+    rw [List.splitOnPPrepend.eq_def]
+    have ha : P a = false := h a (List.mem_cons.mpr (.inl rfl))
+    simp only [ha]
+    rw [ih (a :: acc) (fun x hx => h x (List.mem_cons.mpr (.inr hx)))]
+    simp [List.reverse_cons, List.append_assoc]
+
+/-- `splitOnPPrepend` on a list with exactly one separator produces two segments. -/
+theorem splitOnPPrepend_single (P : α → Bool) (as bs acc : List α) (sep : α)
+    (hsep : P sep = true) (has : ∀ x ∈ as, P x = false) (hbs : ∀ x ∈ bs, P x = false) :
+    List.splitOnPPrepend P (as ++ sep :: bs) acc = (acc.reverse ++ as) :: [bs] := by
+  induction as generalizing acc with
+  | nil =>
+    rw [List.nil_append, List.splitOnPPrepend.eq_def]
+    simp only [hsep, ite_true]
+    rw [splitOnPPrepend_none P bs [] hbs]; simp
+  | cons a t ih =>
+    simp only [List.cons_append]
+    rw [List.splitOnPPrepend.eq_def]
+    have ha : P a = false := has a (List.mem_cons.mpr (.inl rfl))
+    simp only [ha]
+    rw [ih (a :: acc) (fun x hx => has x (List.mem_cons.mpr (.inr hx)))]
+    simp [List.reverse_cons, List.append_assoc]
+
+/-- Splitting `s₁ ++ sep ++ s₂` on `sep` yields `[s₁, s₂]` when neither part contains `sep`. -/
+theorem splitToList_eq (s₁ s₂ : String) (p : Char → Bool) (sep : Char)
+    (hsep : p sep = true) (h₁ : ∀ c ∈ s₁.toList, p c = false)
+    (h₂ : ∀ c ∈ s₂.toList, p c = false) :
+    (s₁ ++ String.singleton sep ++ s₂).splitToList p = [s₁, s₂] := by
+  rw [String.splitToList_of_valid]
+  simp [String.toList_append, List.append_assoc]
+  change List.map String.ofList (List.splitOnPPrepend p (s₁.toList ++ sep :: s₂.toList) []) = _
+  rw [splitOnPPrepend_single p s₁.toList s₂.toList [] sep hsep h₁ h₂]
+  simp
+
+/-- The string representation of a natural number never contains `'.'`. -/
+theorem repr_no_dot (n : Nat) :
+    ∀ c ∈ (toString n).toList, (fun x : Char => decide (x = '.')) c = false := by
+  intro c hc; simp only [decide_eq_false_iff_not]; intro heq
+  have hc' : c ∈ (Nat.repr n).toList := by rwa [← Nat.toString_eq_repr]
+  have hc'' : c ∈ Nat.toDigits 10 n := by
+    rwa [Nat.repr_eq_ofList_toDigits, String.toList_ofList] at hc'
+  rw [heq] at hc''
+  exact absurd (Nat.isDigit_of_mem_toDigits (by omega) (by omega) hc'') (by decide)
+
+/-- A zero-padded natural number string never contains `'.'`. -/
+theorem zeros_repr_no_dot (zeros : String) (n : Nat)
+    (hz : ∀ c ∈ zeros.toList, c = '0') :
+    ∀ c ∈ (zeros ++ toString n).toList, (fun x : Char => decide (x = '.')) c = false := by
+  intro c hc; rw [String.toList_append] at hc
+  simp only [decide_eq_false_iff_not]; intro heq
+  cases List.mem_append.mp hc with
+  | inl h => rw [hz c h] at heq; exact absurd heq (by decide)
+  | inr h => exact absurd (repr_no_dot n c h) (by simp [heq])
+
+/-- The underscore-guarded foldl equals the plain foldl when no char is `'_'`. -/
+theorem foldl_no_underscore_eq (l : List Char) (acc : Nat)
+    (hno : ∀ c ∈ l, c ≠ '_') :
+    List.foldl (fun n c => if c = '_' then n else n * 10 + (c.toNat - 48)) acc l =
+    List.foldl (fun n c => n * 10 + (c.toNat - 48)) acc l := by
+  induction l generalizing acc with
+  | nil => rfl
+  | cons a t ih =>
+    simp only [List.foldl]
+    have ha : a ≠ '_' := hno a (List.Mem.head _)
+    simp only [ha, ↓reduceIte]
+    exact ih _ (fun c hc => hno c (List.Mem.tail _ hc))
+
+/-- The positional-value foldl equals `Nat.ofDigitChars` (modulo argument order). -/
+theorem foldl_eq_ofDigitChars (l : List Char) (acc : Nat) :
+    List.foldl (fun n c => n * 10 + (c.toNat - 48)) acc l =
+    Nat.ofDigitChars 10 l acc := by
+  induction l generalizing acc with
+  | nil => rfl
+  | cons a t ih =>
+    simp only [List.foldl, Nat.ofDigitChars, show Char.toNat '0' = 48 from by rfl]
+    rw [Nat.mul_comm 10 acc]
+    exact ih _
+
+/-- The `Slice.toNat?` foldl on `Nat.toDigits 10 n` recovers `n`. -/
+theorem toDigits_foldl_roundtrip (n : Nat) :
+    List.foldl (fun acc c => if c = '_' then acc else acc * 10 + (c.toNat - 48)) 0
+      (Nat.toDigits 10 n) = n := by
+  rw [foldl_no_underscore_eq _ 0 (fun c hc heq => Nat.underscore_not_in_toDigits (heq ▸ hc)),
+    foldl_eq_ofDigitChars]
+  exact Nat.ofDigitChars_toDigits (by omega) (by omega)

--- a/cedar-lean/Cedar/Thm/Data/String.lean
+++ b/cedar-lean/Cedar/Thm/Data/String.lean
@@ -1,8 +1,10 @@
 import Std.Data.String
 import Batteries.Data.String
+import Cedar.Spec.Ext.Util
 
-/-- `splitOnPPrepend` on a list with no separator produces a single segment. -/
-theorem splitOnPPrepend_none (P : α → Bool) (l acc : List α)
+/-- If no element of `l` satisfies `P`, then `splitOnPPrepend P l acc` returns
+    the single segment `[acc.reverse ++ l]` (the accumulator is prepended in reverse). -/
+theorem splitOnPPrepend_no_sep (P : α → Bool) (l acc : List α)
     (h : ∀ x ∈ l, P x = false) :
     List.splitOnPPrepend P l acc = [(acc.reverse ++ l)] := by
   induction l generalizing acc with
@@ -14,15 +16,16 @@ theorem splitOnPPrepend_none (P : α → Bool) (l acc : List α)
     rw [ih (a :: acc) (fun x hx => h x (List.mem_cons.mpr (.inr hx)))]
     simp [List.reverse_cons, List.append_assoc]
 
-/-- `splitOnPPrepend` on a list with exactly one separator produces two segments. -/
-theorem splitOnPPrepend_single (P : α → Bool) (as bs acc : List α) (sep : α)
+/-- If `as ++ [sep] ++ bs` has exactly one element satisfying `P` (namely `sep`),
+    then `splitOnPPrepend P (as ++ sep :: bs) acc` returns `[acc.reverse ++ as, bs]`. -/
+theorem splitOnPPrepend_one_sep (P : α → Bool) (as bs acc : List α) (sep : α)
     (hsep : P sep = true) (has : ∀ x ∈ as, P x = false) (hbs : ∀ x ∈ bs, P x = false) :
     List.splitOnPPrepend P (as ++ sep :: bs) acc = (acc.reverse ++ as) :: [bs] := by
   induction as generalizing acc with
   | nil =>
     rw [List.nil_append, List.splitOnPPrepend.eq_def]
     simp only [hsep, ite_true]
-    rw [splitOnPPrepend_none P bs [] hbs]; simp
+    rw [splitOnPPrepend_no_sep P bs [] hbs]; simp
   | cons a t ih =>
     simp only [List.cons_append]
     rw [List.splitOnPPrepend.eq_def]
@@ -39,10 +42,10 @@ theorem splitToList_eq (s₁ s₂ : String) (p : Char → Bool) (sep : Char)
   rw [String.splitToList_of_valid]
   simp [String.toList_append, List.append_assoc]
   change List.map String.ofList (List.splitOnPPrepend p (s₁.toList ++ sep :: s₂.toList) []) = _
-  rw [splitOnPPrepend_single p s₁.toList s₂.toList [] sep hsep h₁ h₂]
+  rw [splitOnPPrepend_one_sep p s₁.toList s₂.toList [] sep hsep h₁ h₂]
   simp
 
-/-- The string representation of a natural number never contains `'.'`. -/
+/-- No character in `toString n` is `'.'` (digits never produce a dot). -/
 theorem repr_no_dot (n : Nat) :
     ∀ c ∈ (toString n).toList, (fun x : Char => decide (x = '.')) c = false := by
   intro c hc; simp only [decide_eq_false_iff_not]; intro heq
@@ -52,7 +55,7 @@ theorem repr_no_dot (n : Nat) :
   rw [heq] at hc''
   exact absurd (Nat.isDigit_of_mem_toDigits (by omega) (by omega) hc'') (by decide)
 
-/-- A zero-padded natural number string never contains `'.'`. -/
+/-- No character in a zero-padded `toString n` string is `'.'`. -/
 theorem zeros_repr_no_dot (zeros : String) (n : Nat)
     (hz : ∀ c ∈ zeros.toList, c = '0') :
     ∀ c ∈ (zeros ++ toString n).toList, (fun x : Char => decide (x = '.')) c = false := by
@@ -60,9 +63,12 @@ theorem zeros_repr_no_dot (zeros : String) (n : Nat)
   simp only [decide_eq_false_iff_not]; intro heq
   cases List.mem_append.mp hc with
   | inl h => rw [hz c h] at heq; exact absurd heq (by decide)
-  | inr h => exact absurd (repr_no_dot n c h) (by simp [heq])
+  | inr h =>
+    have := repr_no_dot n c h
+    simp [heq] at this
 
-/-- The underscore-guarded foldl equals the plain foldl when no char is `'_'`. -/
+/-- When no character in `l` is `'_'`, the underscore-skipping foldl reduces to the plain
+    digit-accumulating foldl. -/
 theorem foldl_no_underscore_eq (l : List Char) (acc : Nat)
     (hno : ∀ c ∈ l, c ≠ '_') :
     List.foldl (fun n c => if c = '_' then n else n * 10 + (c.toNat - 48)) acc l =
@@ -75,7 +81,7 @@ theorem foldl_no_underscore_eq (l : List Char) (acc : Nat)
     simp only [ha, ↓reduceIte]
     exact ih _ (fun c hc => hno c (List.Mem.tail _ hc))
 
-/-- The positional-value foldl equals `Nat.ofDigitChars` (modulo argument order). -/
+/-- The plain digit-accumulating foldl is equivalent to `Nat.ofDigitChars 10 l acc`. -/
 theorem foldl_eq_ofDigitChars (l : List Char) (acc : Nat) :
     List.foldl (fun n c => n * 10 + (c.toNat - 48)) acc l =
     Nat.ofDigitChars 10 l acc := by
@@ -86,10 +92,19 @@ theorem foldl_eq_ofDigitChars (l : List Char) (acc : Nat) :
     rw [Nat.mul_comm 10 acc]
     exact ih _
 
-/-- The `Slice.toNat?` foldl on `Nat.toDigits 10 n` recovers `n`. -/
+/-- Folding the underscore-skipping digit accumulator over `Nat.toDigits 10 n` recovers `n`. -/
 theorem toDigits_foldl_roundtrip (n : Nat) :
     List.foldl (fun acc c => if c = '_' then acc else acc * 10 + (c.toNat - 48)) 0
       (Nat.toDigits 10 n) = n := by
   rw [foldl_no_underscore_eq _ 0 (fun c hc heq => Nat.underscore_not_in_toDigits (heq ▸ hc)),
     foldl_eq_ofDigitChars]
   exact Nat.ofDigitChars_toDigits (by omega) (by omega)
+
+open Cedar.Spec.Ext
+
+/-- If `toNat?'` succeeds then the string is non-empty. -/
+theorem toNat?'_isSome_length_pos (s : String) (h : (toNat?' s).isSome) : s.length > 0 := by
+  by_contra hlen
+  simp at hlen
+  subst hlen
+  simp [toNat?', String.toNat?, String.Slice.toNat?, String.Slice.isNat] at h

--- a/cedar-lean/Cedar/Thm/Ext/Decimal.lean
+++ b/cedar-lean/Cedar/Thm/Ext/Decimal.lean
@@ -1,0 +1,420 @@
+import Cedar.Spec.Ext.Decimal
+import Std.Data.String
+
+namespace Cedar.Thm.Decimal
+open Cedar.Spec.Ext
+
+def IsWfStr (s : String) : Prop :=
+ ∃ left right,
+    s.splitToList (· = '.') = [left, right] ∧
+    left ≠ "-" ∧
+    0 < right.length ∧
+    right.length ≤ DECIMAL_DIGITS ∧
+    (toInt?' left).isSome ∧
+    (toNat?' right).isSome
+
+def computeValue (s : String) : Int :=
+  match s.splitToList (· = '.') with
+  | [left, right] =>
+    let rlen := right.length
+    match toInt?' left, toNat?' right with
+      | .some l, .some r =>
+        let l' := l * (Int.pow 10 DECIMAL_DIGITS)
+        let r' := r * (Int.pow 10 (DECIMAL_DIGITS - rlen))
+        let i  := if !left.startsWith "-" then l' + r' else l' - r'
+        i
+      | _, _ => 0
+  | _ => 0
+
+-- TODO: move to Cedar.Thm.Data.String
+/-- `splitOnPPrepend` on a list with no separator produces a single segment. -/
+private theorem splitOnPPrepend_none (P : α → Bool) (l acc : List α)
+    (h : ∀ x ∈ l, P x = false) :
+    List.splitOnPPrepend P l acc = [(acc.reverse ++ l)] := by
+  induction l generalizing acc with
+  | nil => rw [List.splitOnPPrepend.eq_def]; simp
+  | cons a t ih =>
+    rw [List.splitOnPPrepend.eq_def]
+    have ha : P a = false := h a (List.mem_cons.mpr (.inl rfl))
+    simp only [ha]
+    rw [ih (a :: acc) (fun x hx => h x (List.mem_cons.mpr (.inr hx)))]
+    simp [List.reverse_cons, List.append_assoc]
+
+-- TODO: move to Cedar.Thm.Data.String
+/-- `splitOnPPrepend` on a list with exactly one separator produces two segments. -/
+private theorem splitOnPPrepend_single (P : α → Bool) (as bs acc : List α) (sep : α)
+    (hsep : P sep = true) (has : ∀ x ∈ as, P x = false) (hbs : ∀ x ∈ bs, P x = false) :
+    List.splitOnPPrepend P (as ++ sep :: bs) acc = (acc.reverse ++ as) :: [bs] := by
+  induction as generalizing acc with
+  | nil =>
+    rw [List.nil_append, List.splitOnPPrepend.eq_def]
+    simp only [hsep, ite_true]
+    rw [splitOnPPrepend_none P bs [] hbs]; simp
+  | cons a t ih =>
+    simp only [List.cons_append]
+    rw [List.splitOnPPrepend.eq_def]
+    have ha : P a = false := has a (List.mem_cons.mpr (.inl rfl))
+    simp only [ha]
+    rw [ih (a :: acc) (fun x hx => has x (List.mem_cons.mpr (.inr hx)))]
+    simp [List.reverse_cons, List.append_assoc]
+
+-- TODO: move to Cedar.Thm.Data.String
+/-- Splitting `s₁ ++ sep ++ s₂` on `sep` yields `[s₁, s₂]` when neither part contains `sep`. -/
+private theorem splitToList_eq (s₁ s₂ : String) (p : Char → Bool) (sep : Char)
+    (hsep : p sep = true) (h₁ : ∀ c ∈ s₁.toList, p c = false)
+    (h₂ : ∀ c ∈ s₂.toList, p c = false) :
+    (s₁ ++ String.singleton sep ++ s₂).splitToList p = [s₁, s₂] := by
+  rw [String.splitToList_of_valid]
+  simp [String.toList_append, List.append_assoc]
+  change List.map String.ofList (List.splitOnPPrepend p (s₁.toList ++ sep :: s₂.toList) []) = _
+  rw [splitOnPPrepend_single p s₁.toList s₂.toList [] sep hsep h₁ h₂]
+  simp
+
+-- TODO: move to Cedar.Thm.Data.String (generalize to arbitrary non-digit char)
+/-- The string representation of a natural number never contains `'.'`. -/
+private theorem repr_no_dot (n : Nat) :
+    ∀ c ∈ (toString n).toList, (fun x : Char => decide (x = '.')) c = false := by
+  intro c hc; simp only [decide_eq_false_iff_not]; intro heq
+  have hc' : c ∈ (Nat.repr n).toList := by rwa [← Nat.toString_eq_repr]
+  have hc'' : c ∈ Nat.toDigits 10 n := by
+    rwa [Nat.repr_eq_ofList_toDigits, String.toList_ofList] at hc'
+  rw [heq] at hc''
+  exact absurd (Nat.isDigit_of_mem_toDigits (by omega) (by omega) hc'') (by decide)
+
+-- TODO: move to Cedar.Thm.Data.String (generalize to arbitrary non-digit char)
+/-- A zero-padded natural number string never contains `'.'`. -/
+private theorem zeros_repr_no_dot (zeros : String) (n : Nat)
+    (hz : ∀ c ∈ zeros.toList, c = '0') :
+    ∀ c ∈ (zeros ++ toString n).toList, (fun x : Char => decide (x = '.')) c = false := by
+  intro c hc; rw [String.toList_append] at hc
+  simp only [decide_eq_false_iff_not]; intro heq
+  cases List.mem_append.mp hc with
+  | inl h => rw [hz c h] at heq; exact absurd heq (by decide)
+  | inr h => exact absurd (repr_no_dot n c h) (by simp [heq])
+
+-- TODO: move to Cedar.Thm.Data.String
+/-- The underscore-guarded foldl equals the plain foldl when no char is `'_'`. -/
+private theorem foldl_no_underscore_eq (l : List Char) (acc : Nat)
+    (hno : ∀ c ∈ l, c ≠ '_') :
+    List.foldl (fun n c => if c = '_' then n else n * 10 + (c.toNat - 48)) acc l =
+    List.foldl (fun n c => n * 10 + (c.toNat - 48)) acc l := by
+  induction l generalizing acc with
+  | nil => rfl
+  | cons a t ih =>
+    simp only [List.foldl]
+    have ha : a ≠ '_' := hno a (List.Mem.head _)
+    simp only [ha, ↓reduceIte]
+    exact ih _ (fun c hc => hno c (List.Mem.tail _ hc))
+
+-- TODO: move to Cedar.Thm.Data.String
+/-- The positional-value foldl equals `Nat.ofDigitChars` (modulo argument order). -/
+private theorem foldl_eq_ofDigitChars (l : List Char) (acc : Nat) :
+    List.foldl (fun n c => n * 10 + (c.toNat - 48)) acc l =
+    Nat.ofDigitChars 10 l acc := by
+  induction l generalizing acc with
+  | nil => rfl
+  | cons a t ih =>
+    simp only [List.foldl, Nat.ofDigitChars, show Char.toNat '0' = 48 from by rfl]
+    rw [Nat.mul_comm 10 acc]
+    exact ih _
+
+-- TODO: move to Cedar.Thm.Data.String
+/-- The `Slice.toNat?` foldl on `Nat.toDigits 10 n` recovers `n`. -/
+private theorem toDigits_foldl_roundtrip (n : Nat) :
+    List.foldl (fun acc c => if c = '_' then acc else acc * 10 + (c.toNat - 48)) 0
+      (Nat.toDigits 10 n) = n := by
+  rw [foldl_no_underscore_eq _ 0 (fun c hc heq => Nat.underscore_not_in_toDigits (heq ▸ hc)),
+    foldl_eq_ofDigitChars]
+  exact Nat.ofDigitChars_toDigits (by omega) (by omega)
+
+/-- `toString d` splits into concrete parts whose parse-relevant properties are known: -/
+theorem toString_split (d : Decimal) :
+    let leftPart := (if d < 0 then "-" else "") ++ toString (d.natAbs / Nat.pow 10 4)
+    let rightNat := d.natAbs % Nat.pow 10 4
+    let rightPart :=
+      if rightNat < 10 then "000" ++ toString rightNat
+      else if rightNat < 100 then "00" ++ toString rightNat
+      else if rightNat < 1000 then "0" ++ toString rightNat
+      else toString rightNat
+    (toString d).splitToList (· = '.') = [leftPart, rightPart] ∧
+    rightPart.length = 4 ∧
+    toInt?' leftPart = some (if d < 0 then -(↑(d.natAbs / Nat.pow 10 4) : Int)
+      else (↑(d.natAbs / Nat.pow 10 4) : Int)) ∧
+    toNat?' rightPart = some rightNat ∧
+    (!leftPart.startsWith "-") = !(d < 0) := by
+  intro leftPart rightNat rightPart
+  refine ⟨?_, ?_, ?_, ?_, ?_⟩
+  · -- splitToList
+    have h_left_no_dot : ∀ c ∈ leftPart.toList,
+        (fun x : Char => decide (x = '.')) c = false := by
+      intro c hc; simp only [leftPart, String.toList_append] at hc
+      simp only [decide_eq_false_iff_not]; intro heq
+      cases List.mem_append.mp hc with
+      | inl h =>
+        split at h
+        · simp at h; rw [h] at heq; exact absurd heq (by decide)
+        · simp at h
+      | inr h => exact absurd (repr_no_dot _ c h) (by simp [heq])
+    have h_right_no_dot : ∀ c ∈ rightPart.toList,
+        (fun x : Char => decide (x = '.')) c = false := by
+      intro c hc; simp only [rightPart] at hc
+      split at hc
+      · exact zeros_repr_no_dot "000" _ (by simp) c hc
+      · split at hc
+        · exact zeros_repr_no_dot "00" _ (by simp) c hc
+        · split at hc
+          · exact zeros_repr_no_dot "0" _ (by simp) c hc
+          · exact repr_no_dot _ c hc
+    have h_toString : toString d = leftPart ++ String.singleton '.' ++ rightPart := by
+      show leftPart ++ (if rightNat < 10 then ".000" ++ toString rightNat
+        else if rightNat < 100 then ".00" ++ toString rightNat
+        else if rightNat < 1000 then ".0" ++ toString rightNat
+        else "." ++ toString rightNat) = leftPart ++ String.singleton '.' ++ rightPart
+      simp only [rightPart, String.append_assoc]; congr 1
+      split
+      · rfl
+      · split
+        · rfl
+        · split
+          · rfl
+          · rfl
+    rw [h_toString]
+    exact splitToList_eq leftPart rightPart _ '.' (by rfl) h_left_no_dot h_right_no_dot
+  · -- rightPart.length = 4
+    -- TODO: replace with custom `digit_length` tactic that automates toDigitsCore unfolding
+    simp only [rightPart, rightNat]
+    have hmod : d.natAbs % 10000 < 10000 := Nat.mod_lt _ (by omega)
+    split
+    · have : ("000" : String).length = 3 := by rfl
+      have : (d.natAbs % Nat.pow 10 4).repr.length = 1 := by
+        rw [Nat.repr_eq_ofList_toDigits, String.length_ofList, Nat.toDigits,
+          show d.natAbs % Nat.pow 10 4 + 1 = Nat.succ (d.natAbs % Nat.pow 10 4) from rfl,
+          Nat.toDigitsCore.eq_def]
+        simp [show d.natAbs % Nat.pow 10 4 / 10 = 0 from by omega]
+      simp [*]
+    · split
+      · have : ("00" : String).length = 2 := by rfl
+        have : (d.natAbs % Nat.pow 10 4).repr.length = 2 := by
+          rw [Nat.repr_eq_ofList_toDigits, String.length_ofList, Nat.toDigits,
+            show d.natAbs % Nat.pow 10 4 + 1 = Nat.succ (d.natAbs % Nat.pow 10 4) from rfl,
+            Nat.toDigitsCore.eq_def]
+          simp only [show d.natAbs % Nat.pow 10 4 / 10 ≠ 0 from by omega]
+          rw [show d.natAbs % Nat.pow 10 4 = Nat.succ (d.natAbs % Nat.pow 10 4 - 1) from by omega,
+            Nat.toDigitsCore.eq_def]
+          simp [show (d.natAbs % Nat.pow 10 4 - 1).succ / 10 / 10 = 0 from by omega]
+        simp [*]
+      · split
+        · have : ("0" : String).length = 1 := by rfl
+          have : (d.natAbs % Nat.pow 10 4).repr.length = 3 := by
+            rw [Nat.repr_eq_ofList_toDigits, String.length_ofList, Nat.toDigits,
+              show d.natAbs % Nat.pow 10 4 + 1 = Nat.succ (d.natAbs % Nat.pow 10 4) from rfl,
+              Nat.toDigitsCore.eq_def]
+            simp only [show d.natAbs % Nat.pow 10 4 / 10 ≠ 0 from by omega]
+            rw [show d.natAbs % Nat.pow 10 4 = Nat.succ (d.natAbs % Nat.pow 10 4 - 1) from by omega,
+              Nat.toDigitsCore.eq_def]
+            simp only [show (d.natAbs % Nat.pow 10 4 - 1).succ / 10 / 10 ≠ 0 from by omega, ↓reduceIte]
+            rw [show (d.natAbs % Nat.pow 10 4 - 1) = Nat.succ (d.natAbs % Nat.pow 10 4 - 2) from by omega,
+              Nat.toDigitsCore.eq_def]
+            simp [show (d.natAbs % Nat.pow 10 4 - 2).succ.succ / 10 / 10 / 10 = 0 from by omega]
+          simp [*]
+        · have : (d.natAbs % Nat.pow 10 4).repr.length = 4 := by
+            rw [Nat.repr_eq_ofList_toDigits, String.length_ofList, Nat.toDigits,
+              show d.natAbs % Nat.pow 10 4 + 1 = Nat.succ (d.natAbs % Nat.pow 10 4) from rfl,
+              Nat.toDigitsCore.eq_def]
+            simp only [show d.natAbs % Nat.pow 10 4 / 10 ≠ 0 from by omega]
+            rw [show d.natAbs % Nat.pow 10 4 = Nat.succ (d.natAbs % Nat.pow 10 4 - 1) from by omega,
+              Nat.toDigitsCore.eq_def]
+            simp only [show (d.natAbs % Nat.pow 10 4 - 1).succ / 10 / 10 ≠ 0 from by omega]
+            rw [show (d.natAbs % Nat.pow 10 4 - 1) = Nat.succ (d.natAbs % Nat.pow 10 4 - 2) from by omega,
+              Nat.toDigitsCore.eq_def]
+            simp only [show (d.natAbs % Nat.pow 10 4 - 2).succ.succ / 10 / 10 / 10 ≠ 0 from by omega]
+            rw [show (d.natAbs % Nat.pow 10 4 - 2) = Nat.succ (d.natAbs % Nat.pow 10 4 - 3) from by omega,
+              Nat.toDigitsCore.eq_def]
+            simp [show (d.natAbs % Nat.pow 10 4 - 3).succ.succ.succ / 10 / 10 / 10 / 10 = 0 from
+              by simp; omega]
+          simp [*]
+  · -- toInt?' leftPart = some (...)
+    simp only [leftPart, toInt?']
+    split <;> simp
+  · -- toNat?' rightPart = some rightNat
+    simp only [rightPart, rightNat, toNat?']
+    have hno_us : ∀ (pad : String) (n : Nat), (∀ c ∈ pad.toList, c = '0') →
+        (pad ++ toString n).contains '_' = false := by
+      intro pad n hz
+      have h : ¬ ('_' ∈ (pad ++ toString n).toList) := by
+        rw [String.toList_append]
+        intro h
+        cases List.mem_append.mp h with
+        | inl h => exact absurd (hz '_' h) (by decide)
+        | inr h =>
+          rw [Nat.toString_eq_repr, Nat.toList_repr] at h
+          exact Nat.underscore_not_in_toDigits h
+      simpa [String.contains] using h
+    split
+    · -- "000" ++ toString n, n < 10
+      rename_i h
+      rw [hno_us "000" _ (by simp)]
+      simp [String.toNat?, String.Slice.toNat?]
+      simp [toDigits_foldl_roundtrip _]
+      simp [String.isNat_iff]
+      refine ⟨?_, ?_, ?_⟩
+      · -- ∀ c ∈ list, c.isDigit ∨ c = '_'
+        intro c hc
+        left
+        apply Nat.isDigit_of_mem_toDigits _ _ hc <;> omega
+      · -- ¬ ['_', '_'] <:+: list
+        intro ⟨s, t, ht⟩
+        have hmem : '_' ∈ ('0' :: '0' :: '0' :: Nat.toDigits 10 (d.natAbs % 10000)) := by
+          rw [← ht]; simp [List.mem_append, List.mem_cons]
+        simp [List.mem_cons] at hmem
+      · -- getLast? ≠ some '_'
+        intro h
+        have hne : ('0' :: Nat.toDigits 10 (d.natAbs % 10000)) ≠ [] := List.cons_ne_nil _ _
+        rw [List.getLast?_eq_some_getLast hne] at h
+        have hmem := List.getLast_mem hne
+        injection h with h; rw [h] at hmem
+        simp [List.mem_cons] at hmem
+    · split
+      · -- "00" ++ toString n, 10 ≤ n < 100
+        rename_i h2 h1
+        rw [hno_us "00" _ (by simp)]
+        simp [String.toNat?, String.Slice.toNat?]
+        simp[toDigits_foldl_roundtrip _]
+        simp [String.isNat_iff]; refine ⟨?_, ?_, ?_⟩
+        · intro c hc;
+          left
+          apply Nat.isDigit_of_mem_toDigits _ _ hc <;> omega
+        · intro ⟨s, t, ht⟩
+          have : '_' ∈ ('0' :: '0' :: Nat.toDigits 10 (d.natAbs % 10000)) := by
+            rw [← ht]; simp [List.mem_append, List.mem_cons]
+          simp [List.mem_cons] at this
+        · intro h
+          have hne : ('0' :: Nat.toDigits 10 (d.natAbs % 10000)) ≠ [] := List.cons_ne_nil _ _
+          rw [List.getLast?_eq_some_getLast hne] at h
+          have hmem := List.getLast_mem hne
+          injection h with h; rw [h] at hmem
+          simp [List.mem_cons] at hmem
+      · split
+        · -- "0" ++ toString n, 100 ≤ n < 1000
+          rename_i h3 h2 h1
+          rw [hno_us "0" _ (by simp)]
+          simp [String.toNat?, String.Slice.toNat?]
+          simp [toDigits_foldl_roundtrip _]
+          simp [String.isNat_iff]; refine ⟨?_, ?_, ?_⟩
+          · intro c hc
+            left
+            apply Nat.isDigit_of_mem_toDigits _ _ hc <;> omega
+          · intro ⟨s, t, ht⟩
+            have : '_' ∈ ('0' :: Nat.toDigits 10 (d.natAbs % 10000)) := by
+              rw [← ht]; simp [List.mem_append, List.mem_cons]
+            simp [List.mem_cons] at this
+          · intro h
+            have hne : ('0' :: Nat.toDigits 10 (d.natAbs % 10000)) ≠ [] := List.cons_ne_nil _ _
+            rw [List.getLast?_eq_some_getLast hne] at h
+            have hmem := List.getLast_mem hne
+            injection h with h; rw [h] at hmem
+            simp [List.mem_cons] at hmem
+        · -- toString n, 1000 ≤ n < 10000
+          rename_i h3 h2 h1
+          have hc : (toString (d.natAbs % Nat.pow 10 4)).contains '_' = false := by
+            have h := hno_us "" (d.natAbs % Nat.pow 10 4) (by simp)
+            rwa [String.empty_append] at h
+          simp only [hc]
+          simp [String.toNat?, String.Slice.toNat?]
+          exact toDigits_foldl_roundtrip _
+  · -- (!leftPart.startsWith "-") = !(d < 0)
+    simp [leftPart]
+    by_cases hd : d < 0
+    · simp [hd]
+    · simp [hd]
+      intro h
+      have hmem : '-' ∈ Nat.toDigits 10 (d.natAbs / 10000) :=
+        List.IsPrefix.subset h (List.Mem.head _)
+      exact absurd (Nat.isDigit_of_mem_toDigits (by omega) (by omega) hmem) (by decide)
+
+/-- The string produced by `toString d` is well-formed for parsing. -/
+theorem toString_isWfStr (d : Decimal) : IsWfStr (toString d) := by
+  obtain ⟨h_split, h_rlen, h_lint, h_rnat, _⟩ := toString_split d
+  refine ⟨_, _, h_split, ?_, ?_, ?_, ?_, ?_⟩
+  · -- leftPart ≠ "-"
+    intro h; by_cases hd : d < 0
+    · simp [hd] at h
+    · simp [hd] at h
+      have hdigits : ∀ c ∈ (d.natAbs / 10000).repr.toList, c.isDigit = true := by
+        intro c hc
+        have hc' : c ∈ Nat.toDigits 10 (d.natAbs / 10000) := by
+          rwa [Nat.repr_eq_ofList_toDigits, String.toList_ofList] at hc
+        exact Nat.isDigit_of_mem_toDigits (by omega) (by omega) hc'
+      rw [h] at hdigits; exact absurd (hdigits '-' (by simp)) (by decide)
+  · -- 0 < rightPart.length
+    rw [h_rlen]; omega
+  · -- rightPart.length ≤ DECIMAL_DIGITS
+    rw [h_rlen]; simp [DECIMAL_DIGITS]
+  · -- (toInt?' leftPart).isSome
+    rw [h_lint]; simp
+  · -- (toNat?' rightPart).isSome
+    rw [h_rnat]; simp
+
+/-- If a string is well-formed, `parse` succeeds and reconstructs the value. -/
+theorem parse_of_isWfStr (s : String) (d : Decimal)
+    (hwf : IsWfStr s) (hval : computeValue s = d.toInt) :
+    Decimal.parse s = some d := by
+  obtain ⟨left, right, h_split, h_ne, h_rpos, h_rle, h_lint, h_rnat⟩ := hwf
+  unfold Decimal.parse
+  rw [h_split]
+  split
+  · rename_i heq; exact absurd ((List.cons.inj heq).1) h_ne
+  · rename_i _ _ _ heq; simp at heq; obtain ⟨hl', hr'⟩ := heq; subst hl'; subst hr'
+    simp only [show 0 < right.length ∧ right.length ≤ DECIMAL_DIGITS from ⟨h_rpos, h_rle⟩]
+    obtain ⟨l, hl⟩ := Option.isSome_iff_exists.mp h_lint
+    obtain ⟨r, hr⟩ := Option.isSome_iff_exists.mp h_rnat
+    simp only [hl, hr, Decimal.decimal?]
+    have hval' : (if !left.startsWith "-"
+        then l * Int.pow 10 DECIMAL_DIGITS + ↑r * Int.pow 10 (DECIMAL_DIGITS - right.length)
+        else l * Int.pow 10 DECIMAL_DIGITS - ↑r * Int.pow 10 (DECIMAL_DIGITS - right.length))
+        = d.toInt := by
+      simpa only [computeValue, h_split, hl, hr] using hval
+    rw [hval']
+    exact Int64.ofInt?_toInt d
+  · rename_i h; exact (h left right rfl).elim
+
+/-- The `computeValue` of `toString d` equals `d.toInt`. -/
+theorem computeValue_toString (d : Decimal) : computeValue (toString d) = d.toInt := by
+  obtain ⟨h_split, h_rlen, h_lint, h_rnat, h_starts⟩ := toString_split d
+  simp only [computeValue, h_split, h_lint, h_rnat, h_rlen, h_starts, DECIMAL_DIGITS]
+  simp only [show Nat.pow 10 4 = 10000 from rfl, show (4 : Nat) - 4 = 0 from rfl,
+    show Int.pow 10 4 = (10000 : Int) from rfl,
+    show Int.pow 10 0 = (1 : Int) from rfl, Int.mul_one]
+  simp (config := { decide := true }) only [Int64.natAbs]
+  by_cases hd : d < 0
+  · simp only [hd, ↓reduceIte, decide_true, Bool.not_true, Bool.false_eq_true]
+    -- Goal: -↑(n/10000) * 10000 - ↑(n%10000) = d.toInt
+    have h1 := Int.natAbs_eq d.toInt
+    have h3 : -(↑(d.toInt.natAbs / 10000) : Int) * 10000 - ↑(d.toInt.natAbs % 10000) =
+        -↑d.toInt.natAbs := by
+      have := Nat.div_add_mod d.toInt.natAbs 10000; omega
+    simp_all
+    apply Eq.symm (Int.eq_neg_natAbs_of_nonpos (by
+      rw [Int64.lt_def_toInt] at hd
+      have : (0 : Int64).toInt = 0 := by rfl
+      omega))
+  · simp only [hd, ↓reduceIte, decide_false, Bool.not_false]
+    have hge : d.toInt ≥ 0 := by
+      simp only [Int64.lt_def_toInt] at hd
+      have : (0 : Int64).toInt = 0 := by rfl
+      omega
+    have h3 : (↑(d.toInt.natAbs / 10000) : Int) * 10000 + ↑(d.toInt.natAbs % 10000) =
+        ↑d.toInt.natAbs := by
+      have := Nat.div_add_mod d.toInt.natAbs 10000; omega
+    rw [h3, Int.natAbs_of_nonneg hge]
+
+/-- Roundtrip: `Decimal.parse (toString d) = some d`. -/
+theorem parse_toString_roundtrip (d : Decimal) :
+    Decimal.parse (toString d) = some d :=
+  parse_of_isWfStr (toString d) d (toString_isWfStr d) (computeValue_toString d)
+
+theorem parse_eq_none_iff (s : String) :
+    Decimal.parse s = none ↔ ¬ IsWfStr s ∨
+    computeValue s < Int64.MIN ∨ computeValue s > Int64.MAX := by sorry
+
+end Cedar.Thm.Decimal

--- a/cedar-lean/Cedar/Thm/Ext/Decimal.lean
+++ b/cedar-lean/Cedar/Thm/Ext/Decimal.lean
@@ -413,8 +413,76 @@ theorem parse_toString_roundtrip (d : Decimal) :
     Decimal.parse (toString d) = some d :=
   parse_of_isWfStr (toString d) d (toString_isWfStr d) (computeValue_toString d)
 
+/-- `parse` fails iff the string is malformed or its value overflows `Int64`. -/
 theorem parse_eq_none_iff (s : String) :
     Decimal.parse s = none ↔ ¬ IsWfStr s ∨
-    computeValue s < Int64.MIN ∨ computeValue s > Int64.MAX := by sorry
+    computeValue s < Int64.MIN ∨ computeValue s > Int64.MAX := by
+  constructor
+  · -- → direction: parse s = none implies malformed or overflow
+    intro h
+    by_cases hwf : IsWfStr s
+    · -- s is well-formed, so it must be overflow
+      right
+      obtain ⟨left, right, h_split, h_ne, h_rpos, h_rle, h_lint, h_rnat⟩ := hwf
+      obtain ⟨l, hl⟩ := Option.isSome_iff_exists.mp h_lint
+      obtain ⟨r, hr⟩ := Option.isSome_iff_exists.mp h_rnat
+      -- parse returned none despite well-formedness → decimal? returned none → overflow
+      unfold Decimal.parse at h
+      rw [h_split] at h
+      simp only [show 0 < right.length ∧ right.length ≤ DECIMAL_DIGITS from ⟨h_rpos, h_rle⟩,
+        hl, hr, Decimal.decimal?, ite_true, and_true] at h
+      -- h : Int64.ofInt? (if ... then ... + ... else ... - ...) = none
+      have hcv : computeValue s = (if !left.startsWith "-"
+          then l * Int.pow 10 DECIMAL_DIGITS + ↑r * Int.pow 10 (DECIMAL_DIGITS - right.length)
+          else l * Int.pow 10 DECIMAL_DIGITS - ↑r * Int.pow 10 (DECIMAL_DIGITS - right.length)) := by
+        simp only [computeValue, h_split, hl, hr]
+      rw [hcv]
+      exact Int64.ofInt?_none_iff.mpr h
+    · left; exact hwf
+  · -- ← direction: malformed or overflow implies parse s = none
+    intro h
+    rcases h with h | h
+    · -- ¬ IsWfStr s → parse s = none
+      by_contra hne
+      have ⟨d, hd⟩ := Option.ne_none_iff_exists'.mp hne
+      exact absurd (parse_some_isWfStr s d hd) h
+    · -- overflow → parse s = none
+      -- If s is not well-formed, parse = none trivially
+      by_cases hwf : IsWfStr s
+      · -- s is well-formed but overflows
+        obtain ⟨left, right, h_split, h_ne, h_rpos, h_rle, h_lint, h_rnat⟩ := hwf
+        obtain ⟨l, hl⟩ := Option.isSome_iff_exists.mp h_lint
+        obtain ⟨r, hr⟩ := Option.isSome_iff_exists.mp h_rnat
+        unfold Decimal.parse
+        rw [h_split]
+        simp only [show 0 < right.length ∧ right.length ≤ DECIMAL_DIGITS from ⟨h_rpos, h_rle⟩,
+          hl, hr, Decimal.decimal?, ite_true, and_true]
+        -- Goal: Int64.ofInt? (if ... then ... else ...) = none
+        -- We know computeValue s is out of range, and computeValue s = this expression
+        have hcv : computeValue s = (if !left.startsWith "-"
+            then l * Int.pow 10 DECIMAL_DIGITS + ↑r * Int.pow 10 (DECIMAL_DIGITS - right.length)
+            else l * Int.pow 10 DECIMAL_DIGITS - ↑r * Int.pow 10 (DECIMAL_DIGITS - right.length)) := by
+          simp only [computeValue, h_split, hl, hr]
+        rw [← hcv]
+        exact Int64.ofInt?_none_iff.mp h
+      · -- s is not well-formed → parse = none (same as the other branch)
+        by_contra hne
+        have ⟨d, hd⟩ := Option.ne_none_iff_exists'.mp hne
+        exact absurd (parse_some_isWfStr s d hd) hwf
+
+where
+  parse_some_isWfStr (s : String) (d : Decimal) (h : Decimal.parse s = some d) : IsWfStr s := by
+    unfold Decimal.parse at h
+    split at h
+    · exact absurd h (by simp)
+    · rename_i left right h_ne h_split
+      split at h
+      · rename_i l r heq_l heq_r
+        have h_len : 0 < right.length ∧ right.length ≤ DECIMAL_DIGITS := by
+          by_contra hc; simp [hc] at h
+        exact ⟨left, right, h_split, h_ne, h_len.1, h_len.2,
+          by rw [heq_l]; rfl, by rw [heq_r]; rfl⟩
+      · simp at h
+    · simp at h
 
 end Cedar.Thm.Decimal

--- a/cedar-lean/Cedar/Thm/Ext/Decimal.lean
+++ b/cedar-lean/Cedar/Thm/Ext/Decimal.lean
@@ -1,5 +1,5 @@
 import Cedar.Spec.Ext.Decimal
-import Std.Data.String
+import Cedar.Thm.Data.String
 
 namespace Cedar.Thm.Decimal
 open Cedar.Spec.Ext
@@ -25,107 +25,6 @@ def computeValue (s : String) : Int :=
         i
       | _, _ => 0
   | _ => 0
-
--- TODO: move to Cedar.Thm.Data.String
-/-- `splitOnPPrepend` on a list with no separator produces a single segment. -/
-private theorem splitOnPPrepend_none (P : α → Bool) (l acc : List α)
-    (h : ∀ x ∈ l, P x = false) :
-    List.splitOnPPrepend P l acc = [(acc.reverse ++ l)] := by
-  induction l generalizing acc with
-  | nil => rw [List.splitOnPPrepend.eq_def]; simp
-  | cons a t ih =>
-    rw [List.splitOnPPrepend.eq_def]
-    have ha : P a = false := h a (List.mem_cons.mpr (.inl rfl))
-    simp only [ha]
-    rw [ih (a :: acc) (fun x hx => h x (List.mem_cons.mpr (.inr hx)))]
-    simp [List.reverse_cons, List.append_assoc]
-
--- TODO: move to Cedar.Thm.Data.String
-/-- `splitOnPPrepend` on a list with exactly one separator produces two segments. -/
-private theorem splitOnPPrepend_single (P : α → Bool) (as bs acc : List α) (sep : α)
-    (hsep : P sep = true) (has : ∀ x ∈ as, P x = false) (hbs : ∀ x ∈ bs, P x = false) :
-    List.splitOnPPrepend P (as ++ sep :: bs) acc = (acc.reverse ++ as) :: [bs] := by
-  induction as generalizing acc with
-  | nil =>
-    rw [List.nil_append, List.splitOnPPrepend.eq_def]
-    simp only [hsep, ite_true]
-    rw [splitOnPPrepend_none P bs [] hbs]; simp
-  | cons a t ih =>
-    simp only [List.cons_append]
-    rw [List.splitOnPPrepend.eq_def]
-    have ha : P a = false := has a (List.mem_cons.mpr (.inl rfl))
-    simp only [ha]
-    rw [ih (a :: acc) (fun x hx => has x (List.mem_cons.mpr (.inr hx)))]
-    simp [List.reverse_cons, List.append_assoc]
-
--- TODO: move to Cedar.Thm.Data.String
-/-- Splitting `s₁ ++ sep ++ s₂` on `sep` yields `[s₁, s₂]` when neither part contains `sep`. -/
-private theorem splitToList_eq (s₁ s₂ : String) (p : Char → Bool) (sep : Char)
-    (hsep : p sep = true) (h₁ : ∀ c ∈ s₁.toList, p c = false)
-    (h₂ : ∀ c ∈ s₂.toList, p c = false) :
-    (s₁ ++ String.singleton sep ++ s₂).splitToList p = [s₁, s₂] := by
-  rw [String.splitToList_of_valid]
-  simp [String.toList_append, List.append_assoc]
-  change List.map String.ofList (List.splitOnPPrepend p (s₁.toList ++ sep :: s₂.toList) []) = _
-  rw [splitOnPPrepend_single p s₁.toList s₂.toList [] sep hsep h₁ h₂]
-  simp
-
--- TODO: move to Cedar.Thm.Data.String (generalize to arbitrary non-digit char)
-/-- The string representation of a natural number never contains `'.'`. -/
-private theorem repr_no_dot (n : Nat) :
-    ∀ c ∈ (toString n).toList, (fun x : Char => decide (x = '.')) c = false := by
-  intro c hc; simp only [decide_eq_false_iff_not]; intro heq
-  have hc' : c ∈ (Nat.repr n).toList := by rwa [← Nat.toString_eq_repr]
-  have hc'' : c ∈ Nat.toDigits 10 n := by
-    rwa [Nat.repr_eq_ofList_toDigits, String.toList_ofList] at hc'
-  rw [heq] at hc''
-  exact absurd (Nat.isDigit_of_mem_toDigits (by omega) (by omega) hc'') (by decide)
-
--- TODO: move to Cedar.Thm.Data.String (generalize to arbitrary non-digit char)
-/-- A zero-padded natural number string never contains `'.'`. -/
-private theorem zeros_repr_no_dot (zeros : String) (n : Nat)
-    (hz : ∀ c ∈ zeros.toList, c = '0') :
-    ∀ c ∈ (zeros ++ toString n).toList, (fun x : Char => decide (x = '.')) c = false := by
-  intro c hc; rw [String.toList_append] at hc
-  simp only [decide_eq_false_iff_not]; intro heq
-  cases List.mem_append.mp hc with
-  | inl h => rw [hz c h] at heq; exact absurd heq (by decide)
-  | inr h => exact absurd (repr_no_dot n c h) (by simp [heq])
-
--- TODO: move to Cedar.Thm.Data.String
-/-- The underscore-guarded foldl equals the plain foldl when no char is `'_'`. -/
-private theorem foldl_no_underscore_eq (l : List Char) (acc : Nat)
-    (hno : ∀ c ∈ l, c ≠ '_') :
-    List.foldl (fun n c => if c = '_' then n else n * 10 + (c.toNat - 48)) acc l =
-    List.foldl (fun n c => n * 10 + (c.toNat - 48)) acc l := by
-  induction l generalizing acc with
-  | nil => rfl
-  | cons a t ih =>
-    simp only [List.foldl]
-    have ha : a ≠ '_' := hno a (List.Mem.head _)
-    simp only [ha, ↓reduceIte]
-    exact ih _ (fun c hc => hno c (List.Mem.tail _ hc))
-
--- TODO: move to Cedar.Thm.Data.String
-/-- The positional-value foldl equals `Nat.ofDigitChars` (modulo argument order). -/
-private theorem foldl_eq_ofDigitChars (l : List Char) (acc : Nat) :
-    List.foldl (fun n c => n * 10 + (c.toNat - 48)) acc l =
-    Nat.ofDigitChars 10 l acc := by
-  induction l generalizing acc with
-  | nil => rfl
-  | cons a t ih =>
-    simp only [List.foldl, Nat.ofDigitChars, show Char.toNat '0' = 48 from by rfl]
-    rw [Nat.mul_comm 10 acc]
-    exact ih _
-
--- TODO: move to Cedar.Thm.Data.String
-/-- The `Slice.toNat?` foldl on `Nat.toDigits 10 n` recovers `n`. -/
-private theorem toDigits_foldl_roundtrip (n : Nat) :
-    List.foldl (fun acc c => if c = '_' then acc else acc * 10 + (c.toNat - 48)) 0
-      (Nat.toDigits 10 n) = n := by
-  rw [foldl_no_underscore_eq _ 0 (fun c hc heq => Nat.underscore_not_in_toDigits (heq ▸ hc)),
-    foldl_eq_ofDigitChars]
-  exact Nat.ofDigitChars_toDigits (by omega) (by omega)
 
 /-- `toString d` splits into concrete parts whose parse-relevant properties are known: -/
 theorem toString_split (d : Decimal) :
@@ -181,9 +80,7 @@ theorem toString_split (d : Decimal) :
     rw [h_toString]
     exact splitToList_eq leftPart rightPart _ '.' (by rfl) h_left_no_dot h_right_no_dot
   · -- rightPart.length = 4
-    -- TODO: replace with custom `digit_length` tactic that automates toDigitsCore unfolding
     simp only [rightPart, rightNat]
-    have hmod : d.natAbs % 10000 < 10000 := Nat.mod_lt _ (by omega)
     split
     · have : ("000" : String).length = 3 := by rfl
       have : (d.natAbs % Nat.pow 10 4).repr.length = 1 := by

--- a/cedar-lean/Cedar/Thm/Ext/Decimal.lean
+++ b/cedar-lean/Cedar/Thm/Ext/Decimal.lean
@@ -13,6 +13,8 @@ def IsWfStr (s : String) : Prop :=
     (toInt?' left).isSome ∧
     (toNat?' right).isSome
 
+/-- Compute the integer value that a well-formed decimal string represents.
+    Returns a junk value (0) for malformed inputs; only meaningful under `IsWfStr`. -/
 def computeValue (s : String) : Int :=
   match s.splitToList (· = '.') with
   | [left, right] =>
@@ -26,8 +28,13 @@ def computeValue (s : String) : Int :=
       | _, _ => 0
   | _ => 0
 
-/-- `toString d` splits into concrete parts whose parse-relevant properties are known: -/
-theorem toString_split (d : Decimal) :
+/-- Canonical-form normalizer: parse the string and re-serialize.
+    Returns `none` for malformed or out-of-range inputs. -/
+def normalize (s : String) : Option String := (Decimal.parse s).map toString
+
+/-- Decomposes `toString d` into its left (integer) and right (fractional) parts, establishing
+    their split structure, right-part length, parsability, and sign behavior. -/
+private theorem toString_split (d : Decimal) :
     let leftPart := (if d < 0 then "-" else "") ++ toString (d.natAbs / Nat.pow 10 4)
     let rightNat := d.natAbs % Nat.pow 10 4
     let rightPart :=
@@ -252,7 +259,7 @@ theorem toString_isWfStr (d : Decimal) : IsWfStr (toString d) := by
   · -- (toNat?' rightPart).isSome
     rw [h_rnat]; simp
 
-/-- If a string is well-formed, `parse` succeeds and reconstructs the value. -/
+/-- If a string is well-formed and its computed value matches `d.toInt`, then `parse` returns `d`. -/
 theorem parse_of_isWfStr (s : String) (d : Decimal)
     (hwf : IsWfStr s) (hval : computeValue s = d.toInt) :
     Decimal.parse s = some d := by
@@ -275,7 +282,7 @@ theorem parse_of_isWfStr (s : String) (d : Decimal)
     exact Int64.ofInt?_toInt d
   · rename_i h; exact (h left right rfl).elim
 
-/-- The `computeValue` of `toString d` equals `d.toInt`. -/
+/-- The canonical string representation of a decimal encodes the same integer value. -/
 theorem computeValue_toString (d : Decimal) : computeValue (toString d) = d.toInt := by
   obtain ⟨h_split, h_rlen, h_lint, h_rnat, h_starts⟩ := toString_split d
   simp only [computeValue, h_split, h_lint, h_rnat, h_rlen, h_starts, DECIMAL_DIGITS]
@@ -305,12 +312,12 @@ theorem computeValue_toString (d : Decimal) : computeValue (toString d) = d.toIn
       have := Nat.div_add_mod d.toInt.natAbs 10000; omega
     rw [h3, Int.natAbs_of_nonneg hge]
 
-/-- Roundtrip: `Decimal.parse (toString d) = some d`. -/
+/-- Parsing the canonical string representation of a decimal returns the same decimal. -/
 theorem parse_toString_roundtrip (d : Decimal) :
     Decimal.parse (toString d) = some d :=
   parse_of_isWfStr (toString d) d (toString_isWfStr d) (computeValue_toString d)
 
-/-- `parse` fails iff the string is malformed or its value overflows `Int64`. -/
+/-- Parsing fails iff the string is not well-formed or its value overflows `Int64` range. -/
 theorem parse_eq_none_iff (s : String) :
     Decimal.parse s = none ↔ ¬ IsWfStr s ∨
     computeValue s < Int64.MIN ∨ computeValue s > Int64.MAX := by
@@ -381,5 +388,29 @@ where
           by rw [heq_l]; rfl, by rw [heq_r]; rfl⟩
       · simp at h
     · simp at h
+
+/-- `toString` is injective: distinct decimals produce distinct strings. -/
+theorem toString_injective (d d' : Decimal) (h : toString d = toString d') : d = d' := by
+  have h₁ := parse_toString_roundtrip d
+  have h₂ := parse_toString_roundtrip d'
+  rw [h] at h₁
+  rw [h₁] at h₂
+  injection h₂
+
+/-- Equal normal form iff equal value: normalization decides decimal equality. -/
+theorem normalize_eq_iff_parse_eq (s s' : String) :
+    normalize s = normalize s' ↔ Decimal.parse s = Decimal.parse s' := by
+  constructor
+  · intro h
+    unfold normalize at h
+    match hps : Decimal.parse s, hps' : Decimal.parse s' with
+    | .some d, .some d' =>
+      simp [hps, hps', Option.map] at h
+      exact congrArg _ (toString_injective d d' h)
+    | .some d, .none => simp [hps, hps', Option.map] at h
+    | .none, .some d' => simp [hps, hps', Option.map] at h
+    | .none, .none => rfl
+  · intro h
+    simp [normalize, h]
 
 end Cedar.Thm.Decimal


### PR DESCRIPTION
Because of the `module` keyword, all declared definitions are default to private. Therefore the `public` is needed for referencing it from the Thm file. The `abbrev` is a cosmetic change that makes the definition reducible by default.