### PR TITLE
Adopt simp_do_let in Validation/Levels proofs

### DIFF
--- a/cedar-lean/Cedar/Thm/Validation/Levels/GetAttr.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Levels/GetAttr.lean
@@ -77,7 +77,7 @@ theorem level_based_slicing_is_sound_get_attr_record {e : Expr} {tx : TypedExpr}
   rename_i hl
   have ih := ihe hc hr htx hl
   simp only [evaluate, ←ih]
-  cases he₁ : evaluate e request entities <;> simp only [Except.bind_err, Except.bind_ok]
+  simp_do_let (evaluate e request entities) as he₁
   rename_i v
   have ⟨avs, he⟩ : ∃ avs, v = .record avs := by
     have ⟨ _, _, he, hty⟩ := type_of_is_sound hc hr htx

--- a/cedar-lean/Cedar/Thm/Validation/Levels/HasAttr.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Levels/HasAttr.lean
@@ -61,7 +61,7 @@ theorem level_based_slicing_is_sound_has_attr_record {e : Expr} {tx : TypedExpr}
   rename_i hl
   have ih := ihe hc hr htx hl
   simp only [evaluate, ←ih]
-  cases he₁ : evaluate e request entities <;> simp only [Except.bind_err, Except.bind_ok]
+  simp_do_let (evaluate e request entities) as he₁
   rename_i v
   have ⟨avs, he⟩ : ∃ avs, v = .record avs := by
     have ⟨ _, _, he, hty⟩ := type_of_is_sound hc hr htx

--- a/cedar-lean/Cedar/Thm/Validation/Levels/IfThenElse.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Levels/IfThenElse.lean
@@ -51,7 +51,7 @@ theorem level_based_slicing_is_sound_if {x₁ x₂ x₃ : Expr} {n : Nat} {c₀ 
     rename_i hl₁ hl₂ hl₃
     specialize ih₁ hc hr htx₁ hl₁
     simp only [ih₁, evaluate]
-    cases he₁' : Result.as Bool (evaluate x₁ request (entities.sliceAtLevel request n)) <;> simp only [Except.bind_err, Except.bind_ok]
+    simp_do_let (Result.as Bool (evaluate x₁ request (entities.sliceAtLevel request n))) as he₁'
     rename_i b
     replace he₁' : evaluate x₁ request (entities.sliceAtLevel request n) = .ok (.prim (.bool b)) := by
       simp only [Result.as, Coe.coe, Value.asBool] at he₁'

--- a/cedar-lean/Cedar/Thm/Validation/Levels/Record.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Levels/Record.lean
@@ -59,7 +59,7 @@ theorem level_based_slicing_is_sound_record_attrs {rxs : List (Attr × Expr)} {n
     specialize ihx hc hr htx hlx
     simp only [List.mapM_cons, ←ihx]
     have ih' := level_based_slicing_is_sound_record_attrs hc hr htl hl ih
-    cases he₁ : evaluate rx.snd request entities <;> simp only [Except.bind_err, Except.bind_ok]
+    simp_do_let (evaluate rx.snd request entities) as he₁
     simp only [List.mapM₂_eq_mapM (λ x : (Attr × Expr) => do let v ← evaluate x.snd request entities; .ok (x.fst, v))] at ih'
     simp only [List.mapM₂_eq_mapM (λ x : (Attr × Expr) => do let v ← evaluate x.snd request (entities.sliceAtLevel request n); .ok (x.fst, v))] at ih'
     rw [ih']


### PR DESCRIPTION
*Issue #, if available:* #279

*Description of changes:*. Continues the simp_do_let adoption from #955/#958: convert the four remaining canonical `cases _ : evaluate … <;> simp only [Except.bind_err, Except.bind_ok]` do-bind sites in Validation/Levels (HasAttr, GetAttr, IfThenElse, Record) to `simp_do_let … as h`. 

