### PR TITLE
Lift error-kind guarantees to the authorizer Response (erroringPolicies)

### DIFF
--- a/cedar-lean/Cedar/Thm/Validation.lean
+++ b/cedar-lean/Cedar/Thm/Validation.lean
@@ -25,6 +25,7 @@ import Cedar.Thm.Validation.EnvironmentValidation
 import Cedar.Thm.Validation.Levels
 import Cedar.Thm.Validation.SubstituteAction
 import Cedar.Thm.Validation.Typechecker
+import Cedar.Thm.Authorization
 
 /-!
 This file contains the top-level correctness properties for the Cedar validator.
@@ -113,5 +114,80 @@ theorem validate_with_level_no_dne {ps : Policies} {schema : Schema} {n : Nat} {
 := validate_with_level_no_dne_wf
     (request_and_entities_validate_implies_instance_of_wf_schema _ _ _ hwf hr he)
     (closedAtLevel_iff.mp hcl) htl
+
+/--
+Bridge from `Response.erroringPolicies` membership back to the evaluator: if a
+policy id appears in the erroring set produced by `isAuthorized`, then some
+policy in `ps` with that id genuinely errored on evaluation.  Because policy ids
+need not be unique, this recovers *a* policy with the id, not necessarily a
+specific one.
+-/
+theorem error_of_mem_erroringPolicies {ps : Policies} {request : Request} {entities : Entities} {pid : PolicyID}
+  (h : pid ∈ (isAuthorized request entities ps).erroringPolicies) :
+  ∃ p ∈ ps, p.id = pid ∧ ∃ e, evaluate p.toExpr request entities = .error e
+:= by
+  unfold isAuthorized errorPolicies errored at h
+  simp only [apply_ite, ite_self, Set.mem_make, List.mem_filterMap,
+    Option.ite_none_right_eq_some, Option.some.injEq] at h
+  obtain ⟨p, hp, herr, hid⟩ := h
+  refine ⟨p, hp, hid, ?_⟩
+  cases heq : evaluate p.toExpr request entities with
+  | ok v => simp [hasError, heq] at herr
+  | error e => exact ⟨e, rfl⟩
+
+/--
+`Response`-level form of `validate_with_level_no_dne` (issue #642): for a policy
+set that validates at level `n` over a store closed at that level, no policy in
+the authorizer's `erroringPolicies` errored with `entityDoesNotExist`.  The
+`erroringPolicies` membership premise is not needed for soundness — *no* policy
+evaluates to `entityDoesNotExist` at all (`validate_with_level_no_dne`) — but it
+phrases the guarantee at the `isAuthorized` `Response` level.
+-/
+theorem validate_with_level_no_dne_response {ps : Policies} {schema : Schema} {n : Nat} {request : Request} {entities : Entities}
+  (hwf : schema.validateWellFormed = .ok ())
+  (hr : validateRequest schema request = .ok ())
+  (he : validateEntities schema entities = .ok ())
+  (hcl : entities.closedAtLevel request n)
+  (htl : validateWithLevel ps schema n = .ok ()) :
+  ∀ p ∈ ps, p.id ∈ (isAuthorized request entities ps).erroringPolicies →
+    evaluate p.toExpr request entities ≠ .error .entityDoesNotExist
+:= by
+  intro p hp _
+  exact validate_with_level_no_dne hwf hr he hcl htl p hp
+
+/--
+`Response`-level form of `validation_is_sound`: for a validated policy set with
+unique policy ids, every policy in the authorizer's `erroringPolicies` errored
+with one of the three errors validation cannot rule out (`entityDoesNotExist`,
+`extensionError`, `arithBoundsError`).  Uniqueness of ids (`PolicyIdsUnique`, as
+in `determining_erroring_disjoint_when_unique_ids`) is required: an id in
+`erroringPolicies` only witnesses that *some* policy with that id errored, so
+without uniqueness it need not be the policy `p` quantified over.
+-/
+theorem validation_is_sound_response (policies : Policies) (schema : Schema) (request : Request) (entities : Entities)
+  (huniq : PolicyIdsUnique policies)
+  (hwf : schema.validateWellFormed = .ok ())
+  (hv : validate policies schema = .ok ())
+  (hr : validateRequest schema request = .ok ())
+  (he : validateEntities schema entities = .ok ()) :
+  ∀ p ∈ policies, p.id ∈ (isAuthorized request entities policies).erroringPolicies →
+    evaluate p.toExpr request entities = .error .entityDoesNotExist ∨
+    evaluate p.toExpr request entities = .error .extensionError ∨
+    evaluate p.toExpr request entities = .error .arithBoundsError
+:= by
+  intro p hp hmem
+  obtain ⟨p', hp', hid, e, herr⟩ := error_of_mem_erroringPolicies hmem
+  have hpeq : p' = p := huniq p' hp' p hp hid
+  rw [hpeq] at herr
+  have hsound : AllEvaluateToBool policies request entities :=
+    validation_is_sound policies schema request entities hwf hv hr he
+  have hev : EvaluatesToBool p.toExpr request entities := hsound p hp
+  obtain ⟨b, hev⟩ := hev
+  unfold EvaluatesTo at hev
+  rcases hev with h | h | h | h
+  · exact Or.inl h
+  · exact Or.inr (Or.inl h)
+  · exact Or.inr (Or.inr h)
+  · rw [herr] at h; exact absurd h (by simp)
 
 end Cedar.Thm


### PR DESCRIPTION
*Issue #, if available:* #642 #963 

*Description of changes:*

Follow-up to #963 (issue #642), as suggested by @john-h-kastner-aws: lift the per-policy evaluation guarantees up to the authorizer's Response.erroringPolicies.

- error_of_mem_erroringPolicies: bridge, an id in erroringPolicies is witnessed by a policy in ps that errored.
- validate_with_level_no_dne_response: Response-level form of validate_with_level_no_dne (no erroring policy errored with entityDoesNotExist).
- validation_is_sound_response: Response-level form of validation_is_sound (every erroring policy errored with one of entityDoesNotExist, extensionError, arithBoundsError).

validation_is_sound_response takes PolicyIdsUnique (as in determining_erroring_disjoint_when_unique_ids): an id in erroringPolicies only witnesses that some policy with that id errored. The no-DNE form needs no such premise. Kastner's (ps.find pid) phrasing is rendered by quantifying over the policy directly, since Policies is a list with no by-id lookup.


