### PR TITLE
fuzz targets for proto Schema::decode

### DIFF
--- a/cedar-drt/fuzz/Cargo.toml
+++ b/cedar-drt/fuzz/Cargo.toml
@@ -270,6 +270,12 @@ test = false
 doc = false
 
 [[bin]]
+name = "protobuf-decode-gen-schema"
+path = "fuzz_targets/protobuf-decode/protobuf-decode-gen-schema.rs"
+test = false
+doc = false
+
+[[bin]]
 name = "protobuf-decode-gen-template"
 path = "fuzz_targets/protobuf-decode/protobuf-decode-gen-template.rs"
 test = false

--- a/cedar-drt/fuzz/fuzz_targets/protobuf-decode/protobuf-decode-bytes-schema.rs
+++ b/cedar-drt/fuzz/fuzz_targets/protobuf-decode/protobuf-decode-bytes-schema.rs
@@ -19,6 +19,7 @@
 use cedar_drt_inner::fuzz_target;
 
 use cedar_drt_inner::props::{schema_to_cedar_parses, schema_to_json_deserializes};
+use cedar_drt_inner::schemas::schemas_are_equivalent;
 use cedar_policy::Schema;
 use cedar_policy::proto::traits::Protobuf;
 
@@ -27,8 +28,16 @@ use cedar_policy::proto::traits::Protobuf;
 fuzz_target!(|input: &[u8]| {
     match Schema::decode(input) {
         Ok(schema) => {
-            schema_to_cedar_parses(&schema);
-            schema_to_json_deserializes(&schema);
+            schemas_are_equivalent(
+                &schema,
+                &schema_to_cedar_parses(&schema),
+                "Cedar Roundtripped",
+            );
+            schemas_are_equivalent(
+                &schema,
+                &schema_to_json_deserializes(&schema),
+                "JSON Roundtripped",
+            );
         }
         Err(_) => (), // we expect errors
     }

--- a/cedar-drt/fuzz/fuzz_targets/protobuf-decode/protobuf-decode-bytes-schema.rs
+++ b/cedar-drt/fuzz/fuzz_targets/protobuf-decode/protobuf-decode-bytes-schema.rs
@@ -18,7 +18,7 @@
 
 use cedar_drt_inner::fuzz_target;
 
-use cedar_drt_inner::props::{schema_to_cedar_roundtrips, schema_to_json_roundtrips};
+use cedar_drt_inner::props::{schema_to_cedar_parses, schema_to_json_deserializes};
 use cedar_policy::Schema;
 use cedar_policy::proto::traits::Protobuf;
 
@@ -27,8 +27,8 @@ use cedar_policy::proto::traits::Protobuf;
 fuzz_target!(|input: &[u8]| {
     match Schema::decode(input) {
         Ok(schema) => {
-            schema_to_cedar_roundtrips(&schema);
-            schema_to_json_roundtrips(&schema);
+            schema_to_cedar_parses(&schema);
+            schema_to_json_deserializes(&schema);
         }
         Err(_) => (), // we expect errors
     }

--- a/cedar-drt/fuzz/fuzz_targets/protobuf-decode/protobuf-decode-gen-schema.rs
+++ b/cedar-drt/fuzz/fuzz_targets/protobuf-decode/protobuf-decode-gen-schema.rs
@@ -17,19 +17,26 @@
 #![no_main]
 
 use cedar_drt_inner::fuzz_target;
-
 use cedar_drt_inner::props::{schema_to_cedar_roundtrips, schema_to_json_roundtrips};
-use cedar_policy::Schema;
-use cedar_policy::proto::traits::Protobuf;
+use cedar_drt_inner::proto_gen::ProtoSchemaInput;
 
-// Feed arbitrary bytes into Schema protobuf decoder.
-// The property under test: decode either returns Ok or Err, never panics.
-fuzz_target!(|input: &[u8]| {
-    match Schema::decode(input) {
-        Ok(schema) => {
-            schema_to_cedar_roundtrips(&schema);
-            schema_to_json_roundtrips(&schema);
-        }
-        Err(_) => (), // we expect errors
-    }
+use cedar_policy::Schema;
+use cedar_policy::proto::models;
+use prost::Message;
+
+// Generates a proto Schema → encode to bytes → decode → convert to domain →
+// roundtrip through JSON and Cedar text.
+fuzz_target!(|input: ProtoSchemaInput| {
+    let buf = input.schema.encode_to_vec();
+
+    let decoded = models::Schema::decode(&buf[..])
+        .expect("Failed to decode proto Schema that was just encoded.");
+
+    let schema = match Schema::try_from(decoded) {
+        Ok(s) => s,
+        Err(_) => return,
+    };
+
+    schema_to_json_roundtrips(&schema);
+    schema_to_cedar_roundtrips(&schema);
 });

--- a/cedar-drt/fuzz/fuzz_targets/protobuf-decode/protobuf-decode-gen-schema.rs
+++ b/cedar-drt/fuzz/fuzz_targets/protobuf-decode/protobuf-decode-gen-schema.rs
@@ -17,7 +17,7 @@
 #![no_main]
 
 use cedar_drt_inner::fuzz_target;
-use cedar_drt_inner::props::{schema_to_cedar_roundtrips, schema_to_json_roundtrips};
+use cedar_drt_inner::props::{schema_to_cedar_parses, schema_to_json_deserializes};
 use cedar_drt_inner::proto_gen::ProtoSchemaInput;
 
 use cedar_policy::Schema;
@@ -39,6 +39,6 @@ fuzz_target!(|input: ProtoSchemaInput| {
         Err(_) => return,
     };
     // It should roundtrip through JSON and Cedar formats.
-    schema_to_json_roundtrips(&schema);
-    schema_to_cedar_roundtrips(&schema);
+    schema_to_json_deserializes(&schema);
+    schema_to_cedar_parses(&schema);
 });

--- a/cedar-drt/fuzz/fuzz_targets/protobuf-decode/protobuf-decode-gen-schema.rs
+++ b/cedar-drt/fuzz/fuzz_targets/protobuf-decode/protobuf-decode-gen-schema.rs
@@ -32,11 +32,13 @@ fuzz_target!(|input: ProtoSchemaInput| {
     let decoded = models::Schema::decode(&buf[..])
         .expect("Failed to decode proto Schema that was just encoded.");
 
+    // Convert proto model -> schema. If it doesn't fail here, then the roundtrips through
+    // other formats should succeed.
     let schema = match Schema::try_from(decoded) {
         Ok(s) => s,
         Err(_) => return,
     };
-
+    // It should roundtrip through JSON and Cedar formats.
     schema_to_json_roundtrips(&schema);
     schema_to_cedar_roundtrips(&schema);
 });

--- a/cedar-drt/fuzz/fuzz_targets/protobuf-decode/protobuf-decode-gen-schema.rs
+++ b/cedar-drt/fuzz/fuzz_targets/protobuf-decode/protobuf-decode-gen-schema.rs
@@ -17,8 +17,11 @@
 #![no_main]
 
 use cedar_drt_inner::fuzz_target;
-use cedar_drt_inner::props::{schema_to_cedar_parses, schema_to_json_deserializes};
 use cedar_drt_inner::proto_gen::ProtoSchemaInput;
+use cedar_drt_inner::{
+    props::{schema_to_cedar_parses, schema_to_json_deserializes},
+    schemas::schemas_are_equivalent,
+};
 
 use cedar_policy::Schema;
 use cedar_policy::proto::models;
@@ -38,7 +41,12 @@ fuzz_target!(|input: ProtoSchemaInput| {
         Ok(s) => s,
         Err(_) => return,
     };
-    // It should roundtrip through JSON and Cedar formats.
-    schema_to_json_deserializes(&schema);
-    schema_to_cedar_parses(&schema);
+    // It should roundtrip through JSON and Cedar formats, and result in equivalent schemas.
+    // Proto decoding should compute tc
+    schemas_are_equivalent(&schema, &schema_to_cedar_parses(&schema), "Cedar roundtrip");
+    schemas_are_equivalent(
+        &schema,
+        &schema_to_json_deserializes(&schema),
+        "JSON roundtrip",
+    );
 });

--- a/cedar-drt/fuzz/src/props.rs
+++ b/cedar-drt/fuzz/src/props.rs
@@ -18,8 +18,10 @@
 
 use crate::roundtrip_entities::pretty_assert_entities_deep_eq;
 use cedar_policy::{
-    Entities, Entity, Expression, Policy, PolicySet, Request, RestrictedExpression, Template,
+    Entities, Entity, Expression, Policy, PolicySet, Request, RestrictedExpression, Schema,
+    Template,
 };
+use cedar_policy_core::validator::ValidatorSchema;
 
 /// An [`Entity`] should roundrtrip through serialization with json and then deserialization.
 /// The [`Entity`] gets converted to a singleton [`Entities`].
@@ -145,4 +147,33 @@ pub fn policyset_to_json_deserializes(original: PolicySet) -> PolicySet {
     PolicySet::from_json_value(json.clone()).unwrap_or_else(|e| {
         panic!("JSON from PolicySet failed to deserialize.\nJSON: {json}\nError: {e:?}")
     })
+}
+
+/// A [`Schema`] should roundtrip through JSON serialization. Convert to a JSON
+/// schema fragment, serialize to JSON, then parse back as a [`Schema`].
+pub fn schema_to_json_roundtrips(schema: &Schema) {
+    let validator_schema: &ValidatorSchema = schema.as_ref();
+    let fragment = validator_schema
+        .to_json_schema()
+        .expect("ValidatorSchema could not be converted to JSON schema fragment");
+    let json = serde_json::to_value(&fragment)
+        .unwrap_or_else(|e| panic!("Schema fragment could not be serialized to JSON.\nError: {e}"));
+    let _roundtripped = Schema::from_json_value(json.clone()).unwrap_or_else(|e| {
+        panic!("JSON from Schema failed to re-parse.\nJSON: {json}\nError: {e}")
+    });
+}
+
+/// A [`Schema`] should roundtrip through Cedar schema syntax. Convert to a JSON
+/// schema fragment, print to Cedar text, then parse back as a [`Schema`].
+pub fn schema_to_cedar_roundtrips(schema: &Schema) {
+    let validator_schema: &ValidatorSchema = schema.as_ref();
+    let fragment = validator_schema
+        .to_json_schema()
+        .expect("ValidatorSchema could not be converted to JSON schema fragment");
+    let cedar_text = fragment
+        .to_cedarschema()
+        .expect("Schema fragment could not be converted to Cedar schema syntax");
+    let _roundtripped = Schema::from_cedarschema_str(&cedar_text).unwrap_or_else(|e| {
+        panic!("Cedar schema text failed to re-parse.\nText: {cedar_text}\nError: {e}")
+    });
 }

--- a/cedar-drt/fuzz/src/props.rs
+++ b/cedar-drt/fuzz/src/props.rs
@@ -149,31 +149,32 @@ pub fn policyset_to_json_deserializes(original: PolicySet) -> PolicySet {
     })
 }
 
-/// A [`Schema`] should roundtrip through JSON serialization. Convert to a JSON
-/// schema fragment, serialize to JSON, then parse back as a [`Schema`].
-pub fn schema_to_json_roundtrips(schema: &Schema) {
+/// A [`Schema`] should serialize to JSON and deserialize again. Panics if serializing or
+/// deserializing fails.
+/// Caller should use the result if they need to assert equality with the input.
+pub fn schema_to_json_deserializes(schema: &Schema) -> Schema {
     let validator_schema: &ValidatorSchema = schema.as_ref();
     let fragment = validator_schema
         .to_json_schema()
         .expect("ValidatorSchema could not be converted to JSON schema fragment");
     let json = serde_json::to_value(&fragment)
         .unwrap_or_else(|e| panic!("Schema fragment could not be serialized to JSON.\nError: {e}"));
-    let _roundtripped = Schema::from_json_value(json.clone()).unwrap_or_else(|e| {
+    Schema::from_json_value(json.clone()).unwrap_or_else(|e| {
         panic!("JSON from Schema failed to re-parse.\nJSON: {json}\nError: {e}")
-    });
+    })
 }
 
-/// A [`Schema`] should roundtrip through Cedar schema syntax. Convert to a JSON
-/// schema fragment, print to Cedar text, then parse back as a [`Schema`].
-pub fn schema_to_cedar_roundtrips(schema: &Schema) {
+/// A [`Schema`] should print to Cedar syntax and then parse again. Panics if printing or parsing
+/// fails.
+/// Caller should use the result if they need to assert equality with the input.
+pub fn schema_to_cedar_parses(schema: &Schema) -> Schema {
     let validator_schema: &ValidatorSchema = schema.as_ref();
-    let fragment = validator_schema
-        .to_json_schema()
-        .expect("ValidatorSchema could not be converted to JSON schema fragment");
-    let cedar_text = fragment
-        .to_cedarschema()
+    let cedar_text = validator_schema
+        .to_cedar_schema()
         .expect("Schema fragment could not be converted to Cedar schema syntax");
-    let _roundtripped = Schema::from_cedarschema_str(&cedar_text).unwrap_or_else(|e| {
-        panic!("Cedar schema text failed to re-parse.\nText: {cedar_text}\nError: {e}")
-    });
+    Schema::from_cedarschema_str(&cedar_text)
+        .unwrap_or_else(|e| {
+            panic!("Cedar schema text failed to re-parse.\nText: {cedar_text}\nError: {e}")
+        })
+        .0
 }

--- a/cedar-drt/fuzz/src/schemas.rs
+++ b/cedar-drt/fuzz/src/schemas.rs
@@ -28,6 +28,7 @@ use std::hash::Hash;
 use cedar_policy::{Entities, Schema};
 use cedar_policy_generators::err::Error;
 use libfuzzer_sys::arbitrary;
+use similar_asserts::SimpleDiff;
 
 pub fn add_actions_to_entities(schema: &Schema, entities: Entities) -> arbitrary::Result<Entities> {
     let actions = schema
@@ -37,6 +38,27 @@ pub fn add_actions_to_entities(schema: &Schema, entities: Entities) -> arbitrary
     Ok(entities
         .add_entities(actions, None)
         .map_err(|e| Error::EntitiesError(format!("Error fetching action entities: {e}")))?)
+}
+
+/// Test that API-level `schema` and `other` are equivalent according to [`equivalence_check`]
+/// after conversion to `json_schema::Fragment`.
+/// Panics if the schemas are not equivalent.
+pub fn schemas_are_equivalent(schema: &Schema, other: &Schema, how_related: &str) {
+    if let Err(msg) = equivalence_check(
+        &schema.as_ref().to_json_schema().unwrap(),
+        &other.as_ref().to_json_schema().unwrap(),
+    ) {
+        println!(
+            "{}",
+            SimpleDiff::from_str(
+                &format!("{:#?}", schema),
+                &format!("{:#?}", other),
+                "Initial Schema",
+                how_related
+            )
+        );
+        panic!("{msg}");
+    };
 }
 
 /// Check if two schema fragments are equivalent, modulo empty apply specs.


### PR DESCRIPTION
Fuzz targets for decoding protobufs of schemas:
- adding roundtrip properties on output of the target testing from bytes,
- new target testing from generated protobuf models.

