### PR TITLE
update target after cedar pR #2387

### DIFF
--- a/cedar-drt/fuzz/fuzz_targets/protobuf-decode/protobuf-decode-gen-entities.rs
+++ b/cedar-drt/fuzz/fuzz_targets/protobuf-decode/protobuf-decode-gen-entities.rs
@@ -21,7 +21,10 @@ use cedar_drt_inner::props::entities_to_json_roundtrips;
 use cedar_drt_inner::proto_gen;
 
 use cedar_policy::Entities;
-use cedar_policy::proto::models;
+use cedar_policy::proto::{
+    models,
+    traits::{DecodeError, Protobuf},
+};
 use prost::Message;
 
 use libfuzzer_sys::arbitrary::{self, Arbitrary, Unstructured};
@@ -51,14 +54,13 @@ fuzz_target!(|input: ProtoEntitiesInput| {
     // a models::Entities.
     let buf = input.entities.encode_to_vec();
 
-    // Decode from bytes.
-    let decoded =
-        models::Entities::decode(&buf[..]).expect("Decoding an encoded models::Entities failed");
-
-    // Convert proto model → domain type.
+    // Decode the encoded `Entities`.
     // This is expected to fail for many inputs.
-    let entities = match Entities::try_from(decoded) {
+    let entities = match Entities::decode(&buf[..]) {
         Ok(e) => e,
+        Err(DecodeError::Proto(err)) => {
+            panic!("Decoding an encoded models::Entities failed: {err}")
+        }
         Err(_) => return,
     };
     // Once we have some `Entities`, then it should roundtrip through JSON. We test that validation

--- a/cedar-drt/fuzz/fuzz_targets/protobuf-decode/protobuf-decode-gen-entity.rs
+++ b/cedar-drt/fuzz/fuzz_targets/protobuf-decode/protobuf-decode-gen-entity.rs
@@ -20,8 +20,10 @@ use cedar_drt_inner::fuzz_target;
 use cedar_drt_inner::proto_gen::ProtoEntityInput;
 
 use cedar_drt_inner::props::entity_to_json_roundtrips;
-use cedar_policy::Entity;
-use cedar_policy::proto::models;
+use cedar_policy::{
+    Entity,
+    proto::traits::{DecodeError, Protobuf},
+};
 use prost::Message;
 
 // This tests that validation when decoding protobufs for an entity is the same as validation
@@ -34,14 +36,13 @@ fuzz_target!(|input: ProtoEntityInput| {
     // Encode the generated proto model to bytes
     let buf = input.entity.encode_to_vec();
 
-    // Decode from bytes
-    let decoded = models::Entity::decode(&buf[..])
-        .expect("Failed to decode proto Entity that was just encoded.");
-
-    // Convert proto model → domain type
+    // Decode the encoded model into an `Entity`.
     // If it doesn't fail here, then all subsequent steps should not fail.
-    let entity = match Entity::try_from(decoded) {
+    let entity = match Entity::decode(&buf[..]) {
         Ok(e) => e,
+        Err(DecodeError::Proto(err)) => {
+            panic!("Failed to decode proto Entity that was just encoded: {err}")
+        }
         Err(_) => return,
     };
     // Once we have an `Entity` it should roundtrip through JSON. We test that validation in the

--- a/cedar-drt/fuzz/fuzz_targets/protobuf-decode/protobuf-decode-gen-expression.rs
+++ b/cedar-drt/fuzz/fuzz_targets/protobuf-decode/protobuf-decode-gen-expression.rs
@@ -21,7 +21,7 @@ use cedar_drt_inner::proto_gen::ProtoExprInput;
 
 use cedar_drt_inner::props::expression_to_cedar_parses;
 use cedar_policy::Expression;
-use cedar_policy::proto::models;
+use cedar_policy::proto::traits::{DecodeError, Protobuf};
 use prost::Message;
 
 // This tests that validation when decoding protobufs for an expression is the same as validation
@@ -34,14 +34,11 @@ fuzz_target!(|input: ProtoExprInput| {
     // Encode the generated proto model to bytes
     let buf = input.expr.encode_to_vec();
 
-    // Decode from bytes
-    let decoded =
-        models::Expr::decode(&buf[..]).expect("Failed to decode proto Expr that was just encoded.");
-
-    // Convert proto model → domain type
+    // Decode encoded model into an `Expression`.
     // If it doesn't fail here, then all subsequent steps should not fail.
-    let expression = match Expression::try_from(decoded) {
+    let expression = match Expression::decode(&buf[..]) {
         Ok(e) => e,
+        Err(DecodeError::Proto(err)) => panic!("Decoding an encoded models::Expr failed: {err}"),
         Err(_) => return,
     };
     // Once we have an `Expression` it should roundtrip through Cedar.

--- a/cedar-drt/fuzz/fuzz_targets/protobuf-decode/protobuf-decode-gen-policyset.rs
+++ b/cedar-drt/fuzz/fuzz_targets/protobuf-decode/protobuf-decode-gen-policyset.rs
@@ -21,7 +21,8 @@ use cedar_drt_inner::props::policyset_to_cedar_parses;
 use cedar_drt_inner::proto_gen::ProtoPolicySetInput;
 
 use cedar_policy::PolicySet;
-use cedar_policy::proto::models;
+use cedar_policy::proto::traits::{DecodeError, Protobuf};
+
 use prost::Message;
 
 // This fuzz target checks that the validation of policy sets on the protobuf decode path is the
@@ -34,15 +35,13 @@ fuzz_target!(|input: ProtoPolicySetInput| {
     // Encode the generated proto model to bytes
     let buf = input.policy_set.encode_to_vec();
 
-    // Decode from bytes (as a real client would). Should not fail since it is the encoding of
-    // a models::PolicySet.
-    let decoded =
-        models::PolicySet::decode(&buf[..]).expect("Decoding an encoded models::PolicySet failed");
-
     // Convert proto model → domain type
     // This is expected to fail
-    let policy_set = match PolicySet::try_from(decoded) {
+    let policy_set = match PolicySet::decode(&buf[..]) {
         Ok(ps) => ps,
+        Err(DecodeError::Proto(err)) => {
+            panic!("Decoding an encoded models::PolicySet failed: {err}")
+        }
         Err(_) => return,
     };
     // Once we have a PolicySet, printing and parsing it back should succeed.

--- a/cedar-drt/fuzz/fuzz_targets/protobuf-decode/protobuf-decode-gen-request.rs
+++ b/cedar-drt/fuzz/fuzz_targets/protobuf-decode/protobuf-decode-gen-request.rs
@@ -21,7 +21,7 @@ use cedar_drt_inner::proto_gen::ProtoRequestInput;
 
 use cedar_drt_inner::props::request_context_to_cedar_parses;
 use cedar_policy::Request;
-use cedar_policy::proto::models;
+use cedar_policy::proto::traits::{DecodeError, Protobuf};
 use prost::Message;
 
 // This tests that validation when decoding protobufs for a request is the same as validation
@@ -35,14 +35,13 @@ fuzz_target!(|input: ProtoRequestInput| {
     // Encode the generated proto model to bytes
     let buf = input.request.encode_to_vec();
 
-    // Decode from bytes
-    let decoded = models::Request::decode(&buf[..])
-        .expect("Failed to decode proto Request that was just encoded.");
-
-    // Convert proto model → domain type
+    // Decode the encoded `Request`.
     // If it doesn't fail here, then all subsequent steps should not fail.
-    let request = match Request::try_from(decoded) {
+    let request = match Request::decode(&buf[..]) {
         Ok(r) => r,
+        Err(DecodeError::Proto(err)) => {
+            panic!("Decoding an encoded models::Request failed: {err}.")
+        }
         Err(_) => return,
     };
     // Once we have a `Request`, its context values should roundtrip through Cedar text.

--- a/cedar-drt/fuzz/fuzz_targets/protobuf-decode/protobuf-decode-gen-template.rs
+++ b/cedar-drt/fuzz/fuzz_targets/protobuf-decode/protobuf-decode-gen-template.rs
@@ -21,6 +21,7 @@ use cedar_drt_inner::{fuzz_target, props::template_to_cedar_parses};
 
 use cedar_policy::Template;
 use cedar_policy::proto::models;
+use cedar_policy::proto::traits::{DecodeError, Protobuf};
 use prost::Message;
 
 use libfuzzer_sys::arbitrary::{self, Arbitrary, Unstructured};
@@ -47,14 +48,12 @@ fuzz_target!(|input: ProtoTemplateInput| {
     // Encode the generated proto model to bytes
     let buf = input.template.encode_to_vec();
 
-    // Decode from bytes
-    let decoded = models::TemplateBody::decode(&buf[..])
-        .expect("Decoding an encoded models::Template failed.");
-
-    // Convert proto model → domain type
-    // We expect this to fail, but when this doesn't faill all subsequent steps should pass.
-    let template = match Template::try_from(decoded) {
+    // Decode into `Template`
+    let template = match Template::decode(&buf[..]) {
         Ok(t) => t,
+        Err(DecodeError::Proto(err)) => {
+            panic!("Decoding an encoded models::Template failed: {err}")
+        }
         Err(_) => return,
     };
     // Once we have a template, it should parse again through a Cedar roundtrip: we test that


### PR DESCRIPTION
Move to use `<Type>::decode(..)` instead of going through `models::<Type'>::decode(..)` and then `<Type>::try_from` since the `decode` API of `<Type>` now validates directly (after changes from https://github.com/cedar-policy/cedar/pull/2387).