### PR TITLE
Update lean model decoding to match Rust z3 fixes

### DIFF
--- a/cedar-lean/Cedar/SymCC/Decoder.lean
+++ b/cedar-lean/Cedar/SymCC/Decoder.lean
@@ -233,11 +233,15 @@ where
     | [.symbol "Set", x]                          => do TermType.set (← x.decodeType types)
     | other                                       => fail "BitVec, Option, or Set" other
 
-partial def SExpr.decodeLit (ids : IdMaps) : SExpr → Result Term
+partial def SExpr.decodeLit (ids : IdMaps) (expectedTy : Option TermType := .none) : SExpr → Result Term
   | .bitvec bv      => Term.bitvec bv
   | .string s       => Term.string s
   | .symbol "true"  => Term.bool true
   | .symbol "false" => Term.bool false
+  | .symbol "none"  =>
+    match expectedTy with
+    | .some (.option ty) => Term.none ty
+    | _                  => fail "option type for bare 'none'" expectedTy
   | .symbol e       => enumOrEmptyRecord e
   | .sexpr xs       => construct xs
   | other           => fail "literal expr" other
@@ -251,9 +255,10 @@ where
     | .some (.entity ety), [SExpr.string eid] =>
       Term.entity ⟨ety, eid⟩
     | .some (.record (Map.mk rty)), _ =>
-      let ts ← args.mapM (SExpr.decodeLit ids)
-      if rty.length != ts.length then
+      if rty.length != args.length then
         fail s!"record literal args of length {rty.length}" args
+      let ts ← (rty.zip args).mapM λ ((_, fieldTy), arg) =>
+        arg.decodeLit ids (.some fieldTy)
       for aty in rty, t in ts do
         if t.typeOf != aty.snd then
           fail s!"attribute {aty.fst} of type {reprStr aty.snd}" t
@@ -267,20 +272,30 @@ where
       | .option ty => Term.none ty
       | other      => fail "option type" other
     | [.sexpr [.symbol "as", .symbol "some", oty], x] => do
-      let t := Term.some (← x.decodeLit ids)
       let ty ← oty.decodeType ids.types
+      let innerTy? := match ty with | .option inner => .some inner | _ => .none
+      let t := Term.some (← x.decodeLit ids innerTy?)
       if t.typeOf != ty then
         fail s!"term of type {reprStr ty}" t
       t
+    | [.symbol "some", x] => do
+      let innerTy := match expectedTy with
+      | .some (.option ty) => .some ty
+      | _ => .none
+      let t ← x.decodeLit ids innerTy
+      Term.some t
     | [.symbol "as", .symbol "set.empty", sty] => do
       match ← sty.decodeType ids.types with
       | .set ty => Term.set Set.empty ty
       | other   => fail "set type" other
     | [.symbol "set.singleton", x] => do
-      let t ← x.decodeLit ids
+      let eltTy := match expectedTy with
+      | .some (.set ty) => .some ty
+      | _ => .none
+      let t ← x.decodeLit ids eltTy
       Term.set (Set.singleton t) t.typeOf
     | [.symbol "set.union", x₁, x₂] => do
-      match ← x₁.decodeLit ids, ← x₂.decodeLit ids with
+      match ← x₁.decodeLit ids expectedTy, ← x₂.decodeLit ids expectedTy with
       | .set ts₁ ty, .set ts₂ _ => Term.set (ts₁ ∪ ts₂) ty
       | t₁, t₂                  => fail "sets" [t₁, t₂]
     | [.symbol "Decimal", @SExpr.bitvec 64 bv]  =>
@@ -312,23 +327,25 @@ where
     | other =>
       fail "literal expr" other
 
-partial def SExpr.decodeUnaryFunctionTable (arg : String) (ids : IdMaps) : SExpr → Result ((List (Term × Term)) × Term)
-  | .sexpr [.symbol "ite", .sexpr [.symbol "=", condExpr, .symbol v], thenExpr, elseExpr] => do
-    if v != arg then
+partial def SExpr.decodeUnaryFunctionTable (arg : String) (ids : IdMaps) (retTy : Option TermType := .none) : SExpr → Result ((List (Term × Term)) × Term)
+  | .sexpr [.symbol "ite", .sexpr [.symbol "=", condExpr, .symbol v], thenExpr, elseExpr]
+  | .sexpr [.symbol "ite", .sexpr [.symbol "=", .symbol v, condExpr], thenExpr, elseExpr] => do
+    if v == arg then
+      let condTerm ← condExpr.decodeLit ids
+      let thenTerm ← thenExpr.decodeLit ids retTy
+      let (elseTable, dflt) ← elseExpr.decodeUnaryFunctionTable arg ids retTy
+      .ok ((condTerm, thenTerm) :: elseTable, dflt)
+    else
       fail arg v
-    let condTerm ← condExpr.decodeLit ids
-    let thenTerm ← thenExpr.decodeLit ids
-    let (elseTable, dflt) ← elseExpr.decodeUnaryFunctionTable arg ids
-    .ok ((condTerm, thenTerm) :: elseTable, dflt)
   | other => do
-    .ok ([], ← other.decodeLit ids)
+    .ok ([], ← other.decodeLit ids retTy)
 
 def SExpr.decodeVarBinding (v : TermVar) (ids : IdMaps) : List SExpr → Result Term
   | [.sexpr [], tyExpr, vExpr] => do
     let ty ← tyExpr.decodeType ids.types
     if ty != v.ty then
       fail s!"type {reprStr v.ty}" ty
-    vExpr.decodeLit ids
+    vExpr.decodeLit ids (.some ty)
   | other                      => fail "variable binding" other
 
 def SExpr.decodeUUFBinding (f : UUF) (ids : IdMaps) : List SExpr → Result UDF
@@ -339,7 +356,7 @@ def SExpr.decodeUUFBinding (f : UUF) (ids : IdMaps) : List SExpr → Result UDF
       fail s!"type {reprStr f.arg}" tyᵢ
     if tyₒ != f.out then
       fail s!"type {reprStr f.out}" tyₒ
-    let (tbl, dflt) ← tblExpr.decodeUnaryFunctionTable v ids
+    let (tbl, dflt) ← tblExpr.decodeUnaryFunctionTable v ids (.some tyₒ)
     .ok ⟨tyᵢ, tyₒ, Map.make tbl, dflt⟩
   | other                      => fail "UUF binding" other
 

--- a/cedar-lean/SymTest/Decoder.lean
+++ b/cedar-lean/SymTest/Decoder.lean
@@ -285,6 +285,8 @@ def testsDecodeInvalidTypeStrings :=
 
 private def testDecodeLitOk := (testDecodeOk (SExpr.decodeLit ids))
 
+private def testDecodeLitWithTyOk (ty : TermType) := (testDecodeOk (SExpr.decodeLit ids (.some ty)))
+
 private def testDecodeLitError := (testDecodeError (SExpr.decodeLit ids))
 
 def testsDecodeValidLitStrings :=
@@ -303,6 +305,7 @@ def testsDecodeValidLitStrings :=
     testDecodeLitOk "E0_m1" (.entity (enums.get! "E0_m1")),
     testDecodeLitOk "E0_m2" (.entity (enums.get! "E0_m2")),
     testDecodeLitOk "((as some (Option E0)) E0_m0)" (.some (.entity (enums.get! "E0_m0"))),
+    testDecodeLitOk "(some E0_m0)" (.some (.entity (enums.get! "E0_m0"))),
     testDecodeLitOk "(as none (Option Bool))" (.none .bool),
     testDecodeLitOk "(as set.empty (Set (_ BitVec 64)))" (.set Set.empty (.bitvec 64)),
     testDecodeLitOk "(set.singleton (set.singleton #b0001))" (.set (Set.singleton (.set (Set.singleton 1#4) (.bitvec 4))) (.set (.bitvec 4))),
@@ -320,6 +323,10 @@ def testsDecodeValidLitStrings :=
     testDecodeLitOk "(R4 (as none (Option Bool)) #b0000000000000000000000000000000000000000000000000000000000001010 E0_m2)"
       (.record (Map.make [("a", .none .bool), ("b", 10#64), ("c", .entity ⟨colorType, "red"⟩)])),
     testDecodeLitOk "(R6 (R5 true))" (.record (Map.make [("d", .record (Map.make [("e", .bool true)]))])),
+    testDecodeLitWithTyOk (.option .bool) "none" (.none .bool),
+    testDecodeLitWithTyOk (.option .bool) "(some true)" (.some (.bool true)),
+    testDecodeLitOk "(R4 none #b0000000000000000000000000000000000000000000000000000000000001010 E0_m2)"
+      (.record (Map.make [("a", .none .bool), ("b", 10#64), ("c", .entity ⟨colorType, "red"⟩)])),
   ]
 
 def testsDecodeInvalidLitStrings :=
@@ -330,7 +337,7 @@ def testsDecodeInvalidLitStrings :=
     testDecodeLitError "(_ bv256 8)",
     testDecodeLitError "(_ bv0 0)",
     testDecodeLitError "(some)",
-    testDecodeLitError "(some E0_m0)",
+    testDecodeLitError "none",
     testDecodeLitError "(as none Bool)",
     testDecodeLitError "(as set.empty Bool)", -- must be a set type
     testDecodeLitError "(set.union (set.singleton true) false)",
@@ -350,13 +357,13 @@ def testsDecodeValidFunctionTableStrings :=
     testDecodeTableOk "true" ([], .bool true),
     testDecodeTableOk "(ite (= #b0000 x) #b0001 #b0010)" ([(0#4, 1#4)], 2#4),
     testDecodeTableOk "(ite (= #b0000 x) #b0001 (ite (= #b0001 x) #b0010 #b0011))" ([(0#4, 1#4), (1#4, 2#4)], 3#4),
+    testDecodeTableOk "(ite (= x #b0000) #b0001 #b0010)" ([(0#4, 1#4)], 2#4),
   ]
 
 def testsDecodeInvalidFunctionTableStrings :=
   suite "Decoder.SExpr.decodeUnaryFunctionTable for invalid unary function body strings"
   [
     testDecodeTableError "foo",
-    testDecodeTableError "(ite (= x #b0000) #b0001 #b0010)",
     testDecodeTableError "(ite (= #b0000 y) #b0001 #b0010)", -- we're using x as var name in these tests
     testDecodeTableError "(ite (= #b0000 x) (ite (= #b0001 x) #b0010 #b0011) #b0010)",
   ]


### PR DESCRIPTION
Applies changes in https://github.com/cedar-policy/cedar/pull/2411 to Lean

We also need to extend our fuzz targets to detect differences in z3 model parsing between Rust and Lean. See #974 
