### PR TITLE
Stop commiting `settings.json`; add `settings.json.default`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,9 +5,10 @@
 .idea
 .kiro
 .claude
-# VSCode settings -- although we have some checked in, we don't want local
-# settings to appear as unstaged changes by default
-.vscode
+# VSCode settings -- use .vscode/settings.json.default for recommended config;
+# local .vscode/ is ignored so developer overrides stay untracked
+.vscode/*
+!.vscode/settings.json.default
 
 # Don't check in the Emacs temp files
 *~

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,0 @@
-{
-    "rust-analyzer.linkedProjects": [
-        "./cedar-drt/fuzz/Cargo.toml",
-        "./cedar/Cargo.toml",
-        "./cedar-lean-cli/Cargo.toml"
-    ]
-}

--- a/.vscode/settings.json.default
+++ b/.vscode/settings.json.default
@@ -1,0 +1,10 @@
+{
+    "rust-analyzer.linkedProjects": [
+        "./cedar-drt/Cargo.toml",
+        "./cedar-drt/fuzz/Cargo.toml",
+        "./cedar/Cargo.toml",
+        "./cedar-lean-cli/Cargo.toml",
+        "./cedar-lean-ffi/Cargo.toml",
+        "./cedar-policy-generators/Cargo.toml"
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -60,19 +60,17 @@ Additional commands available with `cargo fuzz help`.
 
 ## VSCode
 
-To work with `cedar-drt` in VSCode, first configure two settings so that the rust analyzer plugin doesn't error when trying to find the Lean installation and so that it works properly in the `fuzz` crate.
-Add the following entries to your `.vscode/settings.json`. First run `source set_env_vars.sh && echo $LEAN_LIB_DIR` to get the correct value for `LEAN_LIB_DIR`.
+To work with `cedar-drt` in VSCode, copy the recommended settings into place:
+
+```bash
+cp .vscode/settings.json.default .vscode/settings.json
+```
+
+Then add the `LEAN_LIB_DIR` environment variable so rust-analyzer can find the Lean installation. Run `source set_env_vars.sh && echo $LEAN_LIB_DIR`, then add the following to your `.vscode/settings.json`:
 
 ```json
-{
-    "rust-analyzer.linkedProjects": [
-        "./cedar-drt/fuzz/Cargo.toml",
-        "./cedar/Cargo.toml",
-        "./cedar-lean-cli/Cargo.toml",
-    ],
-    "rust-analyzer.cargo.extraEnv": {
-        "LEAN_LIB_DIR": <$LEAN_LIB_DIR as populated by set_env_vars.sh>
-    }
+"rust-analyzer.cargo.extraEnv": {
+    "LEAN_LIB_DIR": <$LEAN_LIB_DIR as populated by set_env_vars.sh>
 }
 ```
 


### PR DESCRIPTION
Having `settings.json` committed creates a lot of conflicts on `git pull` if  I have any local changes to  project-level vscode settings. Stop committing this and instead provide `settings.json.default` as reasonable default settings. 

On initial repo clone developers need to `cp settings.json.default settings.json` to get the settings. They previously had to set LEAN_LIB_DIR manually, so there was already manual setup required.

If someone has a good way to provide the default settings without needing any manual steps I'd be happy to use that.