### PR TITLE
Extend TPE `in` set reduction

### DIFF
--- a/cedar-lean/Cedar/Data/List.lean
+++ b/cedar-lean/Cedar/Data/List.lean
@@ -143,4 +143,12 @@ public def isSorted {α} [LT α] [DecidableLT α] (l : List α) : Bool :=
     else
       false
 
+public def ternaryAny  {α} (l : List α) (p : α → Option Bool) : Option Bool :=
+  if l.map p|>.any (· == some true) then
+    some true
+  else if l.map p|>.any Option.isNone then
+    none
+  else
+    some false
+
 end List

--- a/cedar-lean/Cedar/TPE/Evaluator.lean
+++ b/cedar-lean/Cedar/TPE/Evaluator.lean
@@ -92,7 +92,7 @@ def inₑ (uid₁ uid₂ : EntityUID) (es : PartialEntities) : Option Bool :=
   if uid₁ = uid₂ then .some true else (es.ancestors uid₁).map (Set.contains · uid₂)
 
 def inₛ (uid : EntityUID) (vs : Set Value) (es : PartialEntities): Option Bool := do
-  (← vs.toList.mapM (Except.toOption ∘ Value.asEntityUID)).anyM (inₑ uid · es)
+  (← vs.toList.mapM (Except.toOption ∘ Value.asEntityUID)).ternaryAny (inₑ uid · es)
 
 def hasTag (uid : EntityUID) (tag : String) (es : PartialEntities) : Option Bool :=
   (es.tags uid).map (Map.contains · tag)

--- a/cedar-lean/Cedar/Thm/BatchedEvaluator/Common.lean
+++ b/cedar-lean/Cedar/Thm/BatchedEvaluator/Common.lean
@@ -29,16 +29,13 @@ theorem as_partial_request_refines {req : Request} :
   RequestRefines req req.asPartialRequest := by
   simp only [Request.asPartialRequest, RequestRefines, PartialEntityUID.asEntityUID, Option.map_some]
   constructor
-  · apply PartialIsValid.some
-    rfl
+  · apply PartialIsValid.some <;> rfl
   constructor
   · trivial
   constructor
-  · apply PartialIsValid.some
-    rfl
+  · apply PartialIsValid.some <;> rfl
   constructor
-  · apply PartialIsValid.some
-    rfl
+  · apply PartialIsValid.some <;> rfl
   constructor <;> trivial
 
 theorem any_refines_empty_entities :
@@ -78,8 +75,8 @@ theorem direct_request_and_entities_refine (req : Request) (es : Entities) :
     obtain ⟨data₁, h_find₁, h_eq⟩ := h_mapOnValues
     exists data₁
     exact ⟨h_find₁,
-           by rw [h_eq]; apply PartialIsValid.some; rfl,
-           by rw [h_eq]; apply PartialIsValid.some; rfl,
-           by rw [h_eq]; apply PartialIsValid.some; rfl⟩
+           by rw [h_eq]; apply PartialIsValid.some <;> rfl,
+           by rw [h_eq]; apply PartialIsValid.some <;> rfl,
+           by rw [h_eq]; apply PartialIsValid.some <;> rfl⟩
 
 end Cedar.Thm

--- a/cedar-lean/Cedar/Thm/Data/List/Lemmas.lean
+++ b/cedar-lean/Cedar/Thm/Data/List/Lemmas.lean
@@ -2189,4 +2189,37 @@ public theorem anyM_some_implies_any {α} {xs : List α} {b : Bool}  (f : α →
         specialize h₁ head false h₃
         simp only [h₁, Bool.false_eq_true, false_implies]
 
+
+public theorem ternary_any_some_implies_any {α} {xs : List α} {b : Bool} (f : α → Option Bool) (g : α → Bool) :
+  (∀ x b, f x = some b → g x = b) →
+  xs.ternaryAny f = some b →
+  xs.any g = b
+:= by
+  intro h₁ h₂
+  simp only [ternaryAny, any_map, any_eq_true, Function.comp_apply, beq_iff_eq, Option.isNone_iff_eq_none] at h₂
+  split at h₂
+  case isTrue h₃ =>
+    simp only [Option.some.injEq] at h₂
+    subst h₂
+    obtain ⟨x, hx, hfx⟩ := h₃
+    rw [List.any_eq_true]
+    exact ⟨x, hx, h₁ x true hfx⟩
+  case isFalse h₃ =>
+    split at h₂
+    case isTrue => exact absurd h₂ (by simp)
+    case isFalse h₄ =>
+      simp only [Option.some.injEq] at h₂
+      subst h₂
+      rw [← Bool.not_eq_true, List.any_eq_true]
+      rintro ⟨x, hx, hgx⟩
+      have hfx : f x = some false := by
+        cases hc : f x with
+        | none => exact absurd ⟨x, hx, hc⟩ h₄
+        | some c =>
+          cases c with
+          | true => exact absurd ⟨x, hx, hc⟩ h₃
+          | false => rfl
+      rw [h₁ x false hfx] at hgx
+      exact absurd hgx (by simp)
+
 end List

--- a/cedar-lean/Cedar/Thm/TPE/Input.lean
+++ b/cedar-lean/Cedar/Thm/TPE/Input.lean
@@ -34,25 +34,30 @@ theorem decide_eq_implies_eq {α} [DecidableEq α] {y : α} :
   ∀ x, decide (x = y) → x = y := by
       simp only [decide_eq_true_eq, imp_self, implies_true]
 
-inductive PartialIsValid {α} : (α → Prop) → Option α -> Prop
-  | some (p : α → Prop) (x : α)
-    (h : p x) :
-    PartialIsValid p (.some x)
-  | none :
-    PartialIsValid p .none
+inductive PartialIsValid {α} (p : α → Prop) (o : Option α) : Prop
+  | some (x : α) (heq : o = .some x) (h : p x) :
+    PartialIsValid p o
+  | none (heq : o = .none) :
+    PartialIsValid p o
+
+@[simp]
+theorem PartialIsValid.some_inv {p : α → Prop} {x : α} :  (PartialIsValid p (.some x)) ↔ p x := by
+  constructor
+  · intro h
+    cases h with
+    | some y heq hy => simp only [Option.some.injEq] at heq; subst heq; exact hy
+    | none heq => simp at heq
+  · exact some _ rfl
 
 theorem partial_is_valid_rfl (f : α → Bool) (p : α → Prop) (o : Option α) :
   (∀ x, f x = true → p x) → partialIsValid o f → PartialIsValid p o
 := by
-  intro h₁
-  simp [partialIsValid, Option.map]
-  split <;> simp [Option.getD]
-  case _ x =>
-    intro h₂
-    constructor
-    exact h₁ x h₂
-  case _ =>
-    constructor
+  intro h₁ h₂
+  cases o with
+  | none => exact .none rfl
+  | some x =>
+    simp only [partialIsValid, Option.map_some, Option.getD_some] at h₂
+    exact .some x rfl (h₁ x h₂)
 
 def RequestRefines (req : Request) (preq : PartialRequest) : Prop :=
   PartialIsValid (· = req.principal) preq.principal.asEntityUID ∧

--- a/cedar-lean/Cedar/Thm/TPE/Soundness/Binary.lean
+++ b/cedar-lean/Cedar/Thm/TPE/Soundness/Binary.lean
@@ -103,9 +103,7 @@ theorem partial_evaluate_is_sound_binary_app
           rcases h₄ with ⟨_, h₄⟩
           specialize h₄ uid₁ data heq₅₁
           rcases h₄ with ⟨_, h₄₁, _, h₄₂, _⟩
-          rw [heq₅₂] at h₄₂
-          cases h₄₂
-          rename_i h₄₂
+          simp only [heq₅₂, PartialIsValid.some_inv] at h₄₂
           simp [Spec.inₑ, Entities.ancestorsOrEmpty, h₄₁, ←h₄₂]
           have : (uid₁ == uid₂) = false := by
             simp only [beq_eq_false_iff_ne, ne_eq, heq₄, not_false_eq_true]
@@ -150,35 +148,23 @@ theorem partial_evaluate_is_sound_binary_app
           rw [←List.mapM_ok_iff_forall₂] at heq₄
           simp [heq₄] at h₇
           subst h₇
-          simp [Spec.inₑ]
-          simp [TPE.inₑ] at heq₃₂
           simp [RequestAndEntitiesRefine] at h₄
           rcases h₄ with ⟨_, h₄⟩
-          have : ∀ x b, ((if uid = x then some true else Option.map (fun y => y.contains x) (pes.ancestors uid)) = some b) →
-            (uid == x || (es.ancestorsOrEmpty uid).contains x) = b := by
-            intro x b' h₁
-            split at h₁
-            case isTrue heq =>
-              simp only [Option.some.injEq, Bool.true_eq] at h₁
-              subst h₁
-              simp only [heq, beq_self_eq_true, Bool.true_or]
-            case isFalse heq =>
-              simp [EntitiesRefine] at h₄
-              simp at h₁
-              rcases h₁ with ⟨ancestors₁, h₂, h₃⟩
-              simp [PartialEntities.ancestors, PartialEntities.get, Option.bind] at h₂
-              split at h₂ <;> try cases h₂
-              rename_i data heq₁
-              specialize h₄ uid data heq₁
-              rcases h₄ with ⟨e, h₄, _, h₅, _⟩
-              rw [h₂] at h₅
-              cases h₅
-              rename_i heq₂
-              rw [heq₂] at h₃
-              simp only [Entities.ancestorsOrEmpty, h₄, h₃, Bool.or_eq_right_iff_imp, beq_iff_eq, heq,
-                false_implies]
-          replace heq₃₂ := List.anyM_some_implies_any (fun x => if uid = x then some true else Option.map (fun y => y.contains x) (pes.ancestors uid))
-            (fun x => uid == x || (es.ancestorsOrEmpty uid).contains x) this heq₃₂
+          have : ∀ x b, (TPE.inₑ uid x pes) = .some b → (Spec.inₑ uid x es) = b := by
+            intro x b h
+            simp only [EntitiesRefine] at h₄
+            simp only [TPE.inₑ] at h
+            simp only [Spec.inₑ]
+            split at h
+            case isTrue heq => simp_all
+            case isFalse hneq =>
+              simp only [beq_eq_false_iff_ne.mpr hneq, Bool.false_or,
+                Option.map_eq_some_iff, PartialEntities.ancestors, PartialEntities.get,
+                Option.bind_eq_some_iff, Entities.ancestorsOrEmpty] at h ⊢
+              obtain ⟨anc, ⟨e₂, hfind, hanc⟩, hcontains⟩ := h
+              obtain ⟨e₁, hfind_es, _, hpv, _⟩ := h₄ uid e₂ hfind
+              cases hpv <;> simp_all
+          replace heq₃₂ := List.ternary_any_some_implies_any (TPE.inₑ uid · pes) (Spec.inₑ uid · es) this heq₃₂
           subst heq₃₂
           simp only [Residual.evaluate]
       case _ =>
@@ -203,10 +189,8 @@ theorem partial_evaluate_is_sound_binary_app
         rcases h₄ with ⟨_, h₄⟩
         specialize h₄ uid data heq₃
         rcases h₄ with ⟨_, h₄₁, _, _, h₄₂⟩
-        rw [heq₄] at h₄₂
-        cases h₄₂
-        rename_i heq₅
-        subst heq₅
+        simp only [heq₄, PartialIsValid.some_inv] at h₄₂
+        subst h₄₂
         simp only [Spec.hasTag, Entities.tagsOrEmpty, h₄₁, Residual.evaluate]
       case _ =>
         rw [asValue_some] at heq₁ heq₂
@@ -223,10 +207,8 @@ theorem partial_evaluate_is_sound_binary_app
         rcases h₄ with ⟨_, h₄⟩
         specialize h₄ uid data heq₂
         rcases h₄ with ⟨_, h₄₁, _, _, h₄₂⟩
-        rw [heq₃] at h₄₂
-        cases h₄₂
-        rename_i heq₄
-        subst heq₄
+        simp only [heq₃, PartialIsValid.some_inv] at h₄₂
+        subst h₄₂
         simp only [Spec.getTag, Entities.tags, Data.Map.findOrErr, h₄₁]
         split <;>
         (rename_i heq₁; simp [heq₁, Residual.evaluate, Except.toOption])

--- a/cedar-lean/Cedar/Thm/TPE/Soundness/GetAttr.lean
+++ b/cedar-lean/Cedar/Thm/TPE/Soundness/GetAttr.lean
@@ -78,10 +78,9 @@ theorem partial_evaluate_is_sound_get_attr
       rcases h₄ with ⟨_, h₄⟩
       specialize h₄ uid data heq₂
       rcases h₄ with ⟨_, h₄₁, h₄₂, _⟩
-      rw [heq₃] at h₄₂
-      rcases h₄₂
-      rename_i data' _ h₄
-      subst h₄
+      simp only [heq₃, PartialIsValid.some_inv] at h₄₂
+      subst h₄₂
+      rename_i data' h₄
       simp [Entities.attrs, Data.Map.findOrErr, h₄₁]
       generalize h₄ : data'.attrs.find? attr = res
       cases res <;> simp [someOrError, Residual.evaluate, Except.toOption]

--- a/cedar-lean/Cedar/Thm/TPE/Soundness/HasAttr.lean
+++ b/cedar-lean/Cedar/Thm/TPE/Soundness/HasAttr.lean
@@ -71,10 +71,8 @@ theorem partial_evaluate_is_sound_has_attr
       rcases h₄ with ⟨_, h₄⟩
       specialize h₄ uid data heq₂
       rcases h₄ with ⟨_, h₄₁, h₄₂, _⟩
-      rw [heq₃] at h₄₂
-      rcases h₄₂
-      rename_i h₄
-      subst h₄
+      simp only [heq₃, PartialIsValid.some_inv] at h₄₂
+      subst h₄₂
       simp [Entities.attrsOrEmpty, h₄₁]
     case _ => cases heq
   case _ =>

--- a/cedar-lean/Cedar/Thm/TPE/Soundness/Var.lean
+++ b/cedar-lean/Cedar/Thm/TPE/Soundness/Var.lean
@@ -70,10 +70,8 @@ theorem partial_evaluate_is_sound_var
       simp [Residual.evaluate]
       simp [RequestAndEntitiesRefine, RequestRefines] at h₄
       rcases h₄ with ⟨⟨h₄, _⟩, _⟩
-      rw [heq₁] at h₄
-      cases h₄
-      rename_i heq₂
-      subst heq₂
+      simp only [heq₁, PartialIsValid.some_inv] at h₄
+      subst h₄
       rfl
     case _ heq =>
       simp only [Residual.evaluate]
@@ -86,10 +84,8 @@ theorem partial_evaluate_is_sound_var
       simp [Residual.evaluate]
       simp [RequestAndEntitiesRefine, RequestRefines] at h₄
       rcases h₄ with ⟨⟨_, ⟨_, ⟨h₄, _⟩⟩⟩, _⟩
-      rw [heq₁] at h₄
-      cases h₄
-      rename_i heq₂
-      subst heq₂
+      simp only [heq₁, PartialIsValid.some_inv] at h₄
+      subst h₄
       rfl
     case _ heq =>
       simp only [Residual.evaluate]
@@ -107,10 +103,8 @@ theorem partial_evaluate_is_sound_var
       simp [Residual.evaluate]
       simp [RequestAndEntitiesRefine, RequestRefines] at h₄
       rcases h₄ with ⟨⟨_, ⟨_, ⟨_, ⟨h₄, _, _⟩⟩⟩⟩, _⟩
-      rw [heq₁] at h₄
-      cases h₄
-      rename_i heq₂
-      subst heq₂
+      simp only [heq₁, PartialIsValid.some_inv] at h₄
+      subst h₄
       rfl
     case _ =>
       simp only [Residual.evaluate]

--- a/cedar-lean/Cedar/Thm/TPE/WellTyped/Binary.lean
+++ b/cedar-lean/Cedar/Thm/TPE/WellTyped/Binary.lean
@@ -51,10 +51,9 @@ theorem tags_if_partial_tags
     cases h_pe : pe.tags <;> rw [h_pe] at h_tags
     . simp at h_tags
     . simp only [Option.some.injEq] at h_tags
-      rw [h_pe] at h_pt
-      cases h_pt
-      rename_i h_eq
-      exact ⟨edata, by rw [← h_tags, h_eq], h_entry⟩
+      simp only [h_pe, PartialIsValid.some_inv] at h_pt
+      subst h_pt
+      exact ⟨edata, by simp_all, h_entry⟩
 
 theorem entity_tag_well_typed
   {env : TypeEnv} {req : Request} {es : Entities} {pes : PartialEntities}

--- a/cedar-lean/Cedar/Thm/TPE/WellTyped/GetAttr.lean
+++ b/cedar-lean/Cedar/Thm/TPE/WellTyped/GetAttr.lean
@@ -86,10 +86,9 @@ theorem attrs_if_partial_attrs
     cases h_pe : pe.attrs <;> rw [h_pe] at h_attrs
     . simp at h_attrs
     . simp only [Option.some.injEq] at h_attrs
-      rw [h_pe] at h_pa
-      cases h_pa
-      rename_i h_eq
-      exact ⟨edata, by rw [← h_attrs, h_eq], h_entry⟩
+      simp only [h_pe, PartialIsValid.some_inv] at h_pa
+      subst h_pa
+      exact ⟨edata, by simp_all, h_entry⟩
 
 theorem entity_attr_well_typed
   {env : TypeEnv} {req : Request} {es : Entities} {pes : PartialEntities}

--- a/cedar-lean/Cedar/Thm/TPE/WellTyped/Var.lean
+++ b/cedar-lean/Cedar/Thm/TPE/WellTyped/Var.lean
@@ -49,12 +49,11 @@ theorem partial_eval_well_typed_var {env : TypeEnv} {v : Var} {ty : CedarType} {
       assumption
     case some =>
       simp only [Option.bind_some, varₚ.varₒ, someOrSelf]
-      rw [h] at h_pv
-      cases h_pv with | some _ h₃ =>
+      simp only [h, PartialIsValid.some_inv] at h_pv
+      subst h_pv
       cases h_wt with | var h₄ =>
       cases h₄ with | principal =>
       rcases h_wf with ⟨_, ⟨h_principal, _, _, _⟩, _⟩
-      rw [h₃]
       exact well_typed_entity h_principal
   case resource =>
     simp only [Option.pure_def, Option.bind_eq_bind]
@@ -64,12 +63,11 @@ theorem partial_eval_well_typed_var {env : TypeEnv} {v : Var} {ty : CedarType} {
     . dsimp only [Option.bind_none, varₚ.varₒ, someOrSelf]
       exact h_wt
     . dsimp only [Option.bind_some, varₚ.varₒ, someOrSelf]
-      rw [h] at h_rv
-      cases h_rv with | some _ h₃ =>
+      simp only [h, PartialIsValid.some_inv] at h_rv
+      subst h_rv
       cases h_wt with | var h₄ =>
       cases h₄ with | resource =>
       rcases h_wf with ⟨_, ⟨_, _, h_resource, _⟩, _⟩
-      rw [h₃]
       exact well_typed_entity h_resource
   case action =>
     simp only [varₚ.varₒ, someOrSelf]
@@ -93,10 +91,9 @@ theorem partial_eval_well_typed_var {env : TypeEnv} {v : Var} {ty : CedarType} {
     . simp only [Option.map_none, varₚ.varₒ, someOrSelf]
       exact h_wt
     . simp only [Option.map_some, varₚ.varₒ, someOrSelf]
-      rw [h] at h_cv
+      simp only [h, PartialIsValid.some_inv] at h_cv
+      subst h_cv
       apply Residual.WellTyped.val
-      cases h_cv with | some _ h₃ =>
-      rw [h₃]
       cases h_wt with | var h₄ =>
       cases h₄ with | context =>
 


### PR DESCRIPTION
Extends TPE to evaluate `in` expression to a value in an odd edge case.

If the ancestors of `User::"alice"` are unknown, we would reduce `User::"alice" in [User::"alice", Group::"admins"]` to a concrete value `true` while leaving the equivalent expression  `User::"alice" in [Group::"admins",User::"alice"]` as a residual. This happened because we used `anyM` to check for the list for ancestors, which short circuits after finding the first `none` in the list.

In the Rust we implemented this with `for` loop containing an early return, making it look more noticeably wrong. I don't expect that this simplification matters anywhere. I'm mainly making this change so the implementation makes more sense when reading the code.

This PR also contains a change to the `PartialIsValid` properties used in TPE to make case analysis easier. 

