### PR TITLE
Fail DRT targets on FFI errors

### DIFF
--- a/cedar-drt/fuzz/fuzz_targets/batched-evaluation-drt.rs
+++ b/cedar-drt/fuzz/fuzz_targets/batched-evaluation-drt.rs
@@ -18,7 +18,10 @@
 use cedar_drt::logger::initialize_log;
 use cedar_drt_inner::{abac::FuzzTargetInput, fuzz_target};
 
-use cedar_lean_ffi::CedarLeanFfi;
+use cedar_lean_ffi::{
+    CedarLeanFfi,
+    FfiError::{self, LeanBackendError},
+};
 use cedar_policy::{Schema, TestEntityLoader};
 use cedar_policy_core::batched_evaluator::err::BatchedEvalError;
 
@@ -56,7 +59,10 @@ fuzz_target!(|input: FuzzTargetInput<true>| {
                 (Err(rust_err), Ok(lean_decision)) => {
                     panic!("Lean reached decisions {lean_decision:?} but rust errored: {rust_err}")
                 }
-                (Err(_), Err(_)) => {}
+                (Err(_), Err(FfiError::LeanBackendError(_))) => {}
+                (Err(_), Err(lean_err)) => {
+                    panic!("Unexpected error from Lean FFI: {lean_err}")
+                }
             }
         }
     }

--- a/cedar-drt/fuzz/src/symcc.rs
+++ b/cedar-drt/fuzz/src/symcc.rs
@@ -106,9 +106,9 @@ pub fn lean_smtlib_of_check_asserts(
 }
 
 #[track_caller]
-pub fn assert_smtlib_scripts_match<E1: Display, E2: Display>(
+pub fn assert_smtlib_scripts_match<E1: Display>(
     rust_smtlib: Result<String, E1>,
-    lean_smtlib: Result<String, E2>,
+    lean_smtlib: Result<String, FfiError>,
 ) {
     match (rust_smtlib, lean_smtlib) {
         (Ok(rust), Ok(lean)) => {
@@ -116,7 +116,8 @@ pub fn assert_smtlib_scripts_match<E1: Display, E2: Display>(
         }
         (Ok(_), Err(e)) => panic!("Lean encoding should succeed: {e}"),
         (Err(e), Ok(_)) => panic!("Rust encoding should succeed: {e}"),
-        (Err(_), Err(_)) => {}
+        (Err(_), Err(FfiError::LeanBackendError(_))) => {}
+        (Err(_), Err(lean_err)) => panic!("Unexpected error from Lean FFI: {lean_err}"),
     }
 }
 


### PR DESCRIPTION
Updates batched evaluation and smt-script drt targets to fail on errors in the FFI layer