### PR TITLE
add --compare to compare benchmark results

### DIFF
--- a/cedar-benchmarking/Cargo.toml
+++ b/cedar-benchmarking/Cargo.toml
@@ -51,10 +51,10 @@ large_enum_variant = "allow"
 
 [dependencies]
 arbitrary = "1.4"
-cedar-policy = { version = "=4.11.0", path = "../cedar/cedar-policy", features = [
+cedar-policy = { version = "4", path = "../cedar/cedar-policy", features = [
     "protobufs",
 ] }
-cedar-policy-core = { version = "=4.11.0", path = "../cedar/cedar-policy-core" }
+cedar-policy-core = { version = "4", path = "../cedar/cedar-policy-core" }
 cedar-policy-generators = { version = "4", path = "../cedar-policy-generators", features = [
     "cedar-policy",
 ] }

--- a/cedar-benchmarking/Cargo.toml
+++ b/cedar-benchmarking/Cargo.toml
@@ -64,3 +64,4 @@ rand = "0.9"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sysinfo = "0.33"
+owo-colors = "4"

--- a/cedar-benchmarking/README.md
+++ b/cedar-benchmarking/README.md
@@ -11,12 +11,16 @@ To install from source, run `cargo install --path .`.
 
 ### Options
 
-| Flag | Description |
-|------|-------------|
-| `--corpus <path>` | Path to a `tasks.json` file defining the benchmark corpus (required) |
-| `--targets <list>` | Comma-separated list of targets to run (optional, runs all by default) |
-| `--trials <n>` | Number of iterations per benchmark (default: 1000) |
-| `--output <format>` | Output format: `json` (default) or `table` (human-readable) |
+| Flag                           | Description                                                                                                                                      |
+| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `--corpus <path>`              | Path to a `tasks.json` file defining the benchmark corpus. Mutually exclusive with `--baseline`.                                                 |
+| `--baseline <path>`            | Load "current" results from a previous JSON output file instead of running benchmarks. Mutually exclusive with `--corpus`. Requires `--compare`. |
+| `--targets <list>`             | Comma-separated list of targets to run (optional, runs all by default). Only valid with `--corpus`.                                              |
+| `--trials <n>`                 | Number of iterations per benchmark (default: 1000). Only valid with `--corpus`.                                                                  |
+| `--output <format>`            | Output format: `json` (default) or `table` (human-readable)                                                                                      |
+| `--compare <files...>`         | One or more baseline JSON files to compare against                                                                                               |
+| `--no-color`                   | Disable colored output in comparison tables                                                                                                      |
+| `--regression-threshold <pct>` | Exit non-zero if any benchmark's average regresses beyond this percentage. Requires `--compare`.                                                 |
 
 ### Example: run only parsing benchmarks with 500 trials
 
@@ -72,31 +76,31 @@ Cedar <version> | <hardware information>
 ### Fields
 Each `results` object in the JSON output has the following fields:
 
-| Field | Description |
-|-------|-------------|
-| `average` | Arithmetic mean across all trials |
-| `min` / `max` | Fastest and slowest trial |
-| `stddev` | Standard deviation (lower = more consistent) |
-| `iqr` | Interquartile range (p75 - p25), robust measure of spread |
-| `p50` | Median latency |
-| `p95` / `p99` | Tail latencies |
+| Field         | Description                                               |
+| ------------- | --------------------------------------------------------- |
+| `average`     | Arithmetic mean across all trials                         |
+| `min` / `max` | Fastest and slowest trial                                 |
+| `stddev`      | Standard deviation (lower = more consistent)              |
+| `iqr`         | Interquartile range (p75 - p25), robust measure of spread |
+| `p50`         | Median latency                                            |
+| `p95` / `p99` | Tail latencies                                            |
 
 ## Benchmark targets
 
-| Target | Description |
-|--------|-------------|
-| `policy_parse` | Parse Cedar policy text |
-| `json_policy_parse` | Parse policies from JSON representation |
-| `protobuf_policy_parse` | Parse policies from protobuf encoding |
-| `schema_parse` | Parse Cedar schema text |
-| `json_schema_parse` | Parse schema from JSON representation |
-| `protobuf_schema_parse` | Parse schema from protobuf encoding |
-| `validation` | Validate policies against a schema |
-| `authorization` | Run authorization requests |
-| `entity_parse_with_schema` | Parse entities with schema validation |
-| `entity_parse_without_schema` | Parse entities without schema |
-| `protobuf_entity_parse` | Parse entities from protobuf encoding |
-| `incremental_entities` | Incrementally add entities (measures transitive closure recomputation) |
+| Target                        | Description                                                            |
+| ----------------------------- | ---------------------------------------------------------------------- |
+| `policy_parse`                | Parse Cedar policy text                                                |
+| `json_policy_parse`           | Parse policies from JSON representation                                |
+| `protobuf_policy_parse`       | Parse policies from protobuf encoding                                  |
+| `schema_parse`                | Parse Cedar schema text                                                |
+| `json_schema_parse`           | Parse schema from JSON representation                                  |
+| `protobuf_schema_parse`       | Parse schema from protobuf encoding                                    |
+| `validation`                  | Validate policies against a schema                                     |
+| `authorization`               | Run authorization requests                                             |
+| `entity_parse_with_schema`    | Parse entities with schema validation                                  |
+| `entity_parse_without_schema` | Parse entities without schema                                          |
+| `protobuf_entity_parse`       | Parse entities from protobuf encoding                                  |
+| `incremental_entities`        | Incrementally add entities (measures transitive closure recomputation) |
 
 ## Corpus format
 
@@ -131,7 +135,34 @@ cp target/release/cedar-benchmarking cedar-bench-4.10
 git checkout cedar-benchmarking-v4.11.0 && cargo build --release -p cedar-benchmarking
 cp target/release/cedar-benchmarking cedar-bench-4.11
 
-# Run against same corpus
+# Run against same corpus, use compare to compare
 ./cedar-bench-4.10 --corpus corpus/tasks.json > results-4.10.json
-./cedar-bench-4.11 --corpus corpus/tasks.json > results-4.11.json
+./cedar-bench-4.11 --corpus corpus/tasks.json --compare results-4.10.json
 ```
+
+## Comparing results
+
+Use `--compare` to compare against one or more previous JSON outputs. Benchmarks are matched by `(name, target)` pair; unmatched entries are reported separately.
+
+```bash
+# Compare a live run against saved baselines
+cedar-benchmarking --corpus corpus/tasks.json --compare results-4.10.json results-4.9.json
+
+# Compare two saved results without re-running
+cedar-benchmarking --baseline results-4.11.json --compare results-4.10.json
+
+# CI gate: exit non-zero if any benchmark significantly regresses
+cedar-benchmarking --corpus corpus/tasks.json --compare baseline.json --regression-threshold 5
+```
+
+Comparison output respects `--output`: JSON by default, or a colored table with `--output table`. Use `--no-color` to disable ANSI colors.
+
+### Regression detection
+
+A benchmark is flagged as a regression only when **all three** conditions are met:
+
+1. The average latency increased by more than the threshold percentage (default 5%).
+2. The absolute delta exceeds 10µs (filters out noise on very fast benchmarks).
+3. The absolute delta exceeds 2× the pooled standard deviation (`√(σ_baseline² + σ_current²)`), which accounts for variance in both runs.
+
+This prevents false positives from tiny benchmarks (e.g., 15µs → 16µs = +6.7% but only 1µs absolute) and from high-variance benchmarks where the change is within expected noise.

--- a/cedar-benchmarking/src/compare.rs
+++ b/cedar-benchmarking/src/compare.rs
@@ -1,0 +1,359 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use crate::output::{BenchmarkOutput, BenchmarkResult};
+use miette::IntoDiagnostic;
+use owo_colors::OwoColorize;
+use serde::Serialize;
+use std::collections::HashMap;
+use std::path::Path;
+
+/// Minimum absolute delta (in microseconds) required to consider a change
+/// significant. Changes smaller than this are assumed to be measurement noise,
+/// regardless of percentage. This prevents flagging tiny benchmarks (e.g.,
+/// 15µs → 16µs = +6.7%) as regressions.
+const MIN_DELTA_FLOOR_US: u128 = 10;
+
+/// Number of baseline standard deviations the delta must exceed to be
+/// considered statistically significant. A delta smaller than this many σ is
+/// likely within normal run-to-run variance.
+const SIGNIFICANCE_SIGMA: f64 = 2.0;
+
+/// Whether a change is a significant regression, improvement, or neither.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Significance {
+    Regression,
+    Improvement,
+    Insignificant,
+}
+
+/// A key that uniquely identifies a benchmark result.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
+pub struct BenchmarkKey {
+    pub benchmark: String,
+    pub target: String,
+}
+
+impl BenchmarkKey {
+    fn from_result(r: &BenchmarkResult) -> Self {
+        Self {
+            benchmark: r.benchmark.clone(),
+            target: r.target.clone(),
+        }
+    }
+}
+
+/// Comparison data for a single benchmark that exists in both runs.
+#[derive(Debug, Serialize)]
+pub struct BenchmarkComparison {
+    pub benchmark: String,
+    pub target: String,
+    pub current_avg: u128,
+    pub baseline_avg: u128,
+    pub delta_avg: i128,
+    pub delta_avg_pct: f64,
+    pub baseline_stddev: f64,
+    pub current_stddev: f64,
+    pub current_p50: u128,
+    pub baseline_p50: u128,
+    pub delta_p50_pct: f64,
+    pub current_p99: u128,
+    pub baseline_p99: u128,
+    pub delta_p99_pct: f64,
+}
+
+impl BenchmarkComparison {
+    /// Determines the significance of this comparison.
+    ///
+    /// A change is significant only when ALL three conditions are met:
+    /// 1. The average changed by more than `threshold_pct` percent.
+    /// 2. The absolute delta exceeds [`MIN_DELTA_FLOOR_US`] microseconds.
+    /// 3. The absolute delta exceeds [`SIGNIFICANCE_SIGMA`] × the pooled
+    ///    standard deviation (`sqrt(σ_baseline² + σ_current²)`).
+    ///
+    /// The pooled standard deviation accounts for variance in both runs,
+    /// preventing false positives when either run is noisy.
+    ///
+    /// This avoids false positives from:
+    /// - Tiny benchmarks where a 1µs jitter causes a large percentage swing.
+    /// - High-variance benchmarks where the change is within normal noise.
+    fn significance(&self, threshold_pct: f64) -> Significance {
+        let abs_delta = self.delta_avg.unsigned_abs();
+        if abs_delta < MIN_DELTA_FLOOR_US {
+            return Significance::Insignificant;
+        }
+        let pooled_sigma = self.baseline_stddev.hypot(self.current_stddev);
+        if abs_delta as f64 <= SIGNIFICANCE_SIGMA * pooled_sigma {
+            return Significance::Insignificant;
+        }
+        if self.delta_avg_pct > threshold_pct {
+            Significance::Regression
+        } else if self.delta_avg_pct < -threshold_pct {
+            Significance::Improvement
+        } else {
+            Significance::Insignificant
+        }
+    }
+}
+
+/// Full comparison report between current results and one baseline.
+#[derive(Debug, Serialize)]
+pub struct ComparisonReport {
+    pub baseline_file: String,
+    pub baseline_cedar_version: String,
+    pub current_cedar_version: String,
+    pub matched: Vec<BenchmarkComparison>,
+    pub only_in_current: Vec<BenchmarkKey>,
+    pub only_in_baseline: Vec<BenchmarkKey>,
+}
+
+/// Load a baseline JSON file.
+pub fn load_baseline(path: &Path) -> miette::Result<BenchmarkOutput> {
+    let file = std::fs::File::open(path)
+        .into_diagnostic()
+        .map_err(|e| miette::miette!("Failed to open baseline file '{}': {e}", path.display()))?;
+    serde_json::from_reader(file)
+        .into_diagnostic()
+        .map_err(|e| miette::miette!("Failed to parse baseline file '{}': {e}", path.display()))
+}
+
+/// Compare current results against a baseline, producing a report.
+pub fn compare(
+    current: &BenchmarkOutput,
+    baseline: &BenchmarkOutput,
+    baseline_path: &Path,
+) -> ComparisonReport {
+    let baseline_map: HashMap<BenchmarkKey, &BenchmarkResult> = baseline
+        .results
+        .iter()
+        .map(|r| (BenchmarkKey::from_result(r), r))
+        .collect();
+
+    let current_map: HashMap<BenchmarkKey, &BenchmarkResult> = current
+        .results
+        .iter()
+        .map(|r| (BenchmarkKey::from_result(r), r))
+        .collect();
+
+    let mut matched = Vec::new();
+    let mut only_in_current = Vec::new();
+
+    for result in &current.results {
+        let key = BenchmarkKey::from_result(result);
+        if let Some(baseline_result) = baseline_map.get(&key) {
+            matched.push(compute_comparison(result, baseline_result));
+        } else {
+            only_in_current.push(key);
+        }
+    }
+
+    let only_in_baseline: Vec<BenchmarkKey> = baseline_map
+        .keys()
+        .filter(|k| !current_map.contains_key(k))
+        .cloned()
+        .collect();
+
+    ComparisonReport {
+        baseline_file: baseline_path.display().to_string(),
+        baseline_cedar_version: baseline.cedar_version.clone(),
+        current_cedar_version: current.cedar_version.clone(),
+        matched,
+        only_in_current,
+        only_in_baseline,
+    }
+}
+
+/// Check if any benchmark in the reports represents a significant regression.
+///
+/// See [`BenchmarkComparison::significance`] for the criteria.
+pub fn has_regression(reports: &[ComparisonReport], threshold_pct: f64) -> bool {
+    reports
+        .iter()
+        .flat_map(|r| &r.matched)
+        .any(|c| c.significance(threshold_pct) == Significance::Regression)
+}
+
+/// Print comparison reports as JSON to stdout.
+pub fn print_comparison_json(reports: &[ComparisonReport]) -> miette::Result<()> {
+    serde_json::to_writer_pretty(std::io::stdout(), reports).into_diagnostic()?;
+    println!();
+    Ok(())
+}
+
+/// Print comparison reports as a human-readable table.
+pub fn print_comparison_table(reports: &[ComparisonReport], color: bool, threshold_pct: f64) {
+    for report in reports {
+        println!();
+        println!(
+            "Comparison: Cedar {} (current) vs {} (Cedar {})",
+            report.current_cedar_version, report.baseline_file, report.baseline_cedar_version
+        );
+        println!();
+
+        if report.matched.is_empty() {
+            println!("  No matching benchmarks found.");
+        } else {
+            print_matched_table(&report.matched, color, threshold_pct);
+        }
+
+        print_unmatched(
+            "Benchmarks only in current run (no baseline)",
+            &report.only_in_current,
+        );
+        print_unmatched(
+            "Benchmarks only in baseline (not run)",
+            &report.only_in_baseline,
+        );
+
+        println!();
+    }
+}
+
+fn print_matched_table(matched: &[BenchmarkComparison], color: bool, threshold_pct: f64) {
+    let bench_w = matched
+        .iter()
+        .map(|c| c.benchmark.len())
+        .max()
+        .unwrap_or(9)
+        .max(9);
+
+    // Group by target, preserving insertion order
+    let mut targets: Vec<&str> = Vec::new();
+    let mut grouped: Vec<(&str, Vec<&BenchmarkComparison>)> = Vec::new();
+    for c in matched {
+        if let Some(pos) = targets.iter().position(|&t| t == c.target) {
+            grouped[pos].1.push(c);
+        } else {
+            targets.push(&c.target);
+            grouped.push((&c.target, vec![c]));
+        }
+    }
+
+    let separator = "-".repeat(bench_w + 8 + 8 + 5 + 7 + 7 + 7 + 12);
+
+    for (target, comparisons) in &grouped {
+        println!();
+        println!("  {target}");
+        println!(
+            "  {:<bench_w$}  {:>8}  {:>8}  {:>5}  {:>7}  {:>7}  {:>7}",
+            "Benchmark", "avg (µs)", "Δavg", "σ", "Δavg%", "Δp50%", "Δp99%"
+        );
+        println!("  {separator}");
+
+        for c in comparisons {
+            let delta_str = format_signed(c.delta_avg);
+            let pooled_sigma = c.baseline_stddev.hypot(c.current_stddev);
+            let sigma_str = format!("{pooled_sigma:.0}");
+            let avg_pct = format_pct(c.delta_avg_pct);
+            let p50_pct = format_pct(c.delta_p50_pct);
+            let p99_pct = format_pct(c.delta_p99_pct);
+            let significance = c.significance(threshold_pct);
+
+            // Pad values to their column widths *before* applying color, since
+            // ANSI escape codes are invisible but counted by format width specifiers.
+            let avg_col = format!("{avg_pct:>7}");
+            let p50_col = format!("{p50_pct:>7}");
+            let p99_col = format!("{p99_pct:>7}");
+
+            let (avg_col, p50_col, p99_col, suffix) = if color {
+                match significance {
+                    Significance::Regression => (
+                        format!("{}", avg_col.red().bold()),
+                        format!("{}", p50_col.red().bold()),
+                        format!("{}", p99_col.red().bold()),
+                        format!("{}", " ← REGRESSION".red().bold()),
+                    ),
+                    Significance::Improvement => (
+                        format!("{}", avg_col.green().bold()),
+                        format!("{}", p50_col.green().bold()),
+                        format!("{}", p99_col.green().bold()),
+                        String::new(),
+                    ),
+                    Significance::Insignificant => (avg_col, p50_col, p99_col, String::new()),
+                }
+            } else {
+                let suffix = if significance == Significance::Regression {
+                    " ← REGRESSION".to_string()
+                } else {
+                    String::new()
+                };
+                (avg_col, p50_col, p99_col, suffix)
+            };
+
+            println!(
+                "  {:<bench_w$}  {:>8}  {:>8}  {:>5}  {}  {}  {}{}",
+                c.benchmark, c.current_avg, delta_str, sigma_str, avg_col, p50_col, p99_col, suffix,
+            );
+        }
+    }
+}
+
+fn print_unmatched(header: &str, keys: &[BenchmarkKey]) {
+    if !keys.is_empty() {
+        println!();
+        println!("  {header}:");
+        for key in keys {
+            println!("    {}/{}", key.benchmark, key.target);
+        }
+    }
+}
+
+fn compute_comparison(
+    current: &BenchmarkResult,
+    baseline: &BenchmarkResult,
+) -> BenchmarkComparison {
+    BenchmarkComparison {
+        benchmark: current.benchmark.clone(),
+        target: current.target.clone(),
+        current_avg: current.average,
+        baseline_avg: baseline.average,
+        delta_avg: current.average as i128 - baseline.average as i128,
+        delta_avg_pct: pct_change(current.average, baseline.average),
+        baseline_stddev: baseline.stddev,
+        current_stddev: current.stddev,
+        current_p50: current.p50,
+        baseline_p50: baseline.p50,
+        delta_p50_pct: pct_change(current.p50, baseline.p50),
+        current_p99: current.p99,
+        baseline_p99: baseline.p99,
+        delta_p99_pct: pct_change(current.p99, baseline.p99),
+    }
+}
+
+/// Compute the percentage change from `baseline` to `current`.
+fn pct_change(current: u128, baseline: u128) -> f64 {
+    if baseline == 0 {
+        0.0
+    } else {
+        (current as f64 - baseline as f64) / baseline as f64 * 100.0
+    }
+}
+
+fn format_signed(value: i128) -> String {
+    if value > 0 {
+        format!("+{value}")
+    } else {
+        format!("{value}")
+    }
+}
+
+fn format_pct(pct: f64) -> String {
+    if pct > 0.0 {
+        format!("+{pct:.1}%")
+    } else {
+        format!("{pct:.1}%")
+    }
+}

--- a/cedar-benchmarking/src/compare.rs
+++ b/cedar-benchmarking/src/compare.rs
@@ -334,9 +334,16 @@ fn compute_comparison(
 }
 
 /// Compute the percentage change from `baseline` to `current`.
+/// When `baseline` is 0 and `current` is non-zero, returns a large sentinel
+/// value (`f64::MAX`) to ensure the change is always flagged as significant
+/// while remaining JSON-serializable.
 fn pct_change(current: u128, baseline: u128) -> f64 {
     if baseline == 0 {
-        0.0
+        if current == 0 {
+            0.0
+        } else {
+            f64::MAX
+        }
     } else {
         (current as f64 - baseline as f64) / baseline as f64 * 100.0
     }
@@ -351,7 +358,10 @@ fn format_signed(value: i128) -> String {
 }
 
 fn format_pct(pct: f64) -> String {
-    if pct > 0.0 {
+    // Sentinel value from pct_change when baseline was 0
+    if pct >= f64::MAX {
+        "+∞%".to_string()
+    } else if pct > 0.0 {
         format!("+{pct:.1}%")
     } else {
         format!("{pct:.1}%")

--- a/cedar-benchmarking/src/compare.rs
+++ b/cedar-benchmarking/src/compare.rs
@@ -15,7 +15,7 @@
  */
 
 use crate::output::{BenchmarkOutput, BenchmarkResult};
-use miette::IntoDiagnostic;
+use miette::{Context, IntoDiagnostic};
 use owo_colors::OwoColorize;
 use serde::Serialize;
 use std::collections::HashMap;
@@ -124,10 +124,13 @@ pub struct ComparisonReport {
 pub fn load_baseline(path: &Path) -> miette::Result<BenchmarkOutput> {
     let file = std::fs::File::open(path)
         .into_diagnostic()
-        .map_err(|e| miette::miette!("Failed to open baseline file '{}': {e}", path.display()))?;
+        .wrap_err(format!("Failed to open baseline file '{}'", path.display()))?;
     serde_json::from_reader(file)
         .into_diagnostic()
-        .map_err(|e| miette::miette!("Failed to parse baseline file '{}': {e}", path.display()))
+        .wrap_err(format!(
+            "Failed to parse baseline file '{}'",
+            path.display()
+        ))
 }
 
 /// Compare current results against a baseline, producing a report.

--- a/cedar-benchmarking/src/executor.rs
+++ b/cedar-benchmarking/src/executor.rs
@@ -311,8 +311,10 @@ impl BenchmarkExecutor {
     fn benchmark<T: Clone>(self, f: impl Fn(T), x: T) -> TimingInfo {
         let mut runs = Vec::with_capacity(self.trials);
 
-        // Warm-up run
-        f(x.clone());
+        // Warm-up runs
+        for _ in 0..10 {
+            f(x.clone());
+        }
 
         for _ in 0..self.trials {
             let dur = Self::time(&f, x.clone());

--- a/cedar-benchmarking/src/main.rs
+++ b/cedar-benchmarking/src/main.rs
@@ -52,7 +52,7 @@ struct Args {
     #[arg(short, long, value_delimiter = ',', requires = "corpus")]
     targets: Option<Vec<Target>>,
 
-    /// Number of trials per benchmark. Only valid with --corpus.
+    /// Number of trials per benchmark. Ignored in --baseline mode.
     #[arg(long, default_value = "1000")]
     trials: usize,
 
@@ -90,16 +90,19 @@ fn main() -> miette::Result<()> {
         compare::load_baseline(args.baseline.as_ref().expect("validated above"))?
     };
 
-    // Print benchmark results (only when running, not in baseline-only mode)
+    // Print benchmark results when running benchmarks directly (not in
+    // baseline-only mode). In JSON mode, skip this when --compare is active to
+    // avoid emitting two separate JSON documents on stdout.
     if args.corpus.is_some() {
         match args.output {
-            OutputFormat::Json => {
+            OutputFormat::Json if args.compare.is_none() => {
                 serde_json::to_writer_pretty(std::io::stdout(), &output).into_diagnostic()?;
                 println!();
             }
             OutputFormat::Table => {
                 print_table(&output);
             }
+            _ => {}
         }
     }
 

--- a/cedar-benchmarking/src/main.rs
+++ b/cedar-benchmarking/src/main.rs
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+mod compare;
 mod executor;
 mod output;
 pub mod request;
@@ -22,7 +23,7 @@ mod tasks;
 use clap::{Parser, ValueEnum};
 use miette::IntoDiagnostic;
 use output::{BenchmarkOutput, BenchmarkResult, SystemInfo};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use tasks::Target;
 
 #[derive(Debug, Clone, ValueEnum)]
@@ -38,28 +39,106 @@ enum OutputFormat {
     version
 )]
 struct Args {
-    /// Path to the benchmark corpus (tasks.json)
-    #[arg(short, long)]
-    corpus: PathBuf,
+    /// Path to the benchmark corpus (tasks.json). Mutually exclusive with --baseline.
+    #[arg(short, long, conflicts_with = "baseline")]
+    corpus: Option<PathBuf>,
 
-    /// Only run specific targets (comma-separated)
-    #[arg(short, long, value_delimiter = ',')]
+    /// Load "current" results from a previous JSON output file instead of running
+    /// benchmarks. Mutually exclusive with --corpus. Requires --compare.
+    #[arg(long, conflicts_with = "corpus", requires = "compare")]
+    baseline: Option<PathBuf>,
+
+    /// Only run specific targets (comma-separated). Only valid with --corpus.
+    #[arg(short, long, value_delimiter = ',', requires = "corpus")]
     targets: Option<Vec<Target>>,
 
-    /// Number of trials per benchmark
+    /// Number of trials per benchmark. Only valid with --corpus.
     #[arg(long, default_value = "1000")]
     trials: usize,
 
     /// Output format
     #[arg(short, long, value_enum, default_value = "json")]
     output: OutputFormat,
+
+    /// Compare results against previous run(s) (JSON output files)
+    #[arg(long, value_name = "FILE", num_args = 1..)]
+    compare: Option<Vec<PathBuf>>,
+
+    /// Disable colored output
+    #[arg(long)]
+    no_color: bool,
+
+    /// Exit non-zero if any benchmark's average regresses beyond this percentage.
+    /// Requires --compare.
+    #[arg(long, value_name = "PERCENT", requires = "compare")]
+    regression_threshold: Option<f64>,
 }
 
 fn main() -> miette::Result<()> {
     let args = Args::parse();
-    let tasks = tasks::load_corpus(&args.corpus, args.targets.as_deref())?;
 
-    let exec = executor::BenchmarkExecutor::new(args.trials);
+    if args.corpus.is_none() && args.baseline.is_none() {
+        return Err(miette::miette!(
+            "Either --corpus or --baseline must be provided"
+        ));
+    }
+
+    let output = if let Some(ref corpus) = args.corpus {
+        run_benchmarks(corpus, args.targets.as_deref(), args.trials)?
+    } else {
+        // --baseline is guaranteed present by the validation above
+        compare::load_baseline(args.baseline.as_ref().expect("validated above"))?
+    };
+
+    // Print benchmark results (only when running, not in baseline-only mode)
+    if args.corpus.is_some() {
+        match args.output {
+            OutputFormat::Json => {
+                serde_json::to_writer_pretty(std::io::stdout(), &output).into_diagnostic()?;
+                println!();
+            }
+            OutputFormat::Table => {
+                print_table(&output);
+            }
+        }
+    }
+
+    // Comparison mode
+    if let Some(ref compare_paths) = args.compare {
+        let reports: Vec<compare::ComparisonReport> = compare_paths
+            .iter()
+            .map(|path| {
+                let baseline = compare::load_baseline(path)?;
+                Ok(compare::compare(&output, &baseline, path))
+            })
+            .collect::<miette::Result<_>>()?;
+
+        // Use the user-provided threshold for both the table marker and the
+        // exit-code gate, defaulting to 5% for the table marker.
+        let threshold = args.regression_threshold.unwrap_or(5.0);
+
+        match args.output {
+            OutputFormat::Table => {
+                compare::print_comparison_table(&reports, !args.no_color, threshold);
+            }
+            OutputFormat::Json => compare::print_comparison_json(&reports)?,
+        }
+
+        if args.regression_threshold.is_some() && compare::has_regression(&reports, threshold) {
+            std::process::exit(1);
+        }
+    }
+
+    Ok(())
+}
+
+fn run_benchmarks(
+    corpus: &Path,
+    targets: Option<&[Target]>,
+    trials: usize,
+) -> miette::Result<BenchmarkOutput> {
+    let tasks = tasks::load_corpus(corpus, targets)?;
+    let exec = executor::BenchmarkExecutor::new(trials);
     let mut results = Vec::new();
 
     for task in tasks {
@@ -68,7 +147,7 @@ fn main() -> miette::Result<()> {
             results.push(BenchmarkResult {
                 benchmark: name,
                 target: target.to_string(),
-                trials: args.trials,
+                trials,
                 unit: "microseconds".to_string(),
                 average: timing.average,
                 min: timing.min,
@@ -82,22 +161,11 @@ fn main() -> miette::Result<()> {
         }
     }
 
-    let output = BenchmarkOutput {
+    Ok(BenchmarkOutput {
         cedar_version: cedar_policy::get_sdk_version().to_string(),
         system: SystemInfo::collect(),
         results,
-    };
-
-    match args.output {
-        OutputFormat::Json => {
-            serde_json::to_writer_pretty(std::io::stdout(), &output).into_diagnostic()?;
-            println!();
-        }
-        OutputFormat::Table => {
-            print_table(&output);
-        }
-    }
-    Ok(())
+    })
 }
 
 fn print_table(output: &BenchmarkOutput) {

--- a/cedar-benchmarking/src/output.rs
+++ b/cedar-benchmarking/src/output.rs
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use sysinfo::{CpuRefreshKind, RefreshKind, System};
 
 /// Top-level benchmark output format
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct BenchmarkOutput {
     pub cedar_version: String,
     pub system: SystemInfo,
@@ -26,7 +26,7 @@ pub struct BenchmarkOutput {
 }
 
 /// Information about the system running the benchmarks
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct SystemInfo {
     pub cpu_model: String,
     pub cpu_count: usize,
@@ -57,7 +57,7 @@ impl SystemInfo {
 }
 
 /// A single benchmark result
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct BenchmarkResult {
     pub benchmark: String,
     pub target: String,


### PR DESCRIPTION
Adds a `--compare` option to the benchmarking crate to compare results of different benchmarking runs.

Most of the changes are in `compare.rs` and in the README.

For example, if I generated results before using:
```
./target/release/cedar-benchmarking --corpus corpus/tasks.json --trials 100 > results.json
```
```
./target/release/cedar-benchmarking --corpus corpus/tasks.json --trials 100 --compare results.json --output table
```
The human-readable output looks like:

<img width="864" height="286" alt="Screenshot 2026-07-10 at 4 21 52 PM" src="https://github.com/user-attachments/assets/8bb56504-f1bb-42c9-bb08-aed8e12bc4f5" />

(this not a significant measurement - just illustrating the output).

Also relaxes dependency version so that we can use the benchmarking crate by checking out versions (as opposed to relying on releases of the benchmarking crate).