### PR TITLE
Add partial entity consistency PBT targets

### DIFF
--- a/cedar-drt/fuzz/Cargo.toml
+++ b/cedar-drt/fuzz/Cargo.toml
@@ -360,6 +360,12 @@ test = false
 doc = false
 
 [[bin]]
+name = "concrete-request-convert-partial-consistency-pbt"
+path = "fuzz_targets/concrete-request-convert-partial-consistency-pbt.rs"
+test = false
+doc = false
+
+[[bin]]
 name = "symcc-term-roundtrip-abac-type-directed"
 path = "fuzz_targets/symcc-term-roundtrip-abac-type-directed.rs"
 test = false

--- a/cedar-drt/fuzz/Cargo.toml
+++ b/cedar-drt/fuzz/Cargo.toml
@@ -348,6 +348,18 @@ test = false
 doc = false
 
 [[bin]]
+name = "concrete-entities-convert-partial-consistency-pbt"
+path = "fuzz_targets/concrete-entities-convert-partial-consistency-pbt.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "concrete-entities-parse-partial-consistency-pbt"
+path = "fuzz_targets/concrete-entities-parse-partial-consistency-pbt.rs"
+test = false
+doc = false
+
+[[bin]]
 name = "symcc-term-roundtrip-abac-type-directed"
 path = "fuzz_targets/symcc-term-roundtrip-abac-type-directed.rs"
 test = false

--- a/cedar-drt/fuzz/fuzz_targets/concrete-entities-convert-partial-consistency-pbt.rs
+++ b/cedar-drt/fuzz/fuzz_targets/concrete-entities-convert-partial-consistency-pbt.rs
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-//! All valid concrete entities must be consistent with the partial entities
-//! obtained from [`PartialEntities::from_concrete`].
+//! All valid concrete entities must be consistent with themselves converted to
+//! partial entities with [`PartialEntities::from_concrete`].
 
 #![no_main]
 use cedar_drt_inner::{abac::FuzzTargetInput, fuzz_target};

--- a/cedar-drt/fuzz/fuzz_targets/concrete-entities-convert-partial-consistency-pbt.rs
+++ b/cedar-drt/fuzz/fuzz_targets/concrete-entities-convert-partial-consistency-pbt.rs
@@ -38,7 +38,7 @@ fuzz_target!(|input: FuzzTargetInput<true>| {
         }
     };
 
-    partial.as_ref().check_consistency(&input.entities.as_ref().clone()).unwrap_or_else(|e| {
+    partial.as_ref().check_consistency(input.entities.as_ref()).unwrap_or_else(|e| {
         panic!(
             "Partial entities derived from concrete entities should be consistent with them: {e}"
         )

--- a/cedar-drt/fuzz/fuzz_targets/concrete-entities-convert-partial-consistency-pbt.rs
+++ b/cedar-drt/fuzz/fuzz_targets/concrete-entities-convert-partial-consistency-pbt.rs
@@ -1,0 +1,46 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! All valid concrete entities must be consistent with the partial entities
+//! obtained from [`PartialEntities::from_concrete`].
+
+#![no_main]
+use cedar_drt_inner::{abac::FuzzTargetInput, fuzz_target};
+use cedar_policy::{
+    PartialEntities, Schema,
+    tpe_err::{EntitiesError, EntityValidationError},
+};
+use std::convert::TryFrom;
+
+fuzz_target!(|input: FuzzTargetInput<true>| {
+    let Ok(schema) = Schema::try_from(input.schema) else {
+        return;
+    };
+    // Converting to partial entities should succeed, but here the entities aren't always valid.
+    let partial = match PartialEntities::from_concrete(input.entities.clone(), &schema) {
+        Ok(partial) => partial,
+        Err(EntitiesError::Validation(EntityValidationError::Concrete(_))) => return,
+        Err(e) => {
+            panic!("from_concrete failed on concrete entities with an unexpected error: {e}")
+        }
+    };
+
+    partial.as_ref().check_consistency(&input.entities.as_ref().clone()).unwrap_or_else(|e| {
+        panic!(
+            "Partial entities derived from concrete entities should be consistent with them: {e}"
+        )
+    });
+});

--- a/cedar-drt/fuzz/fuzz_targets/concrete-entities-parse-partial-consistency-pbt.rs
+++ b/cedar-drt/fuzz/fuzz_targets/concrete-entities-parse-partial-consistency-pbt.rs
@@ -1,0 +1,65 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! If we serialize any valid concrete entities to JSON, then the original
+//! entities must be consistent with the partial entities obtained form parsing
+//! the JSON as partial entities.
+
+#![no_main]
+use cedar_drt_inner::roundtrip_entities::assert_entities_to_json;
+use cedar_drt_inner::{abac::FuzzTargetInput, fuzz_target};
+use cedar_policy::tpe_err::{EntitiesError, EntityValidationError};
+use cedar_policy::{Entities, PartialEntities, Schema};
+use cedar_policy_core::{entities as core_entities, extensions::Extensions};
+use std::convert::TryFrom;
+
+fuzz_target!(|input: FuzzTargetInput<true>| {
+    let Ok(schema) = Schema::try_from(input.schema) else {
+        return;
+    };
+    // Serialize only the non-action entities to JSON. Action entities are
+    // rejected by the partial-entity parser.
+    let non_actions: Entities = core_entities::Entities::from_entities(
+        input
+            .entities
+            .as_ref()
+            .iter()
+            .filter(|e| !e.uid().is_action())
+            .cloned(),
+        None::<&core_entities::NoEntitiesSchema>,
+        core_entities::TCComputation::AssumeAlreadyComputed,
+        &Extensions::all_available(),
+    )
+    .unwrap()
+    .into();
+    let Some(json) = assert_entities_to_json(&non_actions) else {
+        return;
+    };
+
+    // Parsing should succeed, but the generated entities are not always valid
+    // against the schema (e.g. enumerated types with invalid eids).
+    let partial = match PartialEntities::from_json_value(json, &schema) {
+        Ok(partial) => partial,
+        Err(EntitiesError::Validation(EntityValidationError::Concrete(_))) => return,
+        Err(e) => panic!("parsing concrete entity JSON failed with an unexpected error: {e}"),
+    };
+
+    partial.as_ref().check_consistency(input.entities.as_ref()).unwrap_or_else(|e| {
+        panic!(
+            "Partial entities parsed from concrete entity JSON should be consistent with them: {e}"
+        )
+    });
+});

--- a/cedar-drt/fuzz/fuzz_targets/concrete-entities-parse-partial-consistency-pbt.rs
+++ b/cedar-drt/fuzz/fuzz_targets/concrete-entities-parse-partial-consistency-pbt.rs
@@ -15,7 +15,7 @@
  */
 
 //! If we serialize any valid concrete entities to JSON, then the original
-//! entities must be consistent with the partial entities obtained form parsing
+//! entities must be consistent with the partial entities obtained from parsing
 //! the JSON as partial entities.
 
 #![no_main]

--- a/cedar-drt/fuzz/fuzz_targets/concrete-request-convert-partial-consistency-pbt.rs
+++ b/cedar-drt/fuzz/fuzz_targets/concrete-request-convert-partial-consistency-pbt.rs
@@ -1,0 +1,68 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! All valid concrete requests must be consistent with themselves converted to
+//! a partial request with .
+
+#![no_main]
+use cedar_drt_inner::{abac::FuzzTargetInput, fuzz_target};
+use cedar_policy::{
+    PartialEntityUid, PartialRequest, PartialRequestCreationError, Request, Schema,
+};
+use std::convert::TryFrom;
+
+fuzz_target!(|input: FuzzTargetInput<true>| {
+    let Ok(schema) = Schema::try_from(input.schema) else {
+        return;
+    };
+
+    for req in input.requests {
+        let request: Request = req.into();
+        // A concrete request always has known components; unwrap them to build a
+        // fully-concrete partial request.
+        let (Some(principal), Some(action), Some(resource), Some(context)) = (
+            request.principal(),
+            request.action(),
+            request.resource(),
+            request.context(),
+        ) else {
+            panic!("concrete request unexpectedly has an unknown component: {request}");
+        };
+
+        // Constructing the partial request should succeed, but here the request isn't always valid.
+        let partial = match PartialRequest::new(
+            PartialEntityUid::from_concrete(principal.clone()),
+            action.clone(),
+            PartialEntityUid::from_concrete(resource.clone()),
+            Some(context.clone()),
+            &schema,
+        ) {
+            Ok(partial) => partial,
+            Err(PartialRequestCreationError::Validation(_)) => continue,
+            Err(e) => {
+                panic!(
+                    "PartialRequest::new failed on a concrete request with an unexpected error: {e}"
+                )
+            }
+        };
+
+        partial.as_ref().check_consistency(request.as_ref()).unwrap_or_else(|e| {
+            panic!(
+                "Partial request derived from a concrete request should be consistent with it: {e}"
+            )
+        });
+    }
+});

--- a/cedar-drt/fuzz/src/roundtrip_entities.rs
+++ b/cedar-drt/fuzz/src/roundtrip_entities.rs
@@ -39,13 +39,18 @@ pub fn pretty_assert_entities_deep_eq(original: &Entities, roundtripped: &Entiti
     }
 }
 
-pub fn fuzz_target(entities: Entities, schema: Option<Schema>) {
-    let json = match entities.as_ref().to_json_value() {
-        Ok(json) => json,
+/// Serialize `entities` to JSON.
+///
+/// Panics on an unexpected failure. Returns `None` on an expected failure. Fuzz targets should
+/// `return` on `None` to assert that there are no unexpected errors while passing on expected
+/// errors.
+pub fn assert_entities_to_json(entities: &Entities) -> Option<serde_json::Value> {
+    match entities.as_ref().to_json_value() {
+        Ok(json) => Some(json),
         Err(EntitiesError::Serialization(JsonSerializationError::ReservedKey(_))) => {
             // Serializing to JSON is expected to fail when there's a record
             // attribute `__entity`, `__expr`, or `__extn`
-            return;
+            None
         }
         Err(EntitiesError::Serialization(JsonSerializationError::ExtnCall2OrMoreArguments(
             err,
@@ -55,11 +60,17 @@ pub fn fuzz_target(entities: Entities, schema: Option<Schema>) {
             // This is because years before AD 1 cannot be constructed using the
             // `datetime` function, of which the valid inputs span from AD 1 to
             // year 9999.
-            return;
+            None
         }
         Err(err) => {
             panic!("Should be able to serialize entities to JSON, instead got error: {err}")
         }
+    }
+}
+
+pub fn fuzz_target(entities: Entities, schema: Option<Schema>) {
+    let Some(json) = assert_entities_to_json(&entities) else {
+        return;
     };
 
     let roundtripped_entities = Entities::from_json_value(json.clone(), None)


### PR DESCRIPTION
Add two PBT targets asserting that valid concrete entities are consistent with themselves when interpreted as partial entities.

These properties are mostly trivial at the moment, but become more interesting with tpe-infinity. 

