### PR TITLE
fuzzing targets for protobuf encode

### DIFF
--- a/cedar-drt/fuzz/Cargo.toml
+++ b/cedar-drt/fuzz/Cargo.toml
@@ -282,6 +282,84 @@ test = false
 doc = false
 
 [[bin]]
+name = "protobuf-encode-bytes-policyset"
+path = "fuzz_targets/protobuf-encode/protobuf-encode-bytes-policyset.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "protobuf-encode-bytes-entity"
+path = "fuzz_targets/protobuf-encode/protobuf-encode-bytes-entity.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "protobuf-encode-bytes-entities"
+path = "fuzz_targets/protobuf-encode/protobuf-encode-bytes-entities.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "protobuf-encode-bytes-schema"
+path = "fuzz_targets/protobuf-encode/protobuf-encode-bytes-schema.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "protobuf-encode-bytes-expression"
+path = "fuzz_targets/protobuf-encode/protobuf-encode-bytes-expression.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "protobuf-encode-bytes-template"
+path = "fuzz_targets/protobuf-encode/protobuf-encode-bytes-template.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "protobuf-encode-gen-policyset"
+path = "fuzz_targets/protobuf-encode/protobuf-encode-gen-policyset.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "protobuf-encode-gen-entity"
+path = "fuzz_targets/protobuf-encode/protobuf-encode-gen-entity.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "protobuf-encode-gen-entities"
+path = "fuzz_targets/protobuf-encode/protobuf-encode-gen-entities.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "protobuf-encode-gen-schema"
+path = "fuzz_targets/protobuf-encode/protobuf-encode-gen-schema.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "protobuf-encode-gen-expression"
+path = "fuzz_targets/protobuf-encode/protobuf-encode-gen-expression.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "protobuf-encode-gen-request"
+path = "fuzz_targets/protobuf-encode/protobuf-encode-gen-request.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "protobuf-encode-gen-template"
+path = "fuzz_targets/protobuf-encode/protobuf-encode-gen-template.rs"
+test = false
+doc = false
+
+[[bin]]
 name = "entity-validation"
 path = "fuzz_targets/entity-validation.rs"
 test = false

--- a/cedar-drt/fuzz/fuzz_targets/protobuf-encode/protobuf-encode-bytes-entities.rs
+++ b/cedar-drt/fuzz/fuzz_targets/protobuf-encode/protobuf-encode-bytes-entities.rs
@@ -20,7 +20,7 @@ use cedar_drt_inner::fuzz_target;
 use cedar_drt_inner::roundtrip_entities::pretty_assert_entities_deep_eq;
 
 use cedar_policy::Entities;
-use cedar_policy::proto::traits::Protobuf;
+use cedar_policy::proto::traits::{EncodeError, Protobuf};
 
 // Feed arbitrary bytes into the Entities JSON parser.
 // Property: if JSON parsing succeeds, encoding to protobuf must not panic,
@@ -32,7 +32,11 @@ fuzz_target!(|input: &[u8]| {
     let Ok(entities) = Entities::from_json_value(json, None) else {
         return;
     };
-    let buf = entities.encode();
+    let buf = match entities.encode() {
+        Ok(buf) => buf,
+        Err(EncodeError::MaxDepthExceeded) => return,
+        Err(e) => panic!("only error expected encoding Entities is MaxDepthExceeded, got {e}"),
+    };
     let decoded =
         Entities::decode(&buf[..]).expect("Failed to decode Entities that were just encoded");
     pretty_assert_entities_deep_eq(&entities, &decoded);

--- a/cedar-drt/fuzz/fuzz_targets/protobuf-encode/protobuf-encode-bytes-entities.rs
+++ b/cedar-drt/fuzz/fuzz_targets/protobuf-encode/protobuf-encode-bytes-entities.rs
@@ -1,0 +1,39 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#![no_main]
+
+use cedar_drt_inner::fuzz_target;
+use cedar_drt_inner::roundtrip_entities::pretty_assert_entities_deep_eq;
+
+use cedar_policy::Entities;
+use cedar_policy::proto::traits::Protobuf;
+
+// Feed arbitrary bytes into the Entities JSON parser.
+// Property: if JSON parsing succeeds, encoding to protobuf must not panic,
+// and decoding the encoded bytes must produce equivalent Entities.
+fuzz_target!(|input: &[u8]| {
+    let Ok(json) = serde_json::from_slice::<serde_json::Value>(input) else {
+        return;
+    };
+    let Ok(entities) = Entities::from_json_value(json, None) else {
+        return;
+    };
+    let buf = entities.encode();
+    let decoded =
+        Entities::decode(&buf[..]).expect("Failed to decode Entities that were just encoded");
+    pretty_assert_entities_deep_eq(&entities, &decoded);
+});

--- a/cedar-drt/fuzz/fuzz_targets/protobuf-encode/protobuf-encode-bytes-entities.rs
+++ b/cedar-drt/fuzz/fuzz_targets/protobuf-encode/protobuf-encode-bytes-entities.rs
@@ -17,7 +17,7 @@
 #![no_main]
 
 use cedar_drt_inner::fuzz_target;
-use cedar_drt_inner::roundtrip_entities::pretty_assert_entities_deep_eq;
+use cedar_drt_inner::props::entities_protobuf_decodes;
 
 use cedar_policy::Entities;
 use cedar_policy::proto::traits::{EncodeError, Protobuf};
@@ -37,7 +37,5 @@ fuzz_target!(|input: &[u8]| {
         Err(EncodeError::MaxDepthExceeded) => return,
         Err(e) => panic!("only error expected encoding Entities is MaxDepthExceeded, got {e}"),
     };
-    let decoded =
-        Entities::decode(&buf[..]).expect("Failed to decode Entities that were just encoded");
-    pretty_assert_entities_deep_eq(&entities, &decoded);
+    entities_protobuf_decodes(&buf[..], &entities);
 });

--- a/cedar-drt/fuzz/fuzz_targets/protobuf-encode/protobuf-encode-bytes-entity.rs
+++ b/cedar-drt/fuzz/fuzz_targets/protobuf-encode/protobuf-encode-bytes-entity.rs
@@ -17,6 +17,7 @@
 #![no_main]
 
 use cedar_drt_inner::fuzz_target;
+use cedar_drt_inner::props::entity_protobuf_decodes;
 
 use cedar_policy::Entity;
 use cedar_policy::proto::traits::{EncodeError, Protobuf};
@@ -36,7 +37,5 @@ fuzz_target!(|input: &[u8]| {
         Err(EncodeError::MaxDepthExceeded) => return,
         Err(e) => panic!("only error expected encoding Entity is MaxDepthExceeded, got {e}"),
     };
-    let decoded =
-        Entity::decode(&buf[..]).expect("Failed to decode an Entity that was just encoded");
-    assert_eq!(entity, decoded);
+    entity_protobuf_decodes(&buf[..], &entity);
 });

--- a/cedar-drt/fuzz/fuzz_targets/protobuf-encode/protobuf-encode-bytes-entity.rs
+++ b/cedar-drt/fuzz/fuzz_targets/protobuf-encode/protobuf-encode-bytes-entity.rs
@@ -19,7 +19,7 @@
 use cedar_drt_inner::fuzz_target;
 
 use cedar_policy::Entity;
-use cedar_policy::proto::traits::Protobuf;
+use cedar_policy::proto::traits::{EncodeError, Protobuf};
 
 // Feed arbitrary bytes into the Entity JSON parser.
 // Property: if JSON parsing succeeds, encoding to protobuf must not panic,
@@ -31,7 +31,11 @@ fuzz_target!(|input: &[u8]| {
     let Ok(entity) = Entity::from_json_value(json, None) else {
         return;
     };
-    let buf = entity.encode();
+    let buf = match entity.encode() {
+        Ok(buf) => buf,
+        Err(EncodeError::MaxDepthExceeded) => return,
+        Err(e) => panic!("only error expected encoding Entity is MaxDepthExceeded, got {e}"),
+    };
     let decoded =
         Entity::decode(&buf[..]).expect("Failed to decode an Entity that was just encoded");
     assert_eq!(entity, decoded);

--- a/cedar-drt/fuzz/fuzz_targets/protobuf-encode/protobuf-encode-bytes-entity.rs
+++ b/cedar-drt/fuzz/fuzz_targets/protobuf-encode/protobuf-encode-bytes-entity.rs
@@ -1,0 +1,38 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#![no_main]
+
+use cedar_drt_inner::fuzz_target;
+
+use cedar_policy::Entity;
+use cedar_policy::proto::traits::Protobuf;
+
+// Feed arbitrary bytes into the Entity JSON parser.
+// Property: if JSON parsing succeeds, encoding to protobuf must not panic,
+// and decoding the encoded bytes must produce an equivalent Entity.
+fuzz_target!(|input: &[u8]| {
+    let Ok(json) = serde_json::from_slice::<serde_json::Value>(input) else {
+        return;
+    };
+    let Ok(entity) = Entity::from_json_value(json, None) else {
+        return;
+    };
+    let buf = entity.encode();
+    let decoded =
+        Entity::decode(&buf[..]).expect("Failed to decode an Entity that was just encoded");
+    assert_eq!(entity, decoded);
+});

--- a/cedar-drt/fuzz/fuzz_targets/protobuf-encode/protobuf-encode-bytes-expression.rs
+++ b/cedar-drt/fuzz/fuzz_targets/protobuf-encode/protobuf-encode-bytes-expression.rs
@@ -1,0 +1,37 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#![no_main]
+
+use cedar_drt_inner::fuzz_target;
+use cedar_drt_inner::props::expression_to_cedar_parses;
+
+use cedar_policy::Expression;
+use cedar_policy::proto::traits::Protobuf;
+
+// Feed arbitrary strings into the Expression parser.
+// Property: if parsing succeeds, encoding to protobuf must not panic,
+// and decoding the encoded bytes must succeed and produce an Expression
+// that prints to Cedar and re-parses.
+fuzz_target!(|input: String| {
+    let Ok(expression) = input.parse::<Expression>() else {
+        return;
+    };
+    let buf = expression.encode();
+    let decoded =
+        Expression::decode(&buf[..]).expect("Failed to decode an Expression that was just encoded");
+    expression_to_cedar_parses(decoded);
+});

--- a/cedar-drt/fuzz/fuzz_targets/protobuf-encode/protobuf-encode-bytes-expression.rs
+++ b/cedar-drt/fuzz/fuzz_targets/protobuf-encode/protobuf-encode-bytes-expression.rs
@@ -17,7 +17,7 @@
 #![no_main]
 
 use cedar_drt_inner::fuzz_target;
-use cedar_drt_inner::props::expression_to_cedar_parses;
+use cedar_drt_inner::props::expression_protobuf_decodes;
 
 use cedar_policy::Expression;
 use cedar_policy::proto::traits::{EncodeError, Protobuf};
@@ -37,7 +37,5 @@ fuzz_target!(|input: String| {
             panic!("only error expected encoding Expression is MaxDepthExceeded, got {e}")
         }
     };
-    let decoded =
-        Expression::decode(&buf[..]).expect("Failed to decode an Expression that was just encoded");
-    expression_to_cedar_parses(decoded);
+    expression_protobuf_decodes(&buf[..]);
 });

--- a/cedar-drt/fuzz/fuzz_targets/protobuf-encode/protobuf-encode-bytes-expression.rs
+++ b/cedar-drt/fuzz/fuzz_targets/protobuf-encode/protobuf-encode-bytes-expression.rs
@@ -20,7 +20,7 @@ use cedar_drt_inner::fuzz_target;
 use cedar_drt_inner::props::expression_to_cedar_parses;
 
 use cedar_policy::Expression;
-use cedar_policy::proto::traits::Protobuf;
+use cedar_policy::proto::traits::{EncodeError, Protobuf};
 
 // Feed arbitrary strings into the Expression parser.
 // Property: if parsing succeeds, encoding to protobuf must not panic,
@@ -30,7 +30,13 @@ fuzz_target!(|input: String| {
     let Ok(expression) = input.parse::<Expression>() else {
         return;
     };
-    let buf = expression.encode();
+    let buf = match expression.encode() {
+        Ok(buf) => buf,
+        Err(EncodeError::MaxDepthExceeded) => return,
+        Err(e) => {
+            panic!("only error expected encoding Expression is MaxDepthExceeded, got {e}")
+        }
+    };
     let decoded =
         Expression::decode(&buf[..]).expect("Failed to decode an Expression that was just encoded");
     expression_to_cedar_parses(decoded);

--- a/cedar-drt/fuzz/fuzz_targets/protobuf-encode/protobuf-encode-bytes-policyset.rs
+++ b/cedar-drt/fuzz/fuzz_targets/protobuf-encode/protobuf-encode-bytes-policyset.rs
@@ -1,0 +1,35 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#![no_main]
+
+use cedar_drt_inner::fuzz_target;
+
+use cedar_policy::PolicySet;
+use cedar_policy::proto::traits::Protobuf;
+
+// Feed arbitrary strings into the Cedar policy parser.
+// Property: if parsing succeeds, encoding to protobuf must not panic,
+// and decoding the encoded bytes must produce an equivalent PolicySet.
+fuzz_target!(|input: String| {
+    let Ok(policy_set) = input.parse::<PolicySet>() else {
+        return;
+    };
+    let buf = policy_set.encode();
+    let decoded =
+        PolicySet::decode(&buf[..]).expect("Failed to decode a PolicySet that was just encoded");
+    assert_eq!(policy_set, decoded);
+});

--- a/cedar-drt/fuzz/fuzz_targets/protobuf-encode/protobuf-encode-bytes-policyset.rs
+++ b/cedar-drt/fuzz/fuzz_targets/protobuf-encode/protobuf-encode-bytes-policyset.rs
@@ -17,6 +17,7 @@
 #![no_main]
 
 use cedar_drt_inner::fuzz_target;
+use cedar_drt_inner::props::policyset_protobuf_decodes;
 
 use cedar_policy::PolicySet;
 use cedar_policy::proto::traits::{EncodeError, Protobuf};
@@ -33,7 +34,5 @@ fuzz_target!(|input: String| {
         Err(EncodeError::MaxDepthExceeded) => return,
         Err(e) => panic!("only error expected encoding PolicySet is MaxDepthExceeded, got {e}"),
     };
-    let decoded =
-        PolicySet::decode(&buf[..]).expect("Failed to decode a PolicySet that was just encoded");
-    assert_eq!(policy_set, decoded);
+    policyset_protobuf_decodes(&buf[..], &policy_set);
 });

--- a/cedar-drt/fuzz/fuzz_targets/protobuf-encode/protobuf-encode-bytes-policyset.rs
+++ b/cedar-drt/fuzz/fuzz_targets/protobuf-encode/protobuf-encode-bytes-policyset.rs
@@ -19,7 +19,7 @@
 use cedar_drt_inner::fuzz_target;
 
 use cedar_policy::PolicySet;
-use cedar_policy::proto::traits::Protobuf;
+use cedar_policy::proto::traits::{EncodeError, Protobuf};
 
 // Feed arbitrary strings into the Cedar policy parser.
 // Property: if parsing succeeds, encoding to protobuf must not panic,
@@ -28,7 +28,11 @@ fuzz_target!(|input: String| {
     let Ok(policy_set) = input.parse::<PolicySet>() else {
         return;
     };
-    let buf = policy_set.encode();
+    let buf = match policy_set.encode() {
+        Ok(buf) => buf,
+        Err(EncodeError::MaxDepthExceeded) => return,
+        Err(e) => panic!("only error expected encoding PolicySet is MaxDepthExceeded, got {e}"),
+    };
     let decoded =
         PolicySet::decode(&buf[..]).expect("Failed to decode a PolicySet that was just encoded");
     assert_eq!(policy_set, decoded);

--- a/cedar-drt/fuzz/fuzz_targets/protobuf-encode/protobuf-encode-bytes-schema.rs
+++ b/cedar-drt/fuzz/fuzz_targets/protobuf-encode/protobuf-encode-bytes-schema.rs
@@ -1,0 +1,36 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#![no_main]
+
+use cedar_drt_inner::fuzz_target;
+use cedar_drt_inner::schemas::Equiv;
+
+use cedar_policy::Schema;
+use cedar_policy::proto::traits::Protobuf;
+
+// Feed arbitrary strings into the Cedar schema parser.
+// Property: if parsing succeeds, encoding to protobuf must not panic,
+// and decoding the encoded bytes must produce an equivalent Schema.
+fuzz_target!(|input: String| {
+    let Ok((schema, _)) = Schema::from_cedarschema_str(&input) else {
+        return;
+    };
+    let buf = schema.encode();
+    let decoded =
+        Schema::decode(&buf[..]).expect("Failed to decode a Schema that was just encoded");
+    Equiv::equiv(schema.as_ref(), decoded.as_ref()).unwrap();
+});

--- a/cedar-drt/fuzz/fuzz_targets/protobuf-encode/protobuf-encode-bytes-schema.rs
+++ b/cedar-drt/fuzz/fuzz_targets/protobuf-encode/protobuf-encode-bytes-schema.rs
@@ -20,7 +20,7 @@ use cedar_drt_inner::fuzz_target;
 use cedar_drt_inner::schemas::Equiv;
 
 use cedar_policy::Schema;
-use cedar_policy::proto::traits::Protobuf;
+use cedar_policy::proto::traits::{EncodeError, Protobuf};
 
 // Feed arbitrary strings into the Cedar schema parser.
 // Property: if parsing succeeds, encoding to protobuf must not panic,
@@ -29,7 +29,11 @@ fuzz_target!(|input: String| {
     let Ok((schema, _)) = Schema::from_cedarschema_str(&input) else {
         return;
     };
-    let buf = schema.encode();
+    let buf = match schema.encode() {
+        Ok(buf) => buf,
+        Err(EncodeError::MaxDepthExceeded) => return,
+        Err(e) => panic!("only error expected encoding Schema is MaxDepthExceeded, got {e}"),
+    };
     let decoded =
         Schema::decode(&buf[..]).expect("Failed to decode a Schema that was just encoded");
     Equiv::equiv(schema.as_ref(), decoded.as_ref()).unwrap();

--- a/cedar-drt/fuzz/fuzz_targets/protobuf-encode/protobuf-encode-bytes-schema.rs
+++ b/cedar-drt/fuzz/fuzz_targets/protobuf-encode/protobuf-encode-bytes-schema.rs
@@ -17,7 +17,7 @@
 #![no_main]
 
 use cedar_drt_inner::fuzz_target;
-use cedar_drt_inner::schemas::Equiv;
+use cedar_drt_inner::props::schema_protobuf_decodes;
 
 use cedar_policy::Schema;
 use cedar_policy::proto::traits::{EncodeError, Protobuf};
@@ -34,7 +34,5 @@ fuzz_target!(|input: String| {
         Err(EncodeError::MaxDepthExceeded) => return,
         Err(e) => panic!("only error expected encoding Schema is MaxDepthExceeded, got {e}"),
     };
-    let decoded =
-        Schema::decode(&buf[..]).expect("Failed to decode a Schema that was just encoded");
-    Equiv::equiv(schema.as_ref(), decoded.as_ref()).unwrap();
+    schema_protobuf_decodes(&buf[..], &schema);
 });

--- a/cedar-drt/fuzz/fuzz_targets/protobuf-encode/protobuf-encode-bytes-template.rs
+++ b/cedar-drt/fuzz/fuzz_targets/protobuf-encode/protobuf-encode-bytes-template.rs
@@ -1,0 +1,35 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#![no_main]
+
+use cedar_drt_inner::fuzz_target;
+
+use cedar_policy::Template;
+use cedar_policy::proto::traits::Protobuf;
+
+// Feed arbitrary strings into the Template parser.
+// Property: if parsing succeeds, encoding to protobuf must not panic,
+// and decoding the encoded bytes must produce an equivalent Template.
+fuzz_target!(|input: String| {
+    let Ok(template) = input.parse::<Template>() else {
+        return;
+    };
+    let buf = template.encode();
+    let decoded =
+        Template::decode(&buf[..]).expect("Failed to decode a Template that was just encoded");
+    assert_eq!(template, decoded);
+});

--- a/cedar-drt/fuzz/fuzz_targets/protobuf-encode/protobuf-encode-bytes-template.rs
+++ b/cedar-drt/fuzz/fuzz_targets/protobuf-encode/protobuf-encode-bytes-template.rs
@@ -17,6 +17,7 @@
 #![no_main]
 
 use cedar_drt_inner::fuzz_target;
+use cedar_drt_inner::props::template_protobuf_decodes;
 
 use cedar_policy::Template;
 use cedar_policy::proto::traits::{EncodeError, Protobuf};
@@ -33,7 +34,5 @@ fuzz_target!(|input: String| {
         Err(EncodeError::MaxDepthExceeded) => return,
         Err(e) => panic!("only error expected encoding Template is MaxDepthExceeded, got {e}"),
     };
-    let decoded =
-        Template::decode(&buf[..]).expect("Failed to decode a Template that was just encoded");
-    assert_eq!(template, decoded);
+    template_protobuf_decodes(&buf[..], &template);
 });

--- a/cedar-drt/fuzz/fuzz_targets/protobuf-encode/protobuf-encode-bytes-template.rs
+++ b/cedar-drt/fuzz/fuzz_targets/protobuf-encode/protobuf-encode-bytes-template.rs
@@ -19,7 +19,7 @@
 use cedar_drt_inner::fuzz_target;
 
 use cedar_policy::Template;
-use cedar_policy::proto::traits::Protobuf;
+use cedar_policy::proto::traits::{EncodeError, Protobuf};
 
 // Feed arbitrary strings into the Template parser.
 // Property: if parsing succeeds, encoding to protobuf must not panic,
@@ -28,7 +28,11 @@ fuzz_target!(|input: String| {
     let Ok(template) = input.parse::<Template>() else {
         return;
     };
-    let buf = template.encode();
+    let buf = match template.encode() {
+        Ok(buf) => buf,
+        Err(EncodeError::MaxDepthExceeded) => return,
+        Err(e) => panic!("only error expected encoding Template is MaxDepthExceeded, got {e}"),
+    };
     let decoded =
         Template::decode(&buf[..]).expect("Failed to decode a Template that was just encoded");
     assert_eq!(template, decoded);

--- a/cedar-drt/fuzz/fuzz_targets/protobuf-encode/protobuf-encode-gen-entities.rs
+++ b/cedar-drt/fuzz/fuzz_targets/protobuf-encode/protobuf-encode-gen-entities.rs
@@ -19,7 +19,7 @@
 use cedar_drt_inner::fuzz_target;
 use cedar_drt_inner::roundtrip_entities::pretty_assert_entities_deep_eq;
 
-use cedar_policy::proto::traits::Protobuf;
+use cedar_policy::proto::traits::{EncodeError, Protobuf};
 use cedar_policy::{Entities, Entity};
 
 use cedar_policy_generators::schema_gen::SchemaGen;
@@ -64,7 +64,11 @@ impl<'a> Arbitrary<'a> for FuzzTargetInput {
 // Property: encoding well-formed Entities must not panic, and decoding
 // the result must produce equivalent Entities.
 fuzz_target!(|input: FuzzTargetInput| {
-    let buf = input.entities.encode();
+    let buf = match input.entities.encode() {
+        Ok(buf) => buf,
+        Err(EncodeError::MaxDepthExceeded) => return,
+        Err(e) => panic!("only error expected encoding Entities is MaxDepthExceeded, got {e}"),
+    };
     let decoded =
         Entities::decode(&buf[..]).expect("Failed to decode Entities that were just encoded");
     pretty_assert_entities_deep_eq(&input.entities, &decoded);

--- a/cedar-drt/fuzz/fuzz_targets/protobuf-encode/protobuf-encode-gen-entities.rs
+++ b/cedar-drt/fuzz/fuzz_targets/protobuf-encode/protobuf-encode-gen-entities.rs
@@ -17,7 +17,7 @@
 #![no_main]
 
 use cedar_drt_inner::fuzz_target;
-use cedar_drt_inner::roundtrip_entities::pretty_assert_entities_deep_eq;
+use cedar_drt_inner::props::entities_protobuf_decodes;
 
 use cedar_policy::proto::traits::{EncodeError, Protobuf};
 use cedar_policy::{Entities, Entity};
@@ -69,7 +69,5 @@ fuzz_target!(|input: FuzzTargetInput| {
         Err(EncodeError::MaxDepthExceeded) => return,
         Err(e) => panic!("only error expected encoding Entities is MaxDepthExceeded, got {e}"),
     };
-    let decoded =
-        Entities::decode(&buf[..]).expect("Failed to decode Entities that were just encoded");
-    pretty_assert_entities_deep_eq(&input.entities, &decoded);
+    entities_protobuf_decodes(&buf[..], &input.entities);
 });

--- a/cedar-drt/fuzz/fuzz_targets/protobuf-encode/protobuf-encode-gen-entities.rs
+++ b/cedar-drt/fuzz/fuzz_targets/protobuf-encode/protobuf-encode-gen-entities.rs
@@ -1,0 +1,71 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#![no_main]
+
+use cedar_drt_inner::fuzz_target;
+use cedar_drt_inner::roundtrip_entities::pretty_assert_entities_deep_eq;
+
+use cedar_policy::proto::traits::Protobuf;
+use cedar_policy::{Entities, Entity};
+
+use cedar_policy_generators::schema_gen::SchemaGen;
+use cedar_policy_generators::{hierarchy::HierarchyGenerator, schema, settings::ABACSettings};
+use libfuzzer_sys::arbitrary::{self, Arbitrary, Unstructured};
+
+#[derive(Debug, Clone)]
+struct FuzzTargetInput {
+    entities: Entities,
+}
+
+const SETTINGS: ABACSettings = ABACSettings {
+    enable_arbitrary_func_call: false,
+    ..ABACSettings::undirected()
+};
+
+impl<'a> Arbitrary<'a> for FuzzTargetInput {
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        let schema: schema::Schema = schema::Schema::arbitrary(SETTINGS.clone(), u)?;
+        let hierarchy = schema.arbitrary_hierarchy(u)?;
+
+        let entities = Entities::from_entities(
+            hierarchy.entities().map(|x| Entity::from(x.to_owned())),
+            None,
+        )
+        .expect("Failed to create entities");
+
+        Ok(Self { entities })
+    }
+
+    fn try_size_hint(
+        depth: usize,
+    ) -> Result<(usize, Option<usize>), arbitrary::MaxRecursionReached> {
+        Ok(arbitrary::size_hint::and_all(&[
+            schema::Schema::arbitrary_size_hint(depth)?,
+            HierarchyGenerator::size_hint(depth),
+        ]))
+    }
+}
+
+// Generate Entities using the ABAC generators, then encode to protobuf.
+// Property: encoding well-formed Entities must not panic, and decoding
+// the result must produce equivalent Entities.
+fuzz_target!(|input: FuzzTargetInput| {
+    let buf = input.entities.encode();
+    let decoded =
+        Entities::decode(&buf[..]).expect("Failed to decode Entities that were just encoded");
+    pretty_assert_entities_deep_eq(&input.entities, &decoded);
+});

--- a/cedar-drt/fuzz/fuzz_targets/protobuf-encode/protobuf-encode-gen-entity.rs
+++ b/cedar-drt/fuzz/fuzz_targets/protobuf-encode/protobuf-encode-gen-entity.rs
@@ -1,0 +1,70 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#![no_main]
+
+use cedar_drt_inner::fuzz_target;
+
+use cedar_policy::Entity;
+use cedar_policy::proto::traits::Protobuf;
+
+use cedar_policy_generators::schema_gen::SchemaGen;
+use cedar_policy_generators::{hierarchy::HierarchyGenerator, schema, settings::ABACSettings};
+use libfuzzer_sys::arbitrary::{self, Arbitrary, Unstructured};
+
+#[derive(Debug, Clone)]
+struct FuzzTargetInput {
+    entity: Entity,
+}
+
+const SETTINGS: ABACSettings = ABACSettings {
+    enable_arbitrary_func_call: false,
+    ..ABACSettings::undirected()
+};
+
+impl<'a> Arbitrary<'a> for FuzzTargetInput {
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        let schema: schema::Schema = schema::Schema::arbitrary(SETTINGS.clone(), u)?;
+        let hierarchy = schema.arbitrary_hierarchy(u)?;
+        let entities: Vec<_> = hierarchy.entities().collect();
+        if entities.is_empty() {
+            return Err(arbitrary::Error::NotEnoughData);
+        }
+        let entity = (*u.choose(&entities)?).clone();
+        Ok(Self {
+            entity: Entity::from(entity),
+        })
+    }
+
+    fn try_size_hint(
+        depth: usize,
+    ) -> Result<(usize, Option<usize>), arbitrary::MaxRecursionReached> {
+        Ok(arbitrary::size_hint::and_all(&[
+            schema::Schema::arbitrary_size_hint(depth)?,
+            HierarchyGenerator::size_hint(depth),
+        ]))
+    }
+}
+
+// Generate an Entity using the ABAC generators, then encode to protobuf.
+// Property: encoding a well-formed Entity must not panic, and decoding
+// the result must produce an equivalent Entity.
+fuzz_target!(|input: FuzzTargetInput| {
+    let buf = input.entity.encode();
+    let decoded =
+        Entity::decode(&buf[..]).expect("Failed to decode an Entity that was just encoded");
+    assert_eq!(input.entity, decoded);
+});

--- a/cedar-drt/fuzz/fuzz_targets/protobuf-encode/protobuf-encode-gen-entity.rs
+++ b/cedar-drt/fuzz/fuzz_targets/protobuf-encode/protobuf-encode-gen-entity.rs
@@ -19,7 +19,7 @@
 use cedar_drt_inner::fuzz_target;
 
 use cedar_policy::Entity;
-use cedar_policy::proto::traits::Protobuf;
+use cedar_policy::proto::traits::{EncodeError, Protobuf};
 
 use cedar_policy_generators::schema_gen::SchemaGen;
 use cedar_policy_generators::{hierarchy::HierarchyGenerator, schema, settings::ABACSettings};
@@ -63,7 +63,11 @@ impl<'a> Arbitrary<'a> for FuzzTargetInput {
 // Property: encoding a well-formed Entity must not panic, and decoding
 // the result must produce an equivalent Entity.
 fuzz_target!(|input: FuzzTargetInput| {
-    let buf = input.entity.encode();
+    let buf = match input.entity.encode() {
+        Ok(buf) => buf,
+        Err(EncodeError::MaxDepthExceeded) => return,
+        Err(e) => panic!("only error expected encoding Entity is MaxDepthExceeded, got {e}"),
+    };
     let decoded =
         Entity::decode(&buf[..]).expect("Failed to decode an Entity that was just encoded");
     assert_eq!(input.entity, decoded);

--- a/cedar-drt/fuzz/fuzz_targets/protobuf-encode/protobuf-encode-gen-entity.rs
+++ b/cedar-drt/fuzz/fuzz_targets/protobuf-encode/protobuf-encode-gen-entity.rs
@@ -17,6 +17,7 @@
 #![no_main]
 
 use cedar_drt_inner::fuzz_target;
+use cedar_drt_inner::props::entity_protobuf_decodes;
 
 use cedar_policy::Entity;
 use cedar_policy::proto::traits::{EncodeError, Protobuf};
@@ -68,7 +69,5 @@ fuzz_target!(|input: FuzzTargetInput| {
         Err(EncodeError::MaxDepthExceeded) => return,
         Err(e) => panic!("only error expected encoding Entity is MaxDepthExceeded, got {e}"),
     };
-    let decoded =
-        Entity::decode(&buf[..]).expect("Failed to decode an Entity that was just encoded");
-    assert_eq!(input.entity, decoded);
+    entity_protobuf_decodes(&buf[..], &input.entity);
 });

--- a/cedar-drt/fuzz/fuzz_targets/protobuf-encode/protobuf-encode-gen-expression.rs
+++ b/cedar-drt/fuzz/fuzz_targets/protobuf-encode/protobuf-encode-gen-expression.rs
@@ -20,7 +20,7 @@ use cedar_drt_inner::fuzz_target;
 use cedar_drt_inner::props::expression_to_cedar_parses;
 
 use cedar_policy::Expression;
-use cedar_policy::proto::traits::Protobuf;
+use cedar_policy::proto::traits::{EncodeError, Protobuf};
 
 use cedar_policy_generators::schema_gen::SchemaGen;
 use cedar_policy_generators::{hierarchy::HierarchyGenerator, schema, settings::ABACSettings};
@@ -66,7 +66,11 @@ impl<'a> Arbitrary<'a> for FuzzTargetInput {
 // between their conditions. If we really wanted to test equality here, we'd need equality for
 // standalone expressions.
 fuzz_target!(|input: FuzzTargetInput| {
-    let buf = input.expression.encode();
+    let buf = match input.expression.encode() {
+        Ok(buf) => buf,
+        Err(EncodeError::MaxDepthExceeded) => return,
+        Err(e) => panic!("only error expected encoding Expression is MaxDepthExceeded, got {e}"),
+    };
     let decoded =
         Expression::decode(&buf[..]).expect("Failed to decode an Expression that was just encoded");
     expression_to_cedar_parses(decoded);

--- a/cedar-drt/fuzz/fuzz_targets/protobuf-encode/protobuf-encode-gen-expression.rs
+++ b/cedar-drt/fuzz/fuzz_targets/protobuf-encode/protobuf-encode-gen-expression.rs
@@ -17,7 +17,7 @@
 #![no_main]
 
 use cedar_drt_inner::fuzz_target;
-use cedar_drt_inner::props::expression_to_cedar_parses;
+use cedar_drt_inner::props::expression_protobuf_decodes;
 
 use cedar_policy::Expression;
 use cedar_policy::proto::traits::{EncodeError, Protobuf};
@@ -71,7 +71,5 @@ fuzz_target!(|input: FuzzTargetInput| {
         Err(EncodeError::MaxDepthExceeded) => return,
         Err(e) => panic!("only error expected encoding Expression is MaxDepthExceeded, got {e}"),
     };
-    let decoded =
-        Expression::decode(&buf[..]).expect("Failed to decode an Expression that was just encoded");
-    expression_to_cedar_parses(decoded);
+    expression_protobuf_decodes(&buf[..]);
 });

--- a/cedar-drt/fuzz/fuzz_targets/protobuf-encode/protobuf-encode-gen-expression.rs
+++ b/cedar-drt/fuzz/fuzz_targets/protobuf-encode/protobuf-encode-gen-expression.rs
@@ -1,0 +1,73 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#![no_main]
+
+use cedar_drt_inner::fuzz_target;
+use cedar_drt_inner::props::expression_to_cedar_parses;
+
+use cedar_policy::Expression;
+use cedar_policy::proto::traits::Protobuf;
+
+use cedar_policy_generators::schema_gen::SchemaGen;
+use cedar_policy_generators::{hierarchy::HierarchyGenerator, schema, settings::ABACSettings};
+use libfuzzer_sys::arbitrary::{self, Arbitrary, Unstructured};
+
+#[derive(Debug, Clone)]
+struct FuzzTargetInput {
+    expression: Expression,
+}
+
+const SETTINGS: ABACSettings = ABACSettings {
+    enable_arbitrary_func_call: false,
+    ..ABACSettings::undirected()
+};
+
+impl<'a> Arbitrary<'a> for FuzzTargetInput {
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        let schema: schema::Schema = schema::Schema::arbitrary(SETTINGS.clone(), u)?;
+        let hierarchy = schema.arbitrary_hierarchy(u)?;
+        let mut expr_gen = schema.exprgenerator(Some(&hierarchy));
+        let expr = expr_gen.generate_expr(SETTINGS.max_depth, u)?;
+        Ok(Self {
+            expression: Expression::from(expr),
+        })
+    }
+
+    fn try_size_hint(
+        depth: usize,
+    ) -> Result<(usize, Option<usize>), arbitrary::MaxRecursionReached> {
+        Ok(arbitrary::size_hint::and_all(&[
+            schema::Schema::arbitrary_size_hint(depth)?,
+            HierarchyGenerator::size_hint(depth),
+        ]))
+    }
+}
+
+// Generate an Expression using the ABAC generators, then encode to protobuf.
+// Property: encoding a well-formed Expression must not panic, and decoding
+// the result must succeed and produce an Expression that prints to Cedar and re-parses.
+//
+// This only tests parsing the encoded-decoded expression because Expression isn't PartialEq.
+// The template and policyset targets already to test equality of policies, which tests equality
+// between their conditions. If we really wanted to test equality here, we'd need equality for
+// standalone expressions.
+fuzz_target!(|input: FuzzTargetInput| {
+    let buf = input.expression.encode();
+    let decoded =
+        Expression::decode(&buf[..]).expect("Failed to decode an Expression that was just encoded");
+    expression_to_cedar_parses(decoded);
+});

--- a/cedar-drt/fuzz/fuzz_targets/protobuf-encode/protobuf-encode-gen-policyset.rs
+++ b/cedar-drt/fuzz/fuzz_targets/protobuf-encode/protobuf-encode-gen-policyset.rs
@@ -19,7 +19,7 @@
 use cedar_drt_inner::fuzz_target;
 
 use cedar_policy::PolicySet;
-use cedar_policy::proto::traits::Protobuf;
+use cedar_policy::proto::traits::{EncodeError, Protobuf};
 
 use cedar_policy_generators::schema_gen::SchemaGen;
 use cedar_policy_generators::{
@@ -61,8 +61,11 @@ impl<'a> Arbitrary<'a> for FuzzTargetInput {
 // the result must produce an equivalent PolicySet.
 fuzz_target!(|input: FuzzTargetInput| {
     let policy_set = input.policy.into_policy_set();
-
-    let buf = policy_set.encode();
+    let buf = match policy_set.encode() {
+        Ok(buf) => buf,
+        Err(EncodeError::MaxDepthExceeded) => return,
+        Err(e) => panic!("only error expected encoding PolicySet is MaxDepthExceeded, got {e}"),
+    };
     let decoded =
         PolicySet::decode(&buf[..]).expect("Failed to decode a PolicySet that was just encoded");
     assert_eq!(policy_set, decoded);

--- a/cedar-drt/fuzz/fuzz_targets/protobuf-encode/protobuf-encode-gen-policyset.rs
+++ b/cedar-drt/fuzz/fuzz_targets/protobuf-encode/protobuf-encode-gen-policyset.rs
@@ -17,8 +17,8 @@
 #![no_main]
 
 use cedar_drt_inner::fuzz_target;
+use cedar_drt_inner::props::policyset_protobuf_decodes;
 
-use cedar_policy::PolicySet;
 use cedar_policy::proto::traits::{EncodeError, Protobuf};
 
 use cedar_policy_generators::schema_gen::SchemaGen;
@@ -66,7 +66,5 @@ fuzz_target!(|input: FuzzTargetInput| {
         Err(EncodeError::MaxDepthExceeded) => return,
         Err(e) => panic!("only error expected encoding PolicySet is MaxDepthExceeded, got {e}"),
     };
-    let decoded =
-        PolicySet::decode(&buf[..]).expect("Failed to decode a PolicySet that was just encoded");
-    assert_eq!(policy_set, decoded);
+    policyset_protobuf_decodes(&buf[..], &policy_set);
 });

--- a/cedar-drt/fuzz/fuzz_targets/protobuf-encode/protobuf-encode-gen-policyset.rs
+++ b/cedar-drt/fuzz/fuzz_targets/protobuf-encode/protobuf-encode-gen-policyset.rs
@@ -1,0 +1,69 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#![no_main]
+
+use cedar_drt_inner::fuzz_target;
+
+use cedar_policy::PolicySet;
+use cedar_policy::proto::traits::Protobuf;
+
+use cedar_policy_generators::schema_gen::SchemaGen;
+use cedar_policy_generators::{
+    abac::ABACPolicy, hierarchy::HierarchyGenerator, schema, settings::ABACSettings,
+};
+use libfuzzer_sys::arbitrary::{self, Arbitrary, Unstructured};
+
+#[derive(Debug, Clone)]
+struct FuzzTargetInput {
+    policy: ABACPolicy,
+}
+
+const SETTINGS: ABACSettings = ABACSettings {
+    enable_arbitrary_func_call: false,
+    ..ABACSettings::undirected()
+};
+
+impl<'a> Arbitrary<'a> for FuzzTargetInput {
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        let schema: schema::Schema = schema::Schema::arbitrary(SETTINGS.clone(), u)?;
+        let hierarchy = schema.arbitrary_hierarchy(u)?;
+        let policy = schema.arbitrary_policy(&hierarchy, u)?;
+        Ok(Self { policy })
+    }
+
+    fn try_size_hint(
+        depth: usize,
+    ) -> Result<(usize, Option<usize>), arbitrary::MaxRecursionReached> {
+        Ok(arbitrary::size_hint::and_all(&[
+            schema::Schema::arbitrary_size_hint(depth)?,
+            HierarchyGenerator::size_hint(depth),
+            schema::Schema::arbitrary_policy_size_hint(&SETTINGS, depth),
+        ]))
+    }
+}
+
+// Generate a PolicySet using the ABAC generators, then encode to protobuf.
+// Property: encoding a well-formed PolicySet must not panic, and decoding
+// the result must produce an equivalent PolicySet.
+fuzz_target!(|input: FuzzTargetInput| {
+    let policy_set = input.policy.into_policy_set();
+
+    let buf = policy_set.encode();
+    let decoded =
+        PolicySet::decode(&buf[..]).expect("Failed to decode a PolicySet that was just encoded");
+    assert_eq!(policy_set, decoded);
+});

--- a/cedar-drt/fuzz/fuzz_targets/protobuf-encode/protobuf-encode-gen-request.rs
+++ b/cedar-drt/fuzz/fuzz_targets/protobuf-encode/protobuf-encode-gen-request.rs
@@ -1,0 +1,68 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#![no_main]
+
+use cedar_drt_inner::fuzz_target;
+
+use cedar_policy::Request;
+use cedar_policy::proto::traits::Protobuf;
+
+use cedar_policy_generators::schema_gen::SchemaGen;
+use cedar_policy_generators::{
+    abac::ABACRequest, hierarchy::HierarchyGenerator, schema, settings::ABACSettings,
+};
+use libfuzzer_sys::arbitrary::{self, Arbitrary, Unstructured};
+
+#[derive(Debug, Clone)]
+struct FuzzTargetInput {
+    request: Request,
+}
+
+const SETTINGS: ABACSettings = ABACSettings {
+    enable_arbitrary_func_call: false,
+    ..ABACSettings::undirected()
+};
+
+impl<'a> Arbitrary<'a> for FuzzTargetInput {
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        let schema: schema::Schema = schema::Schema::arbitrary(SETTINGS.clone(), u)?;
+        let hierarchy = schema.arbitrary_hierarchy(u)?;
+        let request: ABACRequest = schema.arbitrary_request(&hierarchy, u)?;
+        Ok(Self {
+            request: Request::from(request),
+        })
+    }
+
+    fn try_size_hint(
+        depth: usize,
+    ) -> Result<(usize, Option<usize>), arbitrary::MaxRecursionReached> {
+        Ok(arbitrary::size_hint::and_all(&[
+            schema::Schema::arbitrary_size_hint(depth)?,
+            HierarchyGenerator::size_hint(depth),
+        ]))
+    }
+}
+
+// Generate a Request using the ABAC generators, then encode to protobuf.
+// Property: encoding a well-formed Request must not panic, and decoding
+// the result must produce an equivalent Request.
+fuzz_target!(|input: FuzzTargetInput| {
+    let buf = input.request.encode();
+    let decoded =
+        Request::decode(&buf[..]).expect("Failed to decode a Request that was just encoded");
+    assert_eq!(input.request, decoded);
+});

--- a/cedar-drt/fuzz/fuzz_targets/protobuf-encode/protobuf-encode-gen-request.rs
+++ b/cedar-drt/fuzz/fuzz_targets/protobuf-encode/protobuf-encode-gen-request.rs
@@ -17,6 +17,7 @@
 #![no_main]
 
 use cedar_drt_inner::fuzz_target;
+use cedar_drt_inner::props::request_protobuf_decodes;
 
 use cedar_policy::Request;
 use cedar_policy::proto::traits::{EncodeError, Protobuf};
@@ -66,7 +67,5 @@ fuzz_target!(|input: FuzzTargetInput| {
         Err(EncodeError::MaxDepthExceeded) => return,
         Err(e) => panic!("only error expected encoding Request is MaxDepthExceeded, got {e}"),
     };
-    let decoded =
-        Request::decode(&buf[..]).expect("Failed to decode a Request that was just encoded");
-    assert_eq!(input.request, decoded);
+    request_protobuf_decodes(&buf[..], &input.request);
 });

--- a/cedar-drt/fuzz/fuzz_targets/protobuf-encode/protobuf-encode-gen-request.rs
+++ b/cedar-drt/fuzz/fuzz_targets/protobuf-encode/protobuf-encode-gen-request.rs
@@ -19,7 +19,7 @@
 use cedar_drt_inner::fuzz_target;
 
 use cedar_policy::Request;
-use cedar_policy::proto::traits::Protobuf;
+use cedar_policy::proto::traits::{EncodeError, Protobuf};
 
 use cedar_policy_generators::schema_gen::SchemaGen;
 use cedar_policy_generators::{
@@ -61,7 +61,11 @@ impl<'a> Arbitrary<'a> for FuzzTargetInput {
 // Property: encoding a well-formed Request must not panic, and decoding
 // the result must produce an equivalent Request.
 fuzz_target!(|input: FuzzTargetInput| {
-    let buf = input.request.encode();
+    let buf = match input.request.encode() {
+        Ok(buf) => buf,
+        Err(EncodeError::MaxDepthExceeded) => return,
+        Err(e) => panic!("only error expected encoding Request is MaxDepthExceeded, got {e}"),
+    };
     let decoded =
         Request::decode(&buf[..]).expect("Failed to decode a Request that was just encoded");
     assert_eq!(input.request, decoded);

--- a/cedar-drt/fuzz/fuzz_targets/protobuf-encode/protobuf-encode-gen-schema.rs
+++ b/cedar-drt/fuzz/fuzz_targets/protobuf-encode/protobuf-encode-gen-schema.rs
@@ -1,0 +1,62 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#![no_main]
+
+use cedar_drt_inner::fuzz_target;
+use cedar_drt_inner::schemas::Equiv;
+
+use cedar_policy::Schema;
+use cedar_policy::proto::traits::Protobuf;
+
+use cedar_policy_generators::{schema, settings::ABACSettings};
+use libfuzzer_sys::arbitrary::{self, Arbitrary, Unstructured};
+
+#[derive(Debug, Clone)]
+struct FuzzTargetInput {
+    schema: Schema,
+}
+
+const SETTINGS: ABACSettings = ABACSettings {
+    enable_arbitrary_func_call: false,
+    ..ABACSettings::undirected()
+};
+
+impl<'a> Arbitrary<'a> for FuzzTargetInput {
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        let schema: schema::Schema = schema::Schema::arbitrary(SETTINGS.clone(), u)?;
+        let schema = schema
+            .try_into()
+            .expect("Failed to convert schema to ValidatorSchema");
+        Ok(Self { schema })
+    }
+
+    fn try_size_hint(
+        depth: usize,
+    ) -> Result<(usize, Option<usize>), arbitrary::MaxRecursionReached> {
+        schema::Schema::arbitrary_size_hint(depth)
+    }
+}
+
+// Generate a Schema using the ABAC generators, then encode to protobuf.
+// Property: encoding a well-formed Schema must not panic, and decoding
+// the result must produce an equivalent Schema.
+fuzz_target!(|input: FuzzTargetInput| {
+    let buf = input.schema.encode();
+    let decoded =
+        Schema::decode(&buf[..]).expect("Failed to decode a Schema that was just encoded");
+    Equiv::equiv(input.schema.as_ref(), decoded.as_ref()).unwrap();
+});

--- a/cedar-drt/fuzz/fuzz_targets/protobuf-encode/protobuf-encode-gen-schema.rs
+++ b/cedar-drt/fuzz/fuzz_targets/protobuf-encode/protobuf-encode-gen-schema.rs
@@ -20,7 +20,7 @@ use cedar_drt_inner::fuzz_target;
 use cedar_drt_inner::schemas::Equiv;
 
 use cedar_policy::Schema;
-use cedar_policy::proto::traits::Protobuf;
+use cedar_policy::proto::traits::{EncodeError, Protobuf};
 
 use cedar_policy_generators::{schema, settings::ABACSettings};
 use libfuzzer_sys::arbitrary::{self, Arbitrary, Unstructured};
@@ -55,7 +55,11 @@ impl<'a> Arbitrary<'a> for FuzzTargetInput {
 // Property: encoding a well-formed Schema must not panic, and decoding
 // the result must produce an equivalent Schema.
 fuzz_target!(|input: FuzzTargetInput| {
-    let buf = input.schema.encode();
+    let buf = match input.schema.encode() {
+        Ok(buf) => buf,
+        Err(EncodeError::MaxDepthExceeded) => return,
+        Err(e) => panic!("only error expected encoding Schema is MaxDepthExceeded, got {e}"),
+    };
     let decoded =
         Schema::decode(&buf[..]).expect("Failed to decode a Schema that was just encoded");
     Equiv::equiv(input.schema.as_ref(), decoded.as_ref()).unwrap();

--- a/cedar-drt/fuzz/fuzz_targets/protobuf-encode/protobuf-encode-gen-schema.rs
+++ b/cedar-drt/fuzz/fuzz_targets/protobuf-encode/protobuf-encode-gen-schema.rs
@@ -17,7 +17,7 @@
 #![no_main]
 
 use cedar_drt_inner::fuzz_target;
-use cedar_drt_inner::schemas::Equiv;
+use cedar_drt_inner::props::schema_protobuf_decodes;
 
 use cedar_policy::Schema;
 use cedar_policy::proto::traits::{EncodeError, Protobuf};
@@ -60,7 +60,5 @@ fuzz_target!(|input: FuzzTargetInput| {
         Err(EncodeError::MaxDepthExceeded) => return,
         Err(e) => panic!("only error expected encoding Schema is MaxDepthExceeded, got {e}"),
     };
-    let decoded =
-        Schema::decode(&buf[..]).expect("Failed to decode a Schema that was just encoded");
-    Equiv::equiv(input.schema.as_ref(), decoded.as_ref()).unwrap();
+    schema_protobuf_decodes(&buf[..], &input.schema);
 });

--- a/cedar-drt/fuzz/fuzz_targets/protobuf-encode/protobuf-encode-gen-template.rs
+++ b/cedar-drt/fuzz/fuzz_targets/protobuf-encode/protobuf-encode-gen-template.rs
@@ -1,0 +1,66 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#![no_main]
+
+use cedar_drt_inner::fuzz_target;
+
+use cedar_policy::Template;
+use cedar_policy::proto::traits::Protobuf;
+
+use cedar_policy_generators::schema_gen::SchemaGen;
+use cedar_policy_generators::{hierarchy::HierarchyGenerator, schema, settings::ABACSettings};
+use libfuzzer_sys::arbitrary::{self, Arbitrary, Unstructured};
+
+#[derive(Debug, Clone)]
+struct FuzzTargetInput {
+    template: Template,
+}
+
+const SETTINGS: ABACSettings = ABACSettings {
+    enable_arbitrary_func_call: false,
+    ..ABACSettings::undirected()
+};
+
+impl<'a> Arbitrary<'a> for FuzzTargetInput {
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        let schema: schema::Schema = schema::Schema::arbitrary(SETTINGS.clone(), u)?;
+        let hierarchy = schema.arbitrary_hierarchy(u)?;
+        let generated_template = schema.arbitrary_template(&hierarchy, true, u)?;
+        Ok(Self {
+            template: cedar_policy::Template::from(generated_template),
+        })
+    }
+
+    fn try_size_hint(
+        depth: usize,
+    ) -> Result<(usize, Option<usize>), arbitrary::MaxRecursionReached> {
+        Ok(arbitrary::size_hint::and_all(&[
+            schema::Schema::arbitrary_size_hint(depth)?,
+            HierarchyGenerator::size_hint(depth),
+        ]))
+    }
+}
+
+// Generate a Template using the ABAC generators, then encode to protobuf.
+// Property: encoding a well-formed Template must not panic, and decoding
+// the result must produce an equivalent Template.
+fuzz_target!(|input: FuzzTargetInput| {
+    let buf = input.template.encode();
+    let decoded =
+        Template::decode(&buf[..]).expect("Failed to decode a Template that was just encoded");
+    assert_eq!(input.template, decoded);
+});

--- a/cedar-drt/fuzz/fuzz_targets/protobuf-encode/protobuf-encode-gen-template.rs
+++ b/cedar-drt/fuzz/fuzz_targets/protobuf-encode/protobuf-encode-gen-template.rs
@@ -19,7 +19,7 @@
 use cedar_drt_inner::fuzz_target;
 
 use cedar_policy::Template;
-use cedar_policy::proto::traits::Protobuf;
+use cedar_policy::proto::traits::{EncodeError, Protobuf};
 
 use cedar_policy_generators::schema_gen::SchemaGen;
 use cedar_policy_generators::{hierarchy::HierarchyGenerator, schema, settings::ABACSettings};
@@ -59,7 +59,11 @@ impl<'a> Arbitrary<'a> for FuzzTargetInput {
 // Property: encoding a well-formed Template must not panic, and decoding
 // the result must produce an equivalent Template.
 fuzz_target!(|input: FuzzTargetInput| {
-    let buf = input.template.encode();
+    let buf = match input.template.encode() {
+        Ok(buf) => buf,
+        Err(EncodeError::MaxDepthExceeded) => return,
+        Err(e) => panic!("only error expected encoding Template is MaxDepthExceeded, got {e}"),
+    };
     let decoded =
         Template::decode(&buf[..]).expect("Failed to decode a Template that was just encoded");
     assert_eq!(input.template, decoded);

--- a/cedar-drt/fuzz/fuzz_targets/protobuf-encode/protobuf-encode-gen-template.rs
+++ b/cedar-drt/fuzz/fuzz_targets/protobuf-encode/protobuf-encode-gen-template.rs
@@ -17,6 +17,7 @@
 #![no_main]
 
 use cedar_drt_inner::fuzz_target;
+use cedar_drt_inner::props::template_protobuf_decodes;
 
 use cedar_policy::Template;
 use cedar_policy::proto::traits::{EncodeError, Protobuf};
@@ -64,7 +65,5 @@ fuzz_target!(|input: FuzzTargetInput| {
         Err(EncodeError::MaxDepthExceeded) => return,
         Err(e) => panic!("only error expected encoding Template is MaxDepthExceeded, got {e}"),
     };
-    let decoded =
-        Template::decode(&buf[..]).expect("Failed to decode a Template that was just encoded");
-    assert_eq!(input.template, decoded);
+    template_protobuf_decodes(&buf[..], &input.template);
 });

--- a/cedar-drt/fuzz/src/props.rs
+++ b/cedar-drt/fuzz/src/props.rs
@@ -17,6 +17,8 @@
 //! This module contains properties that API-level entities should satisfy.
 
 use crate::roundtrip_entities::pretty_assert_entities_deep_eq;
+use crate::schemas::Equiv;
+use cedar_policy::proto::traits::{DecodeError, Protobuf};
 use cedar_policy::{
     Entities, Entity, Expression, Policy, PolicySet, Request, RestrictedExpression, Schema,
     Template,
@@ -177,4 +179,95 @@ pub fn schema_to_cedar_parses(schema: &Schema) -> Schema {
             panic!("Cedar schema text failed to re-parse.\nText: {cedar_text}\nError: {e}")
         })
         .0
+}
+
+/// Decode an [`Entity`] from a protobuf-encoded buffer and assert it equals the original.
+/// Conversion errors are expected (input has not been validated), but other decode errors
+/// indicate a bug.
+pub fn entity_protobuf_decodes(buf: &[u8], original: &Entity) {
+    match Entity::decode(buf) {
+        Ok(decoded) => assert_eq!(*original, decoded),
+        // we expect conversion errors here: the entity has not been validated first, we only
+        // test that the protobuf decoding part works, not the conversion
+        Err(DecodeError::Conversion(_)) => (),
+        Err(e) => panic!("failed to decode an entity that was just encoded: {e}"),
+    }
+}
+
+/// Decode [`Entities`] from a protobuf-encoded buffer and assert they equal the original.
+/// Conversion errors are expected (input has not been validated), but other decode errors
+/// indicate a bug.
+pub fn entities_protobuf_decodes(buf: &[u8], original: &Entities) {
+    match Entities::decode(buf) {
+        Ok(decoded) => pretty_assert_entities_deep_eq(original, &decoded),
+        // we expect conversion errors here: the entities have not been validated first, we only
+        // test that the protobuf decoding part works, not the conversion
+        Err(DecodeError::Conversion(_)) => (),
+        Err(e) => panic!("failed to decode entities that were just encoded: {e}"),
+    }
+}
+
+/// Decode an [`Expression`] from a protobuf-encoded buffer and check it parses back to Cedar.
+/// Conversion errors are expected (input has not been validated), but other decode errors
+/// indicate a bug.
+pub fn expression_protobuf_decodes(buf: &[u8]) {
+    match Expression::decode(buf) {
+        Ok(decoded) => expression_to_cedar_parses(decoded),
+        // we expect conversion errors here: the expression has not been validated first, we only
+        // test that the protobuf decoding part works, not the conversion
+        Err(DecodeError::Conversion(_)) => (),
+        Err(e) => panic!("failed to decode an expression that was just encoded: {e}"),
+    }
+}
+
+/// Decode a [`PolicySet`] from a protobuf-encoded buffer and assert it equals the original.
+/// Conversion errors are expected (input has not been validated), but other decode errors
+/// indicate a bug.
+pub fn policyset_protobuf_decodes(buf: &[u8], original: &PolicySet) {
+    match PolicySet::decode(buf) {
+        Ok(decoded) => assert_eq!(*original, decoded),
+        // we expect conversion errors here: the policy set has not been validated first, we only
+        // test that the protobuf decoding part works, not the conversion
+        Err(DecodeError::Conversion(_)) => (),
+        Err(e) => panic!("failed to decode a policy set that was just encoded: {e}"),
+    }
+}
+
+/// Decode a [`Request`] from a protobuf-encoded buffer and assert it equals the original.
+/// Conversion errors are expected (input has not been validated), but other decode errors
+/// indicate a bug.
+pub fn request_protobuf_decodes(buf: &[u8], original: &Request) {
+    match Request::decode(buf) {
+        Ok(decoded) => assert_eq!(*original, decoded),
+        // we expect conversion errors here: the request has not been validated first, we only
+        // test that the protobuf decoding part works, not the conversion
+        Err(DecodeError::Conversion(_)) => (),
+        Err(e) => panic!("failed to decode a request that was just encoded: {e}"),
+    }
+}
+
+/// Decode a [`Schema`] from a protobuf-encoded buffer and assert it is equivalent to the original.
+/// Conversion errors are expected (input has not been validated), but other decode errors
+/// indicate a bug.
+pub fn schema_protobuf_decodes(buf: &[u8], original: &Schema) {
+    match Schema::decode(buf) {
+        Ok(decoded) => Equiv::equiv(original.as_ref(), decoded.as_ref()).unwrap(),
+        // we expect conversion errors here: the schema has not been validated first, we only
+        // test that the protobuf decoding part works, not the conversion
+        Err(DecodeError::Conversion(_)) => (),
+        Err(e) => panic!("failed to decode a schema that was just encoded: {e}"),
+    }
+}
+
+/// Decode a [`Template`] from a protobuf-encoded buffer and assert it equals the original.
+/// Conversion errors are expected (input has not been validated), but other decode errors
+/// indicate a bug.
+pub fn template_protobuf_decodes(buf: &[u8], original: &Template) {
+    match Template::decode(buf) {
+        Ok(decoded) => assert_eq!(*original, decoded),
+        // we expect conversion errors here: the template has not been validated first, we only
+        // test that the protobuf decoding part works, not the conversion
+        Err(DecodeError::Conversion(_)) => (),
+        Err(e) => panic!("failed to decode a template that was just encoded: {e}"),
+    }
 }


### PR DESCRIPTION
Adds target testing the `encode` part of the protobuf implementation.

This won't build until https://github.com/cedar-policy/cedar/pull/2479 is merged.




