### PR TITLE
Update cedar spec dep versions

### DIFF
--- a/cedar-benchmarking/Cargo.toml
+++ b/cedar-benchmarking/Cargo.toml
@@ -60,8 +60,8 @@ cedar-policy-generators = { version = "4", path = "../cedar-policy-generators", 
 ] }
 clap = { version = "4", features = ["derive"] }
 miette = { version = "7.6.0", features = ["fancy"] }
-rand = "0.9"
+rand = "0.10.2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-sysinfo = "0.33"
+sysinfo = "0.39.6"
 owo-colors = "4"

--- a/cedar-benchmarking/src/request.rs
+++ b/cedar-benchmarking/src/request.rs
@@ -19,7 +19,7 @@ use cedar_policy::Request;
 use cedar_policy_core::ast;
 use cedar_policy_core::validator::{json_schema::Fragment, RawName};
 use cedar_policy_generators::{hierarchy::Hierarchy, settings::ABACSettings};
-use rand::{rngs::StdRng, Rng, SeedableRng};
+use rand::{rngs::StdRng, RngExt, SeedableRng};
 
 struct RandomBytes {
     bytes: Vec<u8>,

--- a/cedar-drt/Cargo.toml
+++ b/cedar-drt/Cargo.toml
@@ -16,7 +16,7 @@ env_logger = "0.11"
 log = "0.4"
 miette = "7.1.0"
 serde_json = "1.0.140"
-similar-asserts = "1.5.0"
+similar-asserts = "2.0.0"
 smol_str = { version = "0.3", features = ["serde"] }
 indexmap = { version = "2.12.0", features = ["serde"] }
 
@@ -27,7 +27,7 @@ overflow-checks = true
 integration-testing = []
 
 [dev-dependencies]
-statrs = "0.18"
+statrs = "0.19.0"
 
 [patch.crates-io]
 cedar-policy = { path = "../cedar/cedar-policy" }

--- a/cedar-drt/fuzz/Cargo.toml
+++ b/cedar-drt/fuzz/Cargo.toml
@@ -25,16 +25,16 @@ cedar-policy-generators = { path = "../../cedar-policy-generators", version = "4
 ] }
 log = "0.4"
 logos = "0.16.0"
-itertools = "0.14.0"
+itertools = "0.15.0"
 miette = "7.1.0"
 prost = "0.14"
-rand = { version = "0.9", features = ["small_rng"] }
+rand = "0.10.2"
 ref-cast = "1.0"
 regex = "1"
 serde = "1.0"
 serde_json = { version = "1.0", features = ["unbounded_depth"] }
 serde_stacker = "0.1"
-similar-asserts = "1.5.0"
+similar-asserts = "2.0.0"
 smol_str = { version = "0.3", features = ["serde"] }
 thiserror = "2.0"
 uuid = { version = "1.3.1", features = ["v4", "fast-rng"] }

--- a/cedar-drt/fuzz/fuzz_targets/formatter.rs
+++ b/cedar-drt/fuzz/fuzz_targets/formatter.rs
@@ -34,7 +34,7 @@ use libfuzzer_sys::arbitrary::{self, Arbitrary, Unstructured};
 use log::debug;
 use logos::Logos;
 use rand::rngs::SmallRng;
-use rand::{Rng, SeedableRng};
+use rand::{RngExt, SeedableRng};
 use similar_asserts::SimpleDiff;
 use std::sync::Arc;
 use uuid::Builder;

--- a/cedar-lean-cli/Cargo.toml
+++ b/cedar-lean-cli/Cargo.toml
@@ -9,7 +9,7 @@ cedar-policy = { version = "*", path = "../cedar/cedar-policy" }
 cedar-policy-core = { version = "*", path = "../cedar/cedar-policy-core" }
 cedar-lean-ffi = { version = "*", path = "../cedar-lean-ffi" }
 clap = { version = "4.5.36", features = ["derive"] }
-itertools = "0.14"
+itertools = "0.15.0"
 miette = "7.6.0"
 nonempty = "0.12"
 prettytable-rs = "0.10"
@@ -19,7 +19,7 @@ thiserror = "2.0"
 
 [dev-dependencies]
 assert_cmd = "2.0.17"
-insta = { version = "~1.46", features = ["filters"] }
+insta = { version = "1.48.0", features = ["filters"] }
 
 # https://insta.rs/docs/quickstart/ recommends compiling `insta` and `similar` in release mode
 [profile.dev.package]

--- a/cedar-lean-ffi/Cargo.toml
+++ b/cedar-lean-ffi/Cargo.toml
@@ -20,12 +20,12 @@ thiserror = "2.0"
 prost = "0.14"
 miette = "7.6.0"
 smol_str = "0.3.2"
-num-bigint = "0.4.6"
+num-bigint = "0.5.1"
 nonempty = "0.12.0"
 
 [build-dependencies]
 prost-build = "0.14"
-cargo_metadata = "0.20.0"
+cargo_metadata = "0.23.1"
 
 [dev-dependencies]
 cool_asserts = "2.0.3"

--- a/cedar-policy-generators/Cargo.toml
+++ b/cedar-policy-generators/Cargo.toml
@@ -12,7 +12,7 @@ clap = { version = "4.3.16", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0" }
 smol_str = { version = "0.3", features = ["serde", "arbitrary"] }
-rand = "0.9.1"
+rand = "0.10.2"
 anyhow = "1.0.72"
 serde_with = "3.4.0"
 thiserror = "2.0"

--- a/cedar-policy-generators/src/abac.rs
+++ b/cedar-policy-generators/src/abac.rs
@@ -957,7 +957,7 @@ mod tests {
         evaluator::Evaluator,
         extensions::Extensions,
     };
-    use rand::{rngs::StdRng, RngCore, SeedableRng};
+    use rand::{rngs::StdRng, Rng, SeedableRng};
     use smol_str::SmolStr;
 
     use super::ConstantPool;

--- a/cedar-policy-generators/src/schema.rs
+++ b/cedar-policy-generators/src/schema.rs
@@ -1921,7 +1921,7 @@ mod tests {
     use cedar_policy_core::entities::Entities;
     use cedar_policy_core::extensions::Extensions;
     use cedar_policy_core::validator::{json_schema, CoreSchema, RawName, ValidatorSchema};
-    use rand::{rng, rngs::ThreadRng, RngCore};
+    use rand::{rng, rngs::ThreadRng, Rng};
 
     const RANDOM_BYTE_SIZE: u16 = 1024;
     const ITERATION: u8 = 100;


### PR DESCRIPTION
Updates cedar-spec crates to some new major versions of dependencies. Fixes build error introduced by `num-bigint` update in https://github.com/cedar-policy/cedar/pull/2477


