### PR TITLE
Update symcc opt path to use pre-compiled schema

### DIFF
--- a/cedar-lean/Cedar/SymCCOpt/CompiledPolicies.lean
+++ b/cedar-lean/Cedar/SymCCOpt/CompiledPolicies.lean
@@ -21,6 +21,7 @@ public import Cedar.Spec
 public import Cedar.SymCC
 public import Cedar.SymCCOpt.Authorizer
 public import Cedar.SymCCOpt.Compiler
+public import Cedar.SymCCOpt.CompiledSchema
 public import Cedar.Validation.Validator
 
 @[expose] public section -- TODO: make the public interface more granular/intentional, instead of having everything public and exposed
@@ -63,9 +64,10 @@ This function calls the Cedar typechecker to obtain a policy `p'` that is
 semantically equivalent to `p` and well-typed with respect to `Γ`.
 Then, it runs the symbolic compiler to produce a compiled policy.
 -/
-def CompiledPolicy.compile (p : Policy) (Γ : Validation.TypeEnv) : Except CompiledPolicyError CompiledPolicy := do
+def CompiledPolicy.compile (p : Policy) (s : CompiledSchema) (reqty : Validation.RequestType) : Except CompiledPolicyError CompiledPolicy := do
+  let Γ := s.typeEnv reqty
   let policy ← wellTypedPolicy p Γ |>.mapError .validationError
-  let εnv := SymEnv.ofEnv Γ
+  let εnv := s.symEnv reqty
   let { term, footprint } ← Opt.compile policy.toExpr εnv |>.mapError .symCCError
   let acyclicity := footprint.map (SymCC.acyclicity · εnv.entities)
   .ok { term, εnv, policy, footprint, acyclicity }
@@ -94,9 +96,10 @@ This function calls the Cedar typechecker on each `p ∈ ps` to obtain a policy 
 that is semantically equivalent to `p` and well-typed with respect to `Γ`.
 Then, it runs the symbolic compiler to produce a compiled policy.
 -/
-def CompiledPolicySet.compile (ps : Policies) (Γ : Validation.TypeEnv) : Except CompiledPolicyError CompiledPolicySet := do
+def CompiledPolicySet.compile (ps : Policies) (s : CompiledSchema) (reqty : Validation.RequestType) : Except CompiledPolicyError CompiledPolicySet := do
+  let Γ := s.typeEnv reqty
   let policies ← wellTypedPolicies ps Γ |>.mapError .validationError
-  let εnv := SymEnv.ofEnv Γ
+  let εnv := s.symEnv reqty
   let { term, footprint } ← Opt.isAuthorized policies εnv |>.mapError .symCCError
   let acyclicity := footprint.map (SymCC.acyclicity · εnv.entities)
   .ok { term, εnv, policies, footprint, acyclicity }

--- a/cedar-lean/Cedar/SymCCOpt/CompiledSchema.lean
+++ b/cedar-lean/Cedar/SymCCOpt/CompiledSchema.lean
@@ -1,0 +1,46 @@
+/-
+ Copyright Cedar Contributors
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-/
+
+module
+
+public import Cedar.Validation.Types
+public import Cedar.SymCC.Env
+
+namespace Cedar.SymCC
+
+open Cedar.Validation
+open Cedar.Spec
+
+/--
+Represents a schema compiled into a symbolic representation of its entity types,
+stored together with the original schema. Building `SymEntities` is expensive
+but only depends on the schema (and not specific request type), so this
+structure avoids repeating that work on multiple solver queriers using the same
+schema.
+-/
+public structure CompiledSchema where
+  schema : Schema
+  entities : SymEntities
+deriving Repr, Inhabited
+
+public def CompiledSchema.compile (schema : Schema) : CompiledSchema :=
+  ⟨ schema, SymEntities.ofSchema schema.ets schema.acts ⟩
+
+public def CompiledSchema.symEnv (schema : CompiledSchema) (reqty : RequestType) : SymEnv :=
+  ⟨ SymRequest.ofRequestType reqty, schema.entities ⟩
+
+public def CompiledSchema.typeEnv (schema : CompiledSchema) (reqty : RequestType) : TypeEnv :=
+  ⟨ schema.schema.ets, schema.schema.acts, reqty ⟩

--- a/cedar-lean/Cedar/Thm/SymCC/Opt.lean
+++ b/cedar-lean/Cedar/Thm/SymCC/Opt.lean
@@ -36,6 +36,21 @@ namespace Cedar.Thm
 open Cedar.Spec Cedar.SymCC
 
 /--
+The schema obtained by compiling `⟨Γ.ets, Γ.acts⟩` produces exactly the type
+environment `Γ` for request type `Γ.reqty`. Used to bridge `CompiledPolicy.compile`
+(which now takes a `CompiledSchema` and `RequestType`) with the `Γ`-based theorems.
+-/
+@[local simp] private theorem compile_schema_typeEnv {Γ : Validation.TypeEnv} :
+  (CompiledSchema.compile ⟨Γ.ets, Γ.acts⟩).typeEnv Γ.reqty = Γ := rfl
+
+/--
+The schema obtained by compiling `⟨Γ.ets, Γ.acts⟩` produces exactly the symbolic
+environment `SymEnv.ofTypeEnv Γ` for request type `Γ.reqty`.
+-/
+@[local simp] private theorem compile_schema_symEnv {Γ : Validation.TypeEnv} :
+  (CompiledSchema.compile ⟨Γ.ets, Γ.acts⟩).symEnv Γ.reqty = SymEnv.ofTypeEnv Γ := rfl
+
+/--
 If `SymCC.satisfiedPolicies` fails, that must be because `SymCC.compile` failed
 with that error on some policy
 -/
@@ -75,7 +90,7 @@ Note: `Γ.WellFormed` is technically only required for the reverse direction
 -/
 theorem compile_ok_iff_welltypedpolicy_ok {p : Policy} {Γ : Validation.TypeEnv} :
   Γ.WellFormed → (
-  Except.isOk (CompiledPolicy.compile p Γ) ↔
+  Except.isOk (CompiledPolicy.compile p (CompiledSchema.compile ⟨Γ.ets, Γ.acts⟩) Γ.reqty) ↔
   Except.isOk (wellTypedPolicy p Γ)
   )
 := by
@@ -96,7 +111,7 @@ Note: `Γ.WellFormed` is technically only required for the reverse direction
 -/
 theorem compile_ok_iff_welltypedpolicies_ok {ps : Policies} {Γ : Validation.TypeEnv} :
   Γ.WellFormed → (
-  Except.isOk (CompiledPolicySet.compile ps Γ) ↔
+  Except.isOk (CompiledPolicySet.compile ps (CompiledSchema.compile ⟨Γ.ets, Γ.acts⟩) Γ.reqty) ↔
   Except.isOk (wellTypedPolicies ps Γ)
   )
 := by
@@ -127,7 +142,7 @@ Note: Can be proved without `Γ.WellFormed`
 -/
 theorem compile_ok_then_exists_wtp {p : Policy} {cp : CompiledPolicy} {Γ : Validation.TypeEnv} :
   Γ.WellFormed →
-  CompiledPolicy.compile p Γ = .ok cp →
+  CompiledPolicy.compile p (CompiledSchema.compile ⟨Γ.ets, Γ.acts⟩) Γ.reqty = .ok cp →
   ∃ wp, wellTypedPolicy p Γ = .ok wp
 := by
   intro hwf h₀
@@ -145,7 +160,7 @@ Note: Can be proved without `Γ.WellFormed`
 -/
 theorem compile_ok_then_exists_wtps {ps : Policies} {cpset : CompiledPolicySet} {Γ : Validation.TypeEnv} :
   Γ.WellFormed →
-  CompiledPolicySet.compile ps Γ = .ok cpset →
+  CompiledPolicySet.compile ps (CompiledSchema.compile ⟨Γ.ets, Γ.acts⟩) Γ.reqty = .ok cpset →
   ∃ wps, wellTypedPolicies ps Γ = .ok wps
 := by
   intro hwf h₀
@@ -164,7 +179,7 @@ compilation with `CompiledPolicy.compile` succeeds, then `satAsserts?` and
 theorem cp_satAssertsOpt?_eqv_satAsserts?_ok {ps wps : Policies} {cps : List CompiledPolicy} {Γ : Validation.TypeEnv} :
   ps.length = cps.length →
   cps ≠ [] →
-  ps.mapM (CompiledPolicy.compile · Γ) = .ok cps →
+  ps.mapM (CompiledPolicy.compile · (CompiledSchema.compile ⟨Γ.ets, Γ.acts⟩) Γ.reqty) = .ok cps →
   ps.mapM (wellTypedPolicy · Γ) = .ok wps →
   satAsserts? wps asserts (SymEnv.ofTypeEnv Γ) = satAssertsOpt? (cps.map CompiledPolicies.policy) asserts
 := by
@@ -221,14 +236,14 @@ theorem cp_satAssertsOpt?_eqv_satAsserts?_ok {ps wps : Policies} {cps : List Com
       simp [CompiledPolicies.εnv, hεnv, hεnv' cp' hcp']
   · intro cps' hcps'
     cases hcps'
-    · exists p, Γ
+    · exists p, CompiledSchema.compile ⟨Γ.ets, Γ.acts⟩, Γ.reqty
     · rename_i hcps'
       change cps' ∈ cps.map CompiledPolicies.policy at hcps'
       simp only [List.mem_map] at hcps'
       replace ⟨cp', hcp', hcps'⟩ := hcps' ; subst cps'
       simp only
       replace ⟨p', hp', hcps⟩ := List.mapM_ok_implies_all_from_ok hcps cp' hcp'
-      exists p', Γ
+      exists p', CompiledSchema.compile ⟨Γ.ets, Γ.acts⟩, Γ.reqty
 
 /--
 This theorem covers the "happy path" -- showing that if optimized policy
@@ -238,7 +253,7 @@ compilation with `CompiledPolicySet.compile` succeeds, then `satAsserts?` and
 theorem cpset_satAssertsOpt?_eqv_satAsserts?_ok {pss wpss : List Policies} {cpsets : List CompiledPolicySet} {Γ : Validation.TypeEnv} :
   pss.length = cpsets.length →
   cpsets ≠ [] →
-  pss.mapM (CompiledPolicySet.compile · Γ) = .ok cpsets →
+  pss.mapM (CompiledPolicySet.compile · (CompiledSchema.compile ⟨Γ.ets, Γ.acts⟩) Γ.reqty) = .ok cpsets →
   pss.mapM (wellTypedPolicies · Γ) = .ok wpss →
   satAsserts? wpss.flatten asserts (SymEnv.ofTypeEnv Γ) = satAssertsOpt? (cpsets.map CompiledPolicies.pset) asserts
 := by
@@ -298,13 +313,13 @@ theorem cpset_satAssertsOpt?_eqv_satAsserts?_ok {pss wpss : List Policies} {cpse
       simp [CompiledPolicies.εnv, hεnv, hεnv' cpset' hcpset']
   · intro cps hcps
     cases hcps
-    · exists ps, Γ
+    · exists ps, CompiledSchema.compile ⟨Γ.ets, Γ.acts⟩, Γ.reqty
     · rename_i hcps
       change cps ∈ cpsets.map CompiledPolicies.pset at hcps
       simp only [List.mem_map] at hcps
       replace ⟨cpset', hcpset', hcps⟩ := hcps ; subst cps
       replace ⟨ps', hps', hcpsets⟩ := List.mapM_ok_implies_all_from_ok hcpsets cpset' hcpset'
-      exists ps', Γ
+      exists ps', CompiledSchema.compile ⟨Γ.ets, Γ.acts⟩, Γ.reqty
 
 /--
 This theorem covers the "happy path" -- showing that if optimized policy
@@ -313,7 +328,7 @@ compilation succeeds, then `wellTypedPolicy` succeeds and `neverErrors?` and
 -/
 theorem neverErrorsOpt?_eqv_neverErrors?_ok {p : Policy} {cp : CompiledPolicy} {Γ : Validation.TypeEnv} :
   Γ.WellFormed →
-  CompiledPolicy.compile p Γ = .ok cp →
+  CompiledPolicy.compile p (CompiledSchema.compile ⟨Γ.ets, Γ.acts⟩) Γ.reqty = .ok cp →
   ∃ wp,
     wellTypedPolicy p Γ = .ok wp ∧
     neverErrorsOpt? cp = neverErrors? wp (SymEnv.ofTypeEnv Γ)
@@ -339,7 +354,7 @@ compilation succeeds, then `wellTypedPolicy` succeeds and `alwaysMatches?` and
 -/
 theorem alwaysMatchesOpt?_eqv_alwaysMatches?_ok {p : Policy} {cp : CompiledPolicy} {Γ : Validation.TypeEnv} :
   Γ.WellFormed →
-  CompiledPolicy.compile p Γ = .ok cp →
+  CompiledPolicy.compile p (CompiledSchema.compile ⟨Γ.ets, Γ.acts⟩) Γ.reqty = .ok cp →
   ∃ wp,
     wellTypedPolicy p Γ = .ok wp ∧
     alwaysMatchesOpt? cp = alwaysMatches? wp (SymEnv.ofTypeEnv Γ)
@@ -365,7 +380,7 @@ compilation succeeds, then `wellTypedPolicy` succeeds and `neverMatches?` and
 -/
 theorem neverMatchesOpt?_eqv_neverMatches?_ok {p : Policy} {cp : CompiledPolicy} {Γ : Validation.TypeEnv} :
   Γ.WellFormed →
-  CompiledPolicy.compile p Γ = .ok cp →
+  CompiledPolicy.compile p (CompiledSchema.compile ⟨Γ.ets, Γ.acts⟩) Γ.reqty = .ok cp →
   ∃ wp,
     wellTypedPolicy p Γ = .ok wp ∧
     neverMatchesOpt? cp = neverMatches? wp (SymEnv.ofTypeEnv Γ)
@@ -391,8 +406,8 @@ compilation succeeds, then `wellTypedPolicy` succeeds and `matchesEquivalent?` a
 -/
 theorem matchesEquivalentOpt?_eqv_matchesEquivalent?_ok {p₁ p₂ wp₁ wp₂ : Policy} {cp₁ cp₂ : CompiledPolicy} {Γ : Validation.TypeEnv} :
   Γ.WellFormed →
-  CompiledPolicy.compile p₁ Γ = .ok cp₁ →
-  CompiledPolicy.compile p₂ Γ = .ok cp₂ →
+  CompiledPolicy.compile p₁ (CompiledSchema.compile ⟨Γ.ets, Γ.acts⟩) Γ.reqty = .ok cp₁ →
+  CompiledPolicy.compile p₂ (CompiledSchema.compile ⟨Γ.ets, Γ.acts⟩) Γ.reqty = .ok cp₂ →
   wellTypedPolicy p₁ Γ = .ok wp₁ →
   wellTypedPolicy p₂ Γ = .ok wp₂ →
   matchesEquivalentOpt? cp₁ cp₂ = matchesEquivalent? wp₁ wp₂ (SymEnv.ofTypeEnv Γ)
@@ -416,8 +431,8 @@ compilation succeeds, then `wellTypedPolicy` succeeds and `matchesImplies?` and
 -/
 theorem matchesImpliesOpt?_eqv_matchesImplies?_ok {p₁ p₂ wp₁ wp₂ : Policy} {cp₁ cp₂ : CompiledPolicy} {Γ : Validation.TypeEnv} :
   Γ.WellFormed →
-  CompiledPolicy.compile p₁ Γ = .ok cp₁ →
-  CompiledPolicy.compile p₂ Γ = .ok cp₂ →
+  CompiledPolicy.compile p₁ (CompiledSchema.compile ⟨Γ.ets, Γ.acts⟩) Γ.reqty = .ok cp₁ →
+  CompiledPolicy.compile p₂ (CompiledSchema.compile ⟨Γ.ets, Γ.acts⟩) Γ.reqty = .ok cp₂ →
   wellTypedPolicy p₁ Γ = .ok wp₁ →
   wellTypedPolicy p₂ Γ = .ok wp₂ →
   matchesImpliesOpt? cp₁ cp₂ = matchesImplies? wp₁ wp₂ (SymEnv.ofTypeEnv Γ)
@@ -441,8 +456,8 @@ compilation succeeds, then `wellTypedPolicy` succeeds and `matchesDisjoint?` and
 -/
 theorem matchesDisjointOpt?_eqv_matchesDisjoint?_ok {p₁ p₂ wp₁ wp₂ : Policy} {cp₁ cp₂ : CompiledPolicy} {Γ : Validation.TypeEnv} :
   Γ.WellFormed →
-  CompiledPolicy.compile p₁ Γ = .ok cp₁ →
-  CompiledPolicy.compile p₂ Γ = .ok cp₂ →
+  CompiledPolicy.compile p₁ (CompiledSchema.compile ⟨Γ.ets, Γ.acts⟩) Γ.reqty = .ok cp₁ →
+  CompiledPolicy.compile p₂ (CompiledSchema.compile ⟨Γ.ets, Γ.acts⟩) Γ.reqty = .ok cp₂ →
   wellTypedPolicy p₁ Γ = .ok wp₁ →
   wellTypedPolicy p₂ Γ = .ok wp₂ →
   matchesDisjointOpt? cp₁ cp₂ = matchesDisjoint? wp₁ wp₂ (SymEnv.ofTypeEnv Γ)
@@ -466,7 +481,8 @@ Full equivalence for `neverErrors?` and `neverErrorsOpt?`, including both the
 theorem neverErrorsOpt?_eqv_neverErrors? {p : Policy} {Γ : Validation.TypeEnv} :
   Γ.WellFormed →
   (do
-    let cp ← CompiledPolicy.compile p Γ
+    let s := CompiledSchema.compile ⟨Γ.ets, Γ.acts⟩
+    let cp ← CompiledPolicy.compile p s Γ.reqty
     pure $ neverErrorsOpt? cp
   ) =
   (do
@@ -474,13 +490,13 @@ theorem neverErrorsOpt?_eqv_neverErrors? {p : Policy} {Γ : Validation.TypeEnv} 
     pure $ neverErrors? wp (SymEnv.ofTypeEnv Γ)
   )
 := by
-  cases hcp : CompiledPolicy.compile p Γ
+  cases hcp : CompiledPolicy.compile p (CompiledSchema.compile ⟨Γ.ets, Γ.acts⟩) Γ.reqty
   case ok cp =>
     intro hwf
     have ⟨wp, hwp, h⟩ := neverErrorsOpt?_eqv_neverErrors?_ok hwf hcp
-    simp [Except.mapError, hwp, h]
+    simp [Except.mapError, hcp, hwp, h]
   case error e =>
-    simp [Except.mapError]
+    simp [Except.mapError, hcp]
     cases hwp : wellTypedPolicy p Γ
     case error e' =>
       simp [CompiledPolicy.compile, Except.mapError, hwp] at hcp
@@ -497,7 +513,8 @@ Full equivalence for `alwaysMatches?` and `alwaysMatchesOpt?`, including both th
 theorem alwaysMatchesOpt?_eqv_alwaysMatches? {p : Policy} {Γ : Validation.TypeEnv} :
   Γ.WellFormed →
   (do
-    let cp ← CompiledPolicy.compile p Γ
+    let s := CompiledSchema.compile ⟨Γ.ets, Γ.acts⟩
+    let cp ← CompiledPolicy.compile p s Γ.reqty
     pure $ alwaysMatchesOpt? cp
   ) =
   (do
@@ -505,13 +522,13 @@ theorem alwaysMatchesOpt?_eqv_alwaysMatches? {p : Policy} {Γ : Validation.TypeE
     pure $ alwaysMatches? wp (SymEnv.ofTypeEnv Γ)
   )
 := by
-  cases hcp : CompiledPolicy.compile p Γ
+  cases hcp : CompiledPolicy.compile p (CompiledSchema.compile ⟨Γ.ets, Γ.acts⟩) Γ.reqty
   case ok cp =>
     intro hwf
     have ⟨wp, hwp, h⟩ := alwaysMatchesOpt?_eqv_alwaysMatches?_ok hwf hcp
-    simp [Except.mapError, hwp, h]
+    simp [Except.mapError, hcp, hwp, h]
   case error e =>
-    simp [Except.mapError]
+    simp [Except.mapError, hcp]
     cases hwp : wellTypedPolicy p Γ
     case error e' =>
       simp [CompiledPolicy.compile, Except.mapError, hwp] at hcp
@@ -528,7 +545,8 @@ Full equivalence for `neverMatches?` and `neverMatchesOpt?`, including both the
 theorem neverMatchesOpt?_eqv_neverMatches? {p : Policy} {Γ : Validation.TypeEnv} :
   Γ.WellFormed →
   (do
-    let cp ← CompiledPolicy.compile p Γ
+    let s := CompiledSchema.compile ⟨Γ.ets, Γ.acts⟩
+    let cp ← CompiledPolicy.compile p s Γ.reqty
     pure $ neverMatchesOpt? cp
   ) =
   (do
@@ -536,13 +554,13 @@ theorem neverMatchesOpt?_eqv_neverMatches? {p : Policy} {Γ : Validation.TypeEnv
     pure $ neverMatches? wp (SymEnv.ofTypeEnv Γ)
   )
 := by
-  cases hcp : CompiledPolicy.compile p Γ
+  cases hcp : CompiledPolicy.compile p (CompiledSchema.compile ⟨Γ.ets, Γ.acts⟩) Γ.reqty
   case ok cp =>
     intro hwf
     have ⟨wp, hwp, h⟩ := neverMatchesOpt?_eqv_neverMatches?_ok hwf hcp
-    simp [Except.mapError, hwp, h]
+    simp [Except.mapError, hcp, hwp, h]
   case error e =>
-    simp [Except.mapError]
+    simp [Except.mapError, hcp]
     cases hwp : wellTypedPolicy p Γ
     case error e' =>
       simp [CompiledPolicy.compile, Except.mapError, hwp] at hcp
@@ -559,8 +577,9 @@ Full equivalence for `matchesEquivalent?` and `matchesEquivalentOpt?`, including
 theorem matchesEquivalentOpt?_eqv_matchesEquivalent? {p₁ p₂ : Policy} {Γ : Validation.TypeEnv} :
   Γ.WellFormed →
   (do
-    let cp₁ ← CompiledPolicy.compile p₁ Γ
-    let cp₂ ← CompiledPolicy.compile p₂ Γ
+    let s := CompiledSchema.compile ⟨Γ.ets, Γ.acts⟩
+    let cp₁ ← CompiledPolicy.compile p₁ s Γ.reqty
+    let cp₂ ← CompiledPolicy.compile p₂ s Γ.reqty
     pure $ matchesEquivalentOpt? cp₁ cp₂
   ) =
   (do
@@ -572,8 +591,8 @@ theorem matchesEquivalentOpt?_eqv_matchesEquivalent? {p₁ p₂ : Policy} {Γ : 
   intro hwf
   have h₁ := compile_ok_iff_welltypedpolicy_ok hwf (p := p₁)
   have h₂ := compile_ok_iff_welltypedpolicy_ok hwf (p := p₂)
-  cases hcp₁ : CompiledPolicy.compile p₁ Γ
-  <;> cases hcp₂ : CompiledPolicy.compile p₂ Γ
+  cases hcp₁ : CompiledPolicy.compile p₁ (CompiledSchema.compile ⟨Γ.ets, Γ.acts⟩) Γ.reqty
+  <;> cases hcp₂ : CompiledPolicy.compile p₂ (CompiledSchema.compile ⟨Γ.ets, Γ.acts⟩) Γ.reqty
   <;> cases hwp₁ : wellTypedPolicy p₁ Γ
   <;> cases hwp₂ : wellTypedPolicy p₂ Γ
   -- this eliminates all the cases where the behavior of CompiledPolicy.compile is inconsistent
@@ -595,8 +614,9 @@ Full equivalence for `matchesImplies?` and `matchesImpliesOpt?`, including both 
 theorem matchesImpliesOpt?_eqv_matchesImplies? {p₁ p₂ : Policy} {Γ : Validation.TypeEnv} :
   Γ.WellFormed →
   (do
-    let cp₁ ← CompiledPolicy.compile p₁ Γ
-    let cp₂ ← CompiledPolicy.compile p₂ Γ
+    let s := CompiledSchema.compile ⟨Γ.ets, Γ.acts⟩
+    let cp₁ ← CompiledPolicy.compile p₁ s Γ.reqty
+    let cp₂ ← CompiledPolicy.compile p₂ s Γ.reqty
     pure $ matchesImpliesOpt? cp₁ cp₂
   ) =
   (do
@@ -608,8 +628,8 @@ theorem matchesImpliesOpt?_eqv_matchesImplies? {p₁ p₂ : Policy} {Γ : Valida
   intro hwf
   have h₁ := compile_ok_iff_welltypedpolicy_ok hwf (p := p₁)
   have h₂ := compile_ok_iff_welltypedpolicy_ok hwf (p := p₂)
-  cases hcp₁ : CompiledPolicy.compile p₁ Γ
-  <;> cases hcp₂ : CompiledPolicy.compile p₂ Γ
+  cases hcp₁ : CompiledPolicy.compile p₁ (CompiledSchema.compile ⟨Γ.ets, Γ.acts⟩) Γ.reqty
+  <;> cases hcp₂ : CompiledPolicy.compile p₂ (CompiledSchema.compile ⟨Γ.ets, Γ.acts⟩) Γ.reqty
   <;> cases hwp₁ : wellTypedPolicy p₁ Γ
   <;> cases hwp₂ : wellTypedPolicy p₂ Γ
   -- this eliminates all the cases where the behavior of CompiledPolicy.compile is inconsistent
@@ -631,8 +651,9 @@ Full equivalence for `matchesDisjoint?` and `matchesDisjointOpt?`, including bot
 theorem matchesDisjointOpt?_eqv_matchesDisjoint? {p₁ p₂ : Policy} {Γ : Validation.TypeEnv} :
   Γ.WellFormed →
   (do
-    let cp₁ ← CompiledPolicy.compile p₁ Γ
-    let cp₂ ← CompiledPolicy.compile p₂ Γ
+    let s := CompiledSchema.compile ⟨Γ.ets, Γ.acts⟩
+    let cp₁ ← CompiledPolicy.compile p₁ s Γ.reqty
+    let cp₂ ← CompiledPolicy.compile p₂ s Γ.reqty
     pure $ matchesDisjointOpt? cp₁ cp₂
   ) =
   (do
@@ -644,8 +665,8 @@ theorem matchesDisjointOpt?_eqv_matchesDisjoint? {p₁ p₂ : Policy} {Γ : Vali
   intro hwf
   have h₁ := compile_ok_iff_welltypedpolicy_ok hwf (p := p₁)
   have h₂ := compile_ok_iff_welltypedpolicy_ok hwf (p := p₂)
-  cases hcp₁ : CompiledPolicy.compile p₁ Γ
-  <;> cases hcp₂ : CompiledPolicy.compile p₂ Γ
+  cases hcp₁ : CompiledPolicy.compile p₁ (CompiledSchema.compile ⟨Γ.ets, Γ.acts⟩) Γ.reqty
+  <;> cases hcp₂ : CompiledPolicy.compile p₂ (CompiledSchema.compile ⟨Γ.ets, Γ.acts⟩) Γ.reqty
   <;> cases hwp₁ : wellTypedPolicy p₁ Γ
   <;> cases hwp₂ : wellTypedPolicy p₂ Γ
   -- this eliminates all the cases where the behavior of CompiledPolicy.compile is inconsistent
@@ -667,8 +688,8 @@ compilation succeeds, then `wellTypedPolicies` succeeds and `implies?` and
 -/
 theorem impliesOpt?_eqv_implies?_ok {ps₁ ps₂ : Policies} {cpset₁ cpset₂ : CompiledPolicySet} {Γ : Validation.TypeEnv} :
   Γ.WellFormed →
-  CompiledPolicySet.compile ps₁ Γ = .ok cpset₁ →
-  CompiledPolicySet.compile ps₂ Γ = .ok cpset₂ →
+  CompiledPolicySet.compile ps₁ (CompiledSchema.compile ⟨Γ.ets, Γ.acts⟩) Γ.reqty = .ok cpset₁ →
+  CompiledPolicySet.compile ps₂ (CompiledSchema.compile ⟨Γ.ets, Γ.acts⟩) Γ.reqty = .ok cpset₂ →
   ∃ wps₁ wps₂,
     wellTypedPolicies ps₁ Γ = .ok wps₁ ∧
     wellTypedPolicies ps₂ Γ = .ok wps₂ ∧
@@ -699,8 +720,9 @@ Full equivalence for `implies?` and `impliesOpt?`, including both the
 theorem impliesOpt?_eqv_implies? {ps₁ ps₂ : Policies} {Γ : Validation.TypeEnv} :
   Γ.WellFormed →
   (do
-    let cpset₁ ← CompiledPolicySet.compile ps₁ Γ
-    let cpset₂ ← CompiledPolicySet.compile ps₂ Γ
+    let s := CompiledSchema.compile ⟨Γ.ets, Γ.acts⟩
+    let cpset₁ ← CompiledPolicySet.compile ps₁ s Γ.reqty
+    let cpset₂ ← CompiledPolicySet.compile ps₂ s Γ.reqty
     pure $ impliesOpt? cpset₁ cpset₂
   ) =
   (do
@@ -712,8 +734,8 @@ theorem impliesOpt?_eqv_implies? {ps₁ ps₂ : Policies} {Γ : Validation.TypeE
   intro hwf
   have h₁ := compile_ok_iff_welltypedpolicies_ok hwf (ps := ps₁)
   have h₂ := compile_ok_iff_welltypedpolicies_ok hwf (ps := ps₂)
-  cases hcpset₁ : CompiledPolicySet.compile ps₁ Γ
-  <;> cases hcpset₂ : CompiledPolicySet.compile ps₂ Γ
+  cases hcpset₁ : CompiledPolicySet.compile ps₁ (CompiledSchema.compile ⟨Γ.ets, Γ.acts⟩) Γ.reqty
+  <;> cases hcpset₂ : CompiledPolicySet.compile ps₂ (CompiledSchema.compile ⟨Γ.ets, Γ.acts⟩) Γ.reqty
   <;> cases hwps₁ : wellTypedPolicies ps₁ Γ
   <;> cases hwps₂ : wellTypedPolicies ps₂ Γ
   -- this eliminates all the cases where the behavior of CompiledPolicySet.compile is inconsistent
@@ -736,7 +758,7 @@ compilation succeeds, then `wellTypedPolicies` succeeds and `alwaysAllows?` and
 -/
 theorem alwaysAllowsOpt?_eqv_alwaysAllows?_ok {ps : Policies} {cpset : CompiledPolicySet} {Γ : Validation.TypeEnv} :
   Γ.WellFormed →
-  CompiledPolicySet.compile ps Γ = .ok cpset →
+  CompiledPolicySet.compile ps (CompiledSchema.compile ⟨Γ.ets, Γ.acts⟩) Γ.reqty = .ok cpset →
   ∃ wps,
     wellTypedPolicies ps Γ = .ok wps ∧
     alwaysAllowsOpt? cpset = alwaysAllows? wps (SymEnv.ofTypeEnv Γ)
@@ -764,7 +786,8 @@ Full equivalence for `alwaysAllows?` and `alwaysAllowsOpt?`, including both the
 theorem alwaysAllowsOpt?_eqv_alwaysAllows? {ps : Policies} {Γ : Validation.TypeEnv} :
   Γ.WellFormed →
   (do
-    let cpset ← CompiledPolicySet.compile ps Γ
+    let s := CompiledSchema.compile ⟨Γ.ets, Γ.acts⟩
+    let cpset ← CompiledPolicySet.compile ps s Γ.reqty
     pure $ alwaysAllowsOpt? cpset
   ) =
   (do
@@ -774,7 +797,7 @@ theorem alwaysAllowsOpt?_eqv_alwaysAllows? {ps : Policies} {Γ : Validation.Type
 := by
   intro hwf
   have h₁ := compile_ok_iff_welltypedpolicies_ok hwf (ps := ps)
-  cases hcpset : CompiledPolicySet.compile ps Γ
+  cases hcpset : CompiledPolicySet.compile ps (CompiledSchema.compile ⟨Γ.ets, Γ.acts⟩) Γ.reqty
   <;> cases hwps : wellTypedPolicies ps Γ
   -- this eliminates all the cases where the behavior of CompiledPolicySet.compile is inconsistent
   -- with the behavior of wellTypedPolicies on the same policyset
@@ -793,7 +816,7 @@ compilation succeeds, then `wellTypedPolicies` succeeds and `alwaysDenies?` and
 -/
 theorem alwaysDeniesOpt?_eqv_alwaysDenies?_ok {ps : Policies} {cpset : CompiledPolicySet} {Γ : Validation.TypeEnv} :
   Γ.WellFormed →
-  CompiledPolicySet.compile ps Γ = .ok cpset →
+  CompiledPolicySet.compile ps (CompiledSchema.compile ⟨Γ.ets, Γ.acts⟩) Γ.reqty = .ok cpset →
   ∃ wps,
     wellTypedPolicies ps Γ = .ok wps ∧
     alwaysDeniesOpt? cpset = alwaysDenies? wps (SymEnv.ofTypeEnv Γ)
@@ -821,7 +844,8 @@ Full equivalence for `alwaysDenies?` and `alwaysDeniesOpt?`, including both the
 theorem alwaysDeniesOpt?_eqv_alwaysDenies? {ps : Policies} {Γ : Validation.TypeEnv} :
   Γ.WellFormed →
   (do
-    let cpset ← CompiledPolicySet.compile ps Γ
+    let s := CompiledSchema.compile ⟨Γ.ets, Γ.acts⟩
+    let cpset ← CompiledPolicySet.compile ps s Γ.reqty
     pure $ alwaysDeniesOpt? cpset
   ) =
   (do
@@ -831,7 +855,7 @@ theorem alwaysDeniesOpt?_eqv_alwaysDenies? {ps : Policies} {Γ : Validation.Type
 := by
   intro hwf
   have h₁ := compile_ok_iff_welltypedpolicies_ok hwf (ps := ps)
-  cases hcpset : CompiledPolicySet.compile ps Γ
+  cases hcpset : CompiledPolicySet.compile ps (CompiledSchema.compile ⟨Γ.ets, Γ.acts⟩) Γ.reqty
   <;> cases hwps : wellTypedPolicies ps Γ
   -- this eliminates all the cases where the behavior of CompiledPolicySet.compile is inconsistent
   -- with the behavior of wellTypedPolicies on the same policyset
@@ -850,8 +874,8 @@ compilation succeeds, then `wellTypedPolicies` succeeds and `equivalent?` and
 -/
 theorem equivalentOpt?_eqv_equivalent?_ok {ps₁ ps₂ : Policies} {cpset₁ cpset₂ : CompiledPolicySet} {Γ : Validation.TypeEnv} :
   Γ.WellFormed →
-  CompiledPolicySet.compile ps₁ Γ = .ok cpset₁ →
-  CompiledPolicySet.compile ps₂ Γ = .ok cpset₂ →
+  CompiledPolicySet.compile ps₁ (CompiledSchema.compile ⟨Γ.ets, Γ.acts⟩) Γ.reqty = .ok cpset₁ →
+  CompiledPolicySet.compile ps₂ (CompiledSchema.compile ⟨Γ.ets, Γ.acts⟩) Γ.reqty = .ok cpset₂ →
   ∃ wps₁ wps₂,
     wellTypedPolicies ps₁ Γ = .ok wps₁ ∧
     wellTypedPolicies ps₂ Γ = .ok wps₂ ∧
@@ -882,8 +906,9 @@ Full equivalence for `equivalent?` and `equivalentOpt?`, including both the
 theorem equivalentOpt?_eqv_equivalent? {ps₁ ps₂ : Policies} {Γ : Validation.TypeEnv} :
   Γ.WellFormed →
   (do
-    let cpset₁ ← CompiledPolicySet.compile ps₁ Γ
-    let cpset₂ ← CompiledPolicySet.compile ps₂ Γ
+    let s := CompiledSchema.compile ⟨Γ.ets, Γ.acts⟩
+    let cpset₁ ← CompiledPolicySet.compile ps₁ s Γ.reqty
+    let cpset₂ ← CompiledPolicySet.compile ps₂ s Γ.reqty
     pure $ equivalentOpt? cpset₁ cpset₂
   ) =
   (do
@@ -895,8 +920,8 @@ theorem equivalentOpt?_eqv_equivalent? {ps₁ ps₂ : Policies} {Γ : Validation
   intro hwf
   have h₁ := compile_ok_iff_welltypedpolicies_ok hwf (ps := ps₁)
   have h₂ := compile_ok_iff_welltypedpolicies_ok hwf (ps := ps₂)
-  cases hcpset₁ : CompiledPolicySet.compile ps₁ Γ
-  <;> cases hcpset₂ : CompiledPolicySet.compile ps₂ Γ
+  cases hcpset₁ : CompiledPolicySet.compile ps₁ (CompiledSchema.compile ⟨Γ.ets, Γ.acts⟩) Γ.reqty
+  <;> cases hcpset₂ : CompiledPolicySet.compile ps₂ (CompiledSchema.compile ⟨Γ.ets, Γ.acts⟩) Γ.reqty
   <;> cases hwps₁ : wellTypedPolicies ps₁ Γ
   <;> cases hwps₂ : wellTypedPolicies ps₂ Γ
   -- this eliminates all the cases where the behavior of CompiledPolicySet.compile is inconsistent
@@ -919,8 +944,8 @@ compilation succeeds, then `wellTypedPolicies` succeeds and `disjoint?` and
 -/
 theorem disjointOpt?_eqv_disjoint?_ok {ps₁ ps₂ : Policies} {cpset₁ cpset₂ : CompiledPolicySet} {Γ : Validation.TypeEnv} :
   Γ.WellFormed →
-  CompiledPolicySet.compile ps₁ Γ = .ok cpset₁ →
-  CompiledPolicySet.compile ps₂ Γ = .ok cpset₂ →
+  CompiledPolicySet.compile ps₁ (CompiledSchema.compile ⟨Γ.ets, Γ.acts⟩) Γ.reqty = .ok cpset₁ →
+  CompiledPolicySet.compile ps₂ (CompiledSchema.compile ⟨Γ.ets, Γ.acts⟩) Γ.reqty = .ok cpset₂ →
   ∃ wps₁ wps₂,
     wellTypedPolicies ps₁ Γ = .ok wps₁ ∧
     wellTypedPolicies ps₂ Γ = .ok wps₂ ∧
@@ -951,8 +976,9 @@ Full equivalence for `disjoint?` and `disjointOpt?`, including both the
 theorem disjointOpt?_eqv_disjoint? {ps₁ ps₂ : Policies} {Γ : Validation.TypeEnv} :
   Γ.WellFormed →
   (do
-    let cpset₁ ← CompiledPolicySet.compile ps₁ Γ
-    let cpset₂ ← CompiledPolicySet.compile ps₂ Γ
+    let s := CompiledSchema.compile ⟨Γ.ets, Γ.acts⟩
+    let cpset₁ ← CompiledPolicySet.compile ps₁ s Γ.reqty
+    let cpset₂ ← CompiledPolicySet.compile ps₂ s Γ.reqty
     pure $ disjointOpt? cpset₁ cpset₂
   ) =
   (do
@@ -964,8 +990,8 @@ theorem disjointOpt?_eqv_disjoint? {ps₁ ps₂ : Policies} {Γ : Validation.Typ
   intro hwf
   have h₁ := compile_ok_iff_welltypedpolicies_ok hwf (ps := ps₁)
   have h₂ := compile_ok_iff_welltypedpolicies_ok hwf (ps := ps₂)
-  cases hcpset₁ : CompiledPolicySet.compile ps₁ Γ
-  <;> cases hcpset₂ : CompiledPolicySet.compile ps₂ Γ
+  cases hcpset₁ : CompiledPolicySet.compile ps₁ (CompiledSchema.compile ⟨Γ.ets, Γ.acts⟩) Γ.reqty
+  <;> cases hcpset₂ : CompiledPolicySet.compile ps₂ (CompiledSchema.compile ⟨Γ.ets, Γ.acts⟩) Γ.reqty
   <;> cases hwps₁ : wellTypedPolicies ps₁ Γ
   <;> cases hwps₂ : wellTypedPolicies ps₂ Γ
   -- this eliminates all the cases where the behavior of CompiledPolicySet.compile is inconsistent
@@ -988,7 +1014,7 @@ compilation succeeds, then `wellTypedPolicies` succeeds and `checkNeverErrors` a
 -/
 theorem checkNeverErrorsOpt_eqv_checkNeverErrors_ok {p : Policy} {cp : CompiledPolicy} {Γ : Validation.TypeEnv} :
   Γ.WellFormed →
-  CompiledPolicy.compile p Γ = .ok cp →
+  CompiledPolicy.compile p (CompiledSchema.compile ⟨Γ.ets, Γ.acts⟩) Γ.reqty = .ok cp →
   ∃ wp,
     wellTypedPolicy p Γ = .ok wp ∧
     checkNeverErrorsOpt cp = checkNeverErrors wp (SymEnv.ofTypeEnv Γ)
@@ -1012,7 +1038,7 @@ compilation succeeds, then `wellTypedPolicy` succeeds and `checkAlwaysMatches` a
 -/
 theorem checkAlwaysMatchesOpt_eqv_checkAlwaysMatches_ok {p : Policy} {cp : CompiledPolicy} {Γ : Validation.TypeEnv} :
   Γ.WellFormed →
-  CompiledPolicy.compile p Γ = .ok cp →
+  CompiledPolicy.compile p (CompiledSchema.compile ⟨Γ.ets, Γ.acts⟩) Γ.reqty = .ok cp →
   ∃ wp,
     wellTypedPolicy p Γ = .ok wp ∧
     checkAlwaysMatchesOpt cp = checkAlwaysMatches wp (SymEnv.ofTypeEnv Γ)
@@ -1036,7 +1062,7 @@ compilation succeeds, then `wellTypedPolicy` succeeds and `checkNeverMatches` an
 -/
 theorem checkNeverMatchesOpt_eqv_checkNeverMatches_ok {p : Policy} {cp : CompiledPolicy} {Γ : Validation.TypeEnv} :
   Γ.WellFormed →
-  CompiledPolicy.compile p Γ = .ok cp →
+  CompiledPolicy.compile p (CompiledSchema.compile ⟨Γ.ets, Γ.acts⟩) Γ.reqty = .ok cp →
   ∃ wp,
     wellTypedPolicy p Γ = .ok wp ∧
     checkNeverMatchesOpt cp = checkNeverMatches wp (SymEnv.ofTypeEnv Γ)
@@ -1060,8 +1086,8 @@ compilation succeeds, then `wellTypedPolicy` succeeds and `checkMatchesEquivalen
 -/
 theorem checkMatchesEquivalentOpt_eqv_checkMatchesEquivalent_ok {p₁ p₂ wp₁ wp₂ : Policy} {cp₁ cp₂ : CompiledPolicy} {Γ : Validation.TypeEnv} :
   Γ.WellFormed →
-  CompiledPolicy.compile p₁ Γ = .ok cp₁ →
-  CompiledPolicy.compile p₂ Γ = .ok cp₂ →
+  CompiledPolicy.compile p₁ (CompiledSchema.compile ⟨Γ.ets, Γ.acts⟩) Γ.reqty = .ok cp₁ →
+  CompiledPolicy.compile p₂ (CompiledSchema.compile ⟨Γ.ets, Γ.acts⟩) Γ.reqty = .ok cp₂ →
   wellTypedPolicy p₁ Γ = .ok wp₁ →
   wellTypedPolicy p₂ Γ = .ok wp₂ →
   checkMatchesEquivalentOpt cp₁ cp₂ = checkMatchesEquivalent wp₁ wp₂ (SymEnv.ofTypeEnv Γ)
@@ -1083,8 +1109,8 @@ compilation succeeds, then `wellTypedPolicy` succeeds and `checkMatchesImplies` 
 -/
 theorem checkMatchesImpliesOpt_eqv_checkMatchesImplies_ok {p₁ p₂ wp₁ wp₂ : Policy} {cp₁ cp₂ : CompiledPolicy} {Γ : Validation.TypeEnv} :
   Γ.WellFormed →
-  CompiledPolicy.compile p₁ Γ = .ok cp₁ →
-  CompiledPolicy.compile p₂ Γ = .ok cp₂ →
+  CompiledPolicy.compile p₁ (CompiledSchema.compile ⟨Γ.ets, Γ.acts⟩) Γ.reqty = .ok cp₁ →
+  CompiledPolicy.compile p₂ (CompiledSchema.compile ⟨Γ.ets, Γ.acts⟩) Γ.reqty = .ok cp₂ →
   wellTypedPolicy p₁ Γ = .ok wp₁ →
   wellTypedPolicy p₂ Γ = .ok wp₂ →
   checkMatchesImpliesOpt cp₁ cp₂ = checkMatchesImplies wp₁ wp₂ (SymEnv.ofTypeEnv Γ)
@@ -1106,8 +1132,8 @@ compilation succeeds, then `wellTypedPolicy` succeeds and `checkMatchesDisjoint`
 -/
 theorem checkMatchesDisjointOpt_eqv_checkMatchesDisjoint_ok {p₁ p₂ wp₁ wp₂ : Policy} {cp₁ cp₂ : CompiledPolicy} {Γ : Validation.TypeEnv} :
   Γ.WellFormed →
-  CompiledPolicy.compile p₁ Γ = .ok cp₁ →
-  CompiledPolicy.compile p₂ Γ = .ok cp₂ →
+  CompiledPolicy.compile p₁ (CompiledSchema.compile ⟨Γ.ets, Γ.acts⟩) Γ.reqty = .ok cp₁ →
+  CompiledPolicy.compile p₂ (CompiledSchema.compile ⟨Γ.ets, Γ.acts⟩) Γ.reqty = .ok cp₂ →
   wellTypedPolicy p₁ Γ = .ok wp₁ →
   wellTypedPolicy p₂ Γ = .ok wp₂ →
   checkMatchesDisjointOpt cp₁ cp₂ = checkMatchesDisjoint wp₁ wp₂ (SymEnv.ofTypeEnv Γ)
@@ -1129,7 +1155,8 @@ Full equivalence for checkNeverErrors` and `checkNeverErrorsOpt`, including both
 theorem checkNeverErrorsOpt_eqv_checkNeverErrors {p : Policy} {Γ : Validation.TypeEnv} :
   Γ.WellFormed →
   (do
-    let cp ← CompiledPolicy.compile p Γ
+    let s := CompiledSchema.compile ⟨Γ.ets, Γ.acts⟩
+    let cp ← CompiledPolicy.compile p s Γ.reqty
     pure $ checkNeverErrorsOpt cp
   ) =
   (do
@@ -1137,13 +1164,13 @@ theorem checkNeverErrorsOpt_eqv_checkNeverErrors {p : Policy} {Γ : Validation.T
     pure $ checkNeverErrors wp (SymEnv.ofTypeEnv Γ)
   )
 := by
-  cases hcp : CompiledPolicy.compile p Γ
+  cases hcp : CompiledPolicy.compile p (CompiledSchema.compile ⟨Γ.ets, Γ.acts⟩) Γ.reqty
   case ok cp =>
     intro hwf
     have ⟨wp, hwp, h⟩ := checkNeverErrorsOpt_eqv_checkNeverErrors_ok hwf hcp
-    simp [Except.mapError, hwp, h]
+    simp [Except.mapError, hcp, hwp, h]
   case error e =>
-    simp [Except.mapError]
+    simp [Except.mapError, hcp]
     cases hwp : wellTypedPolicy p Γ
     case error e' =>
       simp [CompiledPolicy.compile, Except.mapError, hwp] at hcp
@@ -1160,7 +1187,8 @@ Full equivalence for `checkAlwaysMatches` and `checkAlwaysMatchesOpt`, including
 theorem checkAlwaysMatchesOpt_eqv_checkAlwaysMatches {p : Policy} {Γ : Validation.TypeEnv} :
   Γ.WellFormed →
   (do
-    let cp ← CompiledPolicy.compile p Γ
+    let s := CompiledSchema.compile ⟨Γ.ets, Γ.acts⟩
+    let cp ← CompiledPolicy.compile p s Γ.reqty
     pure $ checkAlwaysMatchesOpt cp
   ) =
   (do
@@ -1168,13 +1196,13 @@ theorem checkAlwaysMatchesOpt_eqv_checkAlwaysMatches {p : Policy} {Γ : Validati
     pure $ checkAlwaysMatches wp (SymEnv.ofTypeEnv Γ)
   )
 := by
-  cases hcp : CompiledPolicy.compile p Γ
+  cases hcp : CompiledPolicy.compile p (CompiledSchema.compile ⟨Γ.ets, Γ.acts⟩) Γ.reqty
   case ok cp =>
     intro hwf
     have ⟨wp, hwp, h⟩ := checkAlwaysMatchesOpt_eqv_checkAlwaysMatches_ok hwf hcp
-    simp [Except.mapError, hwp, h]
+    simp [Except.mapError, hcp, hwp, h]
   case error e =>
-    simp [Except.mapError]
+    simp [Except.mapError, hcp]
     cases hwp : wellTypedPolicy p Γ
     case error e' =>
       simp [CompiledPolicy.compile, Except.mapError, hwp] at hcp
@@ -1191,7 +1219,8 @@ Full equivalence for `checkNeverMatches` and `checkNeverMatchesOpt`, including b
 theorem checkNeverMatchesOpt_eqv_checkNeverMatches {p : Policy} {Γ : Validation.TypeEnv} :
   Γ.WellFormed →
   (do
-    let cp ← CompiledPolicy.compile p Γ
+    let s := CompiledSchema.compile ⟨Γ.ets, Γ.acts⟩
+    let cp ← CompiledPolicy.compile p s Γ.reqty
     pure $ checkNeverMatchesOpt cp
   ) =
   (do
@@ -1199,13 +1228,13 @@ theorem checkNeverMatchesOpt_eqv_checkNeverMatches {p : Policy} {Γ : Validation
     pure $ checkNeverMatches wp (SymEnv.ofTypeEnv Γ)
   )
 := by
-  cases hcp : CompiledPolicy.compile p Γ
+  cases hcp : CompiledPolicy.compile p (CompiledSchema.compile ⟨Γ.ets, Γ.acts⟩) Γ.reqty
   case ok cp =>
     intro hwf
     have ⟨wp, hwp, h⟩ := checkNeverMatchesOpt_eqv_checkNeverMatches_ok hwf hcp
-    simp [Except.mapError, hwp, h]
+    simp [Except.mapError, hcp, hwp, h]
   case error e =>
-    simp [Except.mapError]
+    simp [Except.mapError, hcp]
     cases hwp : wellTypedPolicy p Γ
     case error e' =>
       simp [CompiledPolicy.compile, Except.mapError, hwp] at hcp
@@ -1222,8 +1251,9 @@ Full equivalence for `checkMatchesEquivalent` and `checkMatchesEquivalentOpt`, i
 theorem checkMatchesEquivalentOpt_eqv_checkMatchesEquivalent {p₁ p₂ : Policy} {Γ : Validation.TypeEnv} :
   Γ.WellFormed →
   (do
-    let cp₁ ← CompiledPolicy.compile p₁ Γ
-    let cp₂ ← CompiledPolicy.compile p₂ Γ
+    let s := CompiledSchema.compile ⟨Γ.ets, Γ.acts⟩
+    let cp₁ ← CompiledPolicy.compile p₁ s Γ.reqty
+    let cp₂ ← CompiledPolicy.compile p₂ s Γ.reqty
     pure $ checkMatchesEquivalentOpt cp₁ cp₂
   ) =
   (do
@@ -1235,8 +1265,8 @@ theorem checkMatchesEquivalentOpt_eqv_checkMatchesEquivalent {p₁ p₂ : Policy
   intro hwf
   have h₁ := compile_ok_iff_welltypedpolicy_ok hwf (p := p₁)
   have h₂ := compile_ok_iff_welltypedpolicy_ok hwf (p := p₂)
-  cases hcp₁ : CompiledPolicy.compile p₁ Γ
-  <;> cases hcp₂ : CompiledPolicy.compile p₂ Γ
+  cases hcp₁ : CompiledPolicy.compile p₁ (CompiledSchema.compile ⟨Γ.ets, Γ.acts⟩) Γ.reqty
+  <;> cases hcp₂ : CompiledPolicy.compile p₂ (CompiledSchema.compile ⟨Γ.ets, Γ.acts⟩) Γ.reqty
   <;> cases hwp₁ : wellTypedPolicy p₁ Γ
   <;> cases hwp₂ : wellTypedPolicy p₂ Γ
   -- this eliminates all the cases where the behavior of CompiledPolicy.compile is inconsistent
@@ -1258,8 +1288,9 @@ Full equivalence for `checkMatchesImplies` and `checkMatchesImpliesOpt`, includi
 theorem checkMatchesImpliesOpt_eqv_checkMatchesImplies {p₁ p₂ : Policy} {Γ : Validation.TypeEnv} :
   Γ.WellFormed →
   (do
-    let cp₁ ← CompiledPolicy.compile p₁ Γ
-    let cp₂ ← CompiledPolicy.compile p₂ Γ
+    let s := CompiledSchema.compile ⟨Γ.ets, Γ.acts⟩
+    let cp₁ ← CompiledPolicy.compile p₁ s Γ.reqty
+    let cp₂ ← CompiledPolicy.compile p₂ s Γ.reqty
     pure $ checkMatchesImpliesOpt cp₁ cp₂
   ) =
   (do
@@ -1271,8 +1302,8 @@ theorem checkMatchesImpliesOpt_eqv_checkMatchesImplies {p₁ p₂ : Policy} {Γ 
   intro hwf
   have h₁ := compile_ok_iff_welltypedpolicy_ok hwf (p := p₁)
   have h₂ := compile_ok_iff_welltypedpolicy_ok hwf (p := p₂)
-  cases hcp₁ : CompiledPolicy.compile p₁ Γ
-  <;> cases hcp₂ : CompiledPolicy.compile p₂ Γ
+  cases hcp₁ : CompiledPolicy.compile p₁ (CompiledSchema.compile ⟨Γ.ets, Γ.acts⟩) Γ.reqty
+  <;> cases hcp₂ : CompiledPolicy.compile p₂ (CompiledSchema.compile ⟨Γ.ets, Γ.acts⟩) Γ.reqty
   <;> cases hwp₁ : wellTypedPolicy p₁ Γ
   <;> cases hwp₂ : wellTypedPolicy p₂ Γ
   -- this eliminates all the cases where the behavior of CompiledPolicy.compile is inconsistent
@@ -1294,8 +1325,9 @@ Full equivalence for `checkMatchesDisjoint` and `checkMatchesDisjointOpt`, inclu
 theorem checkMatchesDisjointOpt_eqv_checkMatchesDisjoint {p₁ p₂ : Policy} {Γ : Validation.TypeEnv} :
   Γ.WellFormed →
   (do
-    let cp₁ ← CompiledPolicy.compile p₁ Γ
-    let cp₂ ← CompiledPolicy.compile p₂ Γ
+    let s := CompiledSchema.compile ⟨Γ.ets, Γ.acts⟩
+    let cp₁ ← CompiledPolicy.compile p₁ s Γ.reqty
+    let cp₂ ← CompiledPolicy.compile p₂ s Γ.reqty
     pure $ checkMatchesDisjointOpt cp₁ cp₂
   ) =
   (do
@@ -1307,8 +1339,8 @@ theorem checkMatchesDisjointOpt_eqv_checkMatchesDisjoint {p₁ p₂ : Policy} {�
   intro hwf
   have h₁ := compile_ok_iff_welltypedpolicy_ok hwf (p := p₁)
   have h₂ := compile_ok_iff_welltypedpolicy_ok hwf (p := p₂)
-  cases hcp₁ : CompiledPolicy.compile p₁ Γ
-  <;> cases hcp₂ : CompiledPolicy.compile p₂ Γ
+  cases hcp₁ : CompiledPolicy.compile p₁ (CompiledSchema.compile ⟨Γ.ets, Γ.acts⟩) Γ.reqty
+  <;> cases hcp₂ : CompiledPolicy.compile p₂ (CompiledSchema.compile ⟨Γ.ets, Γ.acts⟩) Γ.reqty
   <;> cases hwp₁ : wellTypedPolicy p₁ Γ
   <;> cases hwp₂ : wellTypedPolicy p₂ Γ
   -- this eliminates all the cases where the behavior of CompiledPolicy.compile is inconsistent
@@ -1330,8 +1362,8 @@ compilation succeeds, then `wellTypedPolicies` succeeds and `checkImplies` and
 -/
 theorem checkImpliesOpt_eqv_checkImplies_ok {ps₁ ps₂ : Policies} {cpset₁ cpset₂ : CompiledPolicySet} {Γ : Validation.TypeEnv} :
   Γ.WellFormed →
-  CompiledPolicySet.compile ps₁ Γ = .ok cpset₁ →
-  CompiledPolicySet.compile ps₂ Γ = .ok cpset₂ →
+  CompiledPolicySet.compile ps₁ (CompiledSchema.compile ⟨Γ.ets, Γ.acts⟩) Γ.reqty = .ok cpset₁ →
+  CompiledPolicySet.compile ps₂ (CompiledSchema.compile ⟨Γ.ets, Γ.acts⟩) Γ.reqty = .ok cpset₂ →
   ∃ wps₁ wps₂,
     wellTypedPolicies ps₁ Γ = .ok wps₁ ∧
     wellTypedPolicies ps₂ Γ = .ok wps₂ ∧
@@ -1358,8 +1390,9 @@ Full equivalence for `checkImplies` and `checkImpliesOpt`, including both the
 theorem checkImpliesOpt_eqv_checkImplies {ps₁ ps₂ : Policies} {Γ : Validation.TypeEnv} :
   Γ.WellFormed →
   (do
-    let cpset₁ ← CompiledPolicySet.compile ps₁ Γ
-    let cpset₂ ← CompiledPolicySet.compile ps₂ Γ
+    let s := CompiledSchema.compile ⟨Γ.ets, Γ.acts⟩
+    let cpset₁ ← CompiledPolicySet.compile ps₁ s Γ.reqty
+    let cpset₂ ← CompiledPolicySet.compile ps₂ s Γ.reqty
     pure $ checkImpliesOpt cpset₁ cpset₂
   ) =
   (do
@@ -1371,8 +1404,8 @@ theorem checkImpliesOpt_eqv_checkImplies {ps₁ ps₂ : Policies} {Γ : Validati
   intro hwf
   have h₁ := compile_ok_iff_welltypedpolicies_ok hwf (ps := ps₁)
   have h₂ := compile_ok_iff_welltypedpolicies_ok hwf (ps := ps₂)
-  cases hcpset₁ : CompiledPolicySet.compile ps₁ Γ
-  <;> cases hcpset₂ : CompiledPolicySet.compile ps₂ Γ
+  cases hcpset₁ : CompiledPolicySet.compile ps₁ (CompiledSchema.compile ⟨Γ.ets, Γ.acts⟩) Γ.reqty
+  <;> cases hcpset₂ : CompiledPolicySet.compile ps₂ (CompiledSchema.compile ⟨Γ.ets, Γ.acts⟩) Γ.reqty
   <;> cases hwps₁ : wellTypedPolicies ps₁ Γ
   <;> cases hwps₂ : wellTypedPolicies ps₂ Γ
   -- this eliminates all the cases where the behavior of CompiledPolicySet.compile is inconsistent
@@ -1395,7 +1428,7 @@ compilation succeeds, then `wellTypedPolicies` succeeds and `checkAlwaysAllows` 
 -/
 theorem checkAlwaysAllowsOpt_eqv_checkAlwaysAllows_ok {ps : Policies} {cpset : CompiledPolicySet} {Γ : Validation.TypeEnv} :
   Γ.WellFormed →
-  CompiledPolicySet.compile ps Γ = .ok cpset →
+  CompiledPolicySet.compile ps (CompiledSchema.compile ⟨Γ.ets, Γ.acts⟩) Γ.reqty = .ok cpset →
   ∃ wps,
     wellTypedPolicies ps Γ = .ok wps ∧
     checkAlwaysAllowsOpt cpset = checkAlwaysAllows wps (SymEnv.ofTypeEnv Γ)
@@ -1419,7 +1452,8 @@ Full equivalence for `checkAlwaysAllows` and `checkAlwaysAllowsOpt`, including b
 theorem checkAlwaysAllowsOpt_eqv_checkAlwaysAllows {ps : Policies} {Γ : Validation.TypeEnv} :
   Γ.WellFormed →
   (do
-    let cpset ← CompiledPolicySet.compile ps Γ
+    let s := CompiledSchema.compile ⟨Γ.ets, Γ.acts⟩
+    let cpset ← CompiledPolicySet.compile ps s Γ.reqty
     pure $ checkAlwaysAllowsOpt cpset
   ) =
   (do
@@ -1429,7 +1463,7 @@ theorem checkAlwaysAllowsOpt_eqv_checkAlwaysAllows {ps : Policies} {Γ : Validat
 := by
   intro hwf
   have h₁ := compile_ok_iff_welltypedpolicies_ok hwf (ps := ps)
-  cases hcpset : CompiledPolicySet.compile ps Γ
+  cases hcpset : CompiledPolicySet.compile ps (CompiledSchema.compile ⟨Γ.ets, Γ.acts⟩) Γ.reqty
   <;> cases hwps : wellTypedPolicies ps Γ
   -- this eliminates all the cases where the behavior of CompiledPolicySet.compile is inconsistent
   -- with the behavior of wellTypedPolicies on the same policyset
@@ -1448,7 +1482,7 @@ compilation succeeds, then `wellTypedPolicies` succeeds and `checkAlwaysDenies` 
 -/
 theorem checkAlwaysDeniesOpt_eqv_checkAlwaysDenies_ok {ps : Policies} {cpset : CompiledPolicySet} {Γ : Validation.TypeEnv} :
   Γ.WellFormed →
-  CompiledPolicySet.compile ps Γ = .ok cpset →
+  CompiledPolicySet.compile ps (CompiledSchema.compile ⟨Γ.ets, Γ.acts⟩) Γ.reqty = .ok cpset →
   ∃ wps,
     wellTypedPolicies ps Γ = .ok wps ∧
     checkAlwaysDeniesOpt cpset = checkAlwaysDenies wps (SymEnv.ofTypeEnv Γ)
@@ -1472,7 +1506,8 @@ Full equivalence for `checkAlwaysDenies` and `checkAlwaysDeniesOpt`, including b
 theorem checkAlwaysDeniesOpt_eqv_checkAlwaysDenies {ps : Policies} {Γ : Validation.TypeEnv} :
   Γ.WellFormed →
   (do
-    let cpset ← CompiledPolicySet.compile ps Γ
+    let s := CompiledSchema.compile ⟨Γ.ets, Γ.acts⟩
+    let cpset ← CompiledPolicySet.compile ps s Γ.reqty
     pure $ checkAlwaysDeniesOpt cpset
   ) =
   (do
@@ -1482,7 +1517,7 @@ theorem checkAlwaysDeniesOpt_eqv_checkAlwaysDenies {ps : Policies} {Γ : Validat
 := by
   intro hwf
   have h₁ := compile_ok_iff_welltypedpolicies_ok hwf (ps := ps)
-  cases hcpset : CompiledPolicySet.compile ps Γ
+  cases hcpset : CompiledPolicySet.compile ps (CompiledSchema.compile ⟨Γ.ets, Γ.acts⟩) Γ.reqty
   <;> cases hwps : wellTypedPolicies ps Γ
   -- this eliminates all the cases where the behavior of CompiledPolicySet.compile is inconsistent
   -- with the behavior of wellTypedPolicies on the same policyset
@@ -1501,8 +1536,8 @@ compilation succeeds, then `wellTypedPolicies` succeeds and `checkEquivalent` an
 -/
 theorem checkEquivalentOpt_eqv_checkEquivalent_ok {ps₁ ps₂ : Policies} {cpset₁ cpset₂ : CompiledPolicySet} {Γ : Validation.TypeEnv} :
   Γ.WellFormed →
-  CompiledPolicySet.compile ps₁ Γ = .ok cpset₁ →
-  CompiledPolicySet.compile ps₂ Γ = .ok cpset₂ →
+  CompiledPolicySet.compile ps₁ (CompiledSchema.compile ⟨Γ.ets, Γ.acts⟩) Γ.reqty = .ok cpset₁ →
+  CompiledPolicySet.compile ps₂ (CompiledSchema.compile ⟨Γ.ets, Γ.acts⟩) Γ.reqty = .ok cpset₂ →
   ∃ wps₁ wps₂,
     wellTypedPolicies ps₁ Γ = .ok wps₁ ∧
     wellTypedPolicies ps₂ Γ = .ok wps₂ ∧
@@ -1529,8 +1564,9 @@ Full equivalence for `checkEquivalent` and `checkEquivalentOpt`, including both 
 theorem checkEquivalentOpt_eqv_checkEquivalent {ps₁ ps₂ : Policies} {Γ : Validation.TypeEnv} :
   Γ.WellFormed →
   (do
-    let cpset₁ ← CompiledPolicySet.compile ps₁ Γ
-    let cpset₂ ← CompiledPolicySet.compile ps₂ Γ
+    let s := CompiledSchema.compile ⟨Γ.ets, Γ.acts⟩
+    let cpset₁ ← CompiledPolicySet.compile ps₁ s Γ.reqty
+    let cpset₂ ← CompiledPolicySet.compile ps₂ s Γ.reqty
     pure $ checkEquivalentOpt cpset₁ cpset₂
   ) =
   (do
@@ -1542,8 +1578,8 @@ theorem checkEquivalentOpt_eqv_checkEquivalent {ps₁ ps₂ : Policies} {Γ : Va
   intro hwf
   have h₁ := compile_ok_iff_welltypedpolicies_ok hwf (ps := ps₁)
   have h₂ := compile_ok_iff_welltypedpolicies_ok hwf (ps := ps₂)
-  cases hcpset₁ : CompiledPolicySet.compile ps₁ Γ
-  <;> cases hcpset₂ : CompiledPolicySet.compile ps₂ Γ
+  cases hcpset₁ : CompiledPolicySet.compile ps₁ (CompiledSchema.compile ⟨Γ.ets, Γ.acts⟩) Γ.reqty
+  <;> cases hcpset₂ : CompiledPolicySet.compile ps₂ (CompiledSchema.compile ⟨Γ.ets, Γ.acts⟩) Γ.reqty
   <;> cases hwps₁ : wellTypedPolicies ps₁ Γ
   <;> cases hwps₂ : wellTypedPolicies ps₂ Γ
   -- this eliminates all the cases where the behavior of CompiledPolicySet.compile is inconsistent
@@ -1566,8 +1602,8 @@ compilation succeeds, then `wellTypedPolicies` succeeds and `checkDisjoint` and
 -/
 theorem checkDisjointOpt_eqv_checkDisjoint_ok {ps₁ ps₂ : Policies} {cpset₁ cpset₂ : CompiledPolicySet} {Γ : Validation.TypeEnv} :
   Γ.WellFormed →
-  CompiledPolicySet.compile ps₁ Γ = .ok cpset₁ →
-  CompiledPolicySet.compile ps₂ Γ = .ok cpset₂ →
+  CompiledPolicySet.compile ps₁ (CompiledSchema.compile ⟨Γ.ets, Γ.acts⟩) Γ.reqty = .ok cpset₁ →
+  CompiledPolicySet.compile ps₂ (CompiledSchema.compile ⟨Γ.ets, Γ.acts⟩) Γ.reqty = .ok cpset₂ →
   ∃ wps₁ wps₂,
     wellTypedPolicies ps₁ Γ = .ok wps₁ ∧
     wellTypedPolicies ps₂ Γ = .ok wps₂ ∧
@@ -1594,8 +1630,9 @@ Full equivalence for `checkDisjoint` and `checkDisjointOpt`, including both the
 theorem checkDisjointOpt_eqv_checkDisjoint {ps₁ ps₂ : Policies} {Γ : Validation.TypeEnv} :
   Γ.WellFormed →
   (do
-    let cpset₁ ← CompiledPolicySet.compile ps₁ Γ
-    let cpset₂ ← CompiledPolicySet.compile ps₂ Γ
+    let s := CompiledSchema.compile ⟨Γ.ets, Γ.acts⟩
+    let cpset₁ ← CompiledPolicySet.compile ps₁ s Γ.reqty
+    let cpset₂ ← CompiledPolicySet.compile ps₂ s Γ.reqty
     pure $ checkDisjointOpt cpset₁ cpset₂
   ) =
   (do
@@ -1607,8 +1644,8 @@ theorem checkDisjointOpt_eqv_checkDisjoint {ps₁ ps₂ : Policies} {Γ : Valida
   intro hwf
   have h₁ := compile_ok_iff_welltypedpolicies_ok hwf (ps := ps₁)
   have h₂ := compile_ok_iff_welltypedpolicies_ok hwf (ps := ps₂)
-  cases hcpset₁ : CompiledPolicySet.compile ps₁ Γ
-  <;> cases hcpset₂ : CompiledPolicySet.compile ps₂ Γ
+  cases hcpset₁ : CompiledPolicySet.compile ps₁ (CompiledSchema.compile ⟨Γ.ets, Γ.acts⟩) Γ.reqty
+  <;> cases hcpset₂ : CompiledPolicySet.compile ps₂ (CompiledSchema.compile ⟨Γ.ets, Γ.acts⟩) Γ.reqty
   <;> cases hwps₁ : wellTypedPolicies ps₁ Γ
   <;> cases hwps₂ : wellTypedPolicies ps₂ Γ
   -- this eliminates all the cases where the behavior of CompiledPolicySet.compile is inconsistent

--- a/cedar-lean/Cedar/Thm/SymCC/Opt/CompiledPolicies.lean
+++ b/cedar-lean/Cedar/Thm/SymCC/Opt/CompiledPolicies.lean
@@ -45,19 +45,20 @@ Toplevel theorem about the correctness of `CompiledPolicy.intoCompiledPolicySet`
 Compiling to a `CompiledPolicy` and then using `intoCompiledPolicySet` should give
 exactly the same result as compiling with `CompiledPolicySet.compile` directly
 -/
-theorem intoCompiledPolicySet_correctness {p : Policy} {Γ : Validation.TypeEnv} :
+theorem intoCompiledPolicySet_correctness {p : Policy} {s : CompiledSchema} {reqty : Validation.RequestType} :
   (do
-    let cp ← CompiledPolicy.compile p Γ
+    let cp ← CompiledPolicy.compile p s reqty
     pure cp.intoCompiledPolicySet
-  ) = CompiledPolicySet.compile [p] Γ
+  ) = CompiledPolicySet.compile [p] s reqty
 := by
   simp [CompiledPolicy.compile, CompiledPolicySet.compile, CompiledPolicy.intoCompiledPolicySet, wellTypedPolicy_wellTypedPolicies, Except.mapError, Except.map]
+  generalize (s.typeEnv reqty) = Γ
   cases wellTypedPolicy p Γ <;> simp
   case ok p' =>
   simp [Opt.isAuthorized, Opt.satisfiedPolicies, Opt.compileWithEffect]
   cases p'.effect <;> simp [Factory.anyTrue, Factory.or, Factory.not, Factory.and]
   all_goals {
-    simp_do_let Opt.compile p'.toExpr (SymEnv.ofEnv Γ) as h
+    simp_do_let Opt.compile p'.toExpr (s.symEnv reqty) as h
     simp only [Except.ok.injEq, CompiledPolicySet.mk.injEq, true_and]
     have hwf := Opt.compile_footprint_wf h
     simp [EmptyCollection.emptyCollection, Data.Set.union_empty_right List.mapUnion_wf, Data.Set.union_empty_left List.mapUnion_wf]
@@ -68,9 +69,9 @@ theorem intoCompiledPolicySet_correctness {p : Policy} {Γ : Validation.TypeEnv}
 /--
 The `.policy` of a `CompiledPolicy` is exactly the policy produced by `wellTypedPolicy`
 -/
-theorem cp_compile_produces_the_right_policy {p wp : Policy} {cp : CompiledPolicy} {Γ : Validation.TypeEnv} :
-  CompiledPolicy.compile p Γ = .ok cp →
-  wellTypedPolicy p Γ = .ok wp →
+theorem cp_compile_produces_the_right_policy {p wp : Policy} {cp : CompiledPolicy} {s : CompiledSchema} {reqty : Validation.RequestType} :
+  CompiledPolicy.compile p s reqty = .ok cp →
+  wellTypedPolicy p (s.typeEnv reqty) = .ok wp →
   cp.policy = wp
 := by
   simp [CompiledPolicy.compile, do_eq_ok, Except.mapError]
@@ -80,35 +81,35 @@ theorem cp_compile_produces_the_right_policy {p wp : Policy} {cp : CompiledPolic
 /--
 The `.policies` of a `CompiledPolicySet` is exactly the policies produced by `wellTypedPolicies`
 -/
-theorem cpset_compile_produces_the_right_policies {ps wps : Policies} {cpset : CompiledPolicySet} {Γ : Validation.TypeEnv} :
-  CompiledPolicySet.compile ps Γ = .ok cpset →
-  wellTypedPolicies ps Γ = .ok wps →
+theorem cpset_compile_produces_the_right_policies {ps wps : Policies} {cpset : CompiledPolicySet} {s : CompiledSchema} {reqty : Validation.RequestType} :
+  CompiledPolicySet.compile ps s reqty = .ok cpset →
+  wellTypedPolicies ps (s.typeEnv reqty) = .ok wps →
   cpset.policies = wps
 := by
   simp [CompiledPolicySet.compile, do_eq_ok, Except.mapError]
   intro ps' h₀ t h₁ h₂ ; subst cpset ; simp
   split at h₀ <;> simp_all
 
-theorem cp_compile_produces_the_right_env {p : Policy} {cp : CompiledPolicy} {Γ : Validation.TypeEnv} :
-  CompiledPolicy.compile p Γ = .ok cp →
-  cp.εnv = SymEnv.ofTypeEnv Γ
+theorem cp_compile_produces_the_right_env {p : Policy} {cp : CompiledPolicy} {s : CompiledSchema} {reqty : Validation.RequestType}  :
+  CompiledPolicy.compile p s reqty = .ok cp →
+  cp.εnv = s.symEnv reqty
 := by
   simp only [CompiledPolicy.compile, Except.mapError, do_eq_ok, Except.ok.injEq, forall_exists_index, and_imp]
   intro p' h₀ t h₁ h₂ ; subst h₂
   simp
 
-theorem cpset_compile_produces_the_right_env {ps : Policies} {cpset : CompiledPolicySet} {Γ : Validation.TypeEnv} :
-  CompiledPolicySet.compile ps Γ = .ok cpset →
-  cpset.εnv = SymEnv.ofTypeEnv Γ
+theorem cpset_compile_produces_the_right_env {ps : Policies} {cpset : CompiledPolicySet} {s : CompiledSchema} {reqty : Validation.RequestType} :
+  CompiledPolicySet.compile ps s reqty = .ok cpset →
+  cpset.εnv = s.symEnv reqty
 := by
   simp only [CompiledPolicySet.compile, Except.mapError, do_eq_ok, Except.ok.injEq, forall_exists_index, and_imp]
   intro ps' h₀ t h₁ h₂ ; subst h₂
   simp
 
-theorem cp_compile_produces_the_right_term {p wp : Policy} {cp : CompiledPolicy} {Γ : Validation.TypeEnv} :
-  CompiledPolicy.compile p Γ = .ok cp →
-  wellTypedPolicy p Γ = .ok wp →
-  cp.term = SymCC.compile wp.toExpr (SymEnv.ofTypeEnv Γ)
+theorem cp_compile_produces_the_right_term {p wp : Policy} {cp : CompiledPolicy} {s : CompiledSchema} {reqty : Validation.RequestType} :
+  CompiledPolicy.compile p s reqty = .ok cp →
+  wellTypedPolicy p (s.typeEnv reqty) = .ok wp →
+  cp.term = SymCC.compile wp.toExpr (s.symEnv reqty)
 := by
   simp [CompiledPolicy.compile, do_eq_ok, Except.mapError]
   intro p' h₀ res h₁ h₂ h₃ ; subst cp ; simp only
@@ -116,13 +117,13 @@ theorem cp_compile_produces_the_right_term {p wp : Policy} {cp : CompiledPolicy}
   split at h₀ <;> simp at h₀
   subst p' ; rename_i wp' h₂
   simp [h₂] at h₃ ; subst wp'
-  cases hcomp : SymCC.compile wp.toExpr (SymEnv.ofTypeEnv Γ) <;> simp [hcomp] at h₁ ⊢
+  cases hcomp : SymCC.compile wp.toExpr (s.symEnv reqty) <;> simp [hcomp] at h₁ ⊢
   case ok t => subst res ; simp
 
-theorem cpset_compile_produces_the_right_term {ps wps : Policies} {cpset : CompiledPolicySet} {Γ : Validation.TypeEnv} :
-  CompiledPolicySet.compile ps Γ = .ok cpset →
-  wellTypedPolicies ps Γ = .ok wps →
-  cpset.term = SymCC.isAuthorized wps (SymEnv.ofTypeEnv Γ)
+theorem cpset_compile_produces_the_right_term {ps wps : Policies} {cpset : CompiledPolicySet} {s : CompiledSchema} {reqty : Validation.RequestType} :
+  CompiledPolicySet.compile ps s reqty = .ok cpset →
+  wellTypedPolicies ps (s.typeEnv reqty) = .ok wps →
+  cpset.term = SymCC.isAuthorized wps (s.symEnv reqty)
 := by
   simp [CompiledPolicySet.compile, do_eq_ok, Except.mapError]
   intro ps' h₀ res h₁ h₂ h₃ ; subst cpset ; simp only
@@ -134,8 +135,8 @@ theorem cpset_compile_produces_the_right_term {ps wps : Policies} {cpset : Compi
   simp only [Except.ok.injEq] at h₁ ; subst res
   simp
 
-theorem cp_compile_produces_the_right_footprint {p : Policy} {cp : CompiledPolicy} {Γ : Validation.TypeEnv} :
-  CompiledPolicy.compile p Γ = .ok cp →
+theorem cp_compile_produces_the_right_footprint {p : Policy} {cp : CompiledPolicy} {s : CompiledSchema} {reqty : Validation.RequestType} :
+  CompiledPolicy.compile p s reqty = .ok cp →
   cp.footprint = footprint cp.policy.toExpr cp.εnv
 := by
   simp [CompiledPolicy.compile, do_eq_ok]
@@ -144,12 +145,12 @@ theorem cp_compile_produces_the_right_footprint {p : Policy} {cp : CompiledPolic
   rw [Opt.compile.correctness] at h₁
   split at h₁ <;> simp at h₁
   subst t ; rename_i res h₁
-  simp_do_let SymCC.compile p.toExpr (SymEnv.ofEnv Γ) at h₁
+  simp_do_let SymCC.compile p.toExpr (s.symEnv reqty) at h₁
   simp only [Except.ok.injEq] at h₁ ; subst res
   simp
 
-theorem cpset_compile_produces_the_right_footprint {ps : Policies} {cpset : CompiledPolicySet} {Γ : Validation.TypeEnv} :
-  CompiledPolicySet.compile ps Γ = .ok cpset →
+theorem cpset_compile_produces_the_right_footprint {ps : Policies} {cpset : CompiledPolicySet} {s : CompiledSchema} {reqty : Validation.RequestType} :
+  CompiledPolicySet.compile ps s reqty = .ok cpset →
   cpset.footprint = footprints (cpset.policies.map Policy.toExpr) cpset.εnv
 := by
   simp [CompiledPolicySet.compile, do_eq_ok]
@@ -158,12 +159,12 @@ theorem cpset_compile_produces_the_right_footprint {ps : Policies} {cpset : Comp
   rw [Opt.isAuthorized.correctness] at h₁
   split at h₁ <;> simp at h₁
   subst t ; rename_i res h₁
-  simp_do_let SymCC.isAuthorized ps (SymEnv.ofEnv Γ) at h₁
+  simp_do_let SymCC.isAuthorized ps (s.symEnv reqty) at h₁
   simp only [Except.ok.injEq] at h₁ ; subst res
   simp
 
-theorem cp_compile_produces_the_right_acyclicity {p : Policy} {cp : CompiledPolicy} {Γ : Validation.TypeEnv} :
-  CompiledPolicy.compile p Γ = .ok cp →
+theorem cp_compile_produces_the_right_acyclicity {p : Policy} {cp : CompiledPolicy} {s : CompiledSchema} {reqty : Validation.RequestType} :
+  CompiledPolicy.compile p s reqty = .ok cp →
   cp.acyclicity = cp.footprint.map (SymCC.acyclicity · cp.εnv.entities)
 := by
   intro temp ; have hf := cp_compile_produces_the_right_footprint temp ; revert temp
@@ -173,8 +174,8 @@ theorem cp_compile_produces_the_right_acyclicity {p : Policy} {cp : CompiledPoli
   simp only at *
   congr
 
-theorem cpset_compile_produces_the_right_acyclicity {ps : Policies} {cpset : CompiledPolicySet} {Γ : Validation.TypeEnv} :
-  CompiledPolicySet.compile ps Γ = .ok cpset →
+theorem cpset_compile_produces_the_right_acyclicity {ps : Policies} {cpset : CompiledPolicySet} {s : CompiledSchema} {reqty : Validation.RequestType} :
+  CompiledPolicySet.compile ps s reqty = .ok cpset →
   cpset.acyclicity = cpset.footprint.map (SymCC.acyclicity · cpset.εnv.entities)
 := by
   intro temp ; have hf := cpset_compile_produces_the_right_footprint temp ; revert temp

--- a/cedar-lean/Cedar/Thm/SymCC/Opt/Enforcer.lean
+++ b/cedar-lean/Cedar/Thm/SymCC/Opt/Enforcer.lean
@@ -30,10 +30,10 @@ open Cedar.Spec Cedar.SymCC
 This theorem covers the "happy path" -- showing that if optimized policy
 compilation succeeds, then `enforce` and `enforceCompiledPolicy` are equivalent.
 -/
-theorem enforceCompiledPolicy_eqv_enforce_ok {p wp : Policy} {cp : CompiledPolicy} {Γ : Validation.TypeEnv} :
-  CompiledPolicy.compile p Γ = .ok cp →
-  wellTypedPolicy p Γ = .ok wp →
-  enforce [wp.toExpr] (SymEnv.ofTypeEnv Γ) = enforceCompiledPolicy cp
+theorem enforceCompiledPolicy_eqv_enforce_ok {p wp : Policy} {cp : CompiledPolicy} {s : CompiledSchema} {reqty : Validation.RequestType}  :
+  CompiledPolicy.compile p s reqty = .ok cp →
+  wellTypedPolicy p (s.typeEnv reqty) = .ok wp →
+  enforce [wp.toExpr] (s.symEnv reqty) = enforceCompiledPolicy cp
 := by
   simp [enforce, enforceCompiledPolicy]
   intro h₀ h₁
@@ -87,12 +87,12 @@ This theorem covers the "happy path" -- showing that if optimized policy
 compilation succeeds, then `enforce` and `enforcePairCompiledPolicy` are
 equivalent.
 -/
-theorem enforcePairCompiledPolicy_eqv_enforce_ok {p₁ p₂ wp₁ wp₂ : Policy} {cp₁ cp₂ : CompiledPolicy} {Γ : Validation.TypeEnv} :
-  CompiledPolicy.compile p₁ Γ = .ok cp₁ →
-  CompiledPolicy.compile p₂ Γ = .ok cp₂ →
-  wellTypedPolicy p₁ Γ = .ok wp₁ →
-  wellTypedPolicy p₂ Γ = .ok wp₂ →
-  enforce [wp₁.toExpr, wp₂.toExpr] (SymEnv.ofTypeEnv Γ) = enforcePairCompiledPolicy cp₁ cp₂
+theorem enforcePairCompiledPolicy_eqv_enforce_ok {p₁ p₂ wp₁ wp₂ : Policy} {cp₁ cp₂ : CompiledPolicy} {s : CompiledSchema} {reqty : Validation.RequestType} :
+  CompiledPolicy.compile p₁ s reqty = .ok cp₁ →
+  CompiledPolicy.compile p₂ s reqty = .ok cp₂ →
+  wellTypedPolicy p₁ (s.typeEnv reqty) = .ok wp₁ →
+  wellTypedPolicy p₂ (s.typeEnv reqty) = .ok wp₂ →
+  enforce [wp₁.toExpr, wp₂.toExpr] (s.symEnv reqty) = enforcePairCompiledPolicy cp₁ cp₂
 := by
   simp [enforce, enforcePairCompiledPolicy]
   intro h₀ h₁ h₂ h₃
@@ -143,12 +143,12 @@ This theorem covers the "happy path" -- showing that if optimized policy
 compilation succeeds, then `enforce` and `enforcePairCompiledPolicySet` are
 equivalent.
 -/
-theorem enforcePairCompiledPolicySet_eqv_enforce_ok {ps₁ ps₂ wps₁ wps₂ : Policies} {cpset₁ cpset₂ : CompiledPolicySet} {Γ : Validation.TypeEnv} :
-  CompiledPolicySet.compile ps₁ Γ = .ok cpset₁ →
-  CompiledPolicySet.compile ps₂ Γ = .ok cpset₂ →
-  wellTypedPolicies ps₁ Γ = .ok wps₁ →
-  wellTypedPolicies ps₂ Γ = .ok wps₂ →
-  enforce (wps₁.map Policy.toExpr ++ wps₂.map Policy.toExpr) (SymEnv.ofTypeEnv Γ) = enforcePairCompiledPolicySet cpset₁ cpset₂
+theorem enforcePairCompiledPolicySet_eqv_enforce_ok {ps₁ ps₂ wps₁ wps₂ : Policies} {cpset₁ cpset₂ : CompiledPolicySet} {s : CompiledSchema} {reqty : Validation.RequestType} :
+  CompiledPolicySet.compile ps₁ s reqty = .ok cpset₁ →
+  CompiledPolicySet.compile ps₂ s reqty = .ok cpset₂ →
+  wellTypedPolicies ps₁ (s.typeEnv reqty) = .ok wps₁ →
+  wellTypedPolicies ps₂ (s.typeEnv reqty) = .ok wps₂ →
+  enforce (wps₁.map Policy.toExpr ++ wps₂.map Policy.toExpr) (s.symEnv reqty) = enforcePairCompiledPolicySet cpset₁ cpset₂
 := by
   simp [enforce, enforcePairCompiledPolicySet]
   intro hcpset₁ hcpset₂ hwps₁ hwps₂

--- a/cedar-lean/Cedar/Thm/SymCC/Opt/Extractor.lean
+++ b/cedar-lean/Cedar/Thm/SymCC/Opt/Extractor.lean
@@ -31,8 +31,8 @@ theorem extractOpt?_eqv_extract? {cpsets : List CompiledPolicies} {I : Interpret
   (∀ cpset ∈ cpsets, cpset.εnv = εnv) →
   -- the `CompiledPolicies` at least have to be constructed with `CompiledPolicy.compile` or `CompiledPolicySet.compile`, even though we don't care about the original uncompiled policies
   (∀ cpset ∈ cpsets, match cpset with
-    | .policy cp => ∃ p Γ, CompiledPolicy.compile p Γ = .ok cp
-    | .pset cpset => ∃ ps Γ, CompiledPolicySet.compile ps Γ = .ok cpset
+    | .policy cp => ∃ p s reqty, CompiledPolicy.compile p s reqty = .ok cp
+    | .pset cpset => ∃ ps s reqty, CompiledPolicySet.compile ps s reqty = .ok cpset
   ) →
   extractOpt? cpsets I = SymEnv.extract? ((cpsets.flatMap CompiledPolicies.allPolicies).map Policy.toExpr) I εnv
 := by
@@ -49,7 +49,7 @@ theorem extractOpt?_eqv_extract? {cpsets : List CompiledPolicies} {I : Interpret
   all_goals {
     subst εnv
     first | rename CompiledPolicy => cp | rename CompiledPolicySet => cps
-    replace ⟨⟨p, Γ, hcompile⟩, hcompile'⟩ := hcompile ; try rename Policies => ps
+    replace ⟨⟨p, s, reqty, hcompile⟩, hcompile'⟩ := hcompile ; try rename Policies => ps
     rw [List.mapUnion_cons]
     · simp only [CompiledPolicies.footprint]
       first
@@ -69,7 +69,7 @@ theorem extractOpt?_eqv_extract? {cpsets : List CompiledPolicies} {I : Interpret
           specialize hcompile' cps hcps
           split at hcompile'
           · rename_i cps cp
-            replace ⟨p', Γ', hcompile'⟩ := hcompile'
+            replace ⟨p', s', reqty', hcompile'⟩ := hcompile'
             have hfoot := cp_compile_produces_the_right_footprint hcompile'
             simp [CompiledPolicies.footprint, hfoot] at ht
             exists cp.policy
@@ -78,7 +78,7 @@ theorem extractOpt?_eqv_extract? {cpsets : List CompiledPolicies} {I : Interpret
             exists .policy cp
             simp [hcps, CompiledPolicies.allPolicies]
           · rename_i cps cpset
-            replace ⟨ps', Γ', hcompile'⟩ := hcompile'
+            replace ⟨ps', s', reqty', hcompile'⟩ := hcompile'
             have hfoot := cpset_compile_produces_the_right_footprint hcompile'
             simp only [footprints, List.mapUnion_map] at hfoot
             rw [Data.Set.eq_means_eqv] at hfoot
@@ -101,14 +101,14 @@ theorem extractOpt?_eqv_extract? {cpsets : List CompiledPolicies} {I : Interpret
           · rename_i cps cp
             simp only [CompiledPolicies.allPolicies, List.mem_cons, List.not_mem_nil,
               or_false] at hp ; subst p
-            replace ⟨p', Γ', hcompile'⟩ := hcompile'
+            replace ⟨p', s', reqty', hcompile'⟩ := hcompile'
             have hfoot := cp_compile_produces_the_right_footprint hcompile'
             simp only [hcps, CompiledPolicies.footprint, hfoot, true_and]
             specialize hεnv (.policy cp) hcps ; simp only at hεnv ; rw [← hεnv] at ht
             exact ht
           · rename_i cps cpset
             simp only [CompiledPolicies.allPolicies] at hp
-            replace ⟨ps', Γ', hcompile'⟩ := hcompile'
+            replace ⟨ps', s', reqty', hcompile'⟩ := hcompile'
             have hfoot := cpset_compile_produces_the_right_footprint hcompile'
             simp only [hcps, CompiledPolicies.footprint, hfoot, footprints, true_and]
             specialize hεnv (.pset cpset) hcps ; simp only at hεnv ; rw [← hεnv] at ht
@@ -125,9 +125,9 @@ theorem extractOpt?_eqv_extract? {cpsets : List CompiledPolicies} {I : Interpret
         specialize hcompile' cps hcps
         split at hcompile'
         · rename_i cps cp
-          replace ⟨p, Γ, hcompile'⟩ := hcompile'
+          replace ⟨p, s, reqty, hcompile'⟩ := hcompile'
           simp [CompiledPolicies.footprint, cp_compile_produces_the_right_footprint hcompile', footprint_wf]
         · rename_i cps cps
-          replace ⟨ps, Γ, hcompile'⟩ := hcompile'
+          replace ⟨ps, s, reqty, hcompile'⟩ := hcompile'
           simp [CompiledPolicies.footprint, cpset_compile_produces_the_right_footprint hcompile', footprints_wf]
   }

--- a/cedar-lean/Cedar/Thm/SymCC/Opt/Verifier.lean
+++ b/cedar-lean/Cedar/Thm/SymCC/Opt/Verifier.lean
@@ -34,15 +34,15 @@ This theorem covers the "happy path" -- showing that if optimized policy
 compilation succeeds, then `verifyEvaluate` and `verifyEvaluateOpt` are
 equivalent.
 -/
-theorem verifyEvaluateOpt_eqv_verifyEvaluate_ok {p wp : Policy} {cp : CompiledPolicy} {Γ : Validation.TypeEnv} {φ : Term → Term} :
-  CompiledPolicy.compile p Γ = .ok cp →
-  wellTypedPolicy p Γ = .ok wp →
-  verifyEvaluate φ wp (SymEnv.ofTypeEnv Γ) ~ .ok (verifyEvaluateOpt φ cp)
+theorem verifyEvaluateOpt_eqv_verifyEvaluate_ok {p wp : Policy} {cp : CompiledPolicy} {s : CompiledSchema} {reqty : Validation.RequestType} {φ : Term → Term} :
+  CompiledPolicy.compile p s reqty = .ok cp →
+  wellTypedPolicy p (s.typeEnv reqty) = .ok wp →
+  verifyEvaluate φ wp (s.symEnv reqty) ~ .ok (verifyEvaluateOpt φ cp)
 := by
   simp [verifyEvaluate, verifyEvaluateOpt, ResultAssertsEquiv]
   intro h₀ h₁
   simp [enforceCompiledPolicy_eqv_enforce_ok h₀ h₁]
-  cases h₂ : compile wp.toExpr (SymEnv.ofTypeEnv Γ) <;> simp
+  cases h₂ : compile wp.toExpr (s.symEnv reqty) <;> simp
   case error e =>
     simp only [CompiledPolicy.compile, Except.mapError, h₁, Except.bind_ok] at h₀
     rw [Opt.compile.correctness] at h₀
@@ -58,12 +58,12 @@ This theorem covers the "happy path" -- showing that if optimized policy
 compilation succeeds, then `verifyEvaluatePair` and `verifyEvaluatePairOpt` are
 equivalent.
 -/
-theorem verifyEvaluatePairOpt_eqv_verifyEvaluatePair_ok {p₁ p₂ wp₁ wp₂ : Policy} {cp₁ cp₂ : CompiledPolicy} {Γ : Validation.TypeEnv} {φ : Term → Term → Term} :
-  CompiledPolicy.compile p₁ Γ = .ok cp₁ →
-  CompiledPolicy.compile p₂ Γ = .ok cp₂ →
-  wellTypedPolicy p₁ Γ = .ok wp₁ →
-  wellTypedPolicy p₂ Γ = .ok wp₂ →
-  verifyEvaluatePair φ wp₁ wp₂ (SymEnv.ofTypeEnv Γ) ~ .ok (verifyEvaluatePairOpt φ cp₁ cp₂)
+theorem verifyEvaluatePairOpt_eqv_verifyEvaluatePair_ok {p₁ p₂ wp₁ wp₂ : Policy} {cp₁ cp₂ : CompiledPolicy} {s : CompiledSchema} {reqty : Validation.RequestType} {φ : Term → Term → Term} :
+  CompiledPolicy.compile p₁ s reqty = .ok cp₁ →
+  CompiledPolicy.compile p₂ s reqty = .ok cp₂ →
+  wellTypedPolicy p₁ (s.typeEnv reqty) = .ok wp₁ →
+  wellTypedPolicy p₂ (s.typeEnv reqty) = .ok wp₂ →
+  verifyEvaluatePair φ wp₁ wp₂ (s.symEnv reqty) ~ .ok (verifyEvaluatePairOpt φ cp₁ cp₂)
 := by
   simp [verifyEvaluatePair, verifyEvaluatePairOpt, ResultAssertsEquiv]
   intro h₀ h₁ h₂ h₃
@@ -71,14 +71,14 @@ theorem verifyEvaluatePairOpt_eqv_verifyEvaluatePair_ok {p₁ p₂ wp₁ wp₂ :
     simp [cp_compile_produces_the_right_env h₀, cp_compile_produces_the_right_env h₁]
   simp [henv]
   simp [enforcePairCompiledPolicy_eqv_enforce_ok h₀ h₁ h₂ h₃]
-  cases h₄ : compile wp₁.toExpr (SymEnv.ofTypeEnv Γ) <;> simp
+  cases h₄ : compile wp₁.toExpr (s.symEnv reqty) <;> simp
   case error e =>
     simp only [CompiledPolicy.compile, Except.mapError, h₂, Except.bind_ok] at h₀
     rw [Opt.compile.correctness] at h₀
     simp [h₄] at h₀
   case ok t₁ =>
     have h₅ := (cp_compile_produces_the_right_term h₀ h₂).symm ; simp [h₄] at h₅ ; subst t₁
-    cases h₆ : compile wp₂.toExpr (SymEnv.ofTypeEnv Γ) <;> simp
+    cases h₆ : compile wp₂.toExpr (s.symEnv reqty) <;> simp
     case error e =>
       simp only [CompiledPolicy.compile, Except.mapError, h₃, Except.bind_ok] at h₁
       rw [Opt.compile.correctness] at h₁
@@ -94,12 +94,12 @@ This theorem covers the "happy path" -- showing that if optimized policy
 compilation succeeds, then `verifyIsAuthorized` and `verifyIsAuthorizedOpt` are
 equivalent.
 -/
-theorem verifyIsAuthorizedOpt_eqv_verifyIsAuthorized_ok {ps₁ ps₂ wps₁ wps₂ : Policies} {cpset₁ cpset₂ : CompiledPolicySet} {Γ : Validation.TypeEnv} {φ : Term → Term → Term} :
-  CompiledPolicySet.compile ps₁ Γ = .ok cpset₁ →
-  CompiledPolicySet.compile ps₂ Γ = .ok cpset₂ →
-  wellTypedPolicies ps₁ Γ = .ok wps₁ →
-  wellTypedPolicies ps₂ Γ = .ok wps₂ →
-  verifyIsAuthorized φ wps₁ wps₂ (SymEnv.ofTypeEnv Γ) ~ .ok (verifyIsAuthorizedOpt φ cpset₁ cpset₂)
+theorem verifyIsAuthorizedOpt_eqv_verifyIsAuthorized_ok {ps₁ ps₂ wps₁ wps₂ : Policies} {cpset₁ cpset₂ : CompiledPolicySet} {s : CompiledSchema} {reqty : Validation.RequestType} {φ : Term → Term → Term} :
+  CompiledPolicySet.compile ps₁ s reqty = .ok cpset₁ →
+  CompiledPolicySet.compile ps₂ s reqty = .ok cpset₂ →
+  wellTypedPolicies ps₁ (s.typeEnv reqty) = .ok wps₁ →
+  wellTypedPolicies ps₂ (s.typeEnv reqty) = .ok wps₂ →
+  verifyIsAuthorized φ wps₁ wps₂ (s.symEnv reqty) ~ .ok (verifyIsAuthorizedOpt φ cpset₁ cpset₂)
 := by
   simp [verifyIsAuthorized, verifyIsAuthorizedOpt, ResultAssertsEquiv]
   intro hcpset₁ hcpset₂ hwps₁ hwps₂
@@ -107,14 +107,14 @@ theorem verifyIsAuthorizedOpt_eqv_verifyIsAuthorized_ok {ps₁ ps₂ wps₁ wps�
   have henvs : cpset₁.εnv = cpset₂.εnv := by
     simp [cpset_compile_produces_the_right_env hcpset₁, cpset_compile_produces_the_right_env hcpset₂]
   simp [henvs]
-  cases h₁ : SymCC.isAuthorized wps₁ (SymEnv.ofTypeEnv Γ) <;> simp
+  cases h₁ : SymCC.isAuthorized wps₁ (s.symEnv reqty) <;> simp
   case error e =>
     simp_all only [CompiledPolicySet.compile, Except.mapError, Except.bind_ok]
     rw [Opt.isAuthorized.correctness] at hcpset₁
     simp [h₁] at hcpset₁
   case ok t =>
     have h₃ := (cpset_compile_produces_the_right_term hcpset₁ hwps₁).symm ; simp [h₁] at h₃ ; subst t
-    cases h₂ : SymCC.isAuthorized wps₂ (SymEnv.ofTypeEnv Γ) <;> simp
+    cases h₂ : SymCC.isAuthorized wps₂ (s.symEnv reqty) <;> simp
     case error e =>
       simp_all only [CompiledPolicySet.compile, Except.mapError, Except.bind_ok]
       rw [Opt.isAuthorized.correctness] at hcpset₂
@@ -130,10 +130,10 @@ This theorem covers the "happy path" -- showing that if optimized policy
 compilation succeeds, then `verifyNeverErrors` and `verifyNeverErrorsOpt` are
 equivalent.
 -/
-theorem verifyNeverErrorsOpt_eqv_verifyNeverErrors_ok {p wp : Policy} {cp : CompiledPolicy} {Γ : Validation.TypeEnv} :
-  CompiledPolicy.compile p Γ = .ok cp →
-  wellTypedPolicy p Γ = .ok wp →
-  verifyNeverErrors wp (SymEnv.ofTypeEnv Γ) ~ .ok (verifyNeverErrorsOpt cp)
+theorem verifyNeverErrorsOpt_eqv_verifyNeverErrors_ok {p wp : Policy} {cp : CompiledPolicy} {s : CompiledSchema} {reqty : Validation.RequestType} :
+  CompiledPolicy.compile p s reqty = .ok cp →
+  wellTypedPolicy p (s.typeEnv reqty) = .ok wp →
+  verifyNeverErrors wp (s.symEnv reqty) ~ .ok (verifyNeverErrorsOpt cp)
 := by
   simp [verifyNeverErrors, verifyNeverErrorsOpt]
   exact verifyEvaluateOpt_eqv_verifyEvaluate_ok
@@ -143,10 +143,10 @@ This theorem covers the "happy path" -- showing that if optimized policy
 compilation succeeds, then `verifyAlwaysMatches` and `verifyAlwaysMatchesOpt` are
 equivalent.
 -/
-theorem verifyAlwaysMatchesOpt_eqv_verifyAlwaysMatches_ok {p wp : Policy} {cp : CompiledPolicy} {Γ : Validation.TypeEnv} :
-  CompiledPolicy.compile p Γ = .ok cp →
-  wellTypedPolicy p Γ = .ok wp →
-  verifyAlwaysMatches wp (SymEnv.ofTypeEnv Γ) ~ .ok (verifyAlwaysMatchesOpt cp)
+theorem verifyAlwaysMatchesOpt_eqv_verifyAlwaysMatches_ok {p wp : Policy} {cp : CompiledPolicy} {s : CompiledSchema} {reqty : Validation.RequestType} :
+  CompiledPolicy.compile p s reqty = .ok cp →
+  wellTypedPolicy p (s.typeEnv reqty) = .ok wp →
+  verifyAlwaysMatches wp (s.symEnv reqty) ~ .ok (verifyAlwaysMatchesOpt cp)
 := by
   simp [verifyAlwaysMatches, verifyAlwaysMatchesOpt]
   exact verifyEvaluateOpt_eqv_verifyEvaluate_ok
@@ -156,10 +156,10 @@ This theorem covers the "happy path" -- showing that if optimized policy
 compilation succeeds, then `verifyNeverMatches` and `verifyNeverMatchesOpt` are
 equivalent.
 -/
-theorem verifyNeverMatchesOpt_eqv_verifyNeverMatches_ok {p wp : Policy} {cp : CompiledPolicy} {Γ : Validation.TypeEnv} :
-  CompiledPolicy.compile p Γ = .ok cp →
-  wellTypedPolicy p Γ = .ok wp →
-  verifyNeverMatches wp (SymEnv.ofTypeEnv Γ) ~ .ok (verifyNeverMatchesOpt cp)
+theorem verifyNeverMatchesOpt_eqv_verifyNeverMatches_ok {p wp : Policy} {cp : CompiledPolicy} {s : CompiledSchema} {reqty : Validation.RequestType} :
+  CompiledPolicy.compile p s reqty = .ok cp →
+  wellTypedPolicy p (s.typeEnv reqty) = .ok wp →
+  verifyNeverMatches wp (s.symEnv reqty) ~ .ok (verifyNeverMatchesOpt cp)
 := by
   simp [verifyNeverMatches, verifyNeverMatchesOpt]
   exact verifyEvaluateOpt_eqv_verifyEvaluate_ok
@@ -169,12 +169,12 @@ This theorem covers the "happy path" -- showing that if optimized policy
 compilation succeeds, then `verifyMatchesEquivalent` and
 `verifyMatchesEquivalentOpt` are equivalent.
 -/
-theorem verifyMatchesEquivalentOpt_eqv_verifyMatchesEquivalent_ok {p₁ p₂ wp₁ wp₂ : Policy} {cp₁ cp₂ : CompiledPolicy} {Γ : Validation.TypeEnv} :
-  CompiledPolicy.compile p₁ Γ = .ok cp₁ →
-  CompiledPolicy.compile p₂ Γ = .ok cp₂ →
-  wellTypedPolicy p₁ Γ = .ok wp₁ →
-  wellTypedPolicy p₂ Γ = .ok wp₂ →
-  verifyMatchesEquivalent wp₁ wp₂ (SymEnv.ofTypeEnv Γ) ~ .ok (verifyMatchesEquivalentOpt cp₁ cp₂)
+theorem verifyMatchesEquivalentOpt_eqv_verifyMatchesEquivalent_ok {p₁ p₂ wp₁ wp₂ : Policy} {cp₁ cp₂ : CompiledPolicy} {s : CompiledSchema} {reqty : Validation.RequestType} :
+  CompiledPolicy.compile p₁ s reqty = .ok cp₁ →
+  CompiledPolicy.compile p₂ s reqty = .ok cp₂ →
+  wellTypedPolicy p₁ (s.typeEnv reqty) = .ok wp₁ →
+  wellTypedPolicy p₂ (s.typeEnv reqty) = .ok wp₂ →
+  verifyMatchesEquivalent wp₁ wp₂ (s.symEnv reqty) ~ .ok (verifyMatchesEquivalentOpt cp₁ cp₂)
 := by
   simp [verifyMatchesEquivalent, verifyMatchesEquivalentOpt]
   exact verifyEvaluatePairOpt_eqv_verifyEvaluatePair_ok
@@ -184,12 +184,12 @@ This theorem covers the "happy path" -- showing that if optimized policy
 compilation succeeds, then `verifyMatchesImplies` and
 `verifyMatchesImpliesOpt` are equivalent.
 -/
-theorem verifyMatchesImpliesOpt_eqv_verifyMatchesImplies_ok {p₁ p₂ wp₁ wp₂ : Policy} {cp₁ cp₂ : CompiledPolicy} {Γ : Validation.TypeEnv} :
-  CompiledPolicy.compile p₁ Γ = .ok cp₁ →
-  CompiledPolicy.compile p₂ Γ = .ok cp₂ →
-  wellTypedPolicy p₁ Γ = .ok wp₁ →
-  wellTypedPolicy p₂ Γ = .ok wp₂ →
-  verifyMatchesImplies wp₁ wp₂ (SymEnv.ofTypeEnv Γ) ~ .ok (verifyMatchesImpliesOpt cp₁ cp₂)
+theorem verifyMatchesImpliesOpt_eqv_verifyMatchesImplies_ok {p₁ p₂ wp₁ wp₂ : Policy} {cp₁ cp₂ : CompiledPolicy} {s : CompiledSchema} {reqty : Validation.RequestType} :
+  CompiledPolicy.compile p₁ s reqty = .ok cp₁ →
+  CompiledPolicy.compile p₂ s reqty = .ok cp₂ →
+  wellTypedPolicy p₁ (s.typeEnv reqty) = .ok wp₁ →
+  wellTypedPolicy p₂ (s.typeEnv reqty) = .ok wp₂ →
+  verifyMatchesImplies wp₁ wp₂ (s.symEnv reqty) ~ .ok (verifyMatchesImpliesOpt cp₁ cp₂)
 := by
   simp [verifyMatchesImplies, verifyMatchesImpliesOpt]
   exact verifyEvaluatePairOpt_eqv_verifyEvaluatePair_ok
@@ -199,12 +199,12 @@ This theorem covers the "happy path" -- showing that if optimized policy
 compilation succeeds, then `verifyMatchesDisjoint` and
 `verifyMatchesDisjointOpt` are equivalent.
 -/
-theorem verifyMatchesDisjointOpt_eqv_verifyMatchesDisjoint_ok {p₁ p₂ wp₁ wp₂ : Policy} {cp₁ cp₂ : CompiledPolicy} {Γ : Validation.TypeEnv} :
-  CompiledPolicy.compile p₁ Γ = .ok cp₁ →
-  CompiledPolicy.compile p₂ Γ = .ok cp₂ →
-  wellTypedPolicy p₁ Γ = .ok wp₁ →
-  wellTypedPolicy p₂ Γ = .ok wp₂ →
-  verifyMatchesDisjoint wp₁ wp₂ (SymEnv.ofTypeEnv Γ) ~ .ok (verifyMatchesDisjointOpt cp₁ cp₂)
+theorem verifyMatchesDisjointOpt_eqv_verifyMatchesDisjoint_ok {p₁ p₂ wp₁ wp₂ : Policy} {cp₁ cp₂ : CompiledPolicy} {s : CompiledSchema} {reqty : Validation.RequestType} :
+  CompiledPolicy.compile p₁ s reqty = .ok cp₁ →
+  CompiledPolicy.compile p₂ s reqty = .ok cp₂ →
+  wellTypedPolicy p₁ (s.typeEnv reqty) = .ok wp₁ →
+  wellTypedPolicy p₂ (s.typeEnv reqty) = .ok wp₂ →
+  verifyMatchesDisjoint wp₁ wp₂ (s.symEnv reqty) ~ .ok (verifyMatchesDisjointOpt cp₁ cp₂)
 := by
   simp [verifyMatchesDisjoint, verifyMatchesDisjointOpt]
   exact verifyEvaluatePairOpt_eqv_verifyEvaluatePair_ok
@@ -214,12 +214,12 @@ This theorem covers the "happy path" -- showing that if optimized policy
 compilation succeeds, then `verifyImplies` and `verifyImpliesOpt` are
 equivalent.
 -/
-theorem verifyImpliesOpt_eqv_verifyImplies_ok {ps₁ ps₂ wps₁ wps₂ : Policies} {cpset₁ cpset₂ : CompiledPolicySet} {Γ : Validation.TypeEnv} :
-  CompiledPolicySet.compile ps₁ Γ = .ok cpset₁ →
-  CompiledPolicySet.compile ps₂ Γ = .ok cpset₂ →
-  wellTypedPolicies ps₁ Γ = .ok wps₁ →
-  wellTypedPolicies ps₂ Γ = .ok wps₂ →
-  verifyImplies wps₁ wps₂ (SymEnv.ofTypeEnv Γ) ~ .ok (verifyImpliesOpt cpset₁ cpset₂)
+theorem verifyImpliesOpt_eqv_verifyImplies_ok {ps₁ ps₂ wps₁ wps₂ : Policies} {cpset₁ cpset₂ : CompiledPolicySet} {s : CompiledSchema} {reqty : Validation.RequestType} :
+  CompiledPolicySet.compile ps₁ s reqty = .ok cpset₁ →
+  CompiledPolicySet.compile ps₂ s reqty = .ok cpset₂ →
+  wellTypedPolicies ps₁ (s.typeEnv reqty) = .ok wps₁ →
+  wellTypedPolicies ps₂ (s.typeEnv reqty) = .ok wps₂ →
+  verifyImplies wps₁ wps₂ (s.symEnv reqty) ~ .ok (verifyImpliesOpt cpset₁ cpset₂)
 := by
   simp [verifyImplies, verifyImpliesOpt]
   exact verifyIsAuthorizedOpt_eqv_verifyIsAuthorized_ok
@@ -229,14 +229,14 @@ This theorem covers the "happy path" -- showing that if optimized policy
 compilation succeeds, then `verifyAlwaysAllows` and `verifyAlwaysAllowsOpt` are
 equivalent.
 -/
-theorem verifyAlwaysAllowsOpt_eqv_verifyAlwaysAllows_ok {ps wps : Policies} {cpset : CompiledPolicySet} {Γ : Validation.TypeEnv} :
-  CompiledPolicySet.compile ps Γ = .ok cpset →
-  wellTypedPolicies ps Γ = .ok wps →
-  verifyAlwaysAllows wps (SymEnv.ofTypeEnv Γ) ~ .ok (verifyAlwaysAllowsOpt cpset)
+theorem verifyAlwaysAllowsOpt_eqv_verifyAlwaysAllows_ok {ps wps : Policies} {cpset : CompiledPolicySet} {s : CompiledSchema} {reqty : Validation.RequestType} :
+  CompiledPolicySet.compile ps s reqty = .ok cpset →
+  wellTypedPolicies ps (s.typeEnv reqty) = .ok wps →
+  verifyAlwaysAllows wps (s.symEnv reqty) ~ .ok (verifyAlwaysAllowsOpt cpset)
 := by
   simp [verifyAlwaysAllows, verifyAlwaysAllowsOpt]
   intro hcpset hwps
-  apply verifyImpliesOpt_eqv_verifyImplies_ok _ hcpset (wellTypedPolicies_allowAll Γ) hwps
+  apply verifyImpliesOpt_eqv_verifyImplies_ok _ hcpset (wellTypedPolicies_allowAll (s.typeEnv reqty)) hwps
   simp [CompiledPolicySet.compile, Except.mapError, do_eq_ok, wellTypedPolicies_allowAll]
   rw [Opt.isAuthorized.correctness]
   simp [isAuthorized_allowAll, footprint_allowAll, CompiledPolicySet.allowAll, cpset_compile_produces_the_right_env hcpset, footprints_singleton, Data.Set.map_empty]
@@ -246,10 +246,10 @@ This theorem covers the "happy path" -- showing that if optimized policy
 compilation succeeds, then `verifyAlwaysAllows` and `verifyAlwaysAllowsOpt` are
 equivalent.
 -/
-theorem verifyAlwaysDeniesOpt_eqv_verifyAlwaysDenies_ok {ps wps : Policies} {cpset : CompiledPolicySet} {Γ : Validation.TypeEnv} :
-  CompiledPolicySet.compile ps Γ = .ok cpset →
-  wellTypedPolicies ps Γ = .ok wps →
-  verifyAlwaysDenies wps (SymEnv.ofTypeEnv Γ) ~ .ok (verifyAlwaysDeniesOpt cpset)
+theorem verifyAlwaysDeniesOpt_eqv_verifyAlwaysDenies_ok {ps wps : Policies} {cpset : CompiledPolicySet} {s : CompiledSchema} {reqty : Validation.RequestType} :
+  CompiledPolicySet.compile ps s reqty = .ok cpset →
+  wellTypedPolicies ps (s.typeEnv reqty) = .ok wps →
+  verifyAlwaysDenies wps (s.symEnv reqty) ~ .ok (verifyAlwaysDeniesOpt cpset)
 := by
   simp [verifyAlwaysDenies, verifyAlwaysDeniesOpt]
   intro hcpset hwps
@@ -265,12 +265,12 @@ This theorem covers the "happy path" -- showing that if optimized policy
 compilation succeeds, then `verifyEquivalent` and `verifyEquivalentOpt` are
 equivalent.
 -/
-theorem verifyEquivalentOpt_eqv_verifyEquivalent_ok {ps₁ ps₂ wps₁ wps₂ : Policies} {cpset₁ cpset₂ : CompiledPolicySet} {Γ : Validation.TypeEnv} :
-  CompiledPolicySet.compile ps₁ Γ = .ok cpset₁ →
-  CompiledPolicySet.compile ps₂ Γ = .ok cpset₂ →
-  wellTypedPolicies ps₁ Γ = .ok wps₁ →
-  wellTypedPolicies ps₂ Γ = .ok wps₂ →
-  verifyEquivalent wps₁ wps₂ (SymEnv.ofTypeEnv Γ) ~ .ok (verifyEquivalentOpt cpset₁ cpset₂)
+theorem verifyEquivalentOpt_eqv_verifyEquivalent_ok {ps₁ ps₂ wps₁ wps₂ : Policies} {cpset₁ cpset₂ : CompiledPolicySet} {s : CompiledSchema} {reqty : Validation.RequestType} :
+  CompiledPolicySet.compile ps₁ s reqty = .ok cpset₁ →
+  CompiledPolicySet.compile ps₂ s reqty = .ok cpset₂ →
+  wellTypedPolicies ps₁ (s.typeEnv reqty) = .ok wps₁ →
+  wellTypedPolicies ps₂ (s.typeEnv reqty) = .ok wps₂ →
+  verifyEquivalent wps₁ wps₂ (s.symEnv reqty) ~ .ok (verifyEquivalentOpt cpset₁ cpset₂)
 := by
   simp [verifyEquivalent, verifyEquivalentOpt]
   exact verifyIsAuthorizedOpt_eqv_verifyIsAuthorized_ok
@@ -280,12 +280,12 @@ This theorem covers the "happy path" -- showing that if optimized policy
 compilation succeeds, then `verifyDisjoint` and `verifyDisjointOpt` are
 equivalent.
 -/
-theorem verifyDisjointOpt_eqv_verifyDisjoint_ok {ps₁ ps₂ wps₁ wps₂ : Policies} {cpset₁ cpset₂ : CompiledPolicySet} {Γ : Validation.TypeEnv} :
-  CompiledPolicySet.compile ps₁ Γ = .ok cpset₁ →
-  CompiledPolicySet.compile ps₂ Γ = .ok cpset₂ →
-  wellTypedPolicies ps₁ Γ = .ok wps₁ →
-  wellTypedPolicies ps₂ Γ = .ok wps₂ →
-  verifyDisjoint wps₁ wps₂ (SymEnv.ofTypeEnv Γ) ~ .ok (verifyDisjointOpt cpset₁ cpset₂)
+theorem verifyDisjointOpt_eqv_verifyDisjoint_ok {ps₁ ps₂ wps₁ wps₂ : Policies} {cpset₁ cpset₂ : CompiledPolicySet} {s : CompiledSchema} {reqty : Validation.RequestType} :
+  CompiledPolicySet.compile ps₁ s reqty = .ok cpset₁ →
+  CompiledPolicySet.compile ps₂ s reqty = .ok cpset₂ →
+  wellTypedPolicies ps₁ (s.typeEnv reqty) = .ok wps₁ →
+  wellTypedPolicies ps₂ (s.typeEnv reqty) = .ok wps₂ →
+  verifyDisjoint wps₁ wps₂ (s.symEnv reqty) ~ .ok (verifyDisjointOpt cpset₁ cpset₂)
 := by
   simp [verifyDisjoint, verifyDisjointOpt]
   exact verifyIsAuthorizedOpt_eqv_verifyIsAuthorized_ok

--- a/cedar-lean/Cedar/Validation/Types.lean
+++ b/cedar-lean/Cedar/Validation/Types.lean
@@ -189,6 +189,7 @@ public def ActionSchema.descendentOf (as : ActionSchema)  (uid₁ uid₂ : Entit
 public structure Schema where
   ets : EntitySchema
   acts : ActionSchema
+deriving Inhabited
 
 public structure RequestType where
   principal : EntityType


### PR DESCRIPTION
Draft PR since we'll also want to make the change to the Rust, and I need to fix up some FFI/CLI parts here. The main change to the Lean model is done and can be reviewed.

Makes the API change proposed here https://github.com/cedar-policy/cedar/pull/2467#issuecomment-4985107815

This PR adds the `CompiledSchema` structure to Lean, and changes the `CompiledPolicy` to use it in its constructor. 

```diff
-def CompiledPolicy.compile (p : Policy) (Γ : Validation.TypeEnv) : Except CompiledPolicyError CompiledPolicy := do
+def CompiledPolicy.compile (p : Policy) (s : CompiledSchema) (reqty : Validation.RequestType) : Except CompiledPolicyError CompiledPolicy := do
+  let Γ := s.typeEnv reqty
   let policy ← wellTypedPolicy p Γ |>.mapError .validationError
-  let εnv := SymEnv.ofEnv Γ
+  let εnv := s.symEnv reqty
   let { term, footprint } ← Opt.compile policy.toExpr εnv |>.mapError .symCCError
   let acyclicity := footprint.map (SymCC.acyclicity · εnv.entities)
   .ok { term, εnv, policy, footprint, acyclicity }
```

Proof are updated to show we can reuse this the compiled schema

```lean4
theorem checkEquivalentOpt_eqv_checkEquivalent {ps₁ ps₂ : Policies} {Γ : Validation.TypeEnv} :
  Γ.WellFormed →
  (do
    let s := CompiledSchema.compile ⟨Γ.ets, Γ.acts⟩
    let cpset₁ ← CompiledPolicySet.compile ps₁ s Γ.reqty
    let cpset₂ ← CompiledPolicySet.compile ps₂ s Γ.reqty
    pure $ checkEquivalentOpt cpset₁ cpset₂
  ) =
  (do
    let wps₁ ← wellTypedPolicies ps₁ Γ |>.mapError .validationError
    let wps₂ ← wellTypedPolicies ps₂ Γ |>.mapError .validationError
    pure $ checkEquivalent wps₁ wps₂ (SymEnv.ofTypeEnv Γ)
  )
```