### PR TITLE
Use schema in TPE to reduce has/hasTag/in/==/is

### DIFF
--- a/cedar-lean/Cedar/TPE/BatchedEvaluator.lean
+++ b/cedar-lean/Cedar/TPE/BatchedEvaluator.lean
@@ -44,6 +44,7 @@ The batched evaluation loop for a single residual expression.
   3. Exits if a value has been found or it hits the maximum iteration limit
 -/
 def batchedEvaluateLoop
+  (env : TypeEnv)
   (residual : Residual)
   (req : Request)
   (loader : EntityLoader)
@@ -55,9 +56,9 @@ def batchedEvaluateLoop
     let newEntities := ((loader toLoad).mapOnValues MaybeEntityData.asPartial)
     let newStore := newEntities ++ store
 
-    match Cedar.TPE.evaluate residual req.asPartialRequest newStore with
+    match Cedar.TPE.evaluate env residual req.asPartialRequest newStore with
     | .val v _ty => .val v _ty
-    | newRes => batchedEvaluateLoop newRes req loader newStore n
+    | newRes => batchedEvaluateLoop env newRes req loader newStore n
 
 def actionEntities (acts : ActionSchema) : PartialEntities :=
   Map.make (acts.toList.map λ (uid, entry) =>
@@ -70,19 +71,21 @@ Performs a maximum of `iter` number of calls to `loader`,
 but may perform fewer when a value is found.
 -/
 def batchedEvaluate
-  (acts : ActionSchema)
+  (env : TypeEnv)
   (x : TypedExpr)
   (req : Request)
   (loader : EntityLoader)
   (iters : Nat)
   : Residual :=
-  let residual := Cedar.TPE.evaluate x.toResidual req.asPartialRequest (actionEntities acts)
-  batchedEvaluateLoop residual req loader (actionEntities acts) iters
+  let residual :=
+    Cedar.TPE.evaluate env x.toResidual req.asPartialRequest (actionEntities env.acts)
+  batchedEvaluateLoop env residual req loader (actionEntities env.acts) iters
 
 /--
 The batched authorization loop for authorization over a list of policies.
 -/
 def batchedAuthorizeLoop
+  (env : TypeEnv)
   (residuals : List ResidualPolicy) (req : Request) (loader : EntityLoader)
   (store : PartialEntities) (n : Nat)
   : Response
@@ -98,8 +101,8 @@ def batchedAuthorizeLoop
       let newStore := newEntities ++ store
 
       let residuals : List ResidualPolicy := residuals.map λ rp =>
-        ⟨rp.id, rp.effect, Cedar.TPE.evaluate rp.residual req.asPartialRequest newStore⟩
-      batchedAuthorizeLoop residuals req loader newStore n
+        ⟨rp.id, rp.effect, Cedar.TPE.evaluate env rp.residual req.asPartialRequest newStore⟩
+      batchedAuthorizeLoop env residuals req loader newStore n
 
 /--
 Evaluate an authorization request using an EntityLoader instead of a full Entities store.
@@ -116,7 +119,10 @@ def batchedAuthorize
   let residualPolicies ← policies.mapM (λ p => do
     pure ⟨p.id, p.effect,
       ← evaluatePolicy schema p req.asPartialRequest (actionEntities schema.acts)⟩)
-  pure (batchedAuthorizeLoop residualPolicies req loader (actionEntities schema.acts) iters)
+  match schema.environment? req.principal.ty req.resource.ty req.action with
+  | .none => .error .invalidEnvironment
+  | .some env =>
+    pure (batchedAuthorizeLoop env residualPolicies req loader (actionEntities schema.acts) iters)
 
 /--
 Create an entity loader for a given entity store.

--- a/cedar-lean/Cedar/TPE/Evaluator.lean
+++ b/cedar-lean/Cedar/TPE/Evaluator.lean
@@ -76,17 +76,24 @@ def or : Residual → Residual → CedarType → Residual
     if l.errorFree then true else .or l (.val true rty) ty
   | l, r, ty           => .or l r ty
 
-def apply₁ (req: PartialRequest) (op₁ : UnaryOp) (r : Residual) (ty : CedarType) : Residual :=
+/-  Given a unary operation applied to a non-value residual, reduce it to a value if possible -/
+def tryDecideResidual₁ (op₁ : UnaryOp) (r : Residual) : Option Value :=
+  if r.errorFree then
+    match op₁, r.typeOf with
+    | .is ety₁, .entity ety₂ => .some (ety₁ == ety₂)
+    | _, _ => .none
+  else .none
+
+def apply₁ (op₁ : UnaryOp) (r : Residual) (ty : CedarType) : Residual :=
   match r with
   | .error _ => .error ty
   | _ =>
-    match r.asValue with
-    | .some v => someOrError (Spec.apply₁ op₁ v).toOption ty
-    | .none   =>
-      match op₁, r with
-      | .is ety, .var .resource _ => .val (req.resource.ty == ety) ty
-      | .is ety, .var .principal _ => .val (req.principal.ty == ety) ty
-      | _, _ => .unaryApp op₁ r ty
+  match tryDecideResidual₁ op₁ r with
+  | .some v => .val v ty
+  | .none =>
+  match r.asValue with
+  | .some v => someOrError (Spec.apply₁ op₁ v).toOption ty
+  | .none => .unaryApp op₁ r ty
 
 def inₑ (uid₁ uid₂ : EntityUID) (es : PartialEntities) : Option Bool :=
   if uid₁ = uid₂ then .some true else (es.ancestors uid₁).map (Set.contains · uid₂)
@@ -102,7 +109,24 @@ def getTag (uid : EntityUID) (tag : String) (es : PartialEntities) (ty : CedarTy
   | .some tags => someOrError (tags.find? tag) ty
   | .none => .binaryApp .getTag uid tag ty
 
-def apply₂ (op₂ : BinaryOp) (r₁ r₂ : Residual) (es : PartialEntities) (ty : CedarType) : Residual :=
+/- Given a unary operation applied to a non-value residuals, reduce it to a value if possible -/
+def tryDecideResidual₂ (env : TypeEnv) (op₂ : BinaryOp) (r₁ r₂ : Residual) : Option Value :=
+  if r₁.errorFree && r₂.errorFree then
+    match op₂, r₁.typeOf, r₂.typeOf with
+    | .mem, .entity ety₁, .entity ety₂
+    | .mem, .entity ety₁, .set (.entity ety₂) => if !env.descendentOf ety₁ ety₂ then .some false else none
+    | .eq,  .entity ety₁, .entity ety₂        => if ety₁ != ety₂ then .some false else none
+    | .hasTag, .entity ety, .string           => if env.ets.tags? ety == some .none then .some false else none
+    | _, _, _                                 => .none
+  else .none
+
+def apply₂ (env : TypeEnv) (op₂ : BinaryOp) (r₁ r₂ : Residual) (es : PartialEntities) (ty : CedarType) : Residual :=
+  match r₁, r₂ with
+  | .error _, _ | _, .error _ => .error ty
+  | _, _ =>
+  match tryDecideResidual₂ env op₂ r₁ r₂ with
+  | .some v => .val v ty
+  | .none =>
   match r₁.asValue, r₂.asValue with
   | .some v₁, .some v₂ =>
     match op₂, v₁, v₂ with
@@ -141,10 +165,7 @@ def apply₂ (op₂ : BinaryOp) (r₁ r₂ : Residual) (es : PartialEntities) (t
     | .getTag, .prim (.entityUID uid₁), .prim (.string tag) =>
       getTag uid₁ tag es ty
     | _, _, _ => .error ty
-  | _, _ =>
-    match r₁, r₂ with
-    | .error _, _ | _, .error _ => .error ty
-    | _, _ => self
+  | _, _ => self
   where
   self := .binaryApp op₂ r₁ r₂ ty
 
@@ -155,13 +176,30 @@ def attrsOf (r : Residual) (lookup : EntityUID → Option (Map Attr Value)) : Op
   | .val (.prim (.entityUID uid)) _ => lookup uid
   | _                               => none
 
-def hasAttr (r : Residual) (a : Attr) (es : PartialEntities) (ty : CedarType) : Residual :=
+/- Given a `has` expression applied to a non-value residuals, reduce it to a value if possible -/
+def tryDecideHasResidual (env : TypeEnv) (r : Residual) (a : Attr) : Option Value :=
+  if r.errorFree then
+    match r.typeOf with
+    | .record rty =>
+      if (rty.find? a).isNone then .some false else .none
+    | .entity ety =>
+      match env.ets.attrs? ety with
+      | .some rty =>
+        if (rty.find? a).isNone then .some false else none
+      | .none => .none
+    | _ => .none
+  else .none
+
+def hasAttr (env : TypeEnv) (r : Residual) (a : Attr) (es : PartialEntities) (ty : CedarType) : Residual :=
   match r with
   | .error _ => .error ty
   | _ =>
-    match attrsOf r es.attrs with
-    | .some m => m.contains a
-    | .none   => .hasAttr r a ty
+  match tryDecideHasResidual env r a with
+  | .some v => .val v ty
+  | .none =>
+  match attrsOf r es.attrs with
+  | .some m => m.contains a
+  | .none   => .hasAttr r a ty
 
 def getAttr (r : Residual) (a : Attr) (es : PartialEntities) (ty : CedarType) : Residual :=
   match r with
@@ -187,6 +225,7 @@ def call (xfn : ExtFun) (rs : List Residual) (ty : CedarType) : Residual :=
   | .none    => if rs.any Residual.isError then .error ty else .call xfn rs ty
 
 def evaluate
+  (env : TypeEnv)
   (x : Residual)
   (req : PartialRequest)
   (es : PartialEntities) : Residual :=
@@ -195,25 +234,25 @@ def evaluate
   | .var v ty => varₚ req v ty
   | .error ty => .error ty
   | .ite x₁ x₂ x₃ ty =>
-    ite (evaluate x₁ req es) (evaluate x₂ req es) (evaluate x₃ req es) ty
+    ite (evaluate env x₁ req es) (evaluate env x₂ req es) (evaluate env x₃ req es) ty
   | .and x₁ x₂ ty =>
-    and (evaluate x₁ req es) (evaluate x₂ req es) ty
+    and (evaluate env x₁ req es) (evaluate env x₂ req es) ty
   | .or x₁ x₂ ty =>
-    or (evaluate x₁ req es) (evaluate x₂ req es) ty
+    or (evaluate env x₁ req es) (evaluate env x₂ req es) ty
   | .unaryApp op₁ x₁ ty =>
-    apply₁ req op₁ (evaluate x₁ req es) ty
+    apply₁ op₁ (evaluate env x₁ req es) ty
   | .binaryApp op₂ x₁ x₂ ty =>
-    apply₂ op₂ (evaluate x₁ req es) (evaluate x₂ req es) es ty
+    apply₂ env op₂ (evaluate env x₁ req es) (evaluate env x₂ req es) es ty
   | .hasAttr x₁ a ty =>
-    hasAttr (evaluate x₁ req es) a es ty
+    hasAttr env (evaluate env x₁ req es) a es ty
   | .getAttr x₁ a ty =>
-    getAttr (evaluate x₁ req es) a es ty
+    getAttr (evaluate env x₁ req es) a es ty
   | .set xs ty =>
-    set (xs.map₁ (λ ⟨x₁, _⟩ => evaluate x₁ req es)) ty
+    set (xs.map₁ (λ ⟨x₁, _⟩ => evaluate env x₁ req es)) ty
   | .record axs ty =>
-    record (axs.map₁ (λ ⟨(a, x₁), _⟩ => (a, (evaluate x₁ req es)))) ty
+    record (axs.map₁ (λ ⟨(a, x₁), _⟩ => (a, (evaluate env x₁ req es)))) ty
   | .call xfn xs ty =>
-    call xfn (xs.map₁ (λ ⟨x₁, _⟩ => evaluate x₁ req es)) ty
+    call xfn (xs.map₁ (λ ⟨x₁, _⟩ => evaluate env x₁ req es)) ty
 termination_by x
 decreasing_by
   all_goals
@@ -252,7 +291,7 @@ def evaluatePolicy (schema : Schema)
           checkEntities schema p.toExpr|>.mapError .invalidPolicy
           let expr := substituteAction env.reqty.action p.toExpr
           let (te, _) ← (typeOf expr ∅ env).mapError Error.invalidPolicy
-          .ok (evaluate te.liftBoolTypes.toResidual req es)
+          .ok (evaluate env te.liftBoolTypes.toResidual req es)
       else .error .invalidRequestOrEntities
     | .error _ => .error .invalidEnvironment
 

--- a/cedar-lean/Cedar/Thm/BatchedEvaluator.lean
+++ b/cedar-lean/Cedar/Thm/BatchedEvaluator.lean
@@ -27,7 +27,7 @@ theorem batched_evaluate_eq_evaluate
   EntityLoader.WellBehaved es loader →
   TypedExpr.WellTyped env x →
   InstanceOfWellFormedEnvironment req es env →
-  (Residual.evaluate (batchedEvaluate env.acts x req loader iters) req es).toOption = (evaluate x.toExpr req es).toOption := by
+  (Residual.evaluate (batchedEvaluate env x req loader iters) req es).toOption = (evaluate x.toExpr req es).toOption := by
   simp only [batchedEvaluate]
   intro h₁ h₂ h₃
   have h₄ := (direct_request_and_entities_refine req es)
@@ -44,7 +44,7 @@ theorem batched_evaluate_eq_evaluate
     . apply as_partial_request_refines
     . exact actionEntities_refines h₃.1 h₃.2.2
   have h₆ : Residual.WellTyped env
-      (TPE.evaluate x.toResidual req.asPartialRequest (actionEntities env.acts)) :=
+      (TPE.evaluate env x.toResidual req.asPartialRequest (actionEntities env.acts)) :=
     partial_eval_preserves_well_typed h₃ h₇ h₅
 
   rw [batched_evaluate_loop_eq_evaluate es h₁ h₆ h₇ h₃]
@@ -72,7 +72,13 @@ theorem batched_authorize_ok_equiv
       evaluatePolicy schema p req.asPartialRequest (actionEntities schema.acts)) with
   | error e => simp [h_mapM, bind_pure_comp] at h_batched
   | ok residualPolicies =>
-    simp only [bind_pure_comp, h_mapM, Except.map_ok, Except.ok.injEq] at h_batched
+    -- `batchedAuthorize` looks the type environment up before entering the loop, so there is an
+    -- extra case for a request the schema gives no environment to.
+    simp only [bind_pure_comp, h_mapM] at h_batched
+    split at h_batched
+    case h_1 => simp at h_batched
+    case h_2 env₀ h_env₀ =>
+    simp only [Except.bind_ok, pure, Except.pure, Except.ok.injEq] at h_batched
     subst h_batched
     rw [List.mapM_ok_iff_forall₂] at h_mapM
     match policies, h_mapM with
@@ -91,6 +97,13 @@ theorem batched_authorize_ok_equiv
           simp [h_ep] at ⊢ h_first
       obtain ⟨env, h_schema_env, h_wf⟩ :=
         evaluatePolicy_ok_implies_well_formed_env h_ep h_schema_wf h_entities
+      -- Flip the direction so `subst` eliminates `env₀` and keeps `env`, which the rest of the
+      -- proof refers to.
+      have h_env_eq : env = env₀ := by
+        simp only [Request.asPartialRequest] at h_schema_env
+        simp only [h_env₀, Option.some.injEq] at h_schema_env
+        exact h_schema_env.symm
+      subst h_env_eq
       have h_acts : env.acts = schema.acts :=
         (environment?_schema (by simpa only [Request.asPartialRequest] using h_schema_env)).2
       have h_ref : RequestAndEntitiesRefine req es req.asPartialRequest

--- a/cedar-lean/Cedar/Thm/BatchedEvaluator/Authorize.lean
+++ b/cedar-lean/Cedar/Thm/BatchedEvaluator/Authorize.lean
@@ -95,7 +95,7 @@ theorem residuals_equiv_preserved
   (h_wf : InstanceOfWellFormedEnvironment req es env)
   (h_ref : RequestAndEntitiesRefine req es req.asPartialRequest pes) :
   ResidualPoliciesEquivAndWellTyped env policies
-    (residuals.map λ rp => ⟨rp.id, rp.effect, Cedar.TPE.evaluate rp.residual req.asPartialRequest pes⟩)
+    (residuals.map λ rp => ⟨rp.id, rp.effect, Cedar.TPE.evaluate env rp.residual req.asPartialRequest pes⟩)
     req es
 := by
   unfold ResidualPoliciesEquivAndWellTyped at *
@@ -114,7 +114,7 @@ theorem batched_authorize_loop_equiv
   ResidualPoliciesEquivAndWellTyped env policies residuals req es →
   RequestAndEntitiesRefine req es req.asPartialRequest current_store →
   InstanceOfWellFormedEnvironment req es env →
-  ∃ rps, batchedAuthorizeLoop residuals req loader current_store iters
+  ∃ rps, batchedAuthorizeLoop env residuals req loader current_store iters
       = isAuthorizedFromResiduals rps ∧
     ResidualPoliciesEquivAndWellTyped env policies rps req es
 := by
@@ -147,7 +147,7 @@ theorem batched_authorize_loop_decision_agrees
   ResidualPoliciesEquivAndWellTyped env policies residuals req es →
   RequestAndEntitiesRefine req es req.asPartialRequest current_store →
   InstanceOfWellFormedEnvironment req es env →
-  (batchedAuthorizeLoop residuals req loader current_store iters).decision = some d →
+  (batchedAuthorizeLoop env residuals req loader current_store iters).decision = some d →
   (Spec.isAuthorized req es policies).decision = d
 := by
   intro h₀ h₁ h₂ h₃ h_dec

--- a/cedar-lean/Cedar/Thm/BatchedEvaluator/Evaluate.lean
+++ b/cedar-lean/Cedar/Thm/BatchedEvaluator/Evaluate.lean
@@ -30,7 +30,7 @@ theorem batched_evaluate_loop_eq_evaluate
   Residual.WellTyped env x →
   RequestAndEntitiesRefine req es req.asPartialRequest current_store →
   InstanceOfWellFormedEnvironment req es env →
-  (Residual.evaluate (batchedEvaluateLoop x req loader current_store iters) req es).toOption = (Residual.evaluate x req es).toOption := by
+  (Residual.evaluate (batchedEvaluateLoop env x req loader current_store iters) req es).toOption = (Residual.evaluate x req es).toOption := by
   intro h₀ h₁ h₂ h₃
   unfold batchedEvaluateLoop
   split
@@ -46,7 +46,7 @@ theorem batched_evaluate_loop_eq_evaluate
       · apply entities_refine_append
         · exact h₂.right
         · exact (h₀ toLoad).2
-    let newRes := TPE.evaluate x req.asPartialRequest newStore
+    let newRes := TPE.evaluate env x req.asPartialRequest newStore
     have h₇ : (Residual.evaluate newRes req es).toOption = (Residual.evaluate x req es).toOption := by
       rw [← partial_evaluate_is_sound h₁ h₃ h₆]
 

--- a/cedar-lean/Cedar/Thm/TPE/PreservesTypeOf.lean
+++ b/cedar-lean/Cedar/Thm/TPE/PreservesTypeOf.lean
@@ -31,7 +31,7 @@ open Cedar.TPE
 abbrev PEPreservesTypeOf (res : Residual) : Prop :=
   ∀ {env : TypeEnv} , Residual.WellTyped env res →
     ∀ (preq : PartialRequest) (pes : PartialEntities),
-      (TPE.evaluate res preq pes).typeOf = res.typeOf
+      (TPE.evaluate env res preq pes).typeOf = res.typeOf
 
 private theorem partial_eval_preserves_typeof_and {a b : Residual} {ty : CedarType}
   (ih_a : PEPreservesTypeOf a)
@@ -116,28 +116,24 @@ private theorem partial_eval_preserves_typeof_unaryApp {op : UnaryOp} {e : Resid
   simp only [TPE.evaluate, TPE.apply₁]
   split
   . simp [Residual.typeOf]
-  . rename CedarType => ty₂
-    rename Residual => r
-    rename_i h₁
-    split
-    . rename Option Value => x
-      rename Value => v
-      rename_i h₂
-      unfold Spec.apply₁
-      split
-      any_goals simp only [Residual.typeOf, someOrError, Except.toOption]
-      case h_2 =>
-        rename Int64 => i
-        cases h₃ : i.neg?
-        all_goals
-          simp [intOrErr]
-    . split <;> simp [Residual.typeOf]
+  . split
+    . simp [Residual.typeOf]
+    . split
+      . unfold someOrError
+        split <;> simp [Residual.typeOf]
+      . simp [Residual.typeOf]
 
 private theorem partial_eval_preserves_typeof_binaryApp {op : BinaryOp} {e1 e2 : Residual} {ty : CedarType} :
   PEPreservesTypeOf (Residual.binaryApp op e1 e2 ty)
 := by
   intro env h_wt preq pes
   simp only [TPE.evaluate, TPE.apply₂, Option.pure_def, Option.bind_eq_bind]
+  split
+  case h_1 => simp [Residual.typeOf]
+  case h_2 => simp [Residual.typeOf]
+  split
+  case h_1 => simp [Residual.typeOf]
+  case h_2 hdec =>
   split
   case h_1 =>
     split
@@ -176,11 +172,7 @@ private theorem partial_eval_preserves_typeof_binaryApp {op : BinaryOp} {e1 e2 :
       case binaryApp.some v =>
         simp only [someOrError]
         cases v.find? tag <;> simp
-  case h_2 =>
-    split
-    · simp [Residual.typeOf]
-    · simp [Residual.typeOf]
-    · simp [apply₂.self, Residual.typeOf]
+  case h_2 => simp [apply₂.self, Residual.typeOf]
 
 private theorem partial_eval_preserves_typeof_call {xfn : ExtFun} {args : List Residual} {ty : CedarType} :
   PEPreservesTypeOf (Residual.call xfn args ty)
@@ -218,10 +210,12 @@ private theorem partial_eval_preserves_typeof_hasAttr {expr : Residual} {attr : 
   split
   . simp [Residual.typeOf]
   . split
-    . cases h_wt
-      . simp [Residual.typeOf]
-      . simp [Residual.typeOf]
     . simp [Residual.typeOf]
+    . split
+      . cases h_wt
+        . simp [Residual.typeOf]
+        . simp [Residual.typeOf]
+      . simp [Residual.typeOf]
 
 private theorem partial_eval_preserves_typeof_set {ls : List Residual} {ty : CedarType} :
   PEPreservesTypeOf (Residual.set ls ty)
@@ -246,7 +240,7 @@ private theorem partial_eval_preserves_typeof_record {ls : List (Attr × Residua
     · simp [Residual.typeOf]
 
 /--
-Theorem: TPE.evaluate preserves the typeOf property.
+Theorem: TPE.evaluate env preserves the typeOf property.
 
 If a residual has a certain type, then partially evaluating it produces
 a residual with the same type.

--- a/cedar-lean/Cedar/Thm/TPE/Soundness.lean
+++ b/cedar-lean/Cedar/Thm/TPE/Soundness.lean
@@ -51,7 +51,7 @@ theorem partial_evaluate_is_sound_error
 {pes : PartialEntities}
 {ty : CedarType} :
   Except.toOption ((Residual.error ty).evaluate req es) =
-  Except.toOption ((TPE.evaluate (Residual.error ty) preq pes).evaluate req es)
+  Except.toOption ((TPE.evaluate env (Residual.error ty) preq pes).evaluate req es)
 := by
   simp [TPE.evaluate, Residual.evaluate]
 
@@ -70,7 +70,7 @@ theorem partial_evaluate_is_sound
   Residual.WellTyped env x →
   InstanceOfWellFormedEnvironment req es env →
   RequestAndEntitiesRefine req es preq pes →
-  (x.evaluate req es).toOption = ((Cedar.TPE.evaluate x preq pes).evaluate req es).toOption
+  (x.evaluate req es).toOption = ((Cedar.TPE.evaluate env x preq pes).evaluate req es).toOption
 := by
   intro h₁ h₂ h₃
   induction h₁
@@ -84,14 +84,14 @@ theorem partial_evaluate_is_sound
     exact partial_evaluate_is_sound_and h₂ h₃ hᵢ₁ hᵢ₂ hᵢ₃ hᵢ₄ hᵢ₅ hᵢ₆
   case or x₁ x₂ hᵢ₁ hᵢ₂ hᵢ₃ hᵢ₄ hᵢ₅ hᵢ₆ =>
     exact partial_evaluate_is_sound_or h₂ h₃ hᵢ₁ hᵢ₂ hᵢ₃ hᵢ₄ hᵢ₅ hᵢ₆
-  case unaryApp op₁ x₁ ty hᵢ₁ =>
-    exact partial_evaluate_is_sound_unary_app h₃ hᵢ₁
-  case binaryApp op₂ x₁ x₂ ty _ hwt howt hᵢ₁ hᵢ₂ =>
-    exact partial_evaluate_is_sound_binary_app h₂ h₃ hwt howt hᵢ₁ hᵢ₂
-  case hasAttr_entity ety x₁ attr hᵢ₁ =>
-    exact partial_evaluate_is_sound_has_attr h₃ hᵢ₁
-  case hasAttr_record rty x₁ attr hᵢ₁ =>
-    exact partial_evaluate_is_sound_has_attr h₃ hᵢ₁
+  case unaryApp op₁ x₁ ty hwt _ hᵢ₁ =>
+    exact partial_evaluate_is_sound_unary_app h₂ hwt h₃ hᵢ₁
+  case binaryApp op₂ x₁ x₂ ty hwt₁ hwt howt hᵢ₁ hᵢ₂ =>
+    exact partial_evaluate_is_sound_binary_app h₂ h₃ hwt₁ hwt howt hᵢ₁ hᵢ₂
+  case hasAttr_entity ety x₁ attr hwt _ hᵢ₁ =>
+    exact partial_evaluate_is_sound_has_attr h₂ hwt h₃ hᵢ₁
+  case hasAttr_record rty x₁ attr hwt _ hᵢ₁ =>
+    exact partial_evaluate_is_sound_has_attr h₂ hwt h₃ hᵢ₁
   case getAttr_entity ety rty x₁ attr ty hᵢ₁ =>
     exact partial_evaluate_is_sound_get_attr h₃ hᵢ₁
   case getAttr_record rty x₁ attr ty hᵢ₁ =>

--- a/cedar-lean/Cedar/Thm/TPE/Soundness.lean
+++ b/cedar-lean/Cedar/Thm/TPE/Soundness.lean
@@ -86,8 +86,8 @@ theorem partial_evaluate_is_sound
     exact partial_evaluate_is_sound_or h₂ h₃ hᵢ₁ hᵢ₂ hᵢ₃ hᵢ₄ hᵢ₅ hᵢ₆
   case unaryApp op₁ x₁ ty hwt _ hᵢ₁ =>
     exact partial_evaluate_is_sound_unary_app h₂ hwt h₃ hᵢ₁
-  case binaryApp op₂ x₁ x₂ ty hwt₁ hwt howt hᵢ₁ hᵢ₂ =>
-    exact partial_evaluate_is_sound_binary_app h₂ h₃ hwt₁ hwt howt hᵢ₁ hᵢ₂
+  case binaryApp op₂ x₁ x₂ ty hwt₁ hwt₂ howt hᵢ₁ hᵢ₂ =>
+    exact partial_evaluate_is_sound_binary_app h₂ h₃ hwt₁ hwt₂ howt hᵢ₁ hᵢ₂
   case hasAttr_entity ety x₁ attr hwt _ hᵢ₁ =>
     exact partial_evaluate_is_sound_has_attr h₂ hwt h₃ hᵢ₁
   case hasAttr_record rty x₁ attr hwt _ hᵢ₁ =>

--- a/cedar-lean/Cedar/Thm/TPE/Soundness/And.lean
+++ b/cedar-lean/Cedar/Thm/TPE/Soundness/And.lean
@@ -47,10 +47,10 @@ theorem partial_evaluate_is_sound_and
 (hᵢ₂ : Residual.WellTyped env x₂)
 (hᵢ₃ : x₁.typeOf = CedarType.bool BoolType.anyBool)
 (hᵢ₄ : x₂.typeOf = CedarType.bool BoolType.anyBool)
-(hᵢ₅ : Except.toOption (x₁.evaluate req es) = Except.toOption ((TPE.evaluate x₁ preq pes).evaluate req es))
-(hᵢ₆ : Except.toOption (x₂.evaluate req es) = Except.toOption ((TPE.evaluate x₂ preq pes).evaluate req es)) :
+(hᵢ₅ : Except.toOption (x₁.evaluate req es) = Except.toOption ((TPE.evaluate env x₁ preq pes).evaluate req es))
+(hᵢ₆ : Except.toOption (x₂.evaluate req es) = Except.toOption ((TPE.evaluate env x₂ preq pes).evaluate req es)) :
   Except.toOption ((x₁.and x₂ (CedarType.bool BoolType.anyBool)).evaluate req es) =
-  Except.toOption ((TPE.evaluate (x₁.and x₂ (CedarType.bool BoolType.anyBool)) preq pes).evaluate req es)
+  Except.toOption ((TPE.evaluate env (x₁.and x₂ (CedarType.bool BoolType.anyBool)) preq pes).evaluate req es)
 := by
   simp [TPE.evaluate, TPE.and]
   split
@@ -109,7 +109,7 @@ theorem partial_evaluate_is_sound_and
     simp [Residual.evaluate]
     cases h₅ : x₁.evaluate req es
     · simp [Result.as, Except.toOption]
-      cases h₆ : (TPE.evaluate x₁ preq pes).errorFree <;> simp
+      cases h₆ : (TPE.evaluate env x₁ preq pes).errorFree <;> simp
       · split <;> simp
         rename_i h₇
         simp [Residual.evaluate] at h₇
@@ -123,7 +123,7 @@ theorem partial_evaluate_is_sound_and
         simp [Residual.evaluate] at h₇
         subst h₇
         rw [Residual.error_free_spec] at h₆
-        have h₇ : Residual.WellTyped env (TPE.evaluate x₁ preq pes) :=
+        have h₇ : Residual.WellTyped env (TPE.evaluate env x₁ preq pes) :=
           partial_eval_preserves_well_typed h₂ h₃ hᵢ₁
         have h₈ := error_free_evaluate_ok h₂ h₇ h₆
         simp [Except.isOk, Except.toBool] at h₈
@@ -158,7 +158,7 @@ theorem partial_evaluate_is_sound_and
         · simp
       simp [hb]
       rename_i ty _ _ _ _ _
-      cases he : (TPE.evaluate x₁ preq pes).errorFree<;> simp [Residual.evaluate, hᵢ₅, Result.as, Coe.coe, Value.asBool]
+      cases he : (TPE.evaluate env x₁ preq pes).errorFree<;> simp [Residual.evaluate, hᵢ₅, Result.as, Coe.coe, Value.asBool]
       cases b <;> simp
   case _ =>
     simp [Residual.evaluate]

--- a/cedar-lean/Cedar/Thm/TPE/Soundness/Binary.lean
+++ b/cedar-lean/Cedar/Thm/TPE/Soundness/Binary.lean
@@ -29,10 +29,185 @@ import Cedar.Thm.TPE.Soundness.Basic
 
 namespace Cedar.Thm
 
+open Cedar.Data
 open Cedar.Spec
 open Cedar.Validation
 open Cedar.TPE
 open Cedar.Thm
+
+/-- If the schema does not declare that an entity can have tags, then it does not have any tags. -/
+theorem has_tag_false_of_entity_type_tagless
+  {env : TypeEnv} {request : Request} {entities : Entities}
+  {uid : EntityUID} {tag : Tag}
+  (hwf : InstanceOfWellFormedEnvironment request entities env)
+  (htagless : EntitySchema.tags? env.ets uid.ty = some .none) :
+  Spec.hasTag uid tag entities = .ok (.prim (.bool false))
+:= by
+  have hnone : (entities.tagsOrEmpty uid).find? tag = .none := by
+    simp only [Entities.tagsOrEmpty]
+    split
+    case _ d hfind =>
+      have ⟨_, _, hschema, _⟩ := hwf
+      simp only [InstanceOfSchemaEntry] at hschema
+      replace hschema := hschema uid d hfind
+      cases hschema with
+      | inl hents =>
+        have ⟨entry, hfind_entry, _, _, _, htags⟩ := hents
+        simp only [EntitySchema.tags?, Option.map, hfind_entry,
+          Option.some.injEq] at htagless
+        simp only [InstanceOfEntityTags, htagless] at htags
+        simp only [htags, Map.find?_empty]
+      | inr hacts =>
+        have ⟨_, htags, _⟩ := hacts
+        simp only [htags, Map.find?_empty]
+    case _ =>
+      exact Map.find?_empty tag
+  simp only [Spec.hasTag, Map.contains, hnone, Option.isSome_none]
+
+/-- Two values of distinct entity types cannot be equal. -/
+theorem eq_false_of_distinct_entity_types
+  {env : TypeEnv} {v₁ v₂ : Value} {ety₁ ety₂ : EntityType}
+  (hinst₁ : InstanceOfType env v₁ (.entity ety₁))
+  (hinst₂ : InstanceOfType env v₂ (.entity ety₂))
+  (hne : ety₁ ≠ ety₂) :
+  (v₁ == v₂) = false
+:= by
+  have ⟨uid₁, hty₁, hv₁⟩ := instance_of_entity_type_is_entity hinst₁
+  have ⟨uid₂, hty₂, hv₂⟩ := instance_of_entity_type_is_entity hinst₂
+  subst hv₁ hv₂
+  simp only [beq_eq_false_iff_ne, ne_eq, Value.prim.injEq, Prim.entityUID.injEq]
+  intro heq
+  subst heq
+  exact hne (hty₁ ▸ hty₂ ▸ rfl)
+
+/-- An entity of type `ety₁` cannot be `in` an entity of type `ety₂` when the schema does not declare `ety₂` an ancestor type of `ety₁`. -/
+theorem mem_false_of_cannot_be_inₑ
+  {env : TypeEnv} {request : Request} {entities : Entities}
+  {v₁ v₂ : Value} {ety₁ ety₂ : EntityType}
+  (hwf : InstanceOfWellFormedEnvironment request entities env)
+  (hinst₁ : InstanceOfType env v₁ (.entity ety₁))
+  (hinst₂ : InstanceOfType env v₂ (.entity ety₂))
+  (hdesc : env.descendentOf ety₁ ety₂ = false) :
+  Spec.apply₂ .mem v₁ v₂ entities = .ok (Value.prim (Prim.bool false))
+:= by
+  have ⟨uid₁, hty₁, hv₁⟩ := instance_of_entity_type_is_entity hinst₁
+  have ⟨uid₂, hty₂, hv₂⟩ := instance_of_entity_type_is_entity hinst₂
+  subst hv₁ hv₂ hty₁ hty₂
+  simp only [Spec.apply₂, entity_type_in_false_implies_inₑ_false hwf hdesc]
+
+/-- The set-valued counterpart of `mem_false_of_cannot_be_inₑ`. -/
+theorem mem_false_of_cannot_be_inₛ
+  {env : TypeEnv} {request : Request} {entities : Entities}
+  {v₁ v₂ : Value} {ety₁ ety₂ : EntityType}
+  (hwf : InstanceOfWellFormedEnvironment request entities env)
+  (hinst₁ : InstanceOfType env v₁ (.entity ety₁))
+  (hinst₂ : InstanceOfType env v₂ (.set (.entity ety₂)))
+  (hdesc : env.descendentOf ety₁ ety₂ = false) :
+  Spec.apply₂ .mem v₁ v₂ entities = .ok (Value.prim (Prim.bool false))
+:= by
+  have ⟨uid₁, hty₁, hv₁⟩ := instance_of_entity_type_is_entity hinst₁
+  have ⟨s, hv₂, _⟩ := instance_of_set_type_is_set hinst₂
+  subst hv₁ hv₂ hty₁
+  cases s
+  rename_i vs
+  have ⟨euids, hmap, htys⟩ := entity_set_type_implies_set_of_entities hinst₂
+  simp only [Spec.apply₂, Spec.inₛ, Set.mapOrErr, Set.elts, hmap, Except.bind_ok,
+    entity_type_in_false_implies_inₛ_false hwf hdesc htys]
+
+/-- Whenever `TPE.inₑ` decides `in` for two concrete UIDs, concrete evaluation agrees. -/
+theorem tpe_inₑ_agrees
+{es : Entities}
+{pes : PartialEntities}
+{uid₁ uid₂ : EntityUID}
+{b : Bool}
+(href : EntitiesRefine es pes)
+(hdec : TPE.inₑ uid₁ uid₂ pes = .some b) :
+  Spec.inₑ uid₁ uid₂ es = b
+:= by
+  simp only [TPE.inₑ] at hdec
+  split at hdec
+  case isTrue heq =>
+    simp only [Option.some.injEq] at hdec
+    subst hdec heq
+    simp [Spec.inₑ]
+  case isFalse hneq =>
+    simp only [beq_eq_false_iff_ne.mpr hneq, Bool.false_or, Spec.inₑ,
+      Option.map_eq_some_iff, PartialEntities.ancestors, PartialEntities.get,
+      Option.bind_eq_some_iff, Entities.ancestorsOrEmpty] at hdec ⊢
+    obtain ⟨anc, ⟨e₂, hfind, hanc⟩, hcontains⟩ := hdec
+    obtain ⟨e₁, hfind_es, _, hpv, _⟩ := href uid₁ e₂ hfind
+    cases hpv <;> simp_all
+
+/--
+If `tryDecideResidual₂` decides a binary operation from the operands' types,
+then concrete evaluation agrees.
+-/
+theorem try_decide_residual₂_sound
+{env : TypeEnv}
+{op₂ : BinaryOp}
+{r₁ r₂ : Residual}
+{req : Request}
+{es : Entities}
+{v : Value}
+(hwf : InstanceOfWellFormedEnvironment req es env)
+(hwt₁ : Residual.WellTyped env r₁)
+(hwt₂ : Residual.WellTyped env r₂)
+(hdec : TPE.tryDecideResidual₂ env op₂ r₁ r₂ = .some v) :
+  ∃ v₁ v₂, r₁.evaluate req es = .ok v₁ ∧ r₂.evaluate req es = .ok v₂ ∧
+    Spec.apply₂ op₂ v₁ v₂ es = .ok v
+:= by
+  unfold TPE.tryDecideResidual₂ at hdec
+  split at hdec
+  case isFalse => simp at hdec
+  case isTrue hef =>
+  simp only [Bool.and_eq_true] at hef
+  have hok₁ := error_free_evaluate_ok hwf hwt₁ ((Residual.error_free_spec _).mp hef.left)
+  have hok₂ := error_free_evaluate_ok hwf hwt₂ ((Residual.error_free_spec _).mp hef.right)
+  rw [Except.isOk_iff_exists] at hok₁ hok₂
+  have ⟨v₁, hev₁⟩ := hok₁
+  have ⟨v₂, hev₂⟩ := hok₂
+  have hinst₁ := residual_well_typed_is_sound hwf hwt₁ hev₁
+  have hinst₂ := residual_well_typed_is_sound hwf hwt₂ hev₂
+  refine ⟨v₁, v₂, hev₁, hev₂, ?_⟩
+  split at hdec
+  case h_1 ety₁ ety₂ hty₁ hty₂ =>
+    rw [hty₁] at hinst₁ ; rw [hty₂] at hinst₂
+    split at hdec
+    case isFalse => simp at hdec
+    case isTrue hcond =>
+    simp only [Option.some.injEq] at hdec
+    subst hdec
+    exact mem_false_of_cannot_be_inₑ hwf hinst₁ hinst₂ (by simpa using hcond)
+  case h_2 ety₁ ety₂ hty₁ hty₂ =>
+    rw [hty₁] at hinst₁ ; rw [hty₂] at hinst₂
+    split at hdec
+    case isFalse => simp at hdec
+    case isTrue hcond =>
+    simp only [Option.some.injEq] at hdec
+    subst hdec
+    exact mem_false_of_cannot_be_inₛ hwf hinst₁ hinst₂ (by simpa using hcond)
+  case h_3 ety₁ ety₂ hty₁ hty₂ =>
+    rw [hty₁] at hinst₁ ; rw [hty₂] at hinst₂
+    split at hdec
+    case isFalse => simp at hdec
+    case isTrue hcond =>
+    simp only [Option.some.injEq] at hdec
+    subst hdec
+    simp only [Spec.apply₂,
+      eq_false_of_distinct_entity_types hinst₁ hinst₂ (by simpa using hcond)]
+  case h_4 ety hty₁ hty₂ =>
+    rw [hty₁] at hinst₁
+    have ⟨uid, hety, hv₁⟩ := instance_of_entity_type_is_entity hinst₁
+    have ⟨t, hv₂⟩ := instance_of_string_is_string (hty₂ ▸ hinst₂)
+    subst hv₁ hv₂ hety
+    split at hdec
+    case isFalse => simp at hdec
+    case isTrue hcond =>
+    simp only [Option.some.injEq] at hdec
+    subst hdec
+    simp only [Spec.apply₂,
+      has_tag_false_of_entity_type_tagless hwf (by simpa using hcond)]
+  case h_5 => simp at hdec
 
 theorem partial_evaluate_is_sound_binary_app
 {op₂ : BinaryOp}
@@ -45,14 +220,37 @@ theorem partial_evaluate_is_sound_binary_app
 {env : TypeEnv}
 (h₂ : InstanceOfWellFormedEnvironment req es env)
 (h₄ : RequestAndEntitiesRefine req es preq pes)
+(hwt₁ : Residual.WellTyped env x₁)
 (hwt : Residual.WellTyped env x₂)
 (howt : BinaryResidualWellTyped env op₂ x₁ x₂ ty)
-(hᵢ₁ : Except.toOption (x₁.evaluate req es) = Except.toOption ((TPE.evaluate x₁ preq pes).evaluate req es))
-(hᵢ₂ : Except.toOption (x₂.evaluate req es) = Except.toOption ((TPE.evaluate x₂ preq pes).evaluate req es)) :
+(hᵢ₁ : Except.toOption (x₁.evaluate req es) = Except.toOption ((TPE.evaluate env x₁ preq pes).evaluate req es))
+(hᵢ₂ : Except.toOption (x₂.evaluate req es) = Except.toOption ((TPE.evaluate env x₂ preq pes).evaluate req es)) :
   Except.toOption ((Residual.binaryApp op₂ x₁ x₂ ty).evaluate req es) =
-  Except.toOption ((TPE.evaluate (Residual.binaryApp op₂ x₁ x₂ ty) preq pes).evaluate req es)
+  Except.toOption ((TPE.evaluate env (Residual.binaryApp op₂ x₁ x₂ ty) preq pes).evaluate req es)
 := by
   simp [TPE.evaluate, TPE.apply₂]
+  split
+  case _ heq =>
+    simp [heq, Residual.evaluate] at hᵢ₁
+    rcases to_option_right_err hᵢ₁ with ⟨_, hᵢ₁⟩
+    simp [Residual.evaluate, hᵢ₁, Except.toOption]
+  case _ heq _ =>
+    simp [heq, Residual.evaluate] at hᵢ₂
+    rcases to_option_right_err hᵢ₂ with ⟨_, hᵢ₂⟩
+    simp only [Residual.evaluate, hᵢ₂, Except.bind_err, do_error_to_option]
+    simp only [Except.toOption]
+  split
+  case h_1 hdec =>
+    have hwt₁' := partial_eval_preserves_well_typed h₂ h₄ hwt₁
+    have hwt₂' := partial_eval_preserves_well_typed h₂ h₄ hwt
+    have ⟨v₁, v₂, hev₁, hev₂, hres⟩ := try_decide_residual₂_sound h₂ hwt₁' hwt₂' hdec
+    have hev₁' : Except.toOption (x₁.evaluate req es) = some v₁ := by
+      rw [hᵢ₁, hev₁]; rfl
+    have hev₂' : Except.toOption (x₂.evaluate req es) = some v₂ := by
+      rw [hᵢ₂, hev₂]; rfl
+    rw [to_option_some] at hev₁' hev₂'
+    simp [Residual.evaluate, hev₁', hev₂', hres, Except.toOption]
+  case h_2 hdec =>
   split
   case _ heq₁ heq₂ =>
     rw [asValue_evaluate_val heq₁] at hᵢ₁
@@ -86,28 +284,7 @@ theorem partial_evaluate_is_sound_binary_app
         rcases heq₃ with ⟨_, heq₃₁, heq₃₂⟩
         simp only [Option.some.injEq] at heq₃₂
         subst heq₃₂
-        simp [Residual.evaluate]
-        simp [TPE.inₑ] at heq₃₁
-        split at heq₃₁
-        case _ heq₄ =>
-          simp at heq₃₁
-          subst heq₃₁
-          simp [Spec.inₑ, heq₄]
-        case _ heq₄ =>
-          simp [Option.map] at heq₃₁
-          split at heq₃₁ <;> cases heq₃₁
-          rename_i heq₅
-          simp [PartialEntities.ancestors, PartialEntities.get, Option.bind_eq_some_iff] at heq₅
-          rcases heq₅ with ⟨data, heq₅₁, heq₅₂⟩
-          simp [RequestAndEntitiesRefine, EntitiesRefine] at h₄
-          rcases h₄ with ⟨_, h₄⟩
-          specialize h₄ uid₁ data heq₅₁
-          rcases h₄ with ⟨_, h₄₁, _, h₄₂, _⟩
-          simp only [heq₅₂, PartialIsValid.some_inv] at h₄₂
-          simp [Spec.inₑ, Entities.ancestorsOrEmpty, h₄₁, ←h₄₂]
-          have : (uid₁ == uid₂) = false := by
-            simp only [beq_eq_false_iff_ne, ne_eq, heq₄, not_false_eq_true]
-          simp only [this, Bool.false_or]
+        simp only [Residual.evaluate, tpe_inₑ_agrees h₄.right heq₃₁]
       case _ heq₃ =>
         rw [asValue_some] at heq₁ heq₂
         rw [heq₁.choose_spec, heq₂.choose_spec]
@@ -148,22 +325,8 @@ theorem partial_evaluate_is_sound_binary_app
           rw [←List.mapM_ok_iff_forall₂] at heq₄
           simp [heq₄] at h₇
           subst h₇
-          simp [RequestAndEntitiesRefine] at h₄
-          rcases h₄ with ⟨_, h₄⟩
-          have : ∀ x b, (TPE.inₑ uid x pes) = .some b → (Spec.inₑ uid x es) = b := by
-            intro x b h
-            simp only [EntitiesRefine] at h₄
-            simp only [TPE.inₑ] at h
-            simp only [Spec.inₑ]
-            split at h
-            case isTrue heq => simp_all
-            case isFalse hneq =>
-              simp only [beq_eq_false_iff_ne.mpr hneq, Bool.false_or,
-                Option.map_eq_some_iff, PartialEntities.ancestors, PartialEntities.get,
-                Option.bind_eq_some_iff, Entities.ancestorsOrEmpty] at h ⊢
-              obtain ⟨anc, ⟨e₂, hfind, hanc⟩, hcontains⟩ := h
-              obtain ⟨e₁, hfind_es, _, hpv, _⟩ := h₄ uid e₂ hfind
-              cases hpv <;> simp_all
+          have : ∀ x b, (TPE.inₑ uid x pes) = .some b → (Spec.inₑ uid x es) = b :=
+            λ _ _ h => tpe_inₑ_agrees h₄.right h
           replace heq₃₂ := List.ternary_any_some_implies_any (TPE.inₑ uid · pes) (Spec.inₑ uid · es) this heq₃₂
           subst heq₃₂
           simp only [Residual.evaluate]
@@ -216,20 +379,9 @@ theorem partial_evaluate_is_sound_binary_app
         simp only [Residual.evaluate, Spec.apply₂, Except.bind_ok]
     case _ => simp [Except.toOption]
   case _ =>
-    split
-    case _ heq =>
-      simp [heq, Residual.evaluate] at hᵢ₁
-      rcases to_option_right_err hᵢ₁ with ⟨_, hᵢ₁⟩
-      simp [Residual.evaluate, hᵢ₁, Except.toOption]
-    case _ heq _ =>
-      simp [heq, Residual.evaluate] at hᵢ₂
-      rcases to_option_right_err hᵢ₂ with ⟨_, hᵢ₂⟩
-      simp only [Residual.evaluate, hᵢ₂, Except.bind_err, do_error_to_option]
-      simp only [Except.toOption]
-    case _ =>
-      simp [Residual.evaluate, apply₂.self]
-      exact to_option_eq_do₂
-        (λ x y => Spec.apply₂ op₂ x y es) hᵢ₁ hᵢ₂
+    simp [Residual.evaluate, apply₂.self]
+    exact to_option_eq_do₂
+      (λ x y => Spec.apply₂ op₂ x y es) hᵢ₁ hᵢ₂
 
 
 end Cedar.Thm

--- a/cedar-lean/Cedar/Thm/TPE/Soundness/Binary.lean
+++ b/cedar-lean/Cedar/Thm/TPE/Soundness/Binary.lean
@@ -221,7 +221,7 @@ theorem partial_evaluate_is_sound_binary_app
 (h₂ : InstanceOfWellFormedEnvironment req es env)
 (h₄ : RequestAndEntitiesRefine req es preq pes)
 (hwt₁ : Residual.WellTyped env x₁)
-(hwt : Residual.WellTyped env x₂)
+(hwt₂ : Residual.WellTyped env x₂)
 (howt : BinaryResidualWellTyped env op₂ x₁ x₂ ty)
 (hᵢ₁ : Except.toOption (x₁.evaluate req es) = Except.toOption ((TPE.evaluate env x₁ preq pes).evaluate req es))
 (hᵢ₂ : Except.toOption (x₂.evaluate req es) = Except.toOption ((TPE.evaluate env x₂ preq pes).evaluate req es)) :
@@ -242,7 +242,7 @@ theorem partial_evaluate_is_sound_binary_app
   split
   case h_1 hdec =>
     have hwt₁' := partial_eval_preserves_well_typed h₂ h₄ hwt₁
-    have hwt₂' := partial_eval_preserves_well_typed h₂ h₄ hwt
+    have hwt₂' := partial_eval_preserves_well_typed h₂ h₄ hwt₂
     have ⟨v₁, v₂, hev₁, hev₂, hres⟩ := try_decide_residual₂_sound h₂ hwt₁' hwt₂' hdec
     have hev₁' : Except.toOption (x₁.evaluate req es) = some v₁ := by
       rw [hᵢ₁, hev₁]; rfl
@@ -299,7 +299,7 @@ theorem partial_evaluate_is_sound_binary_app
         subst heq₃₂
         simp [Spec.inₛ]
         cases howt <;>
-        (rename_i h₅; have h₆ := residual_well_typed_is_sound h₂ hwt hᵢ₂; rw [h₅] at h₆; cases h₆)
+        (rename_i h₅; have h₆ := residual_well_typed_is_sound h₂ hwt₂ hᵢ₂; rw [h₅] at h₆; cases h₆)
         rename_i h₆
         simp [Data.Set.mapOrErr]
         generalize h₇ : List.mapM Value.asEntityUID vs.elts = res

--- a/cedar-lean/Cedar/Thm/TPE/Soundness/Binary.lean
+++ b/cedar-lean/Cedar/Thm/TPE/Soundness/Binary.lean
@@ -44,12 +44,11 @@ theorem has_tag_false_of_entity_type_tagless
   Spec.hasTag uid tag entities = .ok (.prim (.bool false))
 := by
   have hnone : (entities.tagsOrEmpty uid).find? tag = .none := by
-    simp only [Entities.tagsOrEmpty]
-    split
+    unfold Entities.tagsOrEmpty ; split
     case _ d hfind =>
       have ⟨_, _, hschema, _⟩ := hwf
       simp only [InstanceOfSchemaEntry] at hschema
-      replace hschema := hschema uid d hfind
+      specialize hschema uid d hfind
       cases hschema with
       | inl hents =>
         have ⟨entry, hfind_entry, _, _, _, htags⟩ := hents

--- a/cedar-lean/Cedar/Thm/TPE/Soundness/Call.lean
+++ b/cedar-lean/Cedar/Thm/TPE/Soundness/Call.lean
@@ -44,9 +44,9 @@ theorem partial_evaluate_is_sound_call
 {ty : CedarType}
 (hᵢ₁ : ∀ (x : Residual),
   x ∈ args →
-    Except.toOption (x.evaluate req es) = Except.toOption ((TPE.evaluate x preq pes).evaluate req es)) :
+    Except.toOption (x.evaluate req es) = Except.toOption ((TPE.evaluate env x preq pes).evaluate req es)) :
   Except.toOption ((Residual.call xfn args ty).evaluate req es) =
-  Except.toOption ((TPE.evaluate (Residual.call xfn args ty) preq pes).evaluate req es)
+  Except.toOption ((TPE.evaluate env (Residual.call xfn args ty) preq pes).evaluate req es)
 := by
   simp only [TPE.evaluate, TPE.call, List.map₁, List.map_subtype, List.unattach_attach,
     List.mapM_map, Function.comp_def, List.any_map, List.any_eq_true]
@@ -54,7 +54,7 @@ theorem partial_evaluate_is_sound_call
   case _ vs heq =>
     simp only [Residual.evaluate, List.mapM₁_eq_mapM (Residual.evaluate · req es), someOrError]
     simp only [List.mapM_some_iff_forall₂] at heq
-    have h_tpe_ok : List.mapM (λ x => (TPE.evaluate x preq pes).evaluate req es) args = .ok vs := by
+    have h_tpe_ok : List.mapM (λ x => (TPE.evaluate env x preq pes).evaluate req es) args = .ok vs := by
       rw [List.mapM_ok_iff_forall₂]
       exact List.Forall₂.imp (fun _ _ h => asValue_evaluate_val h req es) heq
     have h₅ : List.mapM (λ x => x.evaluate req es) args = .ok vs := by

--- a/cedar-lean/Cedar/Thm/TPE/Soundness/GetAttr.lean
+++ b/cedar-lean/Cedar/Thm/TPE/Soundness/GetAttr.lean
@@ -43,9 +43,9 @@ theorem partial_evaluate_is_sound_get_attr
 {attr : Attr}
 {ty : CedarType}
 (h₄ : RequestAndEntitiesRefine req es preq pes)
-(hᵢ₁ : Except.toOption (x₁.evaluate req es) = Except.toOption ((TPE.evaluate x₁ preq pes).evaluate req es)) :
+(hᵢ₁ : Except.toOption (x₁.evaluate req es) = Except.toOption ((TPE.evaluate env x₁ preq pes).evaluate req es)) :
   Except.toOption ((x₁.getAttr attr ty).evaluate req es) =
-  Except.toOption ((TPE.evaluate (x₁.getAttr attr ty) preq pes).evaluate req es)
+  Except.toOption ((TPE.evaluate env (x₁.getAttr attr ty) preq pes).evaluate req es)
 := by
   simp [TPE.evaluate, TPE.getAttr]
   split

--- a/cedar-lean/Cedar/Thm/TPE/Soundness/HasAttr.lean
+++ b/cedar-lean/Cedar/Thm/TPE/Soundness/HasAttr.lean
@@ -26,25 +26,115 @@ import Cedar.Thm.WellTyped
 import Cedar.Thm.Data.Control
 
 import Cedar.Thm.TPE.Soundness.Basic
+import Cedar.Thm.TPE.PreservesTypeOf
 
 namespace Cedar.Thm
 
+open Cedar.Data
 open Cedar.Spec
 open Cedar.Validation
 open Cedar.TPE
 open Cedar.Thm
 
+/-- A record value whose type does not declare an attribute `a` does not have `a`. -/
+theorem has_attr_false_of_record_type_absent
+  {env : TypeEnv} {r : Map Attr Value} {rty : RecordType} {a : Attr} {es : Entities}
+  (hinst : InstanceOfType env (.record r) (.record rty))
+  (hnone : rty.find? a = .none) :
+  Spec.hasAttr (.record r) a es = .ok (.prim (.bool false))
+:= by
+  have habsent := absent_attribute_is_absent hinst hnone
+  simp only [Spec.hasAttr, Spec.attrsOf, Except.bind_ok, Map.contains, habsent,
+    Option.isSome_none]
+
+/-- If the schema does not declare an attribute `a` for an entity, then it does not have `a`. -/
+theorem has_attr_false_of_entity_type_absent
+  {env : TypeEnv} {request : Request} {entities : Entities}
+  {uid : EntityUID} {rty : RecordType} {a : Attr}
+  (hwf : InstanceOfWellFormedEnvironment request entities env)
+  (hattrs : EntitySchema.attrs? env.ets uid.ty = some rty)
+  (hnone : rty.find? a = .none) :
+  Spec.hasAttr (.prim (.entityUID uid)) a entities = .ok (.prim (.bool false))
+:= by
+  have habsent : (entities.attrsOrEmpty uid).find? a = .none := by
+    simp only [Entities.attrsOrEmpty]
+    split
+    case _ d hfind =>
+      exact absent_attribute_is_absent (well_typed_entity_attributes hwf hfind hattrs) hnone
+    case _ =>
+      exact Map.find?_empty a
+  simp only [Spec.hasAttr, Spec.attrsOf, Except.bind_ok, Map.contains, habsent,
+    Option.isSome_none]
+
+/--
+If `tryDecideHasResidual` decides a `has` expression from the operand's type,
+then concrete evaluation agrees.
+-/
+theorem try_decide_has_residual_sound
+{env : TypeEnv}
+{r₁ : Residual}
+{req : Request}
+{es : Entities}
+{attr : Attr}
+{v : Value}
+(hwf : InstanceOfWellFormedEnvironment req es env)
+(hwt : Residual.WellTyped env r₁)
+(hdec : TPE.tryDecideHasResidual env r₁ attr = .some v) :
+  ∃ v', r₁.evaluate req es = .ok v' ∧ Spec.hasAttr v' attr es = .ok v
+:= by
+  unfold TPE.tryDecideHasResidual at hdec
+  split at hdec
+  case isFalse => simp at hdec
+  case isTrue hef =>
+  have hok := error_free_evaluate_ok hwf hwt ((Residual.error_free_spec _).mp hef)
+  rw [Except.isOk_iff_exists] at hok
+  have ⟨v', hev⟩ := hok
+  have hinst := residual_well_typed_is_sound hwf hwt hev
+  refine ⟨v', hev, ?_⟩
+  split at hdec
+  case h_1 rty heqty =>
+    rw [heqty] at hinst
+    have ⟨r, hr⟩ := instance_of_record_type_is_record hinst
+    subst hr
+    split at hdec
+    case isFalse => simp at hdec
+    case isTrue hnone =>
+    simp only [Option.some.injEq] at hdec
+    subst hdec
+    exact has_attr_false_of_record_type_absent hinst (Option.isNone_iff_eq_none.mp hnone)
+  case h_2 ety heqty =>
+    rw [heqty] at hinst
+    cases hinst
+    case instance_of_entity uid hient =>
+      split at hdec
+      case h_1 rty hattrs =>
+        split at hdec
+        case isFalse => simp at hdec
+        case isTrue hnone =>
+        simp only [Option.some.injEq] at hdec
+        subst hdec
+        have hty : uid.ty = ety := by
+          simp only [InstanceOfEntityType] at hient
+          exact hient.left.symm
+        exact has_attr_false_of_entity_type_absent hwf (by rw [hty]; exact hattrs)
+          (Option.isNone_iff_eq_none.mp hnone)
+      case h_2 => simp at hdec
+  case h_3 => simp at hdec
+
 theorem partial_evaluate_is_sound_has_attr
+{env : TypeEnv}
 {x₁ : Residual}
 {req : Request}
 {es : Entities}
 {preq : PartialRequest}
 {pes : PartialEntities}
 {attr : Attr}
+(h₂ : InstanceOfWellFormedEnvironment req es env)
+(hwt : Residual.WellTyped env x₁)
 (h₄ : RequestAndEntitiesRefine req es preq pes)
-(hᵢ₁ : Except.toOption (x₁.evaluate req es) = Except.toOption ((TPE.evaluate x₁ preq pes).evaluate req es)) :
+(hᵢ₁ : Except.toOption (x₁.evaluate req es) = Except.toOption ((TPE.evaluate env x₁ preq pes).evaluate req es)) :
   Except.toOption ((x₁.hasAttr attr (CedarType.bool BoolType.anyBool)).evaluate req es) =
-  Except.toOption ((TPE.evaluate (x₁.hasAttr attr (CedarType.bool BoolType.anyBool)) preq pes).evaluate req es)
+  Except.toOption ((TPE.evaluate env (x₁.hasAttr attr (CedarType.bool BoolType.anyBool)) preq pes).evaluate req es)
 := by
   simp [TPE.evaluate, TPE.hasAttr]
   split
@@ -52,6 +142,15 @@ theorem partial_evaluate_is_sound_has_attr
     simp [heq, Residual.evaluate] at hᵢ₁
     rcases to_option_right_err hᵢ₁ with ⟨_, hᵢ₁⟩
     simp [Residual.evaluate, hᵢ₁, Except.toOption]
+  split
+  case h_1 hdec =>
+    have hwt' := partial_eval_preserves_well_typed h₂ h₄ hwt
+    have ⟨v, hev, hres⟩ := try_decide_has_residual_sound h₂ hwt' hdec
+    have hev₁ : Except.toOption (x₁.evaluate req es) = some v := by
+      rw [hᵢ₁, hev]; rfl
+    rw [to_option_some] at hev₁
+    simp [Residual.evaluate, hev₁, hres, Except.toOption]
+  case h_2 =>
   split
   case _ heq =>
     simp [TPE.attrsOf] at heq

--- a/cedar-lean/Cedar/Thm/TPE/Soundness/HasAttr.lean
+++ b/cedar-lean/Cedar/Thm/TPE/Soundness/HasAttr.lean
@@ -37,7 +37,7 @@ open Cedar.TPE
 open Cedar.Thm
 
 /-- A record value whose type does not declare an attribute `a` does not have `a`. -/
-theorem has_attr_false_of_record_type_absent
+theorem has_attr_false_of_absent_in_record_type
   {env : TypeEnv} {r : Map Attr Value} {rty : RecordType} {a : Attr} {es : Entities}
   (hinst : InstanceOfType env (.record r) (.record rty))
   (hnone : rty.find? a = .none) :
@@ -48,7 +48,7 @@ theorem has_attr_false_of_record_type_absent
     Option.isSome_none]
 
 /-- If the schema does not declare an attribute `a` for an entity, then it does not have `a`. -/
-theorem has_attr_false_of_entity_type_absent
+theorem has_attr_false_of_absent_in_entity_type
   {env : TypeEnv} {request : Request} {entities : Entities}
   {uid : EntityUID} {rty : RecordType} {a : Attr}
   (hwf : InstanceOfWellFormedEnvironment request entities env)
@@ -63,8 +63,7 @@ theorem has_attr_false_of_entity_type_absent
       exact absent_attribute_is_absent (well_typed_entity_attributes hwf hfind hattrs) hnone
     case _ =>
       exact Map.find?_empty a
-  simp only [Spec.hasAttr, Spec.attrsOf, Except.bind_ok, Map.contains, habsent,
-    Option.isSome_none]
+  simp only [Spec.hasAttr, Spec.attrsOf, Except.bind_ok, Map.contains, habsent, Option.isSome_none]
 
 /--
 If `tryDecideHasResidual` decides a `has` expression from the operand's type,
@@ -101,7 +100,7 @@ theorem try_decide_has_residual_sound
     case isTrue hnone =>
     simp only [Option.some.injEq] at hdec
     subst hdec
-    exact has_attr_false_of_record_type_absent hinst (Option.isNone_iff_eq_none.mp hnone)
+    exact has_attr_false_of_absent_in_record_type hinst (Option.isNone_iff_eq_none.mp hnone)
   case h_2 ety heqty =>
     rw [heqty] at hinst
     cases hinst
@@ -116,8 +115,7 @@ theorem try_decide_has_residual_sound
         have hty : uid.ty = ety := by
           simp only [InstanceOfEntityType] at hient
           exact hient.left.symm
-        exact has_attr_false_of_entity_type_absent hwf (by rw [hty]; exact hattrs)
-          (Option.isNone_iff_eq_none.mp hnone)
+        exact has_attr_false_of_absent_in_entity_type hwf (by rw [hty]; exact hattrs) (Option.isNone_iff_eq_none.mp hnone)
       case h_2 => simp at hdec
   case h_3 => simp at hdec
 

--- a/cedar-lean/Cedar/Thm/TPE/Soundness/IfThenElse.lean
+++ b/cedar-lean/Cedar/Thm/TPE/Soundness/IfThenElse.lean
@@ -44,11 +44,11 @@ theorem partial_evaluate_is_sound_ite
 (h₂ : InstanceOfWellFormedEnvironment req es env)
 (hwt : Residual.WellTyped env x₁)
 (hₜ : x₁.typeOf = CedarType.bool BoolType.anyBool)
-(hᵢ₁ : Except.toOption (x₁.evaluate req es) = Except.toOption ((TPE.evaluate x₁ preq pes).evaluate req es))
-(hᵢ₂ : Except.toOption (x₂.evaluate req es) = Except.toOption ((TPE.evaluate x₂ preq pes).evaluate req es))
-(hᵢ₃ : Except.toOption (x₃.evaluate req es) = Except.toOption ((TPE.evaluate x₃ preq pes).evaluate req es)) :
+(hᵢ₁ : Except.toOption (x₁.evaluate req es) = Except.toOption ((TPE.evaluate env x₁ preq pes).evaluate req es))
+(hᵢ₂ : Except.toOption (x₂.evaluate req es) = Except.toOption ((TPE.evaluate env x₂ preq pes).evaluate req es))
+(hᵢ₃ : Except.toOption (x₃.evaluate req es) = Except.toOption ((TPE.evaluate env x₃ preq pes).evaluate req es)) :
   Except.toOption ((x₁.ite x₂ x₃ x₂.typeOf).evaluate req es) =
-  Except.toOption ((TPE.evaluate (x₁.ite x₂ x₃ x₂.typeOf) preq pes).evaluate req es) := by
+  Except.toOption ((TPE.evaluate env (x₁.ite x₂ x₃ x₂.typeOf) preq pes).evaluate req es) := by
   simp [Residual.evaluate, TPE.evaluate, TPE.ite]
   split
   case _ heq =>

--- a/cedar-lean/Cedar/Thm/TPE/Soundness/Or.lean
+++ b/cedar-lean/Cedar/Thm/TPE/Soundness/Or.lean
@@ -47,10 +47,10 @@ theorem partial_evaluate_is_sound_or
 (hᵢ₂ : Residual.WellTyped env x₂)
 (hᵢ₃ : x₁.typeOf = CedarType.bool BoolType.anyBool)
 (hᵢ₄ : x₂.typeOf = CedarType.bool BoolType.anyBool)
-(hᵢ₅ : Except.toOption (x₁.evaluate req es) = Except.toOption ((TPE.evaluate x₁ preq pes).evaluate req es))
-(hᵢ₆ : Except.toOption (x₂.evaluate req es) = Except.toOption ((TPE.evaluate x₂ preq pes).evaluate req es)) :
+(hᵢ₅ : Except.toOption (x₁.evaluate req es) = Except.toOption ((TPE.evaluate env x₁ preq pes).evaluate req es))
+(hᵢ₆ : Except.toOption (x₂.evaluate req es) = Except.toOption ((TPE.evaluate env x₂ preq pes).evaluate req es)) :
   Except.toOption ((x₁.or x₂ (CedarType.bool BoolType.anyBool)).evaluate req es) =
-  Except.toOption ((TPE.evaluate (x₁.or x₂ (CedarType.bool BoolType.anyBool)) preq pes).evaluate req es)
+  Except.toOption ((TPE.evaluate env (x₁.or x₂ (CedarType.bool BoolType.anyBool)) preq pes).evaluate req es)
 := by
   simp [TPE.evaluate, TPE.or]
   split
@@ -104,7 +104,7 @@ theorem partial_evaluate_is_sound_or
     simp [Residual.evaluate]
     cases h₅ : x₁.evaluate req es
     · simp [Result.as, Except.toOption]
-      cases h₆ : (TPE.evaluate x₁ preq pes).errorFree <;> simp
+      cases h₆ : (TPE.evaluate env x₁ preq pes).errorFree <;> simp
       · split <;> simp
         rename_i h₇
         simp [Residual.evaluate] at h₇
@@ -118,7 +118,7 @@ theorem partial_evaluate_is_sound_or
         simp [Residual.evaluate] at h₇
         subst h₇
         rw [Residual.error_free_spec] at h₆
-        have h₇ : Residual.WellTyped env (TPE.evaluate x₁ preq pes) :=
+        have h₇ : Residual.WellTyped env (TPE.evaluate env x₁ preq pes) :=
           partial_eval_preserves_well_typed h₂ h₃ hᵢ₁
         have h₈ := error_free_evaluate_ok h₂ h₇ h₆
         simp [Except.isOk, Except.toBool] at h₈
@@ -153,7 +153,7 @@ theorem partial_evaluate_is_sound_or
         · simp
       simp [hb]
       rename_i ty _ _ _ _ _
-      cases he : (TPE.evaluate x₁ preq pes).errorFree<;> simp [Residual.evaluate, hᵢ₅, Result.as, Coe.coe, Value.asBool]
+      cases he : (TPE.evaluate env x₁ preq pes).errorFree<;> simp [Residual.evaluate, hᵢ₅, Result.as, Coe.coe, Value.asBool]
       cases b <;> simp
   case _ =>
     simp [Residual.evaluate]

--- a/cedar-lean/Cedar/Thm/TPE/Soundness/Record.lean
+++ b/cedar-lean/Cedar/Thm/TPE/Soundness/Record.lean
@@ -43,12 +43,12 @@ theorem partial_evaluate_is_sound_record
 {pes : PartialEntities}
 (hᵢ₁ : ∀ (k : Attr) (v : Residual),
   (k, v) ∈ m →
-    Except.toOption (v.evaluate req es) = Except.toOption ((TPE.evaluate v preq pes).evaluate req es)) :
+    Except.toOption (v.evaluate req es) = Except.toOption ((TPE.evaluate env v preq pes).evaluate req es)) :
   Except.toOption ((Residual.record m (CedarType.record rty)).evaluate req es) =
-  Except.toOption ((TPE.evaluate (Residual.record m (CedarType.record rty)) preq pes).evaluate req es)
+  Except.toOption ((TPE.evaluate env (Residual.record m (CedarType.record rty)) preq pes).evaluate req es)
 := by
   simp only [TPE.evaluate, TPE.record,
-    List.map₁_eq_map (fun (x : Attr × Residual) => (x.fst, TPE.evaluate x.snd preq pes)),
+    List.map₁_eq_map (fun (x : Attr × Residual) => (x.fst, TPE.evaluate env x.snd preq pes)),
     List.any_map, List.any_eq_true, Function.comp_apply, Prod.exists]
   split
   case _ vs heq =>
@@ -61,17 +61,17 @@ theorem partial_evaluate_is_sound_record
     exists vs
     simp only [and_true]
     simp only [List.mapM_map, List.mapM_some_iff_forall₂] at heq
-    have : ∀ (x : Attr × Residual) y, bindAttr x.fst (TPE.evaluate x.snd preq pes).asValue = some y → bindAttr x.fst ((TPE.evaluate x.snd preq pes).evaluate req es) = .ok y := by
+    have : ∀ (x : Attr × Residual) y, bindAttr x.fst (TPE.evaluate env x.snd preq pes).asValue = some y → bindAttr x.fst ((TPE.evaluate env x.snd preq pes).evaluate req es) = .ok y := by
       intro x y h
       simp only [bindAttr] at h ⊢
-      cases h₁ : (TPE.evaluate x.snd preq pes).asValue <;>
+      cases h₁ : (TPE.evaluate env x.snd preq pes).asValue <;>
         simp only [h₁, Option.pure_def, Option.bind_none_fun, reduceCtorEq, Option.bind_some_fun, Option.some.injEq] at h
       simp [h, asValue_evaluate_val h₁]
     replace heq := List.Forall₂.imp this heq
     clear this
     rw [←List.mapM_ok_iff_forall₂] at heq
     have : ∀ x ∈ m,
-      Except.toOption (bindAttr x.fst ((TPE.evaluate x.snd preq pes).evaluate req es)) =
+      Except.toOption (bindAttr x.fst ((TPE.evaluate env x.snd preq pes).evaluate req es)) =
       Except.toOption (bindAttr x.fst (x.snd.evaluate req es))
     := by
       intro x h
@@ -84,7 +84,7 @@ theorem partial_evaluate_is_sound_record
   split
   case _ h₁ =>
     simp only [
-      List.map₁_eq_map λ (x : Attr × Residual) => (x.fst, TPE.evaluate x.snd preq pes),
+      List.map₁_eq_map λ (x : Attr × Residual) => (x.fst, TPE.evaluate env x.snd preq pes),
       List.any_map, List.any_eq_true, Function.comp_apply, Prod.exists] at h₁
     rcases h₁ with ⟨k, v, h₂, h₃⟩
     have ⟨tpe_err, h_tpe_err⟩ := isError_evaluate_err h₃ req es
@@ -105,7 +105,7 @@ theorem partial_evaluate_is_sound_record
     apply to_option_eq_do₁
     have : ∀ x ∈ m,
       Except.toOption (bindAttr x.fst (x.snd.evaluate req es)) =
-      Except.toOption (bindAttr x.fst ((TPE.evaluate x.snd preq pes).evaluate req es))
+      Except.toOption (bindAttr x.fst ((TPE.evaluate env x.snd preq pes).evaluate req es))
     := by
       intro x h
       specialize hᵢ₁ x.fst x.snd h

--- a/cedar-lean/Cedar/Thm/TPE/Soundness/Set.lean
+++ b/cedar-lean/Cedar/Thm/TPE/Soundness/Set.lean
@@ -43,16 +43,16 @@ theorem partial_evaluate_is_sound_set
 {ty : CedarType}
 (hᵢ₁ : ∀ (x : Residual),
   x ∈ ls →
-    Except.toOption (x.evaluate req es) = Except.toOption ((TPE.evaluate x preq pes).evaluate req es)) :
+    Except.toOption (x.evaluate req es) = Except.toOption ((TPE.evaluate env x preq pes).evaluate req es)) :
   Except.toOption ((Residual.set ls ty.set).evaluate req es) =
-  Except.toOption ((TPE.evaluate (Residual.set ls ty.set) preq pes).evaluate req es)
+  Except.toOption ((TPE.evaluate env (Residual.set ls ty.set) preq pes).evaluate req es)
 := by
   simp [TPE.evaluate, List.map₁, TPE.set]
   split
   case _ vs heq =>
     simp only [Residual.evaluate, List.mapM₁_eq_mapM (Residual.evaluate · req es)]
     simp only [List.mapM_some_iff_forall₂, Function.comp_apply] at heq
-    have h_tpe_ok : List.mapM (fun x => (TPE.evaluate x preq pes).evaluate req es) ls = .ok vs := by
+    have h_tpe_ok : List.mapM (fun x => (TPE.evaluate env x preq pes).evaluate req es) ls = .ok vs := by
       rw [List.mapM_ok_iff_forall₂]
       exact List.Forall₂.imp (fun _ _ h => asValue_evaluate_val h req es) heq
     have h₅ : List.mapM (λ x => x.evaluate req es) ls = .ok vs := by
@@ -75,8 +75,8 @@ theorem partial_evaluate_is_sound_set
       simp only [Residual.evaluate, List.mapM₁_eq_mapM (Residual.evaluate · req es)]
       apply to_option_eq_do₁ (λ (x : List Value) => (Except.ok (Value.set (Data.Set.make x))))
       -- We need to show that evaluating the original list gives the same result as evaluating the TPE-transformed list
-      -- Since we're in the case where List.mapM (Residual.asValue ∘ fun x => TPE.evaluate x preq pes) ls = none
-      -- and ¬∃ x, x ∈ ls ∧ (TPE.evaluate x preq pes).isError = true
+      -- Since we're in the case where List.mapM (Residual.asValue ∘ fun x => TPE.evaluate env x preq pes) ls = none
+      -- and ¬∃ x, x ∈ ls ∧ (TPE.evaluate env x preq pes).isError = true
       -- we can directly apply our hypothesis hᵢ₁
       rw [List.mapM_to_option_congr hᵢ₁]
       rw [List.mapM_map]

--- a/cedar-lean/Cedar/Thm/TPE/Soundness/Unary.lean
+++ b/cedar-lean/Cedar/Thm/TPE/Soundness/Unary.lean
@@ -46,33 +46,28 @@ theorem is_eq_type_comparison_of_entity_type
   simp only [Spec.apply₁]
 
 theorem try_decide_residual₁_sound
-{env : TypeEnv}
-{r₁ : Residual}
-{req : Request}
-{es : Entities}
-{op₁ : UnaryOp}
-{v : Value}
+{env : TypeEnv} {r₁ : Residual} {req : Request}
+{es : Entities} {op₁ : UnaryOp} {v : Value}
 (hwf : InstanceOfWellFormedEnvironment req es env)
 (hwt : Residual.WellTyped env r₁)
 (hdec : TPE.tryDecideResidual₁ op₁ r₁ = .some v) :
   ∃ v', r₁.evaluate req es = .ok v' ∧ Spec.apply₁ op₁ v' = .ok v
 := by
-  unfold TPE.tryDecideResidual₁ at hdec
-  split at hdec
-  case isFalse => simp at hdec
+  unfold TPE.tryDecideResidual₁ at hdec ; split at hdec
+  case isFalse => contradiction
   case isTrue hef =>
-  have hok := error_free_evaluate_ok hwf hwt ((Residual.error_free_spec _).mp hef)
-  rw [Except.isOk_iff_exists] at hok
-  have ⟨v', hev⟩ := hok
-  have hinst := residual_well_typed_is_sound hwf hwt hev
-  refine ⟨v', hev, ?_⟩
-  split at hdec
-  case h_1 ety₁ ety₂ htyeq =>
-    rw [htyeq] at hinst
-    simp only [Option.some.injEq] at hdec
-    subst hdec
-    exact is_eq_type_comparison_of_entity_type hinst
-  case h_2 => simp at hdec
+    have hok := error_free_evaluate_ok hwf hwt ((Residual.error_free_spec _).mp hef)
+    rw [Except.isOk_iff_exists] at hok
+    have ⟨v', hev⟩ := hok
+    exists v' ; apply And.intro hev
+    split at hdec
+    case h_1 ety₁ ety₂ htyeq =>
+      have hinst := residual_well_typed_is_sound hwf hwt hev
+      rw [htyeq] at hinst
+      simp only [Option.some.injEq] at hdec
+      subst hdec
+      exact is_eq_type_comparison_of_entity_type hinst
+    case h_2 => simp at hdec
 
 theorem partial_evaluate_is_sound_unary_app
 {x₁ : Residual}
@@ -90,7 +85,7 @@ theorem partial_evaluate_is_sound_unary_app
   Except.toOption ((Residual.unaryApp op₁ x₁ ty).evaluate req es) =
   Except.toOption ((TPE.evaluate env (Residual.unaryApp op₁ x₁ ty) preq pes).evaluate req es)
 := by
-  simp [TPE.evaluate, TPE.apply₁]
+  simp only [TPE.evaluate, TPE.apply₁]
   split
   case _ heq =>
     simp only [heq, Residual.evaluate] at hᵢ₁
@@ -110,18 +105,17 @@ theorem partial_evaluate_is_sound_unary_app
       case _ heq =>
         rw [asValue_evaluate_val heq] at hᵢ₁
         replace hᵢ₁ := to_option_right_ok' hᵢ₁
-        simp [someOrError, Residual.evaluate, hᵢ₁]
-        split
+        unfold someOrError ; split
         case _ heq₂ =>
           simp only [to_option_some] at heq₂
-          simp [heq₂, Residual.evaluate]
+          simp [Residual.evaluate, heq₂, hᵢ₁]
         case _ heq₂ =>
           rcases to_option_none.mp heq₂ with ⟨_, heq₂⟩
-          simp [heq₂, Residual.evaluate, Except.toOption]
+          simp [Residual.evaluate, Except.toOption, heq₂, hᵢ₁]
       case _ =>
-        simp [Residual.evaluate]
+        simp only [Residual.evaluate]
         generalize h₅ : x₁.evaluate req es = res₁
-        cases res₁ <;> simp [h₅] at hᵢ₁
+        cases res₁ <;> simp only [h₅] at hᵢ₁
         case error =>
           rcases to_option_left_err hᵢ₁ with ⟨_, hᵢ₁⟩
           simp [hᵢ₁, Except.toOption]

--- a/cedar-lean/Cedar/Thm/TPE/Soundness/Unary.lean
+++ b/cedar-lean/Cedar/Thm/TPE/Soundness/Unary.lean
@@ -29,10 +29,50 @@ import Cedar.Thm.TPE.Soundness.Basic
 
 namespace Cedar.Thm
 
+open Cedar.Data
 open Cedar.Spec
 open Cedar.Validation
 open Cedar.TPE
 open Cedar.Thm
+
+/-- `is` on an entity-typed value is decided by comparing the two types. -/
+theorem is_eq_type_comparison_of_entity_type
+  {env : TypeEnv} {v : Value} {ety₁ ety₂ : EntityType}
+  (hinst : InstanceOfType env v (.entity ety₂)) :
+  Spec.apply₁ (.is ety₁) v = .ok (Value.prim (Prim.bool (ety₁ == ety₂)))
+:= by
+  have ⟨uid, hty, hv⟩ := instance_of_entity_type_is_entity hinst
+  subst hv hty
+  simp only [Spec.apply₁]
+
+theorem try_decide_residual₁_sound
+{env : TypeEnv}
+{r₁ : Residual}
+{req : Request}
+{es : Entities}
+{op₁ : UnaryOp}
+{v : Value}
+(hwf : InstanceOfWellFormedEnvironment req es env)
+(hwt : Residual.WellTyped env r₁)
+(hdec : TPE.tryDecideResidual₁ op₁ r₁ = .some v) :
+  ∃ v', r₁.evaluate req es = .ok v' ∧ Spec.apply₁ op₁ v' = .ok v
+:= by
+  unfold TPE.tryDecideResidual₁ at hdec
+  split at hdec
+  case isFalse => simp at hdec
+  case isTrue hef =>
+  have hok := error_free_evaluate_ok hwf hwt ((Residual.error_free_spec _).mp hef)
+  rw [Except.isOk_iff_exists] at hok
+  have ⟨v', hev⟩ := hok
+  have hinst := residual_well_typed_is_sound hwf hwt hev
+  refine ⟨v', hev, ?_⟩
+  split at hdec
+  case h_1 ety₁ ety₂ htyeq =>
+    rw [htyeq] at hinst
+    simp only [Option.some.injEq] at hdec
+    subst hdec
+    exact is_eq_type_comparison_of_entity_type hinst
+  case h_2 => simp at hdec
 
 theorem partial_evaluate_is_sound_unary_app
 {x₁ : Residual}
@@ -42,10 +82,13 @@ theorem partial_evaluate_is_sound_unary_app
 {pes : PartialEntities}
 {op₁ : UnaryOp}
 {ty : CedarType}
+{env : TypeEnv}
+(h₂ : InstanceOfWellFormedEnvironment req es env)
+(hwt : Residual.WellTyped env x₁)
 (h_ref : RequestAndEntitiesRefine req es preq pes)
-(hᵢ₁ : Except.toOption (x₁.evaluate req es) = Except.toOption ((TPE.evaluate x₁ preq pes).evaluate req es)) :
+(hᵢ₁ : Except.toOption (x₁.evaluate req es) = Except.toOption ((TPE.evaluate env x₁ preq pes).evaluate req es)) :
   Except.toOption ((Residual.unaryApp op₁ x₁ ty).evaluate req es) =
-  Except.toOption ((TPE.evaluate (Residual.unaryApp op₁ x₁ ty) preq pes).evaluate req es)
+  Except.toOption ((TPE.evaluate env (Residual.unaryApp op₁ x₁ ty) preq pes).evaluate req es)
 := by
   simp [TPE.evaluate, TPE.apply₁]
   split
@@ -55,30 +98,28 @@ theorem partial_evaluate_is_sound_unary_app
     simp [Residual.evaluate, hᵢ₁, Except.toOption]
   case _ =>
     split
-    case _ heq =>
-      rw [asValue_evaluate_val heq] at hᵢ₁
-      replace hᵢ₁ := to_option_right_ok' hᵢ₁
-      simp [someOrError, Residual.evaluate, hᵢ₁]
-      split
-      case _ heq₂ =>
-        simp only [to_option_some] at heq₂
-        simp [heq₂, Residual.evaluate]
-      case _ heq₂ =>
-        rcases to_option_none.mp heq₂ with ⟨_, heq₂⟩
-        simp [heq₂, Residual.evaluate, Except.toOption]
+    case _ hdec =>
+      have hwt' := partial_eval_preserves_well_typed h₂ h_ref hwt
+      have ⟨v, hev, hres⟩ := try_decide_residual₁_sound h₂ hwt' hdec
+      have hev₁ : Except.toOption (x₁.evaluate req es) = some v := by
+        rw [hᵢ₁, hev]; rfl
+      rw [to_option_some] at hev₁
+      simp [Residual.evaluate, hev₁, hres, Except.toOption]
     case _ =>
       split
-      · -- .is ety, .var .resource _
-        rename_i ety _ heq_r
-        simp [heq_r, Residual.evaluate] at hᵢ₁ ⊢
+      case _ heq =>
+        rw [asValue_evaluate_val heq] at hᵢ₁
         replace hᵢ₁ := to_option_right_ok' hᵢ₁
-        simp only [hᵢ₁, Spec.apply₁, Except.toOption, Except.bind_ok, h_ref.1.2.2.2.2.2, BEq.comm]
-      · -- .is ety, .var .principal _
-        rename_i ety _ heq_p
-        simp [heq_p, Residual.evaluate] at hᵢ₁ ⊢
-        replace hᵢ₁ := to_option_right_ok' hᵢ₁
-        simp only [hᵢ₁, Spec.apply₁, Except.toOption, Except.bind_ok, h_ref.1.2.2.2.2.1, BEq.comm]
-      · simp [Residual.evaluate]
+        simp [someOrError, Residual.evaluate, hᵢ₁]
+        split
+        case _ heq₂ =>
+          simp only [to_option_some] at heq₂
+          simp [heq₂, Residual.evaluate]
+        case _ heq₂ =>
+          rcases to_option_none.mp heq₂ with ⟨_, heq₂⟩
+          simp [heq₂, Residual.evaluate, Except.toOption]
+      case _ =>
+        simp [Residual.evaluate]
         generalize h₅ : x₁.evaluate req es = res₁
         cases res₁ <;> simp [h₅] at hᵢ₁
         case error =>

--- a/cedar-lean/Cedar/Thm/TPE/Soundness/Var.lean
+++ b/cedar-lean/Cedar/Thm/TPE/Soundness/Var.lean
@@ -42,7 +42,7 @@ theorem partial_evaluate_is_sound_val
 {pes : PartialEntities}
 {ty : CedarType} :
   Except.toOption ((Residual.val v ty).evaluate req es) =
-  Except.toOption ((TPE.evaluate (Residual.val v ty) preq pes).evaluate req es)
+  Except.toOption ((TPE.evaluate env (Residual.val v ty) preq pes).evaluate req es)
 := by
   simp [TPE.evaluate, Residual.evaluate]
 
@@ -56,7 +56,7 @@ theorem partial_evaluate_is_sound_var
 {ty : CedarType}
 (h₄ : RequestAndEntitiesRefine req es preq pes) :
   Except.toOption ((Residual.var v ty).evaluate req es) =
-  Except.toOption ((TPE.evaluate (Residual.var v ty) preq pes).evaluate req es)
+  Except.toOption ((TPE.evaluate env (Residual.var v ty) preq pes).evaluate req es)
 := by
   simp [TPE.evaluate, varₚ]
   split <;>

--- a/cedar-lean/Cedar/Thm/TPE/WellTyped.lean
+++ b/cedar-lean/Cedar/Thm/TPE/WellTyped.lean
@@ -66,7 +66,7 @@ theorem partial_eval_preserves_well_typed
   InstanceOfWellFormedEnvironment req es env →
   RequestAndEntitiesRefine req es preq pes →
   Residual.WellTyped env res →
-  Residual.WellTyped env (TPE.evaluate res preq pes)
+  Residual.WellTyped env (TPE.evaluate env res preq pes)
 := by
   intro h_wf h_ref h_wt
   unfold RequestAndEntitiesRefine at h_ref
@@ -86,43 +86,43 @@ theorem partial_eval_preserves_well_typed
     let h_wt₂ := h_wt
     cases h_wt₂ with
     | and h_a h_b h_ty_a h_ty_b =>
-      have ih_a : Residual.WellTyped env (TPE.evaluate a preq pes) := partial_eval_preserves_well_typed h_wf h_ref h_a
-      have ih_b : Residual.WellTyped env (TPE.evaluate b preq pes) := partial_eval_preserves_well_typed h_wf h_ref h_b
+      have ih_a : Residual.WellTyped env (TPE.evaluate env a preq pes) := partial_eval_preserves_well_typed h_wf h_ref h_a
+      have ih_b : Residual.WellTyped env (TPE.evaluate env b preq pes) := partial_eval_preserves_well_typed h_wf h_ref h_b
       exact partial_eval_well_typed_and ih_a ih_b h_wf h_ref h_wt
   case or a b ty =>
     let h_wt₂ := h_wt
     cases h_wt₂ with
     | or h_a h_b h_ty_a h_ty_b =>
-      have ih_a : Residual.WellTyped env (TPE.evaluate a preq pes) := partial_eval_preserves_well_typed h_wf h_ref h_a
-      have ih_b : Residual.WellTyped env (TPE.evaluate b preq pes) := partial_eval_preserves_well_typed h_wf h_ref h_b
+      have ih_a : Residual.WellTyped env (TPE.evaluate env a preq pes) := partial_eval_preserves_well_typed h_wf h_ref h_a
+      have ih_b : Residual.WellTyped env (TPE.evaluate env b preq pes) := partial_eval_preserves_well_typed h_wf h_ref h_b
       exact partial_eval_well_typed_or ih_a ih_b h_wf h_ref h_wt
   case ite c t e ty =>
     let h_wt₂ := h_wt
     cases h_wt₂ with
     | ite h_c h_t h_e h_ty_c h_ty_t =>
-      have ih_c : Residual.WellTyped env (TPE.evaluate c preq pes) := partial_eval_preserves_well_typed h_wf h_ref h_c
-      have ih_t : Residual.WellTyped env (TPE.evaluate t preq pes) := partial_eval_preserves_well_typed h_wf h_ref h_t
-      have ih_e : Residual.WellTyped env (TPE.evaluate e preq pes) := partial_eval_preserves_well_typed h_wf h_ref h_e
+      have ih_c : Residual.WellTyped env (TPE.evaluate env c preq pes) := partial_eval_preserves_well_typed h_wf h_ref h_c
+      have ih_t : Residual.WellTyped env (TPE.evaluate env t preq pes) := partial_eval_preserves_well_typed h_wf h_ref h_t
+      have ih_e : Residual.WellTyped env (TPE.evaluate env e preq pes) := partial_eval_preserves_well_typed h_wf h_ref h_e
       exact partial_eval_well_typed_ite ih_c ih_t ih_e h_wf h_ref h_wt
   case unaryApp op expr ty =>
     let h_wt₂ := h_wt
     cases h_wt₂ with
     | unaryApp h_expr h_op =>
-      have ih_expr : Residual.WellTyped env (TPE.evaluate expr preq pes) := partial_eval_preserves_well_typed h_wf h_ref h_expr
+      have ih_expr : Residual.WellTyped env (TPE.evaluate env expr preq pes) := partial_eval_preserves_well_typed h_wf h_ref h_expr
       exact partial_eval_well_typed_unaryApp ih_expr h_wf h_ref h_wt
   case binaryApp op expr1 expr2 ty =>
     simp [TPE.evaluate]
     have h_wt₂ := h_wt
     cases h_wt with
     | binaryApp h_expr1 h_expr2 h_op =>
-      have ih1 : Residual.WellTyped env (TPE.evaluate expr1 preq pes) := partial_eval_preserves_well_typed h_wf h_ref h_expr1
-      have ih2 : Residual.WellTyped env (TPE.evaluate expr2 preq pes) := partial_eval_preserves_well_typed h_wf h_ref h_expr2
+      have ih1 : Residual.WellTyped env (TPE.evaluate env expr1 preq pes) := partial_eval_preserves_well_typed h_wf h_ref h_expr1
+      have ih2 : Residual.WellTyped env (TPE.evaluate env expr2 preq pes) := partial_eval_preserves_well_typed h_wf h_ref h_expr2
       apply partial_eval_well_typed_app₂ ih1 ih2 h_wf h_ref h_wt₂
   case set ls ty =>
     let h_wt₂ := h_wt
     cases h_wt₂
     rename_i ty₁ h₀ h₁ h₂
-    have ih_ls : ∀ r ∈ ls, Residual.WellTyped env (TPE.evaluate r preq pes) := by
+    have ih_ls : ∀ r ∈ ls, Residual.WellTyped env (TPE.evaluate env r preq pes) := by
       intros r h_mem
       specialize h₀ r h_mem
       exact partial_eval_preserves_well_typed h_wf h_ref h₀
@@ -131,7 +131,7 @@ theorem partial_eval_preserves_well_typed
     let h_wt₂ := h_wt
     cases h_wt₂
     rename_i ty₁ h₀ h₁
-    have ih_ls : ∀ k v, (k, v) ∈ ls → Residual.WellTyped env (TPE.evaluate v preq pes) := by
+    have ih_ls : ∀ k v, (k, v) ∈ ls → Residual.WellTyped env (TPE.evaluate env v preq pes) := by
       intros k v h_mem
       specialize h₀ k v h_mem
       have termination : sizeOf v <= sizeOf ls := by
@@ -149,25 +149,25 @@ theorem partial_eval_preserves_well_typed
     let h_wt₂ := h_wt
     cases h_wt₂
     case getAttr_entity ety rty h₄ h₅ h₆ h₇ =>
-      have ih_expr : Residual.WellTyped env (TPE.evaluate expr preq pes) := partial_eval_preserves_well_typed h_wf h_ref h₅
+      have ih_expr : Residual.WellTyped env (TPE.evaluate env expr preq pes) := partial_eval_preserves_well_typed h_wf h_ref h₅
       exact partial_eval_well_typed_getAttr ih_expr h_wf h_ref h_wt
     case getAttr_record rty h₄ h₅ h₆ =>
-      have ih_expr : Residual.WellTyped env (TPE.evaluate expr preq pes) := partial_eval_preserves_well_typed h_wf h_ref h₄
+      have ih_expr : Residual.WellTyped env (TPE.evaluate env expr preq pes) := partial_eval_preserves_well_typed h_wf h_ref h₄
       exact partial_eval_well_typed_getAttr ih_expr h_wf h_ref h_wt
   case hasAttr expr attr ty =>
     let h_wt₂ := h_wt
     cases h_wt₂
     case hasAttr_entity ety h₅ h₆ =>
-      have ih_expr : Residual.WellTyped env (TPE.evaluate expr preq pes) := partial_eval_preserves_well_typed h_wf h_ref h₅
+      have ih_expr : Residual.WellTyped env (TPE.evaluate env expr preq pes) := partial_eval_preserves_well_typed h_wf h_ref h₅
       exact partial_eval_well_typed_hasAttr ih_expr h_wf h_ref h_wt
     case hasAttr_record rty h₆ h₇ =>
-      have ih_expr : Residual.WellTyped env (TPE.evaluate expr preq pes) := partial_eval_preserves_well_typed h_wf h_ref h₆
+      have ih_expr : Residual.WellTyped env (TPE.evaluate env expr preq pes) := partial_eval_preserves_well_typed h_wf h_ref h₆
       exact partial_eval_well_typed_hasAttr ih_expr h_wf h_ref h_wt
   case call xfn args ty =>
     let h_wt₂ := h_wt
     cases h_wt₂
     rename_i h₁ h₂
-    have ih_args : ∀ r ∈ args, Residual.WellTyped env (TPE.evaluate r preq pes) := by
+    have ih_args : ∀ r ∈ args, Residual.WellTyped env (TPE.evaluate env r preq pes) := by
       intros r h_mem
       specialize h₁ r h_mem
       exact partial_eval_preserves_well_typed h_wf h_ref h₁

--- a/cedar-lean/Cedar/Thm/TPE/WellTyped/And.lean
+++ b/cedar-lean/Cedar/Thm/TPE/WellTyped/And.lean
@@ -32,9 +32,9 @@ open Cedar.Validation
 open Cedar.TPE
 
 theorem partial_eval_well_typed_and {env : TypeEnv} {a b : Residual} {ty : CedarType} {req : Request} {preq : PartialRequest} {es : Entities} {pes : PartialEntities} :
-  Residual.WellTyped env (TPE.evaluate a preq pes) →
-  Residual.WellTyped env (TPE.evaluate b preq pes) →
-  PEWellTyped env (Residual.and a b ty) (TPE.evaluate (Residual.and a b ty) preq pes) req preq es pes
+  Residual.WellTyped env (TPE.evaluate env a preq pes) →
+  Residual.WellTyped env (TPE.evaluate env b preq pes) →
+  PEWellTyped env (Residual.and a b ty) (TPE.evaluate env (Residual.and a b ty) preq pes) req preq es pes
 := by
   intros h_a_wt h_b_wt h_wf h_ref h_wt
   simp only [TPE.evaluate]

--- a/cedar-lean/Cedar/Thm/TPE/WellTyped/Binary.lean
+++ b/cedar-lean/Cedar/Thm/TPE/WellTyped/Binary.lean
@@ -31,6 +31,17 @@ open Cedar.Spec
 open Cedar.Validation
 open Cedar.TPE
 
+/-- The reductions only ever decide a boolean. -/
+theorem try_decide_residual₂_is_bool
+  {env : TypeEnv} {op₂ : BinaryOp} {r₁ r₂ : Residual} {v : Value}
+  (hdec : TPE.tryDecideResidual₂ env op₂ r₁ r₂ = .some v) :
+  ∃ b : Bool, v = .prim (.bool b)
+:= by
+  unfold TPE.tryDecideResidual₂ at hdec
+  repeat' split at hdec
+  all_goals simp only [Option.some.injEq, reduceCtorEq] at hdec
+  all_goals exact ⟨_, hdec.symm⟩
+
 theorem tags_if_partial_tags
   {env : TypeEnv} {req : Request} {es : Entities} {pes : PartialEntities}
   {uid : EntityUID} {tags : Map Tag Value}
@@ -97,13 +108,13 @@ theorem entity_tag_well_typed
     simp [Map.empty, Map.values] at h_mem
 
 theorem partial_eval_well_typed_app₂_values_hasTag :
-  Residual.WellTyped env (TPE.evaluate expr1 preq pes) →
-  Residual.WellTyped env (TPE.evaluate expr2 preq pes) →
-  (TPE.evaluate expr1 preq pes).asValue = some (Value.prim (Prim.entityUID id₁)) →
-  (TPE.evaluate expr2 preq pes).asValue = some (Value.prim (Prim.string id₂)) →
+  Residual.WellTyped env (TPE.evaluate env expr1 preq pes) →
+  Residual.WellTyped env (TPE.evaluate env expr2 preq pes) →
+  (TPE.evaluate env expr1 preq pes).asValue = some (Value.prim (Prim.entityUID id₁)) →
+  (TPE.evaluate env expr2 preq pes).asValue = some (Value.prim (Prim.string id₂)) →
   PEWellTyped env (Residual.binaryApp BinaryOp.hasTag expr1 expr2 ty)
     (someOrSelf ((TPE.hasTag id1 id2 pes).bind fun a => some (Value.prim (Prim.bool a))) ty
-    (Residual.binaryApp BinaryOp.hasTag (TPE.evaluate expr1 preq pes) (TPE.evaluate expr2 preq pes) ty)) req preq es pes
+    (Residual.binaryApp BinaryOp.hasTag (TPE.evaluate env expr1 preq pes) (TPE.evaluate env expr2 preq pes) ty)) req preq es pes
 := by
   unfold PEWellTyped
   intros ih₁ ih₂ h₁ h₂ h_wf h_ref h_wt
@@ -168,10 +179,10 @@ theorem partial_eval_well_typed_app₂_values_hasTag :
 
 
 theorem partial_eval_well_typed_app₂_values_getTag :
-  Residual.WellTyped env (TPE.evaluate expr1 preq pes) →
-  Residual.WellTyped env (TPE.evaluate expr2 preq pes) →
-  (TPE.evaluate expr1 preq pes).asValue = some (Value.prim (Prim.entityUID id₁)) →
-  (TPE.evaluate expr2 preq pes).asValue = some (Value.prim (Prim.string id₂)) →
+  Residual.WellTyped env (TPE.evaluate env expr1 preq pes) →
+  Residual.WellTyped env (TPE.evaluate env expr2 preq pes) →
+  (TPE.evaluate env expr1 preq pes).asValue = some (Value.prim (Prim.entityUID id₁)) →
+  (TPE.evaluate env expr2 preq pes).asValue = some (Value.prim (Prim.string id₂)) →
   PEWellTyped env (Residual.binaryApp BinaryOp.getTag expr1 expr2 ty) (TPE.getTag id₁ id₂ pes ty) req preq es pes
 := by
   unfold PEWellTyped
@@ -203,7 +214,7 @@ theorem partial_eval_well_typed_app₂_values_getTag :
       have h_ent : InstanceOfEntityType id₁ ety env := by
         have h₂₁ := partial_eval_preserves_typeof _ h_expr1 preq pes
         unfold Residual.asValue at h₁
-        cases h₂₂: TPE.evaluate expr1 preq pes
+        cases h₂₂: TPE.evaluate env expr1 preq pes
         case val v ty₃ =>
           replace h₁ : v = .prim (.entityUID id₁) := by
             simpa [h₂₂] using h₁
@@ -223,7 +234,7 @@ theorem partial_eval_well_typed_app₂_values_getTag :
     . apply Residual.WellTyped.error
   . apply Residual.WellTyped.binaryApp
     . unfold Residual.asValue at h₁
-      cases h₃: TPE.evaluate expr1 preq pes
+      cases h₃: TPE.evaluate env expr1 preq pes
       all_goals (rw [h₃] at h₁
                  simp at h₁)
       rename_i x heq v ty
@@ -274,11 +285,11 @@ theorem partial_eval_well_typed_app₂_values_getTag :
 
 
 theorem partial_eval_well_typed_app₂_values_mem :
-  Residual.WellTyped env (TPE.evaluate expr1 preq pes) →
-  Residual.WellTyped env (TPE.evaluate expr2 preq pes) →
-  (TPE.evaluate expr1 preq pes).asValue = .some v₁ →
-  (TPE.evaluate expr2 preq pes).asValue = .some v₂ →
-  PEWellTyped env (Residual.binaryApp BinaryOp.mem expr1 expr2 ty) (Residual.binaryApp BinaryOp.mem (TPE.evaluate expr1 preq pes) (TPE.evaluate expr2 preq pes) ty) req preq es pes
+  Residual.WellTyped env (TPE.evaluate env expr1 preq pes) →
+  Residual.WellTyped env (TPE.evaluate env expr2 preq pes) →
+  (TPE.evaluate env expr1 preq pes).asValue = .some v₁ →
+  (TPE.evaluate env expr2 preq pes).asValue = .some v₂ →
+  PEWellTyped env (Residual.binaryApp BinaryOp.mem expr1 expr2 ty) (Residual.binaryApp BinaryOp.mem (TPE.evaluate env expr1 preq pes) (TPE.evaluate env expr2 preq pes) ty) req preq es pes
 := by
   unfold PEWellTyped
   intros ih₁ ih₂ h₁ h₂ h_wf h_ref h_wt
@@ -358,11 +369,11 @@ theorem partial_eval_well_typed_app₂_values_mem :
   . contradiction
 
 theorem partial_eval_well_typed_app₂_values :
-  Residual.WellTyped env (TPE.evaluate expr1 preq pes) →
-  Residual.WellTyped env (TPE.evaluate expr2 preq pes) →
-  (TPE.evaluate expr1 preq pes).asValue = .some v₁ →
-  (TPE.evaluate expr2 preq pes).asValue = .some v₂ →
-  PEWellTyped env (Residual.binaryApp op expr1 expr2 ty) (TPE.apply₂ op (TPE.evaluate expr1 preq pes) (TPE.evaluate expr2 preq pes) pes ty) req preq es pes
+  Residual.WellTyped env (TPE.evaluate env expr1 preq pes) →
+  Residual.WellTyped env (TPE.evaluate env expr2 preq pes) →
+  (TPE.evaluate env expr1 preq pes).asValue = .some v₁ →
+  (TPE.evaluate env expr2 preq pes).asValue = .some v₂ →
+  PEWellTyped env (Residual.binaryApp op expr1 expr2 ty) (TPE.apply₂ env op (TPE.evaluate env expr1 preq pes) (TPE.evaluate env expr2 preq pes) pes ty) req preq es pes
 := by
   unfold PEWellTyped
   intros ih₁ ih₂ h₁ h₂ h_wf h_ref h_wt
@@ -376,6 +387,18 @@ theorem partial_eval_well_typed_app₂_values :
   | binaryApp h_expr1 h_expr2 h_op =>
 
   simp only [TPE.apply₂]
+  split
+  case h_1 => exact Residual.WellTyped.error
+  case h_2 => exact Residual.WellTyped.error
+  split
+  case h_1 hdec =>
+    have ⟨_, hb⟩ := try_decide_residual₂_is_bool hdec
+    subst hb
+    cases h_op <;>
+      first
+      | exact well_typed_bool
+      | simp [TPE.tryDecideResidual₂] at hdec
+  case h_2 =>
   rw [h₁, h₂]
   simp only
   split
@@ -415,10 +438,10 @@ theorem partial_eval_well_typed_app₂_values :
     apply Residual.WellTyped.error
 
 theorem partial_eval_well_typed_app₂_nonvalues :
-  Residual.WellTyped env (TPE.evaluate expr1 preq pes) →
-  Residual.WellTyped env (TPE.evaluate expr2 preq pes) →
-  (TPE.evaluate expr1 preq pes).asValue = .none ∨ (TPE.evaluate expr2 preq pes).asValue = .none →
-  PEWellTyped env (Residual.binaryApp op expr1 expr2 ty) (TPE.apply₂ op (TPE.evaluate expr1 preq pes) (TPE.evaluate expr2 preq pes) pes ty) req preq es pes
+  Residual.WellTyped env (TPE.evaluate env expr1 preq pes) →
+  Residual.WellTyped env (TPE.evaluate env expr2 preq pes) →
+  (TPE.evaluate env expr1 preq pes).asValue = .none ∨ (TPE.evaluate env expr2 preq pes).asValue = .none →
+  PEWellTyped env (Residual.binaryApp op expr1 expr2 ty) (TPE.apply₂ env op (TPE.evaluate env expr1 preq pes) (TPE.evaluate env expr2 preq pes) pes ty) req preq es pes
 := by
   unfold PEWellTyped
   intros ih₁ ih₂ h₁ h_wf h_ref h_wt
@@ -434,6 +457,18 @@ theorem partial_eval_well_typed_app₂_nonvalues :
 
   simp only [TPE.apply₂]
   split
+  case h_1 => exact Residual.WellTyped.error
+  case h_2 => exact Residual.WellTyped.error
+  split
+  case h_1 hdec =>
+    have ⟨_, hb⟩ := try_decide_residual₂_is_bool hdec
+    subst hb
+    cases h_op <;>
+      first
+      | exact well_typed_bool
+      | simp [TPE.tryDecideResidual₂] at hdec
+  case h_2 =>
+  split
   case h_1 h₂ h₃ =>
     cases h₁
     case inl h₁ =>
@@ -445,14 +480,6 @@ theorem partial_eval_well_typed_app₂_nonvalues :
   case h_2 _ _ =>
     have h₁ := partial_eval_preserves_typeof _ h_expr1
     have h₂ := partial_eval_preserves_typeof _ h_expr2
-    split
-    case h_1 =>
-      apply Residual.WellTyped.error
-    case h_2 =>
-      apply Residual.WellTyped.error
-
-    case h_3 =>
-    rename_i h₁ r₁ r₂ h₃ h₄
     unfold apply₂.self
     apply Residual.WellTyped.binaryApp
     cases op
@@ -547,19 +574,19 @@ theorem partial_eval_well_typed_app₂_nonvalues :
 
 
 theorem partial_eval_well_typed_app₂ :
-  Residual.WellTyped env (TPE.evaluate expr1 preq pes) →
-  Residual.WellTyped env (TPE.evaluate expr2 preq pes) →
-  PEWellTyped env (Residual.binaryApp op expr1 expr2 ty) (TPE.apply₂ op (TPE.evaluate expr1 preq pes) (TPE.evaluate expr2 preq pes) pes ty) req preq es pes
+  Residual.WellTyped env (TPE.evaluate env expr1 preq pes) →
+  Residual.WellTyped env (TPE.evaluate env expr2 preq pes) →
+  PEWellTyped env (Residual.binaryApp op expr1 expr2 ty) (TPE.apply₂ env op (TPE.evaluate env expr1 preq pes) (TPE.evaluate env expr2 preq pes) pes ty) req preq es pes
 := by
   intro ih₁ ih₂ h₁
-  cases h₂ : (TPE.evaluate expr1 preq pes).asValue
+  cases h₂ : (TPE.evaluate env expr1 preq pes).asValue
   case none =>
     apply partial_eval_well_typed_app₂_nonvalues ih₁ ih₂
     . left
       exact h₂
     . exact h₁
   case some v₁ =>
-    cases h₃ : (TPE.evaluate expr2 preq pes).asValue
+    cases h₃ : (TPE.evaluate env expr2 preq pes).asValue
     case none =>
       apply partial_eval_well_typed_app₂_nonvalues ih₁ ih₂
       . right

--- a/cedar-lean/Cedar/Thm/TPE/WellTyped/Binary.lean
+++ b/cedar-lean/Cedar/Thm/TPE/WellTyped/Binary.lean
@@ -397,7 +397,7 @@ theorem partial_eval_well_typed_app₂_values :
     cases h_op <;>
       first
       | exact well_typed_bool
-      | simp [TPE.tryDecideResidual₂] at hdec
+      | simp only [TPE.tryDecideResidual₂, ite_self, reduceCtorEq] at hdec
   case h_2 =>
   rw [h₁, h₂]
   simp only
@@ -466,7 +466,7 @@ theorem partial_eval_well_typed_app₂_nonvalues :
     cases h_op <;>
       first
       | exact well_typed_bool
-      | simp [TPE.tryDecideResidual₂] at hdec
+      | simp only [TPE.tryDecideResidual₂, ite_self, reduceCtorEq] at hdec
   case h_2 =>
   split
   case h_1 h₂ h₃ =>

--- a/cedar-lean/Cedar/Thm/TPE/WellTyped/Call.lean
+++ b/cedar-lean/Cedar/Thm/TPE/WellTyped/Call.lean
@@ -89,8 +89,8 @@ theorem ext_well_typed_after_map {xfn args ty env f} :
     rw [h₃ x₁ (List.mem_singleton.mpr rfl), h₆]
 
 theorem partial_eval_well_typed_call {env : TypeEnv} {xfn : ExtFun} {args : List Residual} {ty : CedarType} {req : Request} {preq : PartialRequest} {es : Entities} {pes : PartialEntities} :
-  (∀ r ∈ args, Residual.WellTyped env (TPE.evaluate r preq pes)) →
-  PEWellTyped env (Residual.call xfn args ty) (TPE.evaluate (Residual.call xfn args ty) preq pes) req preq es pes
+  (∀ r ∈ args, Residual.WellTyped env (TPE.evaluate env r preq pes)) →
+  PEWellTyped env (Residual.call xfn args ty) (TPE.evaluate env (Residual.call xfn args ty) preq pes) req preq es pes
 := by
   intros h_args_wt h_wf h_ref h_wt
   simp only [TPE.evaluate, TPE.call, List.any_eq_true]
@@ -100,7 +100,7 @@ theorem partial_eval_well_typed_call {env : TypeEnv} {xfn : ExtFun} {args : List
   unfold List.unattach
   rw [List.map_pmap_subtype (fun x => x)]
   simp only [List.map_id_fun', id_eq, List.map_subtype, List.mem_map, List.mem_unattach, List.mem_pmap, Subtype.mk.injEq, exists_prop, exists_eq_right, and_self]
-  simp only [List.map_pmap_subtype (fun x => TPE.evaluate x preq pes)]
+  simp only [List.map_pmap_subtype (fun x => TPE.evaluate env x preq pes)]
   split
   case h_1 x xs h₁ =>
     cases h_wt

--- a/cedar-lean/Cedar/Thm/TPE/WellTyped/GetAttr.lean
+++ b/cedar-lean/Cedar/Thm/TPE/WellTyped/GetAttr.lean
@@ -157,8 +157,8 @@ theorem entity_attr_well_typed
     simp [Map.empty, Map.find?] at h_find
 
 theorem partial_eval_well_typed_getAttr {env : TypeEnv} {expr : Residual} {attr : Attr} {ty : CedarType} {req : Request} {preq : PartialRequest} {es : Entities} {pes : PartialEntities} :
-  Residual.WellTyped env (TPE.evaluate expr preq pes) →
-  PEWellTyped env (Residual.getAttr expr attr ty) (TPE.evaluate (Residual.getAttr expr attr ty) preq pes) req preq es pes
+  Residual.WellTyped env (TPE.evaluate env expr preq pes) →
+  PEWellTyped env (Residual.getAttr expr attr ty) (TPE.evaluate env (Residual.getAttr expr attr ty) preq pes) req preq es pes
 := by
   intros h_expr_wt h_wf h_ref h_wt
   simp only [TPE.evaluate, TPE.getAttr, TPE.attrsOf]

--- a/cedar-lean/Cedar/Thm/TPE/WellTyped/HasAttr.lean
+++ b/cedar-lean/Cedar/Thm/TPE/WellTyped/HasAttr.lean
@@ -31,9 +31,20 @@ open Cedar.Spec
 open Cedar.Validation
 open Cedar.TPE
 
+/-- The reductions only ever decide a boolean. -/
+theorem try_decide_has_residual_is_bool
+  {env : TypeEnv} {r : Residual} {a : Attr} {v : Value}
+  (hdec : TPE.tryDecideHasResidual env r a = .some v) :
+  ∃ b : Bool, v = .prim (.bool b)
+:= by
+  unfold TPE.tryDecideHasResidual at hdec
+  repeat' split at hdec
+  all_goals simp only [Option.some.injEq, reduceCtorEq] at hdec
+  all_goals exact ⟨_, hdec.symm⟩
+
 theorem partial_eval_well_typed_hasAttr {env : TypeEnv} {expr : Residual} {attr : Attr} {ty : CedarType} {req : Request} {preq : PartialRequest} {es : Entities} {pes : PartialEntities} :
-  Residual.WellTyped env (TPE.evaluate expr preq pes) →
-  PEWellTyped env (Residual.hasAttr expr attr ty) (TPE.evaluate (Residual.hasAttr expr attr ty) preq pes) req preq es pes
+  Residual.WellTyped env (TPE.evaluate env expr preq pes) →
+  PEWellTyped env (Residual.hasAttr expr attr ty) (TPE.evaluate env (Residual.hasAttr expr attr ty) preq pes) req preq es pes
 := by
   intros h_expr_wt h_wf h_ref h_wt
   simp only [TPE.evaluate, TPE.hasAttr, TPE.attrsOf]
@@ -41,6 +52,12 @@ theorem partial_eval_well_typed_hasAttr {env : TypeEnv} {expr : Residual} {attr 
   case h_1 =>
     apply Residual.WellTyped.error
   case h_2 r₁ h₁ =>
+    split
+    case h_1 hdec =>
+      have ⟨_, hb⟩ := try_decide_has_residual_is_bool hdec
+      subst hb
+      cases h_wt <;> exact well_typed_bool
+    case h_2 =>
     split
     case h_1 x m h₂ =>
       exact well_typed_bool

--- a/cedar-lean/Cedar/Thm/TPE/WellTyped/IfThenElse.lean
+++ b/cedar-lean/Cedar/Thm/TPE/WellTyped/IfThenElse.lean
@@ -32,10 +32,10 @@ open Cedar.Validation
 open Cedar.TPE
 
 theorem partial_eval_well_typed_ite {env : TypeEnv} {c t e : Residual} {ty : CedarType} {req : Request} {preq : PartialRequest} {es : Entities} {pes : PartialEntities} :
-  Residual.WellTyped env (TPE.evaluate c preq pes) →
-  Residual.WellTyped env (TPE.evaluate t preq pes) →
-  Residual.WellTyped env (TPE.evaluate e preq pes) →
-  PEWellTyped env (Residual.ite c t e ty) (TPE.evaluate (Residual.ite c t e ty) preq pes) req preq es pes
+  Residual.WellTyped env (TPE.evaluate env c preq pes) →
+  Residual.WellTyped env (TPE.evaluate env t preq pes) →
+  Residual.WellTyped env (TPE.evaluate env e preq pes) →
+  PEWellTyped env (Residual.ite c t e ty) (TPE.evaluate env (Residual.ite c t e ty) preq pes) req preq es pes
 := by
   intros h_c_wt h_t_wt h_e_wt h_wf h_ref h_wt
   simp only [TPE.evaluate]

--- a/cedar-lean/Cedar/Thm/TPE/WellTyped/Or.lean
+++ b/cedar-lean/Cedar/Thm/TPE/WellTyped/Or.lean
@@ -33,9 +33,9 @@ open Cedar.TPE
 
 
 theorem partial_eval_well_typed_or {env : TypeEnv} {a b : Residual} {ty : CedarType} {req : Request} {preq : PartialRequest} {es : Entities} {pes : PartialEntities} :
-  Residual.WellTyped env (TPE.evaluate a preq pes) →
-  Residual.WellTyped env (TPE.evaluate b preq pes) →
-  PEWellTyped env (Residual.or a b ty) (TPE.evaluate (Residual.or a b ty) preq pes) req preq es pes
+  Residual.WellTyped env (TPE.evaluate env a preq pes) →
+  Residual.WellTyped env (TPE.evaluate env b preq pes) →
+  PEWellTyped env (Residual.or a b ty) (TPE.evaluate env (Residual.or a b ty) preq pes) req preq es pes
 := by
   intros h_a_wt h_b_wt h_wf h_ref h_wt
   simp only [TPE.evaluate]

--- a/cedar-lean/Cedar/Thm/TPE/WellTyped/Record.lean
+++ b/cedar-lean/Cedar/Thm/TPE/WellTyped/Record.lean
@@ -32,15 +32,15 @@ open Cedar.Validation
 open Cedar.TPE
 
 theorem partial_eval_well_typed_record {env : TypeEnv} {ls : List (Attr × Residual)} {ty : CedarType} {req : Request} {preq : PartialRequest} {es : Entities} {pes : PartialEntities} :
-  (∀ k v, (k, v) ∈ ls → Residual.WellTyped env (TPE.evaluate v preq pes)) →
-  PEWellTyped env (Residual.record ls ty) (TPE.evaluate (Residual.record ls ty) preq pes) req preq es pes
+  (∀ k v, (k, v) ∈ ls → Residual.WellTyped env (TPE.evaluate env v preq pes)) →
+  PEWellTyped env (Residual.record ls ty) (TPE.evaluate env (Residual.record ls ty) preq pes) req preq es pes
 := by
   intros h_ls_wt h_wf h_ref h_wt
   cases h_wt
   rename_i ty₁ h₀ h₁
   simp only [TPE.evaluate]
   unfold List.map₁ List.attach List.attachWith
-  rw [List.map_pmap_subtype (fun x => (x.fst, TPE.evaluate x.snd preq pes)) ls]
+  rw [List.map_pmap_subtype (fun x => (x.fst, TPE.evaluate env x.snd preq pes)) ls]
   simp only [record, List.mapM_map, List.any_map, List.any_eq_true, Function.comp_apply, Prod.exists]
   let m := Map.mk ls
   split
@@ -56,7 +56,7 @@ theorem partial_eval_well_typed_record {env : TypeEnv} {ls : List (Attr × Resid
       unfold Function.comp at h₃
       simp [bindAttr] at h₃
 
-      have h₈ := Map.list_find?_mapM_implies_exists_unmapped (λ x => (TPE.evaluate x preq pes).asValue) h₃ h₄
+      have h₈ := Map.list_find?_mapM_implies_exists_unmapped (λ x => (TPE.evaluate env x preq pes).asValue) h₃ h₄
       rcases h₈ with ⟨v₂, h₈, h₉⟩
 
       rw [Map.list_find?_some_iff_map_find?_some] at h₉
@@ -76,7 +76,7 @@ theorem partial_eval_well_typed_record {env : TypeEnv} {ls : List (Attr × Resid
       rw [← Map.list_find?_iff_make_find?] at h₇
       unfold Function.comp at h₃
       simp only [bindAttr, Option.pure_def, Option.bind_eq_bind] at h₃
-      have h₈ := Map.list_find?_mapM_implies_exists_unmapped (λ x => (TPE.evaluate x preq pes).asValue) h₃ h₆
+      have h₈ := Map.list_find?_mapM_implies_exists_unmapped (λ x => (TPE.evaluate env x preq pes).asValue) h₃ h₆
       rcases h₈ with ⟨v₂, _, h₈⟩
 
 
@@ -128,7 +128,7 @@ theorem partial_eval_well_typed_record {env : TypeEnv} {ls : List (Attr × Resid
 
       unfold Function.comp at h₃
       simp only [bindAttr, Option.pure_def, Option.bind_eq_bind] at h₃
-      have h₆ := Map.list_find?_mapM_implies_exists_mapped (λ x => (TPE.evaluate x preq pes).asValue) h₃ h₅
+      have h₆ := Map.list_find?_mapM_implies_exists_mapped (λ x => (TPE.evaluate env x preq pes).asValue) h₃ h₅
 
       rw [Map.contains_iff_some_find?]
       rcases h₆ with ⟨v₃, _, h₆⟩

--- a/cedar-lean/Cedar/Thm/TPE/WellTyped/Set.lean
+++ b/cedar-lean/Cedar/Thm/TPE/WellTyped/Set.lean
@@ -35,8 +35,8 @@ open Cedar.TPE
 Helper theorem: Partial evaluation preserves well-typedness for set residuals.
 -/
 theorem partial_eval_well_typed_set {env : TypeEnv} {ls : List Residual} {ty : CedarType} {req : Request} {preq : PartialRequest} {es : Entities} {pes : PartialEntities} :
-  (∀ r ∈ ls, Residual.WellTyped env (TPE.evaluate r preq pes)) →
-  PEWellTyped env (Residual.set ls ty) (TPE.evaluate (Residual.set ls ty) preq pes) req preq es pes
+  (∀ r ∈ ls, Residual.WellTyped env (TPE.evaluate env r preq pes)) →
+  PEWellTyped env (Residual.set ls ty) (TPE.evaluate env (Residual.set ls ty) preq pes) req preq es pes
 := by
   intros h_ls_wt h_wf h_ref h_wt
   cases h_wt
@@ -48,7 +48,7 @@ theorem partial_eval_well_typed_set {env : TypeEnv} {ls : List Residual} {ty : C
     apply InstanceOfType.instance_of_set
     intro v h₄
     unfold List.map₁ List.attach List.attachWith at h₃
-    rw [List.map_pmap_subtype (fun x => TPE.evaluate x preq pes), List.mapM_map] at h₃
+    rw [List.map_pmap_subtype (fun x => TPE.evaluate env x preq pes), List.mapM_map] at h₃
     rw [Set.mem_make] at h₄
     have h₅ := List.mem_mapM_some_implies_exists_unmapped h₃ h₄
     rcases h₅ with ⟨y, h₆, h₇⟩

--- a/cedar-lean/Cedar/Thm/TPE/WellTyped/Unary.lean
+++ b/cedar-lean/Cedar/Thm/TPE/WellTyped/Unary.lean
@@ -32,64 +32,76 @@ open Cedar.Validation
 open Cedar.TPE
 
 
+/-- The reductions only ever decide a boolean. -/
+theorem try_decide_residual₁_is_bool
+  {op₁ : UnaryOp} {r : Residual} {v : Value}
+  (hdec : TPE.tryDecideResidual₁ op₁ r = .some v) :
+  ∃ b : Bool, v = .prim (.bool b)
+:= by
+  unfold TPE.tryDecideResidual₁ at hdec
+  repeat' split at hdec
+  all_goals simp only [Option.some.injEq, reduceCtorEq] at hdec
+  all_goals exact ⟨_, hdec.symm⟩
+
 /--
 Helper theorem: Partial evaluation preserves well-typedness for unary application residuals.
 -/
 theorem partial_eval_well_typed_unaryApp {env : TypeEnv} {op : UnaryOp} {expr : Residual} {ty : CedarType} {req : Request} {preq : PartialRequest} {es : Entities} {pes : PartialEntities} :
-  Residual.WellTyped env (TPE.evaluate expr preq pes) →
-  PEWellTyped env (Residual.unaryApp op expr ty) (TPE.evaluate (Residual.unaryApp op expr ty) preq pes) req preq es pes
+  Residual.WellTyped env (TPE.evaluate env expr preq pes) →
+  PEWellTyped env (Residual.unaryApp op expr ty) (TPE.evaluate env (Residual.unaryApp op expr ty) preq pes) req preq es pes
 := by
   intros h_expr_wt h_wf h_ref h_wt
   simp only [TPE.evaluate]
   cases h_wt with
   | unaryApp h_expr h_op =>
-    let expr_eval := TPE.evaluate expr preq pes
     unfold TPE.apply₁
     split
     case h_1 => apply Residual.WellTyped.error
     case h_2 =>
-      cases h : expr_eval.asValue with
-      | some v =>
-        simp only [someOrError]
-        split
-        case h_2 =>
-          apply Residual.WellTyped.error
-        case h_1 v ty ox x v₂ heq =>
-          unfold Spec.apply₁ at heq
-          split at heq
-          any_goals
-            cases h_op
-            simp only [Except.toOption, Option.some.injEq] at heq
-            rw [← heq]
-            exact well_typed_bool
-          case h_2 =>
-            simp only [Except.toOption, intOrErr] at heq
-            rename Int64 => i
-            cases h₂: i.neg?
-            . rw [h₂] at heq
-              simp at heq
-            . rw [h₂] at heq
-              simp only [Option.some.injEq] at heq
-              rw [← heq]
-              cases h_op
-              exact well_typed_int
-          case h_6 =>
-           contradiction
-      | none =>
-        simp only []
-        split
-        . cases h_op; exact well_typed_bool
-        . cases h_op; exact well_typed_bool
-        . case h_3 =>
-          apply Residual.WellTyped.unaryApp
-          exact h_expr_wt
+    split
+    case h_1 hdec =>
+      have ⟨_, hb⟩ := try_decide_residual₁_is_bool hdec
+      subst hb
+      cases h_op <;>
+        first
+        | exact well_typed_bool
+        | simp [TPE.tryDecideResidual₁] at hdec
+    case h_2 =>
+    split
+    case h_1 =>
+      simp only [someOrError]
+      split
+      case h_2 => apply Residual.WellTyped.error
+      case h_1 v ty ox x v₂ heq =>
+        unfold Spec.apply₁ at heq
+        split at heq
+        any_goals
           cases h_op
-          all_goals
-            first
-            | apply UnaryResidualWellTyped.not
-            | apply UnaryResidualWellTyped.neg
-            | apply UnaryResidualWellTyped.isEmpty
-            | apply UnaryResidualWellTyped.like
-            | apply UnaryResidualWellTyped.is
-            rw [partial_eval_preserves_typeof _ h_expr]
-            assumption
+          simp only [Except.toOption, Option.some.injEq] at heq
+          rw [← heq]
+          exact well_typed_bool
+        case h_2 =>
+          simp only [Except.toOption, intOrErr] at heq
+          rename Int64 => i
+          cases h₂: i.neg?
+          . rw [h₂] at heq
+            simp at heq
+          . rw [h₂] at heq
+            simp only [Option.some.injEq] at heq
+            rw [← heq]
+            cases h_op
+            exact well_typed_int
+        case h_6 =>
+          contradiction
+    case h_2 =>
+      apply Residual.WellTyped.unaryApp h_expr_wt
+      cases h_op
+      all_goals
+        first
+        | apply UnaryResidualWellTyped.not
+        | apply UnaryResidualWellTyped.neg
+        | apply UnaryResidualWellTyped.isEmpty
+        | apply UnaryResidualWellTyped.like
+        | apply UnaryResidualWellTyped.is
+        rw [partial_eval_preserves_typeof _ h_expr]
+        assumption

--- a/cedar-lean/Cedar/Thm/TPE/WellTyped/Unary.lean
+++ b/cedar-lean/Cedar/Thm/TPE/WellTyped/Unary.lean
@@ -65,7 +65,7 @@ theorem partial_eval_well_typed_unaryApp {env : TypeEnv} {op : UnaryOp} {expr : 
       cases h_op <;>
         first
         | exact well_typed_bool
-        | simp [TPE.tryDecideResidual₁] at hdec
+        | simp only [TPE.tryDecideResidual₁, ite_self, reduceCtorEq] at hdec
     case h_2 =>
     split
     case h_1 =>

--- a/cedar-lean/Cedar/Thm/TPE/WellTyped/Var.lean
+++ b/cedar-lean/Cedar/Thm/TPE/WellTyped/Var.lean
@@ -32,7 +32,7 @@ open Cedar.Validation
 open Cedar.TPE
 
 theorem partial_eval_well_typed_var {env : TypeEnv} {v : Var} {ty : CedarType} {req : Request} {preq : PartialRequest} {es : Entities} {pes : PartialEntities} :
-  PEWellTyped env (Residual.var v ty) (TPE.evaluate (Residual.var v ty) preq pes) req preq es pes
+  PEWellTyped env (Residual.var v ty) (TPE.evaluate env (Residual.var v ty) preq pes) req preq es pes
 := by
   unfold PEWellTyped
   intro h_wf h_ref h_wt

--- a/cedar-lean/UnitTest/TPE.lean
+++ b/cedar-lean/UnitTest/TPE.lean
@@ -583,8 +583,63 @@ def tests :=
 #eval TestSuite.runAll [tests]
 end UnitTest.TPE.Spec
 
+namespace UnitTest.TPE.SchemaInformed
+open Cedar.TPE
+open Cedar.Spec
+open Cedar.Validation
+open Cedar.Data
+
+/-!
+Tests for the schema-informed reductions of `is`, `==`, `in`, and `hasTag`
+-/
+
+def A0 : EntityType := ⟨"A0", []⟩
+def A1 : EntityType := ⟨"A1", []⟩
+
+def schema : Schema :=
+  ⟨Map.make [
+    (ActionType, .standard ⟨default, default, default⟩),
+    (A0, .standard ⟨Set.singleton A1, default, default⟩),
+    (A1, .standard ⟨default, default, .some (.entity A0)⟩)
+  ],
+  Map.make [
+    (⟨ActionType, "a"⟩, ⟨Set.singleton A0, Set.singleton A1, default, default⟩)
+  ]⟩
+
+def es : PartialEntities :=
+  Map.make [(⟨ActionType, "a"⟩, ⟨.some default, .some default, .some default⟩)]
+
+def req : PartialRequest :=
+  ⟨⟨A0, default⟩, ⟨ActionType, "a"⟩, ⟨A1, default⟩, default⟩
+
+def mkPolicy (x : Expr) : Policy :=
+  ⟨"0", .permit, .principalScope .any, .actionScope .any, .resourceScope .any, [⟨.when, x⟩]⟩
+
+def boolLit (b : Bool) : Residual := .val (.prim (.bool b)) (.bool .anyBool)
+
+def tests :=
+  suite "TPE schema-informed reduction of is/==/in/hasTag/has"
+  [
+    testResult (mkPolicy (.unaryApp (.is A0) (.var .principal))) schema req es
+      (boolLit true),
+    testResult (mkPolicy (.unaryApp (.is A1) (.var .principal))) schema req es
+      (boolLit false),
+    testResult (mkPolicy (.binaryApp .eq (.var .principal) (.var .resource))) schema req es
+      (boolLit false),
+    testResult (mkPolicy (.binaryApp .mem (.var .resource) (.var .principal))) schema req es
+      (boolLit false),
+    testResult (mkPolicy (.binaryApp .hasTag (.var .principal) (.lit (.string "x")))) schema req es
+      (boolLit false),
+    testResult (mkPolicy (.binaryApp .mem (.var .resource) (.set [.var .principal]))) schema req es
+      (boolLit false),
+    testResult (mkPolicy (.hasAttr (.var .principal) "x")) schema req es
+      (boolLit false),
+  ]
+
+end UnitTest.TPE.SchemaInformed
+
 open UnitTest.TPE
 
-def tests := [Basic.tests, Motivation.tests, Spec.tests]
+def tests := [Basic.tests, Motivation.tests, Spec.tests, SchemaInformed.tests]
 
 end UnitTest.TPE


### PR DESCRIPTION
Extends the TPE model so that `has`, `hasTag`, `in`, `==`, and `is` reduce to literals when type information in the schema (plus error-freedom) is enough to reach a concrete value.

Large diff because `TPE.evaluate` now needs a schema.

Key changes addings this functions with calls at appropriate sites. 

```lean
/-- Does the schema prove that applying this operation to types `ty₁` and `ty₂` must produce `false`? -/
def mustBeFalse (env : TypeEnv) (op₂ : BinaryOp) (ty₁ ty₂ : CedarType) : Bool :=
  match op₂, ty₁, ty₂ with
  | .mem, .entity ety₁, .entity ety₂
  | .mem, .entity ety₁, .set (.entity ety₂) => !env.descendentOf ety₁ ety₂
  | .eq,  .entity ety₁, .entity ety₂        => ety₁ != ety₂
  | .hasTag, .entity ety, .string           => env.ets.tags? ety == some .none
  | _, _, _                                 => false
```

```lean
/-- Does the schema prove that a value of type `ty₁` cannot have attribute `a`? -/
def cannotHaveAttr (env : TypeEnv) (ty₁ : CedarType) (a : Attr) : Bool :=
  match ty₁ with
  | .record rty => (rty.find? a).isNone
  | .entity ety =>
    match env.ets.attrs? ety with
    | .some rty => (rty.find? a).isNone
    | .none     => false
  | _ => false
```

*Issue #, if available:*

*Description of changes:*


