### PR TITLE
chore: remove temporary decide simp lemmas now subsumed by core

### DIFF
--- a/cedar-lean/Cedar/Thm/Data/LT.lean
+++ b/cedar-lean/Cedar/Thm/Data/LT.lean
@@ -34,15 +34,6 @@ namespace Cedar.Thm
 open Cedar.Spec
 open Cedar.Data
 
-namespace Decide
--- Temporary `simp` lemmas.  We should be able to get rid of these when we upgrade to a
--- future version of Lean.
-@[simp] theorem decide_eq_true_eq {_ : Decidable p} : (decide p = true) = p := propext <| Iff.intro of_decide_eq_true decide_eq_true
-@[simp] theorem decide_eq_false_eq {h : Decidable p} : (decide p = false) = ¬ p := by cases h <;> simp [decide, *]
-@[simp] theorem decide_not {h : Decidable p} : decide (¬ p) = !decide p := by cases h <;> rfl
-@[simp] theorem not_decide_eq_true {h : Decidable p} : ((!decide p) = true) = ¬ p := by cases h <;> simp [decide, *]
-end Decide
-
 ----- `<` is strict on `IPNetPrefix` -----
 
 public instance IPNetPrefix.strictLT {w} : StrictLT (Ext.IPAddr.IPNetPrefix w) where


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

`Cedar/Thm/Data/LT.lean` defines four `@[simp]` lemmas in `namespace Decide`, with the comment

> "Temporary simp lemmas. We should be able to get rid of these when we upgrade to a future version of Lean."

Batteries `simpNF` linter (`lake exe runLinter Cedar`) reports all four as redundant, 

core simp proves each via `decide_eq_true_eq`, `decide_eq_false_iff_not`, `decide_not`, and `Bool.not_eq_eq_eq_not`,

no call sites, neither name is referenced anywhere,

`lake build Cedar SymCC UnitTest SymTest` is green with zero warnings.

Used Aristotle AI (Harmonic) in making this PR.




