### PR TITLE
Rewrite symcc transitivity enforcement in terms of set products and unions

### DIFF
--- a/cedar-lean/Cedar/Data/Set.lean
+++ b/cedar-lean/Cedar/Data/Set.lean
@@ -131,6 +131,9 @@ public def singleton? [Inhabited α] (s : Set α) : Option α :=
 public def foldl {α β} (f : α → β → α) (init : α) (s : Set β) : α :=
   s.elts.foldl f init
 
+public def product {α β} (s₁ : Set α) (s₂ : Set β) : Set (α × β) :=
+  Set.mk $ s₁.elts.product s₂.elts
+
 ----- Instances -----
 
 public instance [LT α] : LT (Set α) where

--- a/cedar-lean/Cedar/SymCCOpt/Enforcer.lean
+++ b/cedar-lean/Cedar/SymCCOpt/Enforcer.lean
@@ -27,15 +27,15 @@ open Cedar.Data Cedar.Spec Factory
 Returns the ground acyclicity and transitivity assumptions for a single `CompiledPolicy`.
 -/
 public def enforceCompiledPolicy (cp : CompiledPolicy) : Set Term :=
-  let tr := cp.footprint.elts.flatMap (λ t => cp.footprint.elts.map (transitivity t · cp.εnv.entities))
-  Set.make (cp.acyclicity.elts ++ tr)
+  let tr := cp.footprint.product cp.footprint|>.map λ (t₁, t₂) => transitivity t₁ t₂ cp.εnv.entities
+  cp.acyclicity ∪ tr
 
 /--
 Returns the ground acyclicity and transitivity assumptions for a single `CompiledPolicySet`.
 -/
 public def enforceCompiledPolicySet (cpset : CompiledPolicySet) : Set Term :=
-  let tr := cpset.footprint.elts.flatMap (λ t => cpset.footprint.elts.map (transitivity t · cpset.εnv.entities))
-  Set.make (cpset.acyclicity.elts ++ tr)
+  let tr := cpset.footprint.product cpset.footprint|>.map λ (t₁, t₂) => transitivity t₁ t₂ cpset.εnv.entities
+  cpset.acyclicity ∪ tr
 
 /--
 Returns the ground acyclicity and transitivity assumptions for a pair of `CompiledPolicy`.
@@ -43,9 +43,9 @@ Caller guarantees that `cp₁` and `cp₂` were compiled for the same `εnv`.
 -/
 public def enforcePairCompiledPolicy (cp₁ : CompiledPolicy) (cp₂ : CompiledPolicy) : Set Term :=
   assert! cp₁.εnv = cp₂.εnv
-  let footprint := cp₁.footprint ++ cp₂.footprint
-  let tr := footprint.elts.flatMap (λ t => footprint.elts.map (transitivity t · cp₁.εnv.entities))
-  Set.make (cp₁.acyclicity.elts ++ cp₂.acyclicity.elts ++ tr)
+  let footprint := cp₁.footprint ∪ cp₂.footprint
+  let tr := footprint.product footprint|>.map λ (t₁, t₂) => transitivity t₁ t₂ cp₁.εnv.entities
+  cp₁.acyclicity ∪ cp₂.acyclicity ∪ tr
 
 /--
 Returns the ground acyclicity and transitivity assumptions for a pair of `CompiledPolicySet`.
@@ -53,8 +53,8 @@ Caller guarantees that `cpset₁` and `cpset₂` were compiled for the same `εn
 -/
 public def enforcePairCompiledPolicySet (cpset₁ : CompiledPolicySet) (cpset₂ : CompiledPolicySet) : Set Term :=
   assert! cpset₁.εnv = cpset₂.εnv
-  let footprint := cpset₁.footprint ++ cpset₂.footprint
-  let tr := footprint.elts.flatMap (λ t => footprint.elts.map (transitivity t · cpset₁.εnv.entities))
-  Set.make (cpset₁.acyclicity.elts ++ cpset₂.acyclicity.elts ++ tr)
+  let footprint := cpset₁.footprint ∪ cpset₂.footprint
+  let tr := footprint.product footprint|>.map λ (t₁, t₂) => transitivity t₁ t₂ cpset₁.εnv.entities
+  cpset₁.acyclicity ∪ cpset₂.acyclicity ∪ tr
 
 namespace Cedar.SymCC

--- a/cedar-lean/Cedar/Thm/Data/Set.lean
+++ b/cedar-lean/Cedar/Thm/Data/Set.lean
@@ -519,6 +519,12 @@ public theorem make_cons_eq_singleton_union [LT α] [DecidableLT α] [StrictLT �
   · apply List.Equiv.refl
   · simp [List.canonicalize_idempotent]
 
+/-- The `++` notation on sets  is definitionally `∪`. -/
+@[simp]
+public theorem append_eq_union [LT α] [DecidableLT α] (s₁ s₂ : Set α) :
+  s₁ ++ s₂ = s₁ ∪ s₂
+:= rfl
+
 @[simp]
 public theorem mem_union [LT α] [DecidableLT α] [StrictLT α] (s₁ s₂ : Set α) (a : α) :
   a ∈ s₁ ∪ s₂ ↔ (a ∈ s₁ ∨ a ∈ s₂)
@@ -746,7 +752,7 @@ public theorem map_id [LT α] [DecidableLT α] (s : Set α) :
 
 /-- Analogue of `List.mem_map` but for sets -/
 @[simp]
-public theorem mem_map [LT α] [DecidableLT α] [StrictLT α] [LT β] [DecidableLT β] [StrictLT β] {b : β} {f : α → β} {s : Set α} :
+public theorem mem_map [LT β] [DecidableLT β] [StrictLT β] {b : β} {f : α → β} {s : Set α} :
   b ∈ s.map f ↔ ∃ a ∈ s, f a = b
 := by
   simp [Set.map, Set.mem_make, Set.mem_elts_iff_mem_set]
@@ -787,6 +793,21 @@ public theorem map_make [LT α] [DecidableLT α] [StrictLT α] [LT β] [Decidabl
 public theorem map_def [LT β] [DecidableLT β] (f : α → β) (s : Set α) :
   s.map f = Set.make (s.elts.map f)
 := by simp [Set.map]
+
+/-- `Set.map` distributes over `∪`. -/
+public theorem map_union [LT α] [DecidableLT α] [StrictLT α] [LT β] [DecidableLT β] [StrictLT β]
+  (f : α → β) (s₁ s₂ : Set α) :
+  (s₁ ∪ s₂).map f = s₁.map f ∪ s₂.map f
+:= by
+  rw [eq_means_eqv (map_wf _ _) (union_wf _ _)]
+  simp only [List.Equiv, List.subset_def, mem_elts_iff_mem_set, mem_union, mem_map]
+  constructor <;> intro a h
+  · rcases h with ⟨x, hx | hx, hf⟩
+    · exact Or.inl ⟨x, hx, hf⟩
+    · exact Or.inr ⟨x, hx, hf⟩
+  · rcases h with ⟨x, hx, hf⟩ | ⟨x, hx, hf⟩
+    · exact ⟨x, Or.inl hx, hf⟩
+    · exact ⟨x, Or.inr hx, hf⟩
 
 /-! ### filter and differences -/
 
@@ -869,5 +890,32 @@ public theorem all₁_eq_all {s : Set α} {f : α → Bool} :
 public theorem any₁_eq_any {s : Set α} {f : α → Bool} :
   (s.any₁ λ ⟨elt, _⟩ => f elt) = s.any f
 := by simp [any₁, any]
+
+/-! ### product  -/
+
+/-- An element is in `s₁.product s₂` iff its components are in `s₁` and `s₂`. -/
+@[simp]
+public theorem mem_product {α β} {a : α} {b : β} {s₁ : Set α} {s₂ : Set β} :
+  (a, b) ∈ s₁.product s₂ ↔ a ∈ s₁ ∧ b ∈ s₂
+:= by
+  rw [←mem_elts_iff_mem_set]
+  simp only [Set.product, elts, List.product, List.mem_flatMap, List.mem_map]
+  constructor
+  · rintro ⟨x, hx, y, hy, heq⟩
+    simp only [Prod.mk.injEq] at heq
+    obtain ⟨rfl, rfl⟩ := heq
+    exact ⟨hx, hy⟩
+  · rintro ⟨ha, hb⟩
+    exact ⟨a, ha, b, hb, rfl⟩
+
+@[simp]
+public theorem product_empty {α β} (s : Set α) :
+  s.product (Set.empty : Set β) = Set.empty
+:= by simp [product, empty, elts, List.product]
+
+@[simp]
+public theorem empty_product {α β} (s : Set β) :
+  (Set.empty : Set α).product s = Set.empty
+:= by simp [product, List.product, empty, elts]
 
 end Cedar.Data.Set

--- a/cedar-lean/Cedar/Thm/SymCC/Opt/Enforcer.lean
+++ b/cedar-lean/Cedar/Thm/SymCC/Opt/Enforcer.lean
@@ -27,6 +27,29 @@ namespace Cedar.Thm
 open Cedar.Spec Cedar.SymCC
 
 /--
+Rephrases the unoptimized `enforce` as the union of the acyclicity and transitivity constraints
+using the `Set.map`/`Set.product`/`∪` operations that the optimized `enforce*CompiledPolicy*`
+functions are defined with.
+-/
+theorem enforce_eq_map_union {xs : List Expr} {εnv : SymEnv} :
+  enforce xs εnv =
+    (footprints xs εnv).map (acyclicity · εnv.entities) ∪
+    ((footprints xs εnv).product (footprints xs εnv)).map (fun (t₁, t₂) => transitivity t₁ t₂ εnv.entities)
+:= by
+  simp only [enforce]
+  rw [Data.Set.eq_means_eqv (Data.Set.make_wf _) (Data.Set.union_wf _ _)]
+  simp only [List.Equiv, List.subset_def, Data.Set.mem_elts_iff_mem_set, Data.Set.mem_make,
+    Data.Set.mem_union, List.mem_union_iff, List.mem_flatMap, List.mem_map, Data.Set.mem_map]
+  constructor <;> intro a h
+  · rcases h with ⟨x, hx, hf⟩ | ⟨x, hx, y, hy, hf⟩
+    · exact Or.inl ⟨x, hx, hf⟩
+    · exact Or.inr ⟨(x, y), Data.Set.mem_product.mpr ⟨hx, hy⟩, hf⟩
+  · rcases h with ⟨x, hx, hf⟩ | ⟨⟨x, y⟩, hxy, hf⟩
+    · exact Or.inl ⟨x, hx, hf⟩
+    · rw [Data.Set.mem_product] at hxy
+      exact Or.inr ⟨x, hxy.1, y, hxy.2, hf⟩
+
+/--
 This theorem covers the "happy path" -- showing that if optimized policy
 compilation succeeds, then `enforce` and `enforceCompiledPolicy` are equivalent.
 -/
@@ -35,52 +58,16 @@ theorem enforceCompiledPolicy_eqv_enforce_ok {p wp : Policy} {cp : CompiledPolic
   wellTypedPolicy p Γ = .ok wp →
   enforce [wp.toExpr] (SymEnv.ofTypeEnv Γ) = enforceCompiledPolicy cp
 := by
-  simp [enforce, enforceCompiledPolicy]
   intro h₀ h₁
-  simp [
+  simp only [
+    enforceCompiledPolicy,
+    enforce_eq_map_union,
+    footprints_singleton,
     cp_compile_produces_the_right_env h₀,
     cp_compile_produces_the_right_footprint h₀,
     cp_compile_produces_the_right_acyclicity h₀,
     cp_compile_produces_the_right_policy h₀ h₁,
   ]
-  simp [footprints]
-  simp [Data.Set.make_make_eqv, List.Equiv, List.subset_def]
-  constructor
-  · intro t h₂
-    cases h₂
-    · left
-      rename_i h₂
-      replace ⟨t', h₂, ht⟩ := h₂ ; subst t ; rename Term => t
-      rw [Data.Set.mem_elts_iff_mem_set] at *
-      rw [List.mem_mapUnion_iff_mem_exists] at h₂
-      replace ⟨s, hs, h₂⟩ := h₂
-      simp at hs ; subst s
-      simp [Data.Set.mem_map]
-      exists t
-    · right
-      rename_i h₂
-      replace ⟨s, hs, t', ht', h₂⟩ := h₂ ; subst t ; rename Term => t
-      simp [Data.Set.mem_elts_iff_mem_set, List.mem_mapUnion_iff_mem_exists] at *
-      exists s
-      simp [hs]
-      exists t
-  · intro t h₂
-    cases h₂
-    · left
-      rename_i h₂
-      simp [Data.Set.mem_elts_iff_mem_set, Data.Set.mem_map] at h₂
-      replace ⟨t', ht', h₂⟩ := h₂ ; subst t ; rename Term => t
-      exists t
-      simp [Data.Set.mem_elts_iff_mem_set, List.mem_mapUnion_iff_mem_exists]
-      exact ht'
-    · right
-      rename_i h₂
-      replace ⟨s, hs, t', ht', h₂⟩ := h₂ ; subst t ; rename Term => t
-      exists s
-      rw [Data.Set.mem_elts_iff_mem_set] at *
-      simp [List.mem_mapUnion_iff_mem_exists, hs]
-      exists t
-      simp [Data.Set.mem_elts_iff_mem_set, List.mem_mapUnion_iff_mem_exists, ht']
 
 /--
 This theorem covers the "happy path" -- showing that if optimized policy
@@ -94,9 +81,16 @@ theorem enforcePairCompiledPolicy_eqv_enforce_ok {p₁ p₂ wp₁ wp₂ : Policy
   wellTypedPolicy p₂ Γ = .ok wp₂ →
   enforce [wp₁.toExpr, wp₂.toExpr] (SymEnv.ofTypeEnv Γ) = enforcePairCompiledPolicy cp₁ cp₂
 := by
-  simp [enforce, enforcePairCompiledPolicy]
   intro h₀ h₁ h₂ h₃
-  simp [
+  have h_split : [wp₁.toExpr, wp₂.toExpr] = [wp₁.toExpr] ++ [wp₂.toExpr] := by simp
+  simp only [
+    enforcePairCompiledPolicy,
+    enforce_eq_map_union,
+    h_split,
+    footprints_append,
+    footprints_singleton,
+    Data.Set.map_union,
+    Data.Set.append_eq_union,
     cp_compile_produces_the_right_env h₀,
     cp_compile_produces_the_right_env h₁,
     cp_compile_produces_the_right_footprint h₀,
@@ -105,38 +99,8 @@ theorem enforcePairCompiledPolicy_eqv_enforce_ok {p₁ p₂ wp₁ wp₂ : Policy
     cp_compile_produces_the_right_acyclicity h₁,
     cp_compile_produces_the_right_policy h₀ h₂,
     cp_compile_produces_the_right_policy h₁ h₃,
+    reduceIte,
   ]
-  have h_split : [wp₁.toExpr, wp₂.toExpr] = [wp₁.toExpr] ++ [wp₂.toExpr] := by simp
-  rw [h_split, footprints_append, footprints_singleton, footprints_singleton]
-  simp [Data.Set.make_make_eqv, List.Equiv, List.subset_def]
-  constructor
-  · intro t₁ h₁
-    cases h₁ <;> rename_i h₁
-    · replace ⟨t₂, h₁, htemp⟩ := h₁ ; subst t₁
-      simp only [List.cons_append, List.nil_append, Data.Set.mem_elts_iff_mem_set,
-        Data.Set.mem_map] at *
-      change t₂ ∈ _ ∪ _ at h₁
-      rw [Data.Set.mem_union] at h₁
-      cases h₁ <;> rename_i h₁
-      case' inl => left
-      case' inr => right ; left
-      all_goals exists t₂
-    · right ; right
-      simp [*]
-  · intro t₁ h₁
-    cases h₁ <;> rename_i h₁ <;> try (cases h₁ <;> rename_i h₁)
-    case right.inr.inr => right ; exact h₁
-    case' right.inl | right.inr.inl =>
-      left
-      simp [Data.Set.mem_elts_iff_mem_set, Data.Set.mem_map] at h₁
-      replace ⟨t₂, h₁, htemp⟩ := h₁ ; subst t₁
-      exists t₂
-      simp [Data.Set.mem_elts_iff_mem_set, HAppend.hAppend]
-      change t₂ ∈ _ ∪ _
-      rw [Data.Set.mem_union]
-    case' right.inl => left
-    case' right.inr.inl => right
-    all_goals exact h₁
 
 /--
 This theorem covers the "happy path" -- showing that if optimized policy
@@ -150,9 +114,13 @@ theorem enforcePairCompiledPolicySet_eqv_enforce_ok {ps₁ ps₂ wps₁ wps₂ :
   wellTypedPolicies ps₂ Γ = .ok wps₂ →
   enforce (wps₁.map Policy.toExpr ++ wps₂.map Policy.toExpr) (SymEnv.ofTypeEnv Γ) = enforcePairCompiledPolicySet cpset₁ cpset₂
 := by
-  simp [enforce, enforcePairCompiledPolicySet]
   intro hcpset₁ hcpset₂ hwps₁ hwps₂
-  simp [
+  simp only [
+    enforcePairCompiledPolicySet,
+    enforce_eq_map_union,
+    footprints_append,
+    Data.Set.append_eq_union,
+    Data.Set.map_union,
     cpset_compile_produces_the_right_env hcpset₁,
     cpset_compile_produces_the_right_env hcpset₂,
     cpset_compile_produces_the_right_footprint hcpset₁,
@@ -161,49 +129,5 @@ theorem enforcePairCompiledPolicySet_eqv_enforce_ok {ps₁ ps₂ wps₁ wps₂ :
     cpset_compile_produces_the_right_acyclicity hcpset₂,
     cpset_compile_produces_the_right_policies hcpset₁ hwps₁,
     cpset_compile_produces_the_right_policies hcpset₂ hwps₂,
+    reduceIte,
   ]
-  simp [footprints_append]
-  rw [Data.Set.make_make_eqv]
-  simp [List.Equiv, List.subset_def]
-  constructor
-  · intro t₁ h₁
-    cases h₁ <;> rename_i h₁
-    · replace ⟨t₂, h₁, htemp⟩ := h₁ ; subst t₁
-      simp only [Data.Set.mem_elts_iff_mem_set, Data.Set.mem_map] at *
-      simp only [footprints, List.mapUnion_map]
-      change t₂ ∈ _ ∪ _ at h₁
-      rw [Data.Set.mem_union] at h₁
-      cases h₁ <;> rename_i h₁
-      case' inl => left
-      case' inr => right ; left
-      all_goals {
-        simp only [footprints, List.mapUnion_map] at h₁
-        rw [List.mem_mapUnion_iff_mem_exists] at h₁
-        replace ⟨x, h₁, h₂⟩ := h₁
-        exists t₂
-        simp only [List.mem_mapUnion_iff_mem_exists, Function.comp_apply, and_true]
-        exists x
-      }
-    · right ; right
-      simp [*]
-  · intro t₁ h₁
-    cases h₁ <;> rename_i h₁ <;> try (cases h₁ <;> rename_i h₁)
-    case right.inr.inr => right ; exact h₁
-    case' right.inl | right.inr.inl =>
-      left
-      simp [Data.Set.mem_elts_iff_mem_set, Data.Set.mem_map] at h₁
-      replace ⟨t₂, h₁, htemp⟩ := h₁ ; subst t₁
-      simp [mem_footprints_iff] at h₁
-      replace ⟨x, ⟨p, hp, htemp⟩, h₁⟩ := h₁ ; subst x
-      exists t₂
-      simp [Data.Set.mem_elts_iff_mem_set, HAppend.hAppend]
-      change t₂ ∈ _ ∪ _
-      rw [Data.Set.mem_union]
-    case' right.inl => left
-    case' right.inr.inl => right
-    all_goals {
-      simp [mem_footprints_iff]
-      exists p.toExpr
-      apply And.intro _ h₁
-      exists p
-    }


### PR DESCRIPTION

This isn't a functional change (as shown by the equivalence proofs with the unoptimized compiler). It previously use `flatMap` and `++` on the policy footprint to construct transitivity constraints, but the footprint is a set of terms, so this is more naturally expressed in set operations.

*Issue #, if available:*

*Description of changes:*


