### PR TITLE
fix cedar-spec warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
         working-directory: ./cedar-lean
         shell: bash
         run: source ~/.profile && lake build Cedar SymCC
-      - name: Lint for uncheckd theorems
+      - name: Lint for unchecked theorems
         working-directory: ./cedar-lean
         shell: bash
         run: source ~/.profile && lake lint

--- a/cedar-drt/fuzz/fuzz_targets/batched-evaluation-drt.rs
+++ b/cedar-drt/fuzz/fuzz_targets/batched-evaluation-drt.rs
@@ -18,10 +18,7 @@
 use cedar_drt::logger::initialize_log;
 use cedar_drt_inner::{abac::FuzzTargetInput, fuzz_target};
 
-use cedar_lean_ffi::{
-    CedarLeanFfi,
-    FfiError::{self, LeanBackendError},
-};
+use cedar_lean_ffi::{CedarLeanFfi, FfiError};
 use cedar_policy::{Schema, TestEntityLoader};
 use cedar_policy_core::batched_evaluator::err::BatchedEvalError;
 

--- a/cedar-drt/fuzz/fuzz_targets/protobuf-encode/protobuf-encode-gen-entities.rs
+++ b/cedar-drt/fuzz/fuzz_targets/protobuf-encode/protobuf-encode-gen-entities.rs
@@ -19,8 +19,8 @@
 use cedar_drt_inner::fuzz_target;
 use cedar_drt_inner::props::entities_protobuf_decodes;
 
+use cedar_policy::Entities;
 use cedar_policy::proto::traits::{EncodeError, Protobuf};
-use cedar_policy::{Entities, Entity};
 
 use cedar_policy_generators::schema_gen::SchemaGen;
 use cedar_policy_generators::{hierarchy::HierarchyGenerator, schema, settings::ABACSettings};

--- a/cedar-drt/fuzz/fuzz_targets/rbac.rs
+++ b/cedar-drt/fuzz/fuzz_targets/rbac.rs
@@ -69,16 +69,16 @@ pub enum PolicyGroup {
 
 impl std::fmt::Display for FuzzTargetInput {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        writeln!(f, "policy groups: {:?}", &self.policy_groups)?;
-        writeln!(f, "hierarchy: {}", &self.hierarchy)?;
-        writeln!(f, "request: {}", &self.requests[0])?;
-        writeln!(f, "request: {}", &self.requests[1])?;
-        writeln!(f, "request: {}", &self.requests[2])?;
-        writeln!(f, "request: {}", &self.requests[3])?;
-        writeln!(f, "request: {}", &self.requests[4])?;
-        writeln!(f, "request: {}", &self.requests[5])?;
-        writeln!(f, "request: {}", &self.requests[6])?;
-        writeln!(f, "request: {}", &self.requests[7])?;
+        writeln!(f, "policy groups: {:?}", self.policy_groups)?;
+        writeln!(f, "hierarchy: {}", self.hierarchy)?;
+        writeln!(f, "request: {}", self.requests[0])?;
+        writeln!(f, "request: {}", self.requests[1])?;
+        writeln!(f, "request: {}", self.requests[2])?;
+        writeln!(f, "request: {}", self.requests[3])?;
+        writeln!(f, "request: {}", self.requests[4])?;
+        writeln!(f, "request: {}", self.requests[5])?;
+        writeln!(f, "request: {}", self.requests[6])?;
+        writeln!(f, "request: {}", self.requests[7])?;
         Ok(())
     }
 }

--- a/cedar-drt/fuzz/src/pst_equiv.rs
+++ b/cedar-drt/fuzz/src/pst_equiv.rs
@@ -54,8 +54,8 @@ pub fn check_policy_set_equivalence(
             .get(id)
             .unwrap_or_else(|| panic!("Static policy {:?} missing after roundtrip", id));
         check_template_equivalence(
-            &orig.body(),
-            &rt.body(),
+            orig.body(),
+            rt.body(),
             CheckingParams {
                 check_ids: params.check_ids,
             },

--- a/cedar-drt/fuzz/src/schemas.rs
+++ b/cedar-drt/fuzz/src/schemas.rs
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-use cedar_policy_core::ast::{Id, InternalName, Name};
+use cedar_policy_core::ast::{InternalName, Name};
 use cedar_policy_core::validator::RawName;
 use cedar_policy_core::validator::ValidatorEntityTypeKind;
 use cedar_policy_core::validator::json_schema;

--- a/cedar-drt/fuzz/src/symcc.rs
+++ b/cedar-drt/fuzz/src/symcc.rs
@@ -247,7 +247,7 @@ fn arbitrary_policies(
     );
     let mut policies: Vec<StaticABACPolicy> = Vec::with_capacity(len);
     for _ in 0..len {
-        policies.push(schema.arbitrary_static_policy(&hierarchy, u)?);
+        policies.push(schema.arbitrary_static_policy(hierarchy, u)?);
     }
     // we want to ensure that the policies all have unique IDs.
     // this will be a list of policy IDs that we have seen (and will ensure there are no duplicates of)

--- a/cedar-drt/src/tests.rs
+++ b/cedar-drt/src/tests.rs
@@ -94,8 +94,8 @@ pub fn run_auth_test(
             } else {
                 panic!(
                     "Unexpected error for {request}\nPolicies:\n{}\nEntities:\n{}\nError: {err}",
-                    &policies,
-                    &entities.as_ref()
+                    policies,
+                    entities.as_ref()
                 );
             }
         }
@@ -198,8 +198,7 @@ fn compare_validation_results(
                 && !err.contains("unknown extension type")
             {
                 panic!(
-                    "Unexpected error\nPolicies:\n{}\nSchema:\n{:?}\nError: {err}",
-                    &policies, schema
+                    "Unexpected error\nPolicies:\n{policies}\nSchema:\n{schema:?}\nError: {err}"
                 );
             }
         }
@@ -220,7 +219,7 @@ fn compare_validation_results(
                 assert!(
                     definitional_res.validation_passed(),
                     "Mismatch for Policies:\n{}\nSchema:\n{:?}\ncedar-policy response: {:?}\nTest engine response: {:?}\n",
-                    &policies,
+                    policies,
                     schema,
                     miette::Report::new(rust_res),
                     definitional_res,
@@ -238,7 +237,7 @@ fn compare_validation_results(
                         assert!(
                             !definitional_res.validation_passed(),
                             "Mismatch for Policies:\n{}\nSchema:\n{:?}\ncedar-policy response:\n{:?}\nTest engine response: {:?}\n",
-                            &policies,
+                            policies,
                             schema,
                             miette::Report::new(rust_res),
                             definitional_res,
@@ -264,12 +263,12 @@ pub fn run_ent_val_test(
             panic!("failed to execute entity validation: {e}");
         }
         TestResult::Success(definitional_res) => {
-            if rust_res.is_ok() {
+            if let Ok(rust_res) = rust_res {
                 assert!(
                     definitional_res.validation_passed(),
                     "Definitional Errors: {:?}\n, Rust output: {:?}",
                     definitional_res.errors,
-                    rust_res.unwrap()
+                    rust_res
                 );
             } else {
                 assert!(
@@ -303,12 +302,12 @@ pub fn run_req_val_test(
             panic!("failed to execute request validation: {e}");
         }
         TestResult::Success(definitional_res) => {
-            if rust_res.is_ok() {
+            if let Ok(rust_res) = rust_res {
                 assert!(
                     definitional_res.validation_passed(),
                     "Definitional Errors: {:?}\n, Rust output: {:?}",
                     definitional_res.errors,
-                    rust_res.unwrap()
+                    rust_res
                 );
             } else {
                 assert!(

--- a/cedar-lean-cli/src/analysis.rs
+++ b/cedar-lean-cli/src/analysis.rs
@@ -50,11 +50,6 @@ impl<'a> Analyzer<'a> {
         })
     }
 
-    /// Change the `json_output` setting without reconstructing an entire new `Analyzer`
-    pub fn set_json_output(&mut self, json_output: bool) {
-        self.json_output = json_output;
-    }
-
     /// Analyze a Cedar `PolicySet` with respect to the `Analyzer`'s `Schema` and print the findings
     pub fn analyze_policyset(&self, policy_set: PolicySet) -> Result<(), ExecError> {
         let mut policy_vacuity_results = HashMap::new();
@@ -245,13 +240,13 @@ impl PerSigFindings {
 
     pub fn nfindings(&self) -> usize {
         let mut ret = self.equiv_classes.len();
-        for (_, s) in self.permit_shadowed_by_permits.iter() {
+        for s in self.permit_shadowed_by_permits.values() {
             ret += s.len();
         }
-        for (_, s) in self.permit_overridden_by_forbids.iter() {
+        for s in self.permit_overridden_by_forbids.values() {
             ret += s.len();
         }
-        for (_, s) in self.forbid_shadowed_by_forbids.iter() {
+        for s in self.forbid_shadowed_by_forbids.values() {
             ret += s.len();
         }
         ret

--- a/cedar-lean-ffi/src/lean_ffi.rs
+++ b/cedar-lean-ffi/src/lean_ffi.rs
@@ -1235,7 +1235,7 @@ impl CedarLeanFfi {
             call_lean_ffi_takes_protobuf(
                 batchedAuthorizationFFI,
                 &proto::BatchedAuthorizationRequest::new(
-                    &policyset, schema, request, entities, iteration,
+                    policyset, schema, request, entities, iteration,
                 ),
             )
         };

--- a/cedar-policy-generators/src/abac.rs
+++ b/cedar-policy-generators/src/abac.rs
@@ -30,7 +30,6 @@ use std::cell::RefCell;
 use std::collections::BTreeMap;
 use std::net::{Ipv4Addr, Ipv6Addr};
 use std::ops::{Deref, DerefMut};
-use std::str::FromStr;
 use thiserror::Error;
 
 // Mutate a hypothetically valid string (randomly).
@@ -372,21 +371,6 @@ impl ConstantPool {
     pub fn arbitrary_string_constant_size_hint(_depth: usize) -> (usize, Option<usize>) {
         size_hint_for_choose(None)
     }
-}
-
-/// Generate an arbitrary string of up to `bound` size
-fn arbitrary_string(u: &mut Unstructured<'_>, bound: Option<usize>) -> Result<SmolStr> {
-    let s: String = u.arbitrary()?;
-    let result_s = if let Some(bound) = bound {
-        if s.len() < bound {
-            SmolStr::from(s)
-        } else {
-            s.chars().take(bound).collect()
-        }
-    } else {
-        s.into()
-    };
-    Ok(result_s)
 }
 
 /// Data describing an extension function available for use in policies/etc

--- a/cedar-policy-generators/src/expr.rs
+++ b/cedar-policy-generators/src/expr.rs
@@ -774,11 +774,10 @@ impl ExprGenerator<'_> {
                 _ => {
                     let r = m
                         .iter()
-                        .filter_map(|(a, qt)| {
-                            qt.required.then(|| {
-                                self.generate_expr_for_type_structurally_recursive(&qt.ty, u)
-                                    .map(|e| (a.clone(), e))
-                            })
+                        .filter(|(_, qt)| qt.required)
+                        .map(|(a, qt)| {
+                            self.generate_expr_for_type_structurally_recursive(&qt.ty, u)
+                                .map(|e| (a.clone(), e))
                         })
                         .collect::<Result<IndexMap<_, _>>>()?;
                     Ok(ast::Expr::record(r)

--- a/cedar-policy-generators/src/schema.rs
+++ b/cedar-policy-generators/src/schema.rs
@@ -1338,8 +1338,8 @@ impl Schema {
             .chain(
                 nsdef
                     .actions
-                    .iter()
-                    .filter_map(|(_, action)| action.applies_to.as_ref())
+                    .values()
+                    .filter_map(|action| action.applies_to.as_ref())
                     .map(|a| attrs_from_attrs_or_context(&nsdef, &a.context)),
             );
         let attributes: Vec<(SmolStr, json_schema::Type<_>)> = attrsorcontexts

--- a/cedar-policy-generators/src/schema_gen.rs
+++ b/cedar-policy-generators/src/schema_gen.rs
@@ -522,7 +522,7 @@ impl SchemaGen for ValidatorSchema<'_> {
         TypeGenerator {
             schema: self,
             constant_pool: &self.constant_pool,
-            settings: &self.settings,
+            settings: self.settings,
         }
     }
     fn arbitrary_hierarchy(&self, u: &mut Unstructured<'_>) -> Result<Hierarchy> {


### PR DESCRIPTION
Fixes a build warning causing CI failure introduced by #998. Fixes some existing clippy warnings. 

