### PR TITLE
generate `getTag` in non-type-directed expr generator

### DIFF
--- a/cedar-policy-generators/src/expr.rs
+++ b/cedar-policy-generators/src/expr.rs
@@ -263,6 +263,14 @@ impl ExprGenerator<'_> {
                         );
                         let e = self.generate_expr(max_depth - 1, u)?;
                         Ok(ast::Expr::has_tag(e, tag_name))
+                    },
+                    4 => {
+                        let tag_name = uniform!(u,
+                            self.generate_expr(max_depth - 1, u)?,
+                            ast::Expr::val(self.schema.arbitrary_attr(u)?)
+                        );
+                        let e = self.generate_expr(max_depth - 1, u)?;
+                        Ok(ast::Expr::get_tag(e, tag_name))
                     }
                 )
             })


### PR DESCRIPTION
apparently the non-type-directed generator never generates `getTag`

