### PR TITLE
Updated SymCC to emit unique selector names for eid.

### DIFF
--- a/cedar-lean/Cedar/SymCC/Encoder.lean
+++ b/cedar-lean/Cedar/SymCC/Encoder.lean
@@ -37,7 +37,9 @@ into a list of SMT assertions. Term encoding is trusted.
    will translate `Term.some` nodes in the Term language as applications of the
    `val` selector function.
  * `TermType.entity E`: we represent Cedar entities of entity type E as values
-   of the SMT algebraic datatype E with a single constructor, `(E (eid String))`.
+   of the SMT algebraic datatype E with a single constructor, `(E (E_eid String))`.
+   The selector is named `E_eid`, after the entity type, since SMT-LIB requires
+   unique selector and constructor names across all datatypes.
    Each entity type E gets an uninterpreted function `f: E → Record_E` that maps
    instances of E to their attributes.  Similarly, each E
    gets N uninterpreted functions `g₁: E → Set E₁, ..., gₙ: E → Set Eₙ` that map
@@ -109,7 +111,7 @@ def declareEntityType (ety : EntityType) : EncoderM String := do
     declareType etyId (members.mapIdx λ i _ => s!"({enumId etyId i})")
   | .none =>
     comment s!"{toString ety}"
-    declareType etyId [s!"({etyId} (eid String))"]
+    declareType etyId [s!"({etyId} ({etyId}_eid String))"]
 
 def declareExtType : ExtType → EncoderM String
   | .decimal =>


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/cedar-policy/cedar-spec/issues/1007

*Description of changes:*

Updated SymCC to emit unique selector names for `eid`.
