### PR TITLE
three new benchmarks for unchecked protobuf API

### DIFF
--- a/cedar-benchmarking/README.md
+++ b/cedar-benchmarking/README.md
@@ -92,14 +92,17 @@ Each `results` object in the JSON output has the following fields:
 | `policy_parse`                | Parse Cedar policy text                                                |
 | `json_policy_parse`           | Parse policies from JSON representation                                |
 | `protobuf_policy_parse`       | Parse policies from protobuf encoding                                  |
+| `protobuf_policy_parse_unchecked` | Parse policies from protobuf encoding, skipping input validation   |
 | `schema_parse`                | Parse Cedar schema text                                                |
 | `json_schema_parse`           | Parse schema from JSON representation                                  |
 | `protobuf_schema_parse`       | Parse schema from protobuf encoding                                    |
+| `protobuf_schema_parse_unchecked` | Parse schema from protobuf encoding, skipping input validation     |
 | `validation`                  | Validate policies against a schema                                     |
 | `authorization`               | Run authorization requests                                             |
 | `entity_parse_with_schema`    | Parse entities with schema validation                                  |
 | `entity_parse_without_schema` | Parse entities without schema                                          |
 | `protobuf_entity_parse`       | Parse entities from protobuf encoding                                  |
+| `protobuf_entity_parse_unchecked` | Parse entities from protobuf encoding, skipping input validation   |
 | `incremental_entities`        | Incrementally add entities (measures transitive closure recomputation) |
 
 ## Corpus format

--- a/cedar-benchmarking/corpus/tasks.json
+++ b/cedar-benchmarking/corpus/tasks.json
@@ -30,7 +30,8 @@
         "policy_file": "clauses/policies_1KB.cedar",
         "exclude_targets": [
             "json_policy_parse",
-            "protobuf_policy_parse"
+            "protobuf_policy_parse",
+            "protobuf_policy_parse_unchecked"
         ]
     },
     {
@@ -38,7 +39,8 @@
         "policy_file": "clauses/policies_10KB.cedar",
         "exclude_targets": [
             "json_policy_parse",
-            "protobuf_policy_parse"
+            "protobuf_policy_parse",
+            "protobuf_policy_parse_unchecked"
         ]
     },
     {

--- a/cedar-benchmarking/src/executor.rs
+++ b/cedar-benchmarking/src/executor.rs
@@ -49,6 +49,9 @@ impl BenchmarkExecutor {
             BenchmarkTask::ProtobufPolicyParse { policy_file, .. } => {
                 self.bench_protobuf_policy_parsing(policy_file)
             }
+            BenchmarkTask::ProtobufPolicyParseUnchecked { policy_file, .. } => {
+                self.bench_protobuf_policy_parsing_unchecked(policy_file)
+            }
             BenchmarkTask::SchemaParse {
                 cedar_schema_file, ..
             } => self.bench_schema_parsing(cedar_schema_file),
@@ -58,6 +61,9 @@ impl BenchmarkExecutor {
             BenchmarkTask::ProtobufSchemaParse {
                 cedar_schema_file, ..
             } => self.bench_protobuf_schema_parsing(cedar_schema_file),
+            BenchmarkTask::ProtobufSchemaParseUnchecked {
+                cedar_schema_file, ..
+            } => self.bench_protobuf_schema_parsing_unchecked(cedar_schema_file),
             BenchmarkTask::Validation {
                 policy_file,
                 cedar_schema_file,
@@ -85,6 +91,9 @@ impl BenchmarkExecutor {
             }
             BenchmarkTask::ProtobufEntityParse { entities_file, .. } => {
                 self.bench_protobuf_entity_parsing(entities_file)
+            }
+            BenchmarkTask::ProtobufEntityParseUnchecked { entities_file, .. } => {
+                self.bench_protobuf_entity_parsing_unchecked(entities_file)
             }
             BenchmarkTask::IncrementalEntities {
                 cedar_schema_file,
@@ -138,6 +147,22 @@ impl BenchmarkExecutor {
         ))
     }
 
+    fn bench_protobuf_policy_parsing_unchecked(
+        self,
+        policy_file: &Path,
+    ) -> miette::Result<TimingInfo> {
+        let src = std::fs::read_to_string(policy_file).into_diagnostic()?;
+        let policy_set = src.parse::<PolicySet>()?;
+        let proto = policy_set.encode().expect("policy encoding failed");
+        Ok(self.benchmark(
+            |proto| {
+                PolicySet::decode_unchecked(proto.as_slice())
+                    .expect("protobuf policy parse failed");
+            },
+            &proto,
+        ))
+    }
+
     fn bench_schema_parsing(self, schema_file: &Path) -> miette::Result<TimingInfo> {
         let src = std::fs::read_to_string(schema_file).into_diagnostic()?;
         Ok(self.benchmark(
@@ -164,6 +189,20 @@ impl BenchmarkExecutor {
         Ok(self.benchmark(
             |proto| {
                 Schema::decode(proto.as_slice()).expect("protobuf schema parse failed");
+            },
+            &proto,
+        ))
+    }
+
+    fn bench_protobuf_schema_parsing_unchecked(
+        self,
+        schema_file: &Path,
+    ) -> miette::Result<TimingInfo> {
+        let schema = Self::load_cedar_schema(schema_file)?;
+        let proto = schema.encode().expect("schema encoding failed");
+        Ok(self.benchmark(
+            |proto| {
+                Schema::decode_unchecked(proto.as_slice()).expect("protobuf schema parse failed");
             },
             &proto,
         ))
@@ -249,6 +288,23 @@ impl BenchmarkExecutor {
         Ok(self.benchmark(
             |proto| {
                 cedar_policy::Entities::decode(proto.as_slice())
+                    .expect("protobuf entity parse failed");
+            },
+            &proto,
+        ))
+    }
+
+    fn bench_protobuf_entity_parsing_unchecked(
+        self,
+        entities_file: &Path,
+    ) -> miette::Result<TimingInfo> {
+        let entities_str = std::fs::read_to_string(entities_file).into_diagnostic()?;
+        let entities =
+            cedar_policy::Entities::from_json_str(&entities_str, None).into_diagnostic()?;
+        let proto = entities.encode().expect("entity encoding failed");
+        Ok(self.benchmark(
+            |proto| {
+                cedar_policy::Entities::decode_unchecked(proto.as_slice())
                     .expect("protobuf entity parse failed");
             },
             &proto,

--- a/cedar-benchmarking/src/tasks.rs
+++ b/cedar-benchmarking/src/tasks.rs
@@ -25,14 +25,17 @@ pub enum Target {
     PolicyParse,
     JsonPolicyParse,
     ProtobufPolicyParse,
+    ProtobufPolicyParseUnchecked,
     SchemaParse,
     JsonSchemaParse,
     ProtobufSchemaParse,
+    ProtobufSchemaParseUnchecked,
     Validation,
     Authorization,
     EntityParseWithSchema,
     EntityParseWithoutSchema,
     ProtobufEntityParse,
+    ProtobufEntityParseUnchecked,
     IncrementalEntities,
 }
 
@@ -42,14 +45,17 @@ impl std::fmt::Display for Target {
             Self::PolicyParse => write!(f, "policy_parse"),
             Self::JsonPolicyParse => write!(f, "json_policy_parse"),
             Self::ProtobufPolicyParse => write!(f, "protobuf_policy_parse"),
+            Self::ProtobufPolicyParseUnchecked => write!(f, "protobuf_policy_parse_unchecked"),
             Self::SchemaParse => write!(f, "schema_parse"),
             Self::JsonSchemaParse => write!(f, "json_schema_parse"),
             Self::ProtobufSchemaParse => write!(f, "protobuf_schema_parse"),
+            Self::ProtobufSchemaParseUnchecked => write!(f, "protobuf_schema_parse_unchecked"),
             Self::Validation => write!(f, "validation"),
             Self::Authorization => write!(f, "authorization"),
             Self::EntityParseWithSchema => write!(f, "entity_parse_with_schema"),
             Self::EntityParseWithoutSchema => write!(f, "entity_parse_without_schema"),
             Self::ProtobufEntityParse => write!(f, "protobuf_entity_parse"),
+            Self::ProtobufEntityParseUnchecked => write!(f, "protobuf_entity_parse_unchecked"),
             Self::IncrementalEntities => write!(f, "incremental_entities"),
         }
     }
@@ -62,14 +68,17 @@ impl std::str::FromStr for Target {
             "policy_parse" => Ok(Self::PolicyParse),
             "json_policy_parse" => Ok(Self::JsonPolicyParse),
             "protobuf_policy_parse" => Ok(Self::ProtobufPolicyParse),
+            "protobuf_policy_parse_unchecked" => Ok(Self::ProtobufPolicyParseUnchecked),
             "schema_parse" => Ok(Self::SchemaParse),
             "json_schema_parse" => Ok(Self::JsonSchemaParse),
             "protobuf_schema_parse" => Ok(Self::ProtobufSchemaParse),
+            "protobuf_schema_parse_unchecked" => Ok(Self::ProtobufSchemaParseUnchecked),
             "validation" => Ok(Self::Validation),
             "authorization" => Ok(Self::Authorization),
             "entity_parse_with_schema" => Ok(Self::EntityParseWithSchema),
             "entity_parse_without_schema" => Ok(Self::EntityParseWithoutSchema),
             "protobuf_entity_parse" => Ok(Self::ProtobufEntityParse),
+            "protobuf_entity_parse_unchecked" => Ok(Self::ProtobufEntityParseUnchecked),
             "incremental_entities" => Ok(Self::IncrementalEntities),
             _ => Err(format!("unknown target: {s}")),
         }
@@ -105,6 +114,10 @@ pub enum BenchmarkTask {
         name: String,
         policy_file: PathBuf,
     },
+    ProtobufPolicyParseUnchecked {
+        name: String,
+        policy_file: PathBuf,
+    },
     SchemaParse {
         name: String,
         cedar_schema_file: PathBuf,
@@ -114,6 +127,10 @@ pub enum BenchmarkTask {
         json_schema_file: PathBuf,
     },
     ProtobufSchemaParse {
+        name: String,
+        cedar_schema_file: PathBuf,
+    },
+    ProtobufSchemaParseUnchecked {
         name: String,
         cedar_schema_file: PathBuf,
     },
@@ -142,6 +159,10 @@ pub enum BenchmarkTask {
         name: String,
         entities_file: PathBuf,
     },
+    ProtobufEntityParseUnchecked {
+        name: String,
+        entities_file: PathBuf,
+    },
     IncrementalEntities {
         name: String,
         cedar_schema_file: PathBuf,
@@ -155,14 +176,17 @@ impl BenchmarkTask {
             Self::PolicyParse { name, .. }
             | Self::JsonPolicyParse { name, .. }
             | Self::ProtobufPolicyParse { name, .. }
+            | Self::ProtobufPolicyParseUnchecked { name, .. }
             | Self::SchemaParse { name, .. }
             | Self::JsonSchemaParse { name, .. }
             | Self::ProtobufSchemaParse { name, .. }
+            | Self::ProtobufSchemaParseUnchecked { name, .. }
             | Self::Validation { name, .. }
             | Self::Authorization { name, .. }
             | Self::EntityParseWithSchema { name, .. }
             | Self::EntityParseWithoutSchema { name, .. }
             | Self::ProtobufEntityParse { name, .. }
+            | Self::ProtobufEntityParseUnchecked { name, .. }
             | Self::IncrementalEntities { name, .. } => name,
         }
     }
@@ -172,14 +196,17 @@ impl BenchmarkTask {
             Self::PolicyParse { .. } => Target::PolicyParse,
             Self::JsonPolicyParse { .. } => Target::JsonPolicyParse,
             Self::ProtobufPolicyParse { .. } => Target::ProtobufPolicyParse,
+            Self::ProtobufPolicyParseUnchecked { .. } => Target::ProtobufPolicyParseUnchecked,
             Self::SchemaParse { .. } => Target::SchemaParse,
             Self::JsonSchemaParse { .. } => Target::JsonSchemaParse,
             Self::ProtobufSchemaParse { .. } => Target::ProtobufSchemaParse,
+            Self::ProtobufSchemaParseUnchecked { .. } => Target::ProtobufSchemaParseUnchecked,
             Self::Validation { .. } => Target::Validation,
             Self::Authorization { .. } => Target::Authorization,
             Self::EntityParseWithSchema { .. } => Target::EntityParseWithSchema,
             Self::EntityParseWithoutSchema { .. } => Target::EntityParseWithoutSchema,
             Self::ProtobufEntityParse { .. } => Target::ProtobufEntityParse,
+            Self::ProtobufEntityParseUnchecked { .. } => Target::ProtobufEntityParseUnchecked,
             Self::IncrementalEntities { .. } => Target::IncrementalEntities,
         }
     }
@@ -216,6 +243,12 @@ impl Task {
                     policy_file: policy_file.clone(),
                 });
             }
+            if self.is_target_enabled(Target::ProtobufPolicyParseUnchecked) {
+                tasks.push(BenchmarkTask::ProtobufPolicyParseUnchecked {
+                    name: self.name.clone(),
+                    policy_file: policy_file.clone(),
+                });
+            }
         }
 
         if let Some(ref cedar_schema_file) = self.cedar_schema_file {
@@ -227,6 +260,12 @@ impl Task {
             }
             if self.is_target_enabled(Target::ProtobufSchemaParse) {
                 tasks.push(BenchmarkTask::ProtobufSchemaParse {
+                    name: self.name.clone(),
+                    cedar_schema_file: cedar_schema_file.clone(),
+                });
+            }
+            if self.is_target_enabled(Target::ProtobufSchemaParseUnchecked) {
+                tasks.push(BenchmarkTask::ProtobufSchemaParseUnchecked {
                     name: self.name.clone(),
                     cedar_schema_file: cedar_schema_file.clone(),
                 });
@@ -298,6 +337,12 @@ impl Task {
             }
             if self.is_target_enabled(Target::ProtobufEntityParse) {
                 tasks.push(BenchmarkTask::ProtobufEntityParse {
+                    name: self.name.clone(),
+                    entities_file: entities_file.clone(),
+                });
+            }
+            if self.is_target_enabled(Target::ProtobufEntityParseUnchecked) {
+                tasks.push(BenchmarkTask::ProtobufEntityParseUnchecked {
                     name: self.name.clone(),
                     entities_file: entities_file.clone(),
                 });


### PR DESCRIPTION
This PR adds 3 new benchmarking targets for the `unchecked` variant of the protobufs' `decode` API:
- protobuf_policy_parse_unchecked for policies,
- protobuf_schema_parse_unchecked for schemas, and
- protobuf_entity_parse_unchecked for entities.