### PR TITLE
Add residual evaluation TPE differential test target

### DIFF
--- a/cedar-drt/README.md
+++ b/cedar-drt/README.md
@@ -19,6 +19,7 @@ The table below lists all available fuzz targets, including which component of t
 | [`entity-validation`](fuzz/fuzz_targets/entity-validation.rs) | Entity Validator | DRT | Diff test entity validation |
 | [`request-validation`](fuzz/fuzz_targets/request-validation.rs) | Request Validator | DRT | Diff test request validation |
 | [`tpe-is-authorized-drt`](fuzz/fuzz_targets/tpe-is-authorized-drt.rs) | TPE (partial authorization) | DRT | Diff test Rust and Lean TPE is_authorized API: decisions, policy categorizations, and residual expressions |
+| [`tpe-residual-reauthorize-drt`](fuzz/fuzz_targets/tpe-residual-reauthorize-drt.rs) | TPE (reauthorization of arbitrary residuals) | DRT | Diff test concrete evaluation of a generated residual. The model walks the residual directly; Rust projects it to an `Expr` and evaluates that, so this compares the two routes `reauthorize` and `Residual.evaluate` take |
 |  |  |  |  |
 | [`formatter`](fuzz/fuzz_targets/formatter.rs) | Policy formatter, Pretty printer, Parser | PBT | Test round trip property: parse ∘ format ∘ pretty-print == id for ASTs |
 | [`formatter-bytes`](fuzz/fuzz_targets/formatter-bytes.rs) | Policy formatter, Parser | PBT | The same as `formatter`, but we start with an arbitrary string instead of pretty-printing a policy AST |

--- a/cedar-drt/fuzz/Cargo.toml
+++ b/cedar-drt/fuzz/Cargo.toml
@@ -396,6 +396,12 @@ test = false
 doc = false
 
 [[bin]]
+name = "tpe-residual-reauthorize-drt"
+path = "fuzz_targets/tpe-residual-reauthorize-drt.rs"
+test = false
+doc = false
+
+[[bin]]
 name = "tpe-is-authorized-abstract-drt"
 path = "fuzz_targets/tpe-is-authorized-abstract-drt.rs"
 test = false

--- a/cedar-drt/fuzz/fuzz_targets/tpe-residual-reauthorize-drt.rs
+++ b/cedar-drt/fuzz/fuzz_targets/tpe-residual-reauthorize-drt.rs
@@ -1,0 +1,43 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! DRT fuzz target for evaluating residuals against concrete data
+//!
+//! Particularly interesting given the current implementations since Rust does this by converting to
+//! a concrete Expr, while Lean directly interprets the residual.
+//!
+//! This intentionally runs over entirely arbitrary residuals which may not be well-typed. TPE
+//! soundness assumes well-typed policies, but we can show Rust and Lean interpret all residuals the
+//! same regardless.
+
+#![no_main]
+use cedar_drt::logger::initialize_log;
+use cedar_drt_inner::{
+    fuzz_target,
+    tpe::{TpeResidualFuzzTargetInput, test_tpe_reauthorize_residual_equiv},
+};
+use cedar_lean_ffi::CedarLeanFfi;
+use cedar_policy::Request;
+
+fuzz_target!(|input: TpeResidualFuzzTargetInput| {
+    initialize_log();
+    let ffi = CedarLeanFfi::new();
+    let entities = input.entities;
+    for request in input.reqs {
+        let request: Request = request.into();
+        test_tpe_reauthorize_residual_equiv(&ffi, &input.residual, &request, &entities);
+    }
+});

--- a/cedar-drt/fuzz/fuzz_targets/tpe-residual-reauthorize-drt.rs
+++ b/cedar-drt/fuzz/fuzz_targets/tpe-residual-reauthorize-drt.rs
@@ -35,9 +35,8 @@ use cedar_policy::Request;
 fuzz_target!(|input: TpeResidualFuzzTargetInput| {
     initialize_log();
     let ffi = CedarLeanFfi::new();
-    let entities = input.entities;
     for request in input.reqs {
         let request: Request = request.into();
-        test_tpe_reauthorize_residual_equiv(&ffi, &input.residual, &request, &entities);
+        test_tpe_reauthorize_residual_equiv(&ffi, &input.residual, &request, &input.entities);
     }
 });

--- a/cedar-drt/fuzz/src/tpe.rs
+++ b/cedar-drt/fuzz/src/tpe.rs
@@ -27,7 +27,7 @@ use cedar_policy_core::ast::{self, Value};
 use cedar_policy_core::tpe::residual::Residual;
 use cedar_policy_generators::abac::ABACRequest;
 use cedar_policy_generators::hierarchy::HierarchyGenerator;
-use cedar_policy_generators::schema as generator_schema;
+use cedar_policy_generators::schema;
 use cedar_policy_generators::schema_gen::SchemaGen;
 use libfuzzer_sys::arbitrary::{self, Arbitrary, Unstructured};
 use log::debug;
@@ -185,7 +185,6 @@ impl<'a> Arbitrary<'a> for TpeFuzzTargetInput {
 /// A schema, a hierarchy, and eight (request, residual) pairs.
 #[derive(Debug, Clone)]
 pub struct TpeResidualFuzzTargetInput {
-    pub schema: Schema,
     pub entities: Entities,
     pub residual: Residual,
     pub reqs: [ABACRequest; 8],
@@ -194,9 +193,9 @@ pub struct TpeResidualFuzzTargetInput {
 impl<'a> Arbitrary<'a> for TpeResidualFuzzTargetInput {
     fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
         let settings = abac::FuzzTargetInput::<true>::settings();
-        let gen_schema = generator_schema::Schema::arbitrary(settings.clone(), u)?;
+        let gen_schema = schema::Schema::arbitrary(settings.clone(), u)?;
         let hierarchy = gen_schema.arbitrary_hierarchy(u)?;
-        let requests = [
+        let reqs = [
             gen_schema.arbitrary_request(&hierarchy, u)?,
             gen_schema.arbitrary_request(&hierarchy, u)?,
             gen_schema.arbitrary_request(&hierarchy, u)?,
@@ -206,23 +205,15 @@ impl<'a> Arbitrary<'a> for TpeResidualFuzzTargetInput {
             gen_schema.arbitrary_request(&hierarchy, u)?,
             gen_schema.arbitrary_request(&hierarchy, u)?,
         ];
-        let reqs: [_; 8] = requests
-            .into_iter()
-            .map(|request| Ok(request))
-            .collect::<arbitrary::Result<Vec<_>>>()?
-            .try_into()
-            .unwrap();
         let residual = gen_schema
             .exprgenerator(Some(&hierarchy))
             .generate_residual(settings.max_depth, u)?;
 
-        let schema = Schema::try_from(gen_schema).map_err(|_| arbitrary::Error::IncorrectFormat)?;
-        let all_entities =
-            Entities::try_from(hierarchy).map_err(|_| arbitrary::Error::NotEnoughData)?;
-        let entities =
-            crate::schemas::add_actions_to_entities(&schema, drop_some_entities(all_entities, u)?)?;
+        let entities = drop_some_entities(
+            Entities::try_from(hierarchy).map_err(|_| arbitrary::Error::NotEnoughData)?,
+            u,
+        )?;
         Ok(Self {
-            schema,
             entities,
             reqs,
             residual,
@@ -233,9 +224,16 @@ impl<'a> Arbitrary<'a> for TpeResidualFuzzTargetInput {
         depth: usize,
     ) -> arbitrary::Result<(usize, Option<usize>), arbitrary::MaxRecursionReached> {
         Ok(arbitrary::size_hint::and_all(&[
-            generator_schema::Schema::arbitrary_size_hint(depth)?,
+            schema::Schema::arbitrary_size_hint(depth)?,
             HierarchyGenerator::size_hint(depth),
-            generator_schema::Schema::arbitrary_request_size_hint(depth),
+            schema::Schema::arbitrary_request_size_hint(depth),
+            schema::Schema::arbitrary_request_size_hint(depth),
+            schema::Schema::arbitrary_request_size_hint(depth),
+            schema::Schema::arbitrary_request_size_hint(depth),
+            schema::Schema::arbitrary_request_size_hint(depth),
+            schema::Schema::arbitrary_request_size_hint(depth),
+            schema::Schema::arbitrary_request_size_hint(depth),
+            schema::Schema::arbitrary_request_size_hint(depth),
         ]))
     }
 }

--- a/cedar-drt/fuzz/src/tpe.rs
+++ b/cedar-drt/fuzz/src/tpe.rs
@@ -24,6 +24,7 @@ use cedar_policy::{
     PartialRequest, PolicyId, PolicySet, Request, Schema, Validator,
 };
 use cedar_policy_core::ast::{self, Value};
+use cedar_policy_core::extensions::Extensions;
 use cedar_policy_core::tpe::residual::Residual;
 use cedar_policy_generators::abac::ABACRequest;
 use cedar_policy_generators::hierarchy::HierarchyGenerator;
@@ -246,16 +247,15 @@ pub fn test_tpe_reauthorize_residual_equiv(
     entities: &Entities,
 ) {
     let expr = ast::Expr::from(residual.clone());
-    let core_entities: &cedar_policy_core::entities::Entities = entities.as_ref();
     let evaluator = cedar_policy_core::evaluator::Evaluator::new(
         request.as_ref().clone(),
-        core_entities,
-        cedar_policy_core::extensions::Extensions::all_available(),
+        entities.as_ref(),
+        Extensions::all_available(),
     );
-    let rust = evaluator.interpret(&expr, &std::collections::HashMap::new());
-    let expected = rust.as_ref().map_err(|_| ());
+    let rust_val = evaluator.interpret(&expr, &HashMap::new());
+    let rust_val = rust_val.as_ref().map_err(|_| ());
 
-    let check = match ffi.check_reauthorize_residual(residual, request, entities, expected) {
+    let check = match ffi.check_reauthorize_residual(residual, request, entities, rust_val) {
         Ok(c) => c,
         Err(FfiError::LeanBackendError(e)) => {
             debug!("{e}");

--- a/cedar-drt/fuzz/src/tpe.rs
+++ b/cedar-drt/fuzz/src/tpe.rs
@@ -16,15 +16,21 @@
 
 //! Test utilities for type-directed partial evaluation fuzz targets
 
+use cedar_drt::tests::drop_some_entities;
 use cedar_lean_ffi::{CedarLeanFfi, FfiError};
 use cedar_policy::pst::{Clause, Expr, UnaryOp};
 use cedar_policy::{
-    Entity, EntityId, EntityUid, PartialEntities, PartialEntity, PartialEntityUid, PartialRequest,
-    PolicyId, PolicySet, Request, Schema, Validator,
+    Entities, Entity, EntityId, EntityUid, PartialEntities, PartialEntity, PartialEntityUid,
+    PartialRequest, PolicyId, PolicySet, Request, Schema, Validator,
 };
 use cedar_policy_core::ast::{self, Value};
+use cedar_policy_core::tpe::residual::Residual;
 use cedar_policy_generators::abac::ABACRequest;
+use cedar_policy_generators::hierarchy::HierarchyGenerator;
+use cedar_policy_generators::schema as generator_schema;
+use cedar_policy_generators::schema_gen::SchemaGen;
 use libfuzzer_sys::arbitrary::{self, Arbitrary, Unstructured};
+use log::debug;
 use ref_cast::RefCast;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::convert::TryFrom;
@@ -174,6 +180,99 @@ impl<'a> Arbitrary<'a> for TpeFuzzTargetInput {
     ) -> arbitrary::Result<(usize, Option<usize>), arbitrary::MaxRecursionReached> {
         abac::FuzzTargetInput::<true>::try_size_hint(depth)
     }
+}
+
+/// A schema, a hierarchy, and eight (request, residual) pairs.
+#[derive(Debug, Clone)]
+pub struct TpeResidualFuzzTargetInput {
+    pub schema: Schema,
+    pub entities: Entities,
+    pub residual: Residual,
+    pub reqs: [ABACRequest; 8],
+}
+
+impl<'a> Arbitrary<'a> for TpeResidualFuzzTargetInput {
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        let settings = abac::FuzzTargetInput::<true>::settings();
+        let gen_schema = generator_schema::Schema::arbitrary(settings.clone(), u)?;
+        let hierarchy = gen_schema.arbitrary_hierarchy(u)?;
+        let requests = [
+            gen_schema.arbitrary_request(&hierarchy, u)?,
+            gen_schema.arbitrary_request(&hierarchy, u)?,
+            gen_schema.arbitrary_request(&hierarchy, u)?,
+            gen_schema.arbitrary_request(&hierarchy, u)?,
+            gen_schema.arbitrary_request(&hierarchy, u)?,
+            gen_schema.arbitrary_request(&hierarchy, u)?,
+            gen_schema.arbitrary_request(&hierarchy, u)?,
+            gen_schema.arbitrary_request(&hierarchy, u)?,
+        ];
+        let reqs: [_; 8] = requests
+            .into_iter()
+            .map(|request| Ok(request))
+            .collect::<arbitrary::Result<Vec<_>>>()?
+            .try_into()
+            .unwrap();
+        let residual = gen_schema
+            .exprgenerator(Some(&hierarchy))
+            .generate_residual(settings.max_depth, u)?;
+
+        let schema = Schema::try_from(gen_schema).map_err(|_| arbitrary::Error::IncorrectFormat)?;
+        let all_entities =
+            Entities::try_from(hierarchy).map_err(|_| arbitrary::Error::NotEnoughData)?;
+        let entities =
+            crate::schemas::add_actions_to_entities(&schema, drop_some_entities(all_entities, u)?)?;
+        Ok(Self {
+            schema,
+            entities,
+            reqs,
+            residual,
+        })
+    }
+
+    fn try_size_hint(
+        depth: usize,
+    ) -> arbitrary::Result<(usize, Option<usize>), arbitrary::MaxRecursionReached> {
+        Ok(arbitrary::size_hint::and_all(&[
+            generator_schema::Schema::arbitrary_size_hint(depth)?,
+            HierarchyGenerator::size_hint(depth),
+            generator_schema::Schema::arbitrary_request_size_hint(depth),
+        ]))
+    }
+}
+
+/// Compare Rust and the model on reauthorizing an arbitrary residual against concrete data.
+pub fn test_tpe_reauthorize_residual_equiv(
+    ffi: &CedarLeanFfi,
+    residual: &Residual,
+    request: &Request,
+    entities: &Entities,
+) {
+    let expr = ast::Expr::from(residual.clone());
+    let core_entities: &cedar_policy_core::entities::Entities = entities.as_ref();
+    let evaluator = cedar_policy_core::evaluator::Evaluator::new(
+        request.as_ref().clone(),
+        core_entities,
+        cedar_policy_core::extensions::Extensions::all_available(),
+    );
+    let rust = evaluator.interpret(&expr, &std::collections::HashMap::new());
+    let expected = rust.as_ref().map_err(|_| ());
+
+    let check = match ffi.check_reauthorize_residual(residual, request, entities, expected) {
+        Ok(c) => c,
+        Err(FfiError::LeanBackendError(e)) => {
+            debug!("{e}");
+            return;
+        }
+        Err(e) => panic!("Unexpected FfiError: {e:?}"),
+    };
+    assert!(
+        check.agrees,
+        "arbitrary-residual reauthorization mismatch\n\
+         input: {residual:?}\n\
+         Rust:  {}\n\
+         Lean:  {}",
+        check.expected, check.actual
+    );
 }
 
 /// Whether a policyset passes strict validation.

--- a/cedar-lean-ffi/protobuf_schema/Messages.proto
+++ b/cedar-lean-ffi/protobuf_schema/Messages.proto
@@ -332,6 +332,56 @@ message PartialAuthorizationRequest {
     PartialEntities entities = 4;
 }
 
+// A TPE residual expression
+message Residual {
+    cedar_policy_validator.Type ty = 1;
+
+    Kind kind = 2;
+
+    // Operands, in the order the corresponding `Residual` constructor takes them.
+    repeated Residual children = 3;
+
+    // A value, carried as a literal `Expr` because that is how Lean parses values — see
+    // `Cedar.Spec.Value.exprToValue`.
+    cedar_policy_core.Expr val = 4;
+    cedar_policy_core.Expr.Var var = 5;
+    string attr = 6;
+    // Record attribute names, positionally paired with `children`.
+    repeated string field_names = 7;
+    cedar_policy_core.Expr.UnaryApp.Op unary_op = 8;
+    cedar_policy_core.Expr.BinaryApp.Op binary_op = 9;
+    cedar_policy_core.Name fn_name = 10;
+    repeated cedar_policy_core.Expr.Like.PatternElem pattern = 11;
+    cedar_policy_core.Name entity_type = 12;
+
+    enum Kind {
+        VAL = 0;
+        VAR = 1;
+        ITE = 2;
+        AND = 3;
+        OR = 4;
+        UNARY_APP = 5;
+        BINARY_APP = 6;
+        GET_ATTR = 7;
+        HAS_ATTR = 8;
+        SET = 9;
+        RECORD = 10;
+        CALL = 11;
+        ERROR = 12;
+        LIKE = 13;
+        IS = 14;
+    }
+}
+
+// Reevaluate a residual against concrete, comparing it to the expected value 
+message ResidualReauthorizationRequest {
+    Residual residual = 1;
+    cedar_policy_core.Request request = 2;
+    cedar_policy_core.Entities entities = 3;
+    cedar_policy_core.Expr expected_value = 4;
+    bool expects_error = 5;
+}
+
 // Batched authorization request
 message BatchedAuthorizationRequest {
     cedar_policy_core.PolicySet policies = 1;

--- a/cedar-lean-ffi/src/datatypes/tpe.rs
+++ b/cedar-lean-ffi/src/datatypes/tpe.rs
@@ -523,3 +523,16 @@ mod convert {
         }
     }
 }
+
+/// The model's verdict on an answer we sent it, mirroring `CedarFFI.CheckResult`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct CheckResult {
+    /// Whether the model reached the same answer we did.
+    pub agrees: bool,
+    /// Our answer, as the model rendered it. Empty when `agrees`.
+    #[serde(default)]
+    pub expected: String,
+    /// The model's answer. Empty when `agrees`.
+    #[serde(default)]
+    pub actual: String,
+}

--- a/cedar-lean-ffi/src/lean_ffi.rs
+++ b/cedar-lean-ffi/src/lean_ffi.rs
@@ -281,6 +281,8 @@ unsafe extern "C" {
 
     fn isAuthorizedPartial(req: *mut lean_object) -> *mut lean_object;
 
+    fn reauthorizeResidual(req: *mut lean_object) -> *mut lean_object;
+
     fn initialize_Cedar_CedarFFI(builtin: u8, ob: *mut lean_object) -> *mut lean_object;
 
     fn loadProtobufSchema(req: *mut lean_object) -> *mut lean_object;

--- a/cedar-lean-ffi/src/lean_ffi/tpe.rs
+++ b/cedar-lean-ffi/src/lean_ffi/tpe.rs
@@ -18,9 +18,9 @@ use crate::datatypes::{self as datatypes, ResultDef, TimedDef, TimedResult, TpeR
 use crate::err::FfiError;
 use crate::messages::proto;
 
-use cedar_policy::{PartialEntities, PartialRequest, PolicySet, Schema};
+use cedar_policy::{Entities, PartialEntities, PartialRequest, PolicySet, Request, Schema};
 
-use super::{CedarLeanFfi, call_lean_ffi_takes_protobuf, isAuthorizedPartial};
+use super::{CedarLeanFfi, call_lean_ffi_takes_protobuf, isAuthorizedPartial, reauthorizeResidual};
 
 impl CedarLeanFfi {
     /// Calls the Lean backend and performs type-aware partial evaluation of the partial request,
@@ -54,6 +54,29 @@ impl CedarLeanFfi {
                 }
                 ResultDef::Error(s) => Err(FfiError::LeanBackendError(s)),
             },
+            ResultDef::Error(s) => Err(FfiError::LeanBackendError(s)),
+        }
+    }
+
+    /// Ask the Lean model to evaluate a residual against concrete data and compare its answer to `expected`.
+    pub fn check_reauthorize_residual(
+        &self,
+        residual: &cedar_policy_core::tpe::residual::Residual,
+        request: &Request,
+        entities: &Entities,
+        expected: Result<&cedar_policy_core::ast::Value, ()>,
+    ) -> Result<datatypes::tpe::CheckResult, FfiError> {
+        let response = unsafe {
+            call_lean_ffi_takes_protobuf(
+                reauthorizeResidual,
+                &proto::ResidualReauthorizationRequest::new(residual, request, entities, expected),
+            )
+        };
+        match response
+            .as_borrowed()
+            .deserialize_into::<ResultDef<TimedDef<datatypes::tpe::CheckResult>>>()?
+        {
+            ResultDef::Ok(resp) => Ok(resp.data),
             ResultDef::Error(s) => Err(FfiError::LeanBackendError(s)),
         }
     }
@@ -93,6 +116,9 @@ mod test {
     use std::str::FromStr;
 
     use crate::CedarLeanFfi;
+    use cedar_policy_core::ast::{EntityUID, Value, Var};
+    use cedar_policy_core::tpe::residual::{Residual, ResidualKind};
+    use cedar_policy_core::validator::types::{EntityKind, EntityLUB, Type};
 
     /// Helper to compare Rust and Lean TPE responses: decision, policy categorizations,
     /// and residual expressions (via PST comparison).
@@ -213,6 +239,115 @@ mod test {
             eprint!("TPE response comparison failed:\n{msg}\n");
             std::process::exit(1);
         }
+    }
+
+    /// Concrete entities for the arbitrary-residual tests.
+    fn concrete_entities() -> cedar_policy::Entities {
+        let schema = tpe_schema();
+        cedar_policy::Entities::from_json_value(
+            serde_json::json!([
+                {
+                    "uid": { "type": "User", "id": "alice" },
+                    "attrs": { "name": "Alice", "age": 30 },
+                    "parents": []
+                }
+            ]),
+            Some(&schema),
+        )
+        .expect("concrete entities should parse")
+    }
+
+    /// Concrete request for the arbitrary-residual tests.
+    fn concrete_req() -> cedar_policy::Request {
+        let schema = tpe_schema();
+        cedar_policy::Request::new(
+            EntityUid::from_str(r#"User::"alice""#).unwrap(),
+            EntityUid::from_str(r#"Action::"transfer""#).unwrap(),
+            EntityUid::from_str(r#"Account::"checking""#).unwrap(),
+            Context::from_pairs([
+                ("amount".into(), RestrictedExpression::new_long(500)),
+                (
+                    "memo".into(),
+                    RestrictedExpression::new_string("rent".into()),
+                ),
+            ])
+            .unwrap(),
+            Some(&schema),
+        )
+        .expect("concrete request should validate")
+    }
+
+    #[test]
+    fn test_residual_check_detects_disagreement() {
+        let request = concrete_req();
+        let entities = concrete_entities();
+        let ffi = CedarLeanFfi::new();
+        let residual = Residual::Concrete {
+            value: Value::from(7),
+            ty: Type::primitive_long(),
+        };
+        let check = ffi
+            .check_reauthorize_residual(&residual, &request, &entities, Ok(&Value::from(8)))
+            .expect("the model should answer");
+        assert!(!check.agrees, "a wrong `expected` must not be accepted");
+        assert!(
+            check.expected.contains('8') && check.actual.contains('7'),
+            "both answers should be rendered, got expected={:?} actual={:?}",
+            check.expected,
+            check.actual
+        );
+    }
+
+    #[test]
+    fn test_residual_agree_concrete() {
+        let request = concrete_req();
+        let entities = concrete_entities();
+        let ffi = CedarLeanFfi::new();
+        let residual = Residual::Concrete {
+            value: Value::from(7),
+            ty: Type::primitive_long(),
+        };
+        let check = ffi
+            .check_reauthorize_residual(&residual, &request, &entities, Ok(&Value::from(7)))
+            .expect("the model should answer");
+        assert!(check.agrees);
+    }
+
+    #[test]
+    fn test_residual_agree_error() {
+        let request = concrete_req();
+        let entities = concrete_entities();
+        let ffi = CedarLeanFfi::new();
+        let residual = Residual::Error(Type::primitive_boolean());
+        let check = ffi
+            .check_reauthorize_residual(&residual, &request, &entities, Err(()))
+            .expect("the model should answer");
+        assert!(check.agrees);
+    }
+
+    #[test]
+    fn test_residual_agree_partial() {
+        let request = concrete_req();
+        let entities = concrete_entities();
+        let ffi = CedarLeanFfi::new();
+        let residual = Residual::Partial {
+            kind: ResidualKind::Var(Var::Principal),
+            ty: Type::Entity(EntityKind::Entity(EntityLUB::single_entity(
+                "User".parse().unwrap(),
+            ))),
+        };
+
+        let check = ffi
+            .check_reauthorize_residual(
+                &residual,
+                &request,
+                &entities,
+                Ok(&Value::from(
+                    EntityUID::from_str(r#"User::"alice""#).unwrap(),
+                )),
+            )
+            .expect("the model should answer");
+        assert!(check.agrees);
     }
 
     fn tpe_schema() -> Schema {

--- a/cedar-lean-ffi/src/messages.rs
+++ b/cedar-lean-ffi/src/messages.rs
@@ -231,7 +231,7 @@ impl proto::RequestValidationRequest {
 }
 
 pub mod tpe {
-    use cedar_policy::{PartialEntities, PartialRequest, PolicySet, Schema};
+    use cedar_policy::{Entities, PartialEntities, PartialRequest, PolicySet, Request, Schema};
 
     use super::proto;
 
@@ -258,6 +258,143 @@ pub mod tpe {
                 policies: Some(cedar_policy::proto::models::PolicySet::from(policies)),
                 request: Some(proto::PartialRequest::from_inner(request.as_ref())),
                 entities: Some(proto::PartialEntities::from_inner(entities.as_ref())),
+            }
+        }
+    }
+
+    impl proto::Residual {
+        pub(crate) fn from_inner(r: &cedar_policy_core::tpe::residual::Residual) -> Self {
+            use cedar_policy_core::ast::{BinaryOp, UnaryOp};
+            use cedar_policy_core::tpe::residual::{Residual as R, ResidualKind as K};
+            use proto::residual::Kind;
+
+            let ty = Some(cedar_policy::proto::models::Type::from(r.ty()));
+            let mut out = Self {
+                ty,
+                ..Default::default()
+            };
+            let child = |r: &cedar_policy_core::tpe::residual::Residual| Self::from_inner(r);
+            match r {
+                R::Concrete { value, .. } => {
+                    out.set_kind(Kind::Val);
+                    out.val = Some(cedar_policy::proto::models::Expr::from(
+                        &cedar_policy_core::ast::Expr::from(value.clone()),
+                    ));
+                }
+                R::Error(_) => out.set_kind(Kind::Error),
+                R::Partial { kind, .. } => match kind {
+                    K::Var(v) => {
+                        out.set_kind(Kind::Var);
+                        out.set_var(cedar_policy::proto::models::expr::Var::from(v));
+                    }
+                    K::If {
+                        test_expr,
+                        then_expr,
+                        else_expr,
+                    } => {
+                        out.set_kind(Kind::Ite);
+                        out.children = vec![child(test_expr), child(then_expr), child(else_expr)];
+                    }
+                    K::And { left, right } => {
+                        out.set_kind(Kind::And);
+                        out.children = vec![child(left), child(right)];
+                    }
+                    K::Or { left, right } => {
+                        out.set_kind(Kind::Or);
+                        out.children = vec![child(left), child(right)];
+                    }
+                    K::UnaryApp { op, arg } => {
+                        out.set_kind(Kind::UnaryApp);
+                        out.set_unary_op(match op {
+                            UnaryOp::Not => cedar_policy::proto::models::expr::unary_app::Op::Not,
+                            UnaryOp::Neg => cedar_policy::proto::models::expr::unary_app::Op::Neg,
+                            UnaryOp::IsEmpty => {
+                                cedar_policy::proto::models::expr::unary_app::Op::IsEmpty
+                            }
+                        });
+                        out.children = vec![child(arg)];
+                    }
+                    K::BinaryApp { op, arg1, arg2 } => {
+                        use cedar_policy::proto::models::expr::binary_app::Op as POp;
+                        out.set_kind(Kind::BinaryApp);
+                        out.set_binary_op(match op {
+                            BinaryOp::Eq => POp::Eq,
+                            BinaryOp::Less => POp::Less,
+                            BinaryOp::LessEq => POp::LessEq,
+                            BinaryOp::Add => POp::Add,
+                            BinaryOp::Sub => POp::Sub,
+                            BinaryOp::Mul => POp::Mul,
+                            BinaryOp::In => POp::In,
+                            BinaryOp::Contains => POp::Contains,
+                            BinaryOp::ContainsAll => POp::ContainsAll,
+                            BinaryOp::ContainsAny => POp::ContainsAny,
+                            BinaryOp::GetTag => POp::GetTag,
+                            BinaryOp::HasTag => POp::HasTag,
+                        });
+                        out.children = vec![child(arg1), child(arg2)];
+                    }
+                    K::GetAttr { expr, attr } => {
+                        out.set_kind(Kind::GetAttr);
+                        out.attr = attr.to_string();
+                        out.children = vec![child(expr)];
+                    }
+                    K::HasAttr { expr, attr } => {
+                        out.set_kind(Kind::HasAttr);
+                        out.attr = attr.to_string();
+                        out.children = vec![child(expr)];
+                    }
+                    K::Like { expr, pattern } => {
+                        out.set_kind(Kind::Like);
+                        out.pattern = pattern
+                            .iter()
+                            .map(cedar_policy::proto::models::expr::like::PatternElem::from)
+                            .collect();
+                        out.children = vec![child(expr)];
+                    }
+                    K::Is { expr, entity_type } => {
+                        out.set_kind(Kind::Is);
+                        out.entity_type =
+                            Some(cedar_policy::proto::models::Name::from(entity_type.name()));
+                        out.children = vec![child(expr)];
+                    }
+                    K::Set(items) => {
+                        out.set_kind(Kind::Set);
+                        out.children = items.iter().map(child).collect();
+                    }
+                    K::Record(attrs) => {
+                        out.set_kind(Kind::Record);
+                        out.field_names = attrs.keys().map(|k| k.to_string()).collect();
+                        out.children = attrs.values().map(child).collect();
+                    }
+                    K::ExtensionFunctionApp { fn_name, args } => {
+                        out.set_kind(Kind::Call);
+                        out.fn_name = Some(cedar_policy::proto::models::Name::from(fn_name));
+                        out.children = args.iter().map(child).collect();
+                    }
+                },
+            }
+            out
+        }
+    }
+
+    /// Serialize a request to reauthorize an arbitrary residual against concrete data.
+    impl proto::ResidualReauthorizationRequest {
+        pub(crate) fn new(
+            residual: &cedar_policy_core::tpe::residual::Residual,
+            request: &Request,
+            entities: &Entities,
+            expected: Result<&cedar_policy_core::ast::Value, ()>,
+        ) -> Self {
+            Self {
+                residual: Some(proto::Residual::from_inner(residual)),
+                request: Some(cedar_policy::proto::models::Request::from(request)),
+                entities: Some(cedar_policy::proto::models::Entities::from(entities)),
+                expected_value: expected.ok().map(|v| {
+                    cedar_policy::proto::models::Expr::from(&cedar_policy_core::ast::Expr::from(
+                        v.clone(),
+                    ))
+                }),
+                expects_error: expected.is_err(),
             }
         }
     }

--- a/cedar-lean/CedarFFI/Main.lean
+++ b/cedar-lean/CedarFFI/Main.lean
@@ -835,6 +835,39 @@ def parsePartialAuthzRequest (req: ByteArray): Except String (Schema × List Pol
 
 
 /--
+The outcome of checking Lean's answer against the one the caller supplied.
+-/
+structure CheckResult where
+  agrees : Bool
+  expected : String := ""
+  actual : String := ""
+deriving Lean.ToJson
+
+def parseResidualReauthorizationRequest (req: ByteArray):
+  Except String Proto.ResidualReauthorizationRequest :=
+  (@Proto.Message.interpret? Proto.ResidualReauthorizationRequest) req
+    |> .mapError (s!"Failed to parse input: {.}")
+
+/--
+  `req`: binary protobuf for a `ResidualReauthorizationRequest`
+
+  Evaluates a residual against a concrete request and entities and compares the result with
+  the caller's expected result.
+-/
+@[export reauthorizeResidual] unsafe def reauthorizeResidual (req: ByteArray): String :=
+  runFfiM do
+    let req ← parseResidualReauthorizationRequest req
+    runAndTime (λ () =>
+      let actual := req.residual.evaluate req.request req.entities
+      let agrees := match actual with
+        | .ok v    => !req.expectsError && v = req.expectedValue
+        | .error _ => req.expectsError
+      if agrees then ({ agrees := true } : CheckResult)
+      else
+        let expected := if req.expectsError then "error" else reprStr req.expectedValue
+        { agrees := false, expected := expected, actual := reprStr actual })
+
+/--
   `req`: binary protobuf for a `PartialAuthorizationRequest`
 
   returns a string containing a JSON encoding of `Timed TPE.Response`

--- a/cedar-lean/CedarProto.lean
+++ b/cedar-lean/CedarProto.lean
@@ -40,4 +40,5 @@ import CedarProto.Type
 import CedarProto.ValidationRequest
 import CedarProto.LevelValidationRequest
 import CedarProto.Value
+import CedarProto.Residual
 import CedarProto.TPERequest

--- a/cedar-lean/CedarProto/Residual.lean
+++ b/cedar-lean/CedarProto/Residual.lean
@@ -1,0 +1,249 @@
+/-
+ Copyright Cedar Contributors
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-/
+
+import Protobuf.Message
+import Protobuf.Map
+import Protobuf.String
+
+-- Message Dependencies
+import CedarProto.Expr
+import CedarProto.Name
+import CedarProto.Type
+import CedarProto.Value
+import Cedar.TPE.Residual
+
+/-!
+Parsing of the `Residual` protobuf message.
+-/
+
+namespace Cedar.Spec.Proto
+
+open _root_.Proto
+
+inductive ResidualKind where
+  | val | var | ite | and | or | unaryApp | binaryApp
+  | getAttr | hasAttr | set | record | call | error | like | is
+deriving Inhabited, Repr
+
+namespace ResidualKind
+
+def fromInt : Int → Except String ResidualKind
+  | 0  => .ok .val
+  | 1  => .ok .var
+  | 2  => .ok .ite
+  | 3  => .ok .and
+  | 4  => .ok .or
+  | 5  => .ok .unaryApp
+  | 6  => .ok .binaryApp
+  | 7  => .ok .getAttr
+  | 8  => .ok .hasAttr
+  | 9  => .ok .set
+  | 10 => .ok .record
+  | 11 => .ok .call
+  | 12 => .ok .error
+  | 13 => .ok .like
+  | 14 => .ok .is
+  | n  => .error s!"Field {n} does not exist in Residual.Kind"
+
+instance : ProtoEnum ResidualKind := { fromInt := fromInt }
+
+end ResidualKind
+
+structure ProtoResidual where
+  ty         : Option Validation.Proto.ProtoType := none
+  kind       : ResidualKind := .val
+  children   : List ProtoResidual := []
+  val        : Option Expr := none
+  var        : Var := .principal
+  attr       : String := ""
+  fieldNames : List String := []
+  unaryOp    : Proto.ExprKind.UnaryApp.Op := .not
+  binaryOp   : Proto.ExprKind.BinaryApp.Op := .eq
+  fnName     : Option Spec.Proto.Name := none
+  pattern    : Pattern := []
+  entityType : Option EntityType := none
+
+instance : Inhabited ProtoResidual where
+  default := {}
+
+namespace ProtoResidual
+
+def merge (r₁ r₂ : ProtoResidual) : ProtoResidual :=
+  { ty         := match r₁.ty, r₂.ty with
+                  | some t₁, some t₂ => some (Validation.Proto.ProtoType.merge t₁ t₂)
+                  | some t, none | none, some t => some t
+                  | none, none => none
+    kind       := r₂.kind
+    children   := r₁.children ++ r₂.children
+    val        := r₂.val.orElse (λ _ => r₁.val)
+    var        := r₂.var
+    attr       := Field.merge r₁.attr r₂.attr
+    fieldNames := r₁.fieldNames ++ r₂.fieldNames
+    unaryOp    := r₂.unaryOp
+    binaryOp   := r₂.binaryOp
+    fnName     := r₂.fnName.orElse (λ _ => r₁.fnName)
+    pattern    := r₁.pattern ++ r₂.pattern
+    entityType := r₂.entityType.orElse (λ _ => r₁.entityType) }
+
+partial def parseField (t : _root_.Proto.Tag) : BParsec (MergeFn ProtoResidual) := do
+  have : Message ProtoResidual := ⟨parseField, merge⟩
+  match t.fieldNum with
+  | 1 =>
+    let x : Validation.Proto.ProtoType ← Field.guardedParse t
+    pureMergeFn (λ r => { r with ty := some (match r.ty with
+                                             | some t₀ => Validation.Proto.ProtoType.merge t₀ x
+                                             | none    => x) })
+  | 2 =>
+    let x : ResidualKind ← Field.guardedParse t
+    pureMergeFn (λ r => { r with kind := x })
+  | 3 =>
+    let x : Repeated ProtoResidual ← Field.guardedParse t
+    pureMergeFn (λ r => { r with children := r.children ++ x.toList })
+  | 4 =>
+    let x : Expr ← Field.guardedParse t
+    pureMergeFn (λ r => { r with val := some x })
+  | 5 =>
+    let x : Var ← Field.guardedParse t
+    pureMergeFn (λ r => { r with var := x })
+  | 6 =>
+    let x : String ← Field.guardedParse t
+    pureMergeFn (λ r => { r with attr := Field.merge r.attr x })
+  | 7 =>
+    let x : Repeated String ← Field.guardedParse t
+    pureMergeFn (λ r => { r with fieldNames := r.fieldNames ++ x.toList })
+  | 8 =>
+    let x : Proto.ExprKind.UnaryApp.Op ← Field.guardedParse t
+    pureMergeFn (λ r => { r with unaryOp := x })
+  | 9 =>
+    let x : Proto.ExprKind.BinaryApp.Op ← Field.guardedParse t
+    pureMergeFn (λ r => { r with binaryOp := x })
+  | 10 =>
+    let x : Spec.Proto.Name ← Field.guardedParse t
+    pureMergeFn (λ r => { r with fnName := some x })
+  | 11 =>
+    let x : Pattern ← Field.guardedParse t
+    pureMergeFn (λ r => { r with pattern := r.pattern ++ x })
+  | 12 =>
+    let x : EntityType ← Field.guardedParse t
+    pureMergeFn (λ r => { r with entityType := some x })
+  | _ =>
+    t.wireType.skip
+    pure ignore
+
+instance : Message ProtoResidual := ⟨parseField, merge⟩
+
+/-! ### Conversion to the model's `Residual` -/
+
+def unaryOpOf : Proto.ExprKind.UnaryApp.Op → UnaryOp
+  | .not     => .not
+  | .neg     => .neg
+  | .isEmpty => .isEmpty
+
+def binaryOpOf : Proto.ExprKind.BinaryApp.Op → BinaryOp
+  | .eq          => .eq
+  | .less        => .less
+  | .lesseq      => .lessEq
+  | .add         => .add
+  | .sub         => .sub
+  | .mul         => .mul
+  | .in          => .mem
+  | .contains    => .contains
+  | .containsAll => .containsAll
+  | .containsAny => .containsAny
+  | .getTag      => .getTag
+  | .hasTag      => .hasTag
+
+def extFunOf (n : Spec.Proto.Name) : Except String ExtFun :=
+  match n.id with
+  | "decimal"            => .ok .decimal
+  | "lessThan"           => .ok .lessThan
+  | "lessThanOrEqual"    => .ok .lessThanOrEqual
+  | "greaterThan"        => .ok .greaterThan
+  | "greaterThanOrEqual" => .ok .greaterThanOrEqual
+  | "ip"                 => .ok .ip
+  | "isIpv4"             => .ok .isIpv4
+  | "isIpv6"             => .ok .isIpv6
+  | "isLoopback"         => .ok .isLoopback
+  | "isMulticast"        => .ok .isMulticast
+  | "isInRange"          => .ok .isInRange
+  | "datetime"           => .ok .datetime
+  | "duration"           => .ok .duration
+  | "offset"             => .ok .offset
+  | "durationSince"      => .ok .durationSince
+  | "toDate"             => .ok .toDate
+  | "toTime"             => .ok .toTime
+  | "toMilliseconds"     => .ok .toMilliseconds
+  | "toSeconds"          => .ok .toSeconds
+  | "toMinutes"          => .ok .toMinutes
+  | "toHours"            => .ok .toHours
+  | "toDays"             => .ok .toDays
+  | _                    => .error s!"unknown extension function {n.toName}"
+
+/--
+Convert a parsed message to a `Residual`.
+-/
+partial def toResidual (r : ProtoResidual) : Except String Residual := do
+  let some protoTy := r.ty
+    | .error s!"Residual: missing `ty` on a {repr r.kind} node"
+  let ty ← protoTy.toCedarType
+  let kids ← r.children.mapM toResidual
+  let arity (n : Nat) : Except String Unit :=
+    if kids.length == n then .ok ()
+    else .error s!"Residual: {repr r.kind} expects {n} children, got {kids.length}"
+  match r.kind, kids with
+  | .val, _ => do
+    arity 0
+    let some e := r.val | .error "Residual: VAL without `val`"
+    .ok (.val (← Value.exprToValue e) ty)
+  | .var, _ => do
+    arity 0
+    .ok (.var r.var ty)
+  | .error, _ => do
+    arity 0
+    .ok (.error ty)
+  | .ite, [c, t, e] => .ok (.ite c t e ty)
+  | .and, [a, b] => .ok (.and a b ty)
+  | .or, [a, b] => .ok (.or a b ty)
+  | .binaryApp, [a, b] => .ok (.binaryApp (binaryOpOf r.binaryOp) a b ty)
+  | .unaryApp, [a] => .ok (.unaryApp (unaryOpOf r.unaryOp) a ty)
+  | .getAttr, [a] => .ok (.getAttr a r.attr ty)
+  | .hasAttr, [a] => .ok (.hasAttr a r.attr ty)
+  | .like, [a] => .ok (.unaryApp (.like r.pattern) a ty)
+  | .is, [a] => do
+    let some ety := r.entityType | .error "Residual: IS without `entity_type`"
+    .ok (.unaryApp (.is ety) a ty)
+  | .set, _ => .ok (.set kids ty)
+  | .call, _ => do
+    let some fn := r.fnName | .error "Residual: CALL without `fn_name`"
+    .ok (.call (← extFunOf fn) kids ty)
+  | .record, _ =>
+    if r.fieldNames.length == kids.length
+    then .ok (.record (r.fieldNames.zip kids) ty)
+    else .error s!"Residual: RECORD has {r.fieldNames.length} names \
+                   but {kids.length} children"
+  -- Wrong number of children for the kind; `arity` produces the message.
+  | .ite, _ => do arity 3; .error "unreachable"
+  | .and, _ | .or, _ | .binaryApp, _ => do arity 2; .error "unreachable"
+  | .unaryApp, _ | .getAttr, _ | .hasAttr, _ | .like, _ | .is, _ => do
+    arity 1; .error "unreachable"
+
+end ProtoResidual
+
+-- Two encodings are two different residuals, so the later one wins rather than being merged.
+instance : Field Residual :=
+  Field.fromInterFieldFallible ProtoResidual.toResidual (λ _ r₂ => r₂)
+
+end Cedar.Spec.Proto

--- a/cedar-lean/CedarProto/TPERequest.lean
+++ b/cedar-lean/CedarProto/TPERequest.lean
@@ -25,6 +25,7 @@ import CedarProto.Entities
 import CedarProto.PolicySet
 import CedarProto.PartialInput
 import CedarProto.Request
+import CedarProto.Residual
 import CedarProto.Schema
 
 open Proto
@@ -88,5 +89,36 @@ instance : Message PartialAuthorizationRequest where
   }
 
 end PartialAuthorizationRequest
+
+/-- Reauthorization of an arbitrary residual: evaluating it against concrete data. -/
+structure ResidualReauthorizationRequest where
+  residual: Spec.Residual
+  request: Spec.Request
+  entities: Spec.Entities
+  expectedValue: Spec.Value
+  expectsError: Bool
+deriving Inhabited
+
+namespace ResidualReauthorizationRequest
+
+instance : Message ResidualReauthorizationRequest where
+  parseField (t: Proto.Tag) := do
+    match t.fieldNum with
+      | 1 => parseFieldElement t residual (update residual)
+      | 2 => parseFieldElement t request (update request)
+      | 3 => parseFieldElement t entities (update entities)
+      | 4 => parseFieldElement t expectedValue (update expectedValue)
+      | 5 => parseFieldElement t expectsError (update expectsError)
+      | _ => let _ <- t.wireType.skip; pure ignore
+
+  merge x y := {
+    residual := Field.merge x.residual y.residual
+    request := Field.merge x.request y.request
+    entities := Field.merge x.entities y.entities
+    expectedValue := Field.merge x.expectedValue y.expectedValue
+    expectsError := Field.merge x.expectsError y.expectsError
+  }
+
+end ResidualReauthorizationRequest
 
 end Cedar.Proto

--- a/cedar-policy-generators/Cargo.toml
+++ b/cedar-policy-generators/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [dependencies]
 arbitrary = "1.4"
-cedar-policy-core = { path = "../cedar/cedar-policy-core", version = "4.*", features = ["arbitrary"] }
+cedar-policy-core = { path = "../cedar/cedar-policy-core", version = "4.*", features = ["arbitrary", "tpe"] }
 cedar-policy = { path = "../cedar/cedar-policy", version = "4.*", optional = true }
 clap = { version = "4.3.16", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/cedar-policy-generators/src/expr.rs
+++ b/cedar-policy-generators/src/expr.rs
@@ -65,11 +65,7 @@ impl ExprGenerator<'_> {
     /// `max_depth`: maximum size (i.e., depth) of the expression.
     /// For instance, maximum depth of nested sets. Not to be confused with the
     /// `depth` parameter to size_hint.
-    pub fn generate_expr(
-        &mut self,
-        max_depth: usize,
-        u: &mut Unstructured<'_>,
-    ) -> Result<ast::Expr> {
+    pub fn generate_expr(&self, max_depth: usize, u: &mut Unstructured<'_>) -> Result<ast::Expr> {
         if max_depth == 0 {
             // no recursion allowed: just generate a literal
             self.generate_literal_or_var(u)

--- a/cedar-policy-generators/src/lib.rs
+++ b/cedar-policy-generators/src/lib.rs
@@ -50,6 +50,9 @@ pub mod rbac;
 /// This module contains the `Request` data structure
 pub mod request;
 
+/// Generation of arbitrary TPE residuals
+pub mod residual;
+
 /// This module contains the `Schema` data structure and methods for generating
 /// both schemas and hierarchies/policies that conform to a schema
 pub mod schema;

--- a/cedar-policy-generators/src/residual.rs
+++ b/cedar-policy-generators/src/residual.rs
@@ -124,7 +124,7 @@ fn residual_of_expr(e: Expr, u: &mut Unstructured<'_>) -> Result<Residual> {
                     .collect::<Result<Vec<_>>>()?,
             ),
         },
-        // We can't translate these, but on the principal that it's better not to error when generating
+        // We can't translate these, but on the principle that it's better not to error when generating
         // inputs, we'll use `true` as a place holder.
         ExprKind::Unknown(_) | ExprKind::Slot(_) => {
             return Ok(Residual::Concrete {

--- a/cedar-policy-generators/src/residual.rs
+++ b/cedar-policy-generators/src/residual.rs
@@ -1,0 +1,140 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! Generation of arbitrary TPE residuals, by translating an arbitrary expression.
+//!
+//! Every node is annotated `Bool`, so the residuals are ill-typed in general. That is fine for
+//! concrete evaluation, which is what these are generated for: the model's `Residual.evaluate`
+//! ignores annotations, and Rust reaches the same answer through `Expr`, which has none. A target
+//! that partially evaluates these would need real annotations, since partial evaluation reads
+//! them, and would want a generator that produces them rather than this translation.
+
+use crate::expr::ExprGenerator;
+use arbitrary::{Result, Unstructured};
+use cedar_policy_core::ast::{Expr, ExprKind, Value};
+use cedar_policy_core::tpe::residual::{Residual, ResidualKind};
+use cedar_policy_core::validator::types::Type;
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+impl<'a> ExprGenerator<'a> {
+    /// Generate an arbitrary residual, annotating every node `Bool`.
+    ///
+    /// Incorrect type annotations can cause trouble for TPE, but this is
+    /// currently only used to test residual evaluation, which never looks at
+    /// the types in either Rust of Lean.
+    pub fn generate_residual(
+        &self,
+        max_depth: usize,
+        u: &mut Unstructured<'_>,
+    ) -> Result<Residual> {
+        let e = self.generate_expr(max_depth, u)?;
+        residual_of_expr(e, u)
+    }
+}
+
+fn residual_of_expr(e: Expr, u: &mut Unstructured<'_>) -> Result<Residual> {
+    if u.ratio(1, 12)? {
+        // `Residual::Error` is not in `Expr`, so we would never test it just translating from expressions.
+        // We inject it randomly instead.
+        return Ok(Residual::Error(Type::primitive_boolean()));
+    }
+    let kind = match e.into_expr_kind() {
+        // A literal is already a value, so it becomes `Concrete` rather than a `ResidualKind`.
+        ExprKind::Lit(l) => {
+            return Ok(Residual::Concrete {
+                value: Value::from(l.clone()),
+                ty: Type::primitive_boolean(),
+            });
+        }
+        ExprKind::Var(v) => ResidualKind::Var(v),
+        ExprKind::If {
+            test_expr,
+            then_expr,
+            else_expr,
+        } => ResidualKind::If {
+            test_expr: Arc::new(residual_of_expr(Arc::unwrap_or_clone(test_expr), u)?),
+            then_expr: Arc::new(residual_of_expr(Arc::unwrap_or_clone(then_expr), u)?),
+            else_expr: Arc::new(residual_of_expr(Arc::unwrap_or_clone(else_expr), u)?),
+        },
+        ExprKind::And { left, right } => ResidualKind::And {
+            left: Arc::new(residual_of_expr(Arc::unwrap_or_clone(left), u)?),
+            right: Arc::new(residual_of_expr(Arc::unwrap_or_clone(right), u)?),
+        },
+        ExprKind::Or { left, right } => ResidualKind::Or {
+            left: Arc::new(residual_of_expr(Arc::unwrap_or_clone(left), u)?),
+            right: Arc::new(residual_of_expr(Arc::unwrap_or_clone(right), u)?),
+        },
+        ExprKind::UnaryApp { op, arg } => ResidualKind::UnaryApp {
+            op,
+            arg: Arc::new(residual_of_expr(Arc::unwrap_or_clone(arg), u)?),
+        },
+        ExprKind::BinaryApp { op, arg1, arg2 } => ResidualKind::BinaryApp {
+            op,
+            arg1: Arc::new(residual_of_expr(Arc::unwrap_or_clone(arg1), u)?),
+            arg2: Arc::new(residual_of_expr(Arc::unwrap_or_clone(arg2), u)?),
+        },
+        ExprKind::GetAttr { expr, attr } => ResidualKind::GetAttr {
+            expr: Arc::new(residual_of_expr(Arc::unwrap_or_clone(expr), u)?),
+            attr: attr.clone(),
+        },
+        ExprKind::HasAttr { expr, attr } => ResidualKind::HasAttr {
+            expr: Arc::new(residual_of_expr(Arc::unwrap_or_clone(expr), u)?),
+            attr: attr.clone(),
+        },
+        ExprKind::Like { expr, pattern } => ResidualKind::Like {
+            expr: Arc::new(residual_of_expr(Arc::unwrap_or_clone(expr), u)?),
+            pattern: pattern.clone(),
+        },
+        ExprKind::Is { expr, entity_type } => ResidualKind::Is {
+            expr: Arc::new(residual_of_expr(Arc::unwrap_or_clone(expr), u)?),
+            entity_type: entity_type.clone(),
+        },
+        ExprKind::Set(items) => ResidualKind::Set(Arc::new(
+            Arc::unwrap_or_clone(items)
+                .into_iter()
+                .map(|i| residual_of_expr(i, u))
+                .collect::<Result<Vec<_>>>()?,
+        )),
+        ExprKind::Record(fields) => ResidualKind::Record(Arc::new(
+            Arc::unwrap_or_clone(fields)
+                .into_iter()
+                .map(|(k, v)| Ok((k.clone(), residual_of_expr(v, u)?)))
+                .collect::<Result<BTreeMap<_, _>>>()?,
+        )),
+        ExprKind::ExtensionFunctionApp { fn_name, args } => ResidualKind::ExtensionFunctionApp {
+            fn_name: fn_name.clone(),
+            args: Arc::new(
+                Arc::unwrap_or_clone(args)
+                    .into_iter()
+                    .map(|a| residual_of_expr(a, u))
+                    .collect::<Result<Vec<_>>>()?,
+            ),
+        },
+        // We can't translate these, but on the principal that it's better not to error when generating
+        // inputs, we'll use `true` as a place holder.
+        ExprKind::Unknown(_) | ExprKind::Slot(_) => {
+            return Ok(Residual::Concrete {
+                value: Value::from(true),
+                ty: Type::primitive_boolean(),
+            })
+        }
+    };
+    Ok(Residual::Partial {
+        kind,
+        ty: Type::primitive_boolean(),
+    })
+}

--- a/cedar-policy-generators/src/schema_gen.rs
+++ b/cedar-policy-generators/src/schema_gen.rs
@@ -285,7 +285,7 @@ pub trait SchemaGen: std::fmt::Debug {
         u: &mut Unstructured<'_>,
     ) -> Result<ast::Expr> {
         let mut abac_constraints = Vec::new();
-        let mut exprgenerator = self.exprgenerator(Some(hierarchy));
+        let exprgenerator = self.exprgenerator(Some(hierarchy));
         u.arbitrary_loop(
             Some(0),
             Some(self.get_abac_settings().max_depth as u32),


### PR DESCRIPTION
Test that taking a residual and evaluating it on concrete requests and entities is the same in Rust and Lean. Particularly interesting since the Rust implementation does not define evaluation on a residual and instead translate to an expression before evaluating, creating room for mistakes.

The target uses arbitrary residuals without (correct) type annotations. This is fine because types are irrelevant for this step of partial eval.

This is a large change because it needs to add a protobuf layer for communicating the residual. 