### PR TITLE
upgrade to Lean v4.33.1

### DIFF
--- a/cedar-lean/Cedar/Thm/Data/Set.lean
+++ b/cedar-lean/Cedar/Thm/Data/Set.lean
@@ -339,7 +339,7 @@ public theorem make_singleton_nonempty [LT α] [DecidableLT α] [StrictLT α] [D
 := by
   simp [make, empty, List.canonicalize_singleton]
 
-public def eq_means_eqv [LT α] [DecidableLT α] [StrictLT α] {s₁ s₂ : Set α} :
+public theorem eq_means_eqv [LT α] [DecidableLT α] [StrictLT α] {s₁ s₂ : Set α} :
   WellFormed s₁ → WellFormed s₂ →
   (s₁ = s₂ ↔ s₁.elts ≡ s₂.elts)
 := by

--- a/cedar-lean/Cedar/Thm/SymCC/Enforcer/Footprint.lean
+++ b/cedar-lean/Cedar/Thm/SymCC/Enforcer/Footprint.lean
@@ -29,7 +29,7 @@ namespace Cedar.SymCC
 
 open Data Spec SymCC Factory
 
-def footprint_ofEntity_wf :
+theorem footprint_ofEntity_wf :
   (footprint.ofEntity x εnv).WellFormed
 := by
   simp [footprint.ofEntity]
@@ -37,7 +37,7 @@ def footprint_ofEntity_wf :
   · split <;> simp [Set.singleton_wf, Set.empty_wf]
   · exact Set.empty_wf
 
-def footprint_ofBranch_wf :
+theorem footprint_ofBranch_wf :
   ft₂.WellFormed →
   ft₃.WellFormed →
   (footprint.ofBranch εnv x ft₁ ft₂ ft₃).WellFormed
@@ -46,7 +46,7 @@ def footprint_ofBranch_wf :
   simp [footprint.ofBranch]
   split <;> simp [h₂, h₃, Set.empty_wf, Set.union_wf]
 
-def footprint_wf (x : Expr) (εnv : SymEnv) :
+theorem footprint_wf (x : Expr) (εnv : SymEnv) :
   (footprint x εnv).WellFormed
 := by
   cases x
@@ -54,7 +54,7 @@ def footprint_wf (x : Expr) (εnv : SymEnv) :
     List.mapUnion₁_eq_mapUnion (footprint · εnv), List.mapUnion₂_eq_mapUnion (λ x => footprint x.snd εnv),
     Set.empty_wf, List.mapUnion_wf, Set.union_wf]
 
-def footprints_wf (xs : List Expr) (εnv : SymEnv) :
+theorem footprints_wf (xs : List Expr) (εnv : SymEnv) :
   (footprints xs εnv).WellFormed
 := by
   simp [footprints, List.mapUnion_wf]

--- a/cedar-lean/Cedar/Thm/Validation/Validator.lean
+++ b/cedar-lean/Cedar/Thm/Validation/Validator.lean
@@ -93,7 +93,7 @@ theorem typecheck_policy_with_environments_is_sound (policy : Policy) (schema : 
   cases h₃ : List.mapM (typecheckPolicy policy) schema.environments with
   | error => simp only [h₃, Except.bind_err, reduceCtorEq] at h₂
   | ok ts =>
-    simp only [h₃, Except.bind_ok, ite_eq_right_iff, allFalse] at h₂
+    simp only [h₃, Except.bind_ok, allFalse] at h₂
     obtain ⟨env, ⟨h₀, h₁⟩⟩ := h₀
     rw [List.mapM_ok_iff_forall₂] at h₃
     have h₄ := List.forall₂_implies_all_left h₃

--- a/cedar-lean/lake-manifest.json
+++ b/cedar-lean/lake-manifest.json
@@ -8,7 +8,7 @@
    "rev": "4488d40d070b9700d4d5a6aa342f0d40c31b2a2d",
    "name": "batteries",
    "manifestFile": "lake-manifest.json",
-   "inputRev": "v4.33.0",
+   "inputRev": "v4.33.1",
    "inherited": false,
    "configFile": "lakefile.toml"}],
  "name": "Cedar",

--- a/cedar-lean/lakefile.lean
+++ b/cedar-lean/lakefile.lean
@@ -18,7 +18,7 @@ import Lake
 open Lake DSL
 
 meta if get_config? env = some "dev" then -- dev is so not everyone has to build it
-require "leanprover" / "doc-gen4" @ git "v4.33.0"
+require "leanprover" / "doc-gen4" @ git "v4.33.1"
 
 require "leanprover-community" / "batteries" @ git "v4.33.0"
 

--- a/cedar-lean/lean-toolchain
+++ b/cedar-lean/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:v4.33.0
+leanprover/lean4:v4.33.1


### PR DESCRIPTION
Upgrades to v4.33.1  and removes some build warnings on propositions beings `def` instead of `theorems`.


