### PR TITLE
Add DRT targets for partial request and entity validity and consistency

### DIFF
--- a/cedar-drt/README.md
+++ b/cedar-drt/README.md
@@ -20,6 +20,10 @@ The table below lists all available fuzz targets, including which component of t
 | [`request-validation`](fuzz/fuzz_targets/request-validation.rs) | Request Validator | DRT | Diff test request validation |
 | [`tpe-is-authorized-drt`](fuzz/fuzz_targets/tpe-is-authorized-drt.rs) | TPE (partial authorization) | DRT | Diff test Rust and Lean TPE is_authorized API: decisions, policy categorizations, and residual expressions |
 | [`tpe-residual-reauthorize-drt`](fuzz/fuzz_targets/tpe-residual-reauthorize-drt.rs) | TPE (reauthorization of arbitrary residuals) | DRT | Diff test concrete evaluation of a generated residual. The model walks the residual directly; Rust projects it to an `Expr` and evaluates that, so this compares the two routes `reauthorize` and `Residual.evaluate` take |
+| [`partial-entity-validation-drt`](fuzz/fuzz_targets/partial-entity-validation-drt.rs) | TPE (partial entity validator) | DRT | Diff test whether partial entities are valid for a schema |
+| [`partial-entity-consistency-drt`](fuzz/fuzz_targets/partial-entity-consistency-drt.rs) | TPE (partial entity validator) | DRT | Diff test whether partial entities are consistent with concrete entities |
+| [`partial-request-validation-drt`](fuzz/fuzz_targets/partial-request-validation-drt.rs) | TPE (partial request validator) | DRT | Diff test whether a partial request is valid for a schema |
+| [`partial-request-consistency-drt`](fuzz/fuzz_targets/partial-request-consistency-drt.rs) | TPE (partial request validator) | DRT | Diff test whether a partial request is consistent with a concrete request |
 |  |  |  |  |
 | [`formatter`](fuzz/fuzz_targets/formatter.rs) | Policy formatter, Pretty printer, Parser | PBT | Test round trip property: parse ∘ format ∘ pretty-print == id for ASTs |
 | [`formatter-bytes`](fuzz/fuzz_targets/formatter-bytes.rs) | Policy formatter, Parser | PBT | The same as `formatter`, but we start with an arbitrary string instead of pretty-printing a policy AST |

--- a/cedar-drt/fuzz/Cargo.toml
+++ b/cedar-drt/fuzz/Cargo.toml
@@ -660,3 +660,27 @@ name = "tc-repair-equivalence"
 path = "fuzz_targets/tc-repair-equivalence.rs"
 test = false
 doc = false
+
+[[bin]]
+name = "partial-entity-validation-drt"
+path = "fuzz_targets/partial-entity-validation-drt.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "partial-entity-consistency-drt"
+path = "fuzz_targets/partial-entity-consistency-drt.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "partial-request-validation-drt"
+path = "fuzz_targets/partial-request-validation-drt.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "partial-request-consistency-drt"
+path = "fuzz_targets/partial-request-consistency-drt.rs"
+test = false
+doc = false

--- a/cedar-drt/fuzz/fuzz_targets/partial-entity-consistency-drt.rs
+++ b/cedar-drt/fuzz/fuzz_targets/partial-entity-consistency-drt.rs
@@ -1,0 +1,72 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! DRT fuzz target checking that Rust and Lean agree on whether partial entities
+//! are consistent with concrete entities.
+
+#![no_main]
+use cedar_drt::{logger::initialize_log, tests::drop_some_entities};
+use cedar_drt_inner::{
+    fuzz_target,
+    tpe::{
+        arbitrary_schema_and_entities, entities_to_partial_entities, schema_and_entities_size_hint,
+        test_partial_entity_consistency_equiv,
+    },
+};
+
+use cedar_lean_ffi::CedarLeanFfi;
+use cedar_policy::{Entities, PartialEntities};
+
+use cedar_policy_generators::settings::ABACSettings;
+use libfuzzer_sys::arbitrary::{self, Arbitrary, Unstructured};
+
+/// Input expected by this fuzz target
+#[derive(Debug, Clone)]
+pub struct FuzzTargetInput {
+    /// partial entities derived from a generated hierarchy, with their attributes and
+    /// tags optionally shuffled so that mismatched values are reachable
+    pub partial_entities: PartialEntities,
+    /// the same hierarchy with some entities dropped, so that missing entities and
+    /// mismatched ancestors are reachable
+    pub entities: Entities,
+}
+
+impl<'a> Arbitrary<'a> for FuzzTargetInput {
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        let (schema, entities) = arbitrary_schema_and_entities(ABACSettings::undirected(), u)?;
+        let partial_entities =
+            entities_to_partial_entities(entities.iter(), u.arbitrary()?, u, &schema)?;
+        Ok(Self {
+            partial_entities,
+            entities: drop_some_entities(entities, u)?,
+        })
+    }
+
+    fn try_size_hint(
+        depth: usize,
+    ) -> arbitrary::Result<(usize, Option<usize>), arbitrary::MaxRecursionReached> {
+        schema_and_entities_size_hint(depth)
+    }
+}
+
+fuzz_target!(|input: FuzzTargetInput| {
+    initialize_log();
+    test_partial_entity_consistency_equiv(
+        &CedarLeanFfi::new(),
+        &input.entities,
+        &input.partial_entities,
+    );
+});

--- a/cedar-drt/fuzz/fuzz_targets/partial-entity-validation-drt.rs
+++ b/cedar-drt/fuzz/fuzz_targets/partial-entity-validation-drt.rs
@@ -1,0 +1,79 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! DRT fuzz target checking that Rust and Lean agree on whether partial entities
+//! are valid for a schema.
+
+#![no_main]
+use cedar_drt::logger::initialize_log;
+use cedar_drt_inner::{
+    fuzz_target,
+    tpe::{
+        arbitrary_schema_and_entities, entity_to_unchecked_partial_entity,
+        schema_and_entities_size_hint, test_partial_entity_validation_equiv,
+    },
+};
+
+use cedar_lean_ffi::{CedarLeanFfi, UncheckedPartialEntity};
+use cedar_policy::Schema;
+
+use cedar_policy_generators::settings::ABACSettings;
+use libfuzzer_sys::arbitrary::{self, Arbitrary, Unstructured};
+
+/// Input expected by this fuzz target
+#[derive(Debug, Clone)]
+pub struct FuzzTargetInput {
+    /// generated schema
+    pub schema: Schema,
+    /// partial entities derived from a generated hierarchy, which is not
+    /// necessarily valid for `schema`
+    pub entities: Vec<UncheckedPartialEntity>,
+}
+
+/// `enable_additional_attributes` makes the generated entities not always valid
+const SETTINGS: ABACSettings = ABACSettings {
+    enable_additional_attributes: true,
+    ..ABACSettings::undirected()
+};
+
+impl<'a> Arbitrary<'a> for FuzzTargetInput {
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        let (schema, entities) = arbitrary_schema_and_entities(SETTINGS.clone(), u)?;
+        // `Entities::iter` order is unspecified, so sort to keep this target reproducible
+        let mut entities: Vec<_> = entities.iter().collect();
+        entities.sort_by_cached_key(|e| e.uid().to_string());
+        Ok(Self {
+            entities: entities
+                .into_iter()
+                .map(|e| entity_to_unchecked_partial_entity(e, u))
+                .collect::<arbitrary::Result<_>>()?,
+            schema,
+        })
+    }
+
+    fn try_size_hint(
+        depth: usize,
+    ) -> arbitrary::Result<(usize, Option<usize>), arbitrary::MaxRecursionReached> {
+        schema_and_entities_size_hint(depth)
+    }
+}
+
+fuzz_target!(|input: FuzzTargetInput| {
+    initialize_log();
+    let ffi = CedarLeanFfi::new();
+    let lean_schema = ffi.load_lean_schema_object(&input.schema).unwrap();
+    test_partial_entity_validation_equiv(&ffi, &input.schema, lean_schema, &input.entities);
+});

--- a/cedar-drt/fuzz/fuzz_targets/partial-request-consistency-drt.rs
+++ b/cedar-drt/fuzz/fuzz_targets/partial-request-consistency-drt.rs
@@ -1,0 +1,76 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! DRT fuzz target checking that Rust and Lean agree on whether a partial request is
+//! consistent with a concrete request.
+
+#![no_main]
+use cedar_drt::logger::initialize_log;
+use cedar_drt_inner::{
+    fuzz_target,
+    tpe::{
+        arbitrary_schema_and_requests, make_partial_request, schema_and_requests_size_hint,
+        test_partial_request_consistency_equiv,
+    },
+};
+
+use cedar_lean_ffi::CedarLeanFfi;
+use cedar_policy::{PartialRequest, Request};
+
+use libfuzzer_sys::arbitrary::{self, Arbitrary, Unstructured};
+
+/// Input expected by this fuzz target
+#[derive(Debug, Clone)]
+pub struct FuzzTargetInput {
+    /// partial requests derived from generated requests
+    pub partial_requests: Vec<PartialRequest>,
+    /// those requests, optionally rotated so that both consistent and inconsistent
+    /// pairings are reachable
+    pub requests: Vec<Request>,
+}
+
+impl<'a> Arbitrary<'a> for FuzzTargetInput {
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        let (schema, generated_requests) = arbitrary_schema_and_requests(u)?;
+        let partial_requests = generated_requests
+            .iter()
+            .map(|req| make_partial_request(req, u, &schema))
+            .collect::<Result<Vec<_>, _>>()?;
+        let mut requests: Vec<Request> = generated_requests.into_iter().map(Into::into).collect();
+        if u.arbitrary()? {
+            // pair each partial request with a different concrete request, so that they can be inconsistent
+            requests.rotate_left(1);
+        }
+        Ok(Self {
+            partial_requests,
+            requests,
+        })
+    }
+
+    fn try_size_hint(
+        depth: usize,
+    ) -> arbitrary::Result<(usize, Option<usize>), arbitrary::MaxRecursionReached> {
+        schema_and_requests_size_hint(depth)
+    }
+}
+
+fuzz_target!(|input: FuzzTargetInput| {
+    initialize_log();
+    let ffi = CedarLeanFfi::new();
+    for (request, partial_request) in input.requests.iter().zip(&input.partial_requests) {
+        test_partial_request_consistency_equiv(&ffi, request, partial_request);
+    }
+});

--- a/cedar-drt/fuzz/fuzz_targets/partial-request-validation-drt.rs
+++ b/cedar-drt/fuzz/fuzz_targets/partial-request-validation-drt.rs
@@ -1,0 +1,78 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! DRT fuzz target checking that Rust and Lean agree on whether a partial request
+//! is valid for a schema.
+
+#![no_main]
+use cedar_drt::logger::initialize_log;
+use cedar_drt_inner::{
+    fuzz_target,
+    tpe::{
+        arbitrary_schema_and_requests, make_unchecked_partial_request,
+        schema_and_requests_size_hint, test_partial_request_validation_equiv,
+    },
+};
+
+use cedar_lean_ffi::{CedarLeanFfi, UncheckedPartialRequest};
+use cedar_policy::Schema;
+
+use libfuzzer_sys::arbitrary::{self, Arbitrary, Unstructured};
+
+/// Input expected by this fuzz target
+#[derive(Debug, Clone)]
+pub struct FuzzTargetInput {
+    /// generated schema
+    pub schema: Schema,
+    /// partial requests built by mixing components of generated requests, so they are
+    /// not necessarily valid for `schema`
+    pub requests: Vec<UncheckedPartialRequest>,
+}
+
+impl<'a> Arbitrary<'a> for FuzzTargetInput {
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        let (schema, requests) = arbitrary_schema_and_requests(u)?;
+        let requests = if u.arbitrary()? {
+            // take the action and context from the next request, so that they are likely invalid
+            requests
+                .iter()
+                .zip(requests.iter().cycle().skip(1))
+                .map(|(req, action_from)| make_unchecked_partial_request(req, action_from, u))
+                .collect::<arbitrary::Result<_>>()?
+        } else {
+            requests
+                .iter()
+                .map(|req| make_unchecked_partial_request(req, req, u))
+                .collect::<arbitrary::Result<_>>()?
+        };
+        Ok(Self { schema, requests })
+    }
+
+    fn try_size_hint(
+        depth: usize,
+    ) -> arbitrary::Result<(usize, Option<usize>), arbitrary::MaxRecursionReached> {
+        schema_and_requests_size_hint(depth)
+    }
+}
+
+fuzz_target!(|input: FuzzTargetInput| {
+    initialize_log();
+    let ffi = CedarLeanFfi::new();
+    let lean_schema = ffi.load_lean_schema_object(&input.schema).unwrap();
+    for request in &input.requests {
+        test_partial_request_validation_equiv(&ffi, &input.schema, lean_schema.clone(), request);
+    }
+});

--- a/cedar-drt/fuzz/fuzz_targets/tpe-query-action-pbt.rs
+++ b/cedar-drt/fuzz/fuzz_targets/tpe-query-action-pbt.rs
@@ -81,7 +81,7 @@ impl<'a> Arbitrary<'a> for FuzzTargetInput {
             .try_into()
             .unwrap();
         let partial_entities =
-            entities_to_partial_entities(abac_input.entities.iter(), u, &cedar_schema)?;
+            entities_to_partial_entities(abac_input.entities.iter(), false, u, &cedar_schema)?;
         Ok(Self {
             abac_input,
             partial_requests,

--- a/cedar-drt/fuzz/src/tpe.rs
+++ b/cedar-drt/fuzz/src/tpe.rs
@@ -17,30 +17,115 @@
 //! Test utilities for type-directed partial evaluation fuzz targets
 
 use cedar_drt::tests::drop_some_entities;
-use cedar_lean_ffi::{CedarLeanFfi, FfiError};
+use cedar_lean_ffi::{
+    CedarLeanFfi, FfiError, LeanSchema, UncheckedPartialEntity, UncheckedPartialRequest,
+    ValidationResponse,
+};
 use cedar_policy::pst::{Clause, Expr, UnaryOp};
 use cedar_policy::{
-    Entities, Entity, EntityId, EntityUid, PartialEntities, PartialEntity, PartialEntityUid,
-    PartialRequest, PolicyId, PolicySet, Request, Schema, Validator,
+    Context, Entities, Entity, EntityId, EntityUid, PartialEntities, PartialEntity,
+    PartialEntityUid, PartialRequest, PolicyId, PolicySet, Request, RestrictedExpression, Schema,
+    Validator,
 };
 use cedar_policy_core::ast::{self, Value};
 use cedar_policy_core::extensions::Extensions;
 use cedar_policy_core::tpe::residual::Residual;
-use cedar_policy_generators::abac::ABACRequest;
-use cedar_policy_generators::hierarchy::HierarchyGenerator;
-use cedar_policy_generators::schema;
-use cedar_policy_generators::schema_gen::SchemaGen;
+use cedar_policy_generators::{
+    abac::ABACRequest, hierarchy::HierarchyGenerator, schema, schema_gen::SchemaGen,
+    settings::ABACSettings,
+};
 use libfuzzer_sys::arbitrary::{self, Arbitrary, Unstructured};
 use log::debug;
 use ref_cast::RefCast;
+use smol_str::SmolStr;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::convert::TryFrom;
 use std::sync::Arc;
 
-use crate::abac;
+use crate::{abac, schemas};
 
+/// Generates a schema and a hierarchy of entities for it, including its action entities.
+pub fn arbitrary_schema_and_entities(
+    settings: ABACSettings,
+    u: &mut Unstructured<'_>,
+) -> arbitrary::Result<(Schema, Entities)> {
+    let generated_schema = schema::Schema::arbitrary(settings, u)?;
+    let hierarchy = generated_schema.arbitrary_hierarchy(u)?;
+    let schema =
+        Schema::try_from(generated_schema).map_err(|_| arbitrary::Error::IncorrectFormat)?;
+    let entities = schemas::add_actions_to_entities(
+        &schema,
+        Entities::try_from(hierarchy).map_err(|_| arbitrary::Error::NotEnoughData)?,
+    )?;
+    Ok((schema, entities))
+}
+
+/// Generates a schema and 8 requests for it.
+pub fn arbitrary_schema_and_requests(
+    u: &mut Unstructured<'_>,
+) -> arbitrary::Result<(Schema, [ABACRequest; 8])> {
+    let generated_schema = schema::Schema::arbitrary(ABACSettings::undirected(), u)?;
+    let hierarchy = generated_schema.arbitrary_hierarchy(u)?;
+    let requests = [
+        generated_schema.arbitrary_request(&hierarchy, u)?,
+        generated_schema.arbitrary_request(&hierarchy, u)?,
+        generated_schema.arbitrary_request(&hierarchy, u)?,
+        generated_schema.arbitrary_request(&hierarchy, u)?,
+        generated_schema.arbitrary_request(&hierarchy, u)?,
+        generated_schema.arbitrary_request(&hierarchy, u)?,
+        generated_schema.arbitrary_request(&hierarchy, u)?,
+        generated_schema.arbitrary_request(&hierarchy, u)?,
+    ];
+    let schema =
+        Schema::try_from(generated_schema).map_err(|_| arbitrary::Error::IncorrectFormat)?;
+    Ok((schema, requests))
+}
+
+/// Size hint for the inputs of [`arbitrary_schema_and_entities`].
+pub fn schema_and_entities_size_hint(
+    depth: usize,
+) -> arbitrary::Result<(usize, Option<usize>), arbitrary::MaxRecursionReached> {
+    Ok(arbitrary::size_hint::and_all(&[
+        schema::Schema::arbitrary_size_hint(depth)?,
+        HierarchyGenerator::size_hint(depth),
+    ]))
+}
+
+/// Size hint for the inputs of [`arbitrary_schema_and_requests`].
+pub fn schema_and_requests_size_hint(
+    depth: usize,
+) -> arbitrary::Result<(usize, Option<usize>), arbitrary::MaxRecursionReached> {
+    Ok(arbitrary::size_hint::and_all(&[
+        schema_and_entities_size_hint(depth)?,
+        schema::Schema::arbitrary_request_size_hint(depth),
+        schema::Schema::arbitrary_request_size_hint(depth),
+        schema::Schema::arbitrary_request_size_hint(depth),
+        schema::Schema::arbitrary_request_size_hint(depth),
+        schema::Schema::arbitrary_request_size_hint(depth),
+        schema::Schema::arbitrary_request_size_hint(depth),
+        schema::Schema::arbitrary_request_size_hint(depth),
+        schema::Schema::arbitrary_request_size_hint(depth),
+    ]))
+}
+
+fn to_restricted_exprs<'a>(
+    pairs: impl Iterator<Item = (&'a SmolStr, &'a ast::PartialValue)>,
+) -> BTreeMap<SmolStr, RestrictedExpression> {
+    pairs
+        .map(|(k, v)| {
+            (
+                k.clone(),
+                ast::RestrictedExpr::from(Value::try_from(v.clone()).unwrap()).into(),
+            )
+        })
+        .collect()
+}
+
+/// Builds a partial entity whose uid and ancestors come from `entity` and whose attributes
+/// and tags come from `attrs_from`, which must have the same entity type as `entity`.
 fn entity_to_partial_entity(
     entity: &Entity,
+    attrs_from: &Entity,
     u: &mut Unstructured<'_>,
     leafs: &HashSet<EntityUid>,
     schema: &Schema,
@@ -51,24 +136,11 @@ fn entity_to_partial_entity(
         if !is_action && u.ratio(1, 4)? {
             None
         } else {
-            Some(BTreeMap::from_iter(entity.as_ref().attrs().map(
-                |(k, v)| {
-                    (
-                        k.clone(),
-                        ast::RestrictedExpr::from(Value::try_from(v.clone()).unwrap()).into(),
-                    )
-                },
-            )))
+            Some(to_restricted_exprs(attrs_from.as_ref().attrs()))
         },
         // We can only mark ancestors of leaf nodes to unknown
-        if !is_action && leafs.contains(&entity.uid()) {
-            if u.ratio(1, 4)? {
-                None
-            } else {
-                Some(HashSet::from_iter(
-                    entity.as_ref().ancestors().cloned().map(Into::into),
-                ))
-            }
+        if !is_action && leafs.contains(&entity.uid()) && u.ratio(1, 4)? {
+            None
         } else {
             Some(HashSet::from_iter(
                 entity.as_ref().ancestors().cloned().map(Into::into),
@@ -77,23 +149,46 @@ fn entity_to_partial_entity(
         if !is_action && u.ratio(1, 4)? {
             None
         } else {
-            Some(BTreeMap::from_iter(entity.as_ref().tags().map(|(k, v)| {
-                (
-                    k.clone(),
-                    ast::RestrictedExpr::from(Value::try_from(v.clone()).unwrap()).into(),
-                )
-            })))
+            Some(to_restricted_exprs(attrs_from.as_ref().tags()))
         },
         schema,
     )
     .map_err(|_| arbitrary::Error::IncorrectFormat)
 }
 
+// Reorders `sorted` so that each entity might be associated with another entity of the same type to
+// take its attributes from. This functions doesn't actually change the attributes. That's done when
+// building the final partial entity.
+fn shuffle_within_entity_types<'a>(
+    sorted: &[&'a Entity],
+    u: &mut Unstructured<'_>,
+) -> arbitrary::Result<Vec<&'a Entity>> {
+    sorted
+        .iter()
+        .enumerate()
+        .map(|(i, e)| {
+            if u.ratio(1, 2)? {
+                Ok(*e)
+            } else {
+                Ok(sorted
+                    .get(i + 1)
+                    .filter(|next| next.uid().type_name() == e.uid().type_name())
+                    .copied()
+                    .unwrap_or(*e))
+            }
+        })
+        .collect()
+}
+
 /// Constructs a `PartialEntities` given some concrete entities, using `u` to
 /// arbitrarily choose some data to delete, making it unknown in subsequent
 /// partial evaluation.
+///
+/// When `shuffle_attrs` is set each resulting partial entity may take its attributes from a different
+/// entity of the same type. This way the entities are valid, but aren't consistent.
 pub fn entities_to_partial_entities<'a>(
     entities: impl Iterator<Item = &'a Entity>,
+    shuffle_attrs: bool,
     u: &mut Unstructured<'_>,
     schema: &Schema,
 ) -> arbitrary::Result<PartialEntities> {
@@ -104,14 +199,23 @@ pub fn entities_to_partial_entities<'a>(
             leafs.remove(RefCast::ref_cast(a));
         }
     }
-    PartialEntities::from_partial_entities(
+    let partial_entities = if shuffle_attrs {
+        // Sort for determinism: `HashSet` iteration order is unspecified
+        let mut sorted: Vec<&Entity> = entities.iter().collect();
+        sorted.sort_by_cached_key(|e| e.uid().to_string());
+        sorted
+            .iter()
+            .zip(shuffle_within_entity_types(&sorted, u)?)
+            .map(|(e, attrs_from)| entity_to_partial_entity(e, attrs_from, u, &leafs, schema))
+            .collect::<arbitrary::Result<Vec<PartialEntity>>>()?
+    } else {
         entities
             .iter()
-            .map(|e| entity_to_partial_entity(e, u, &leafs, schema))
-            .collect::<arbitrary::Result<Vec<PartialEntity>>>()?,
-        schema,
-    )
-    .map_err(|_| arbitrary::Error::IncorrectFormat)
+            .map(|e| entity_to_partial_entity(e, e, u, &leafs, schema))
+            .collect::<arbitrary::Result<Vec<PartialEntity>>>()?
+    };
+    PartialEntities::from_partial_entities(partial_entities, schema)
+        .map_err(|_| arbitrary::Error::IncorrectFormat)
 }
 
 /// Input for TPE fuzz targets: an ABAC hierarchy, schema, and 8 associated partial requests.
@@ -122,6 +226,76 @@ pub struct TpeFuzzTargetInput {
     pub partial_entities: PartialEntities,
 }
 
+fn maybe_eid(
+    uid: &ast::EntityUID,
+    u: &mut Unstructured<'_>,
+) -> arbitrary::Result<PartialEntityUid> {
+    Ok(PartialEntityUid::new(
+        uid.entity_type().clone().into(),
+        if u.ratio(1, 4)? {
+            None
+        } else {
+            Some(EntityId::new(uid.eid()))
+        },
+    ))
+}
+
+/// Constructs a partial request that is not validated against any schema, taking the principal
+/// and resource from `req` but the action and context from `action_from`. Mixing two requests
+/// yields requests whose principal and resource types don't apply to the action, or whose
+/// context doesn't match it.
+pub fn make_unchecked_partial_request(
+    req: &ABACRequest,
+    action_from: &ABACRequest,
+    u: &mut Unstructured<'_>,
+) -> arbitrary::Result<UncheckedPartialRequest> {
+    let ast::Context::Value(context) = &action_from.context else {
+        // generated requests always have concrete contexts
+        return Err(arbitrary::Error::IncorrectFormat);
+    };
+    Ok(UncheckedPartialRequest {
+        principal: maybe_eid(&req.principal, u)?,
+        action: action_from.action.clone().into(),
+        resource: maybe_eid(&req.resource, u)?,
+        context: if u.ratio(1, 4)? {
+            None
+        } else {
+            Some(
+                context
+                    .iter()
+                    .map(|(k, v)| (k.clone(), ast::RestrictedExpr::from(v.clone()).into()))
+                    .collect(),
+            )
+        },
+    })
+}
+
+pub fn entity_to_unchecked_partial_entity(
+    entity: &Entity,
+    u: &mut Unstructured<'_>,
+) -> arbitrary::Result<UncheckedPartialEntity> {
+    Ok(UncheckedPartialEntity {
+        uid: entity.uid(),
+        attrs: if u.ratio(1, 4)? {
+            None
+        } else {
+            Some(to_restricted_exprs(entity.as_ref().attrs()))
+        },
+        ancestors: if u.ratio(1, 4)? {
+            None
+        } else {
+            Some(HashSet::from_iter(
+                entity.as_ref().ancestors().cloned().map(Into::into),
+            ))
+        },
+        tags: if u.ratio(1, 4)? {
+            None
+        } else {
+            Some(to_restricted_exprs(entity.as_ref().tags()))
+        },
+    })
+}
+
 /// Construct a partial request from a concrete request, randomly dropping eids.
 pub fn make_partial_request(
     req: &ABACRequest,
@@ -129,23 +303,9 @@ pub fn make_partial_request(
     schema: &Schema,
 ) -> arbitrary::Result<PartialRequest> {
     PartialRequest::new(
-        PartialEntityUid::new(
-            req.principal.entity_type().clone().into(),
-            if u.ratio(1, 4)? {
-                None
-            } else {
-                Some(EntityId::new(req.principal.eid()))
-            },
-        ),
+        maybe_eid(&req.principal, u)?,
         req.action.clone().into(),
-        PartialEntityUid::new(
-            req.resource.entity_type().clone().into(),
-            if u.ratio(1, 4)? {
-                None
-            } else {
-                Some(EntityId::new(req.resource.eid()))
-            },
-        ),
+        maybe_eid(&req.resource, u)?,
         None,
         schema,
     )
@@ -168,7 +328,7 @@ impl<'a> Arbitrary<'a> for TpeFuzzTargetInput {
             .try_into()
             .unwrap();
         let partial_entities =
-            entities_to_partial_entities(abac_input.entities.iter(), u, &schema)?;
+            entities_to_partial_entities(abac_input.entities.iter(), false, u, &schema)?;
         Ok(Self {
             abac_input,
             partial_requests,
@@ -417,4 +577,121 @@ pub fn test_tpe_is_authorized_equiv(
             lean_rp.id,
         );
     }
+}
+
+/// Panics unless Lean agrees with `rust_passed`. `detail` is only formatted on failure.
+fn assert_lean_agrees(
+    check: &str,
+    rust_passed: bool,
+    lean: &ValidationResponse,
+    detail: impl FnOnce() -> String,
+) {
+    assert_eq!(
+        rust_passed,
+        lean == &ValidationResponse::Ok(()),
+        "{check} mismatch\nLean: {lean:?}\n{}",
+        detail()
+    );
+}
+
+/// Check that Rust and Lean agree on whether `entities` are valid for `schema`.
+pub fn test_partial_entity_validation_equiv(
+    ffi: &CedarLeanFfi,
+    schema: &Schema,
+    lean_schema: LeanSchema,
+    entities: &[UncheckedPartialEntity],
+) {
+    // `PartialEntity::new` validates; unlike `PartialEntities::from_partial_entities` it
+    // does not additionally compute the transitive closure, which Lean does not model.
+    let rust_err = entities.iter().find_map(|e| {
+        PartialEntity::new(
+            e.uid.clone(),
+            e.attrs.clone(),
+            e.ancestors.clone(),
+            e.tags.clone(),
+            schema,
+        )
+        .err()
+    });
+    let lean_res = ffi
+        .validate_partial_entities(lean_schema, entities)
+        .expect("failed to execute partial entity validation");
+    assert_lean_agrees(
+        "partial entity validation",
+        rust_err.is_none(),
+        &lean_res,
+        || format!("Rust: {rust_err:?}\nEntities: {entities:?}"),
+    );
+}
+
+/// Check that Rust and Lean agree on whether `partial_entities` are consistent with `entities`.
+pub fn test_partial_entity_consistency_equiv(
+    ffi: &CedarLeanFfi,
+    entities: &Entities,
+    partial_entities: &PartialEntities,
+) {
+    let rust_res = partial_entities
+        .as_ref()
+        .check_consistency(entities.as_ref());
+    let lean_res = ffi
+        .check_partial_entity_consistency(entities, partial_entities)
+        .expect("failed to execute partial entity consistency check");
+    assert_lean_agrees(
+        "partial entity consistency",
+        rust_res.is_ok(),
+        &lean_res,
+        || {
+            format!(
+                "Rust: {rust_res:?}\nPartial entities: {partial_entities:?}\nEntities: {}",
+                entities.as_ref()
+            )
+        },
+    );
+}
+
+/// Check that Rust and Lean agree on whether `request` is valid for `schema`.
+pub fn test_partial_request_validation_equiv(
+    ffi: &CedarLeanFfi,
+    schema: &Schema,
+    lean_schema: LeanSchema,
+    request: &UncheckedPartialRequest,
+) {
+    let context = request.context.clone().map(|c| {
+        Context::from_pairs(c.into_iter().map(|(k, v)| (k.to_string(), v)))
+            .expect("context built from a concrete context should be valid")
+    });
+    let rust_res = PartialRequest::new(
+        request.principal.clone(),
+        request.action.clone(),
+        request.resource.clone(),
+        context,
+        schema,
+    );
+    let lean_res = ffi
+        .validate_partial_request(lean_schema, request)
+        .expect("failed to execute partial request validation");
+    assert_lean_agrees(
+        "partial request validation",
+        rust_res.is_ok(),
+        &lean_res,
+        || format!("Rust: {:?}\nRequest: {request:?}", rust_res.err()),
+    );
+}
+
+/// Check that Rust and Lean agree on whether `partial_request` is consistent with `request`.
+pub fn test_partial_request_consistency_equiv(
+    ffi: &CedarLeanFfi,
+    request: &Request,
+    partial_request: &PartialRequest,
+) {
+    let rust_res = partial_request.as_ref().check_consistency(request.as_ref());
+    let lean_res = ffi
+        .check_partial_request_consistency(request, partial_request)
+        .expect("failed to execute partial request consistency check");
+    assert_lean_agrees(
+        "partial request consistency",
+        rust_res.is_ok(),
+        &lean_res,
+        || format!("Rust: {rust_res:?}\nPartial request: {partial_request:?}\nRequest: {request}"),
+    );
 }

--- a/cedar-lean-ffi/protobuf_schema/Messages.proto
+++ b/cedar-lean-ffi/protobuf_schema/Messages.proto
@@ -382,6 +382,24 @@ message ResidualReauthorizationRequest {
     bool expects_error = 5;
 }
 
+message PartialEntityValidationRequest {
+    PartialEntities entities = 1;
+}
+
+message PartialRequestValidationRequest {
+    PartialRequest request = 1;
+}
+
+message PartialRequestConsistencyRequest {
+    cedar_policy_core.Request request = 1;
+    PartialRequest partial_request = 2;
+}
+
+message PartialEntityConsistencyRequest {
+    cedar_policy_core.Entities entities = 1;
+    PartialEntities partial_entities = 2;
+}
+
 // Batched authorization request
 message BatchedAuthorizationRequest {
     cedar_policy_core.PolicySet policies = 1;

--- a/cedar-lean-ffi/src/lean_ffi.rs
+++ b/cedar-lean-ffi/src/lean_ffi.rs
@@ -282,6 +282,14 @@ unsafe extern "C" {
     fn isAuthorizedPartial(req: *mut lean_object) -> *mut lean_object;
 
     fn reauthorizeResidual(req: *mut lean_object) -> *mut lean_object;
+    fn validatePartialEntities(schema: *mut lean_object, req: *mut lean_object)
+    -> *mut lean_object;
+
+    fn checkPartialEntityConsistency(req: *mut lean_object) -> *mut lean_object;
+
+    fn validatePartialRequest(schema: *mut lean_object, req: *mut lean_object) -> *mut lean_object;
+
+    fn checkPartialRequestConsistency(req: *mut lean_object) -> *mut lean_object;
 
     fn initialize_Cedar_CedarFFI(builtin: u8, ob: *mut lean_object) -> *mut lean_object;
 

--- a/cedar-lean-ffi/src/lean_ffi/tpe.rs
+++ b/cedar-lean-ffi/src/lean_ffi/tpe.rs
@@ -14,13 +14,20 @@
  * limitations under the License.
  */
 
-use crate::datatypes::{self as datatypes, ResultDef, TimedDef, TimedResult, TpeResponseInner};
+use crate::datatypes::{
+    self as datatypes, ResultDef, TimedDef, TimedResult, TpeResponseInner, ValidationResponse,
+};
 use crate::err::FfiError;
 use crate::messages::proto;
+use crate::messages::tpe::{UncheckedPartialEntity, UncheckedPartialRequest};
 
 use cedar_policy::{Entities, PartialEntities, PartialRequest, PolicySet, Request, Schema};
 
-use super::{CedarLeanFfi, call_lean_ffi_takes_protobuf, isAuthorizedPartial, reauthorizeResidual};
+use super::{
+    CedarLeanFfi, LeanSchema, call_lean_ffi_takes_obj_and_protobuf, call_lean_ffi_takes_protobuf,
+    checkPartialEntityConsistency, checkPartialRequestConsistency, isAuthorizedPartial,
+    reauthorizeResidual, validatePartialEntities, validatePartialRequest,
+};
 
 impl CedarLeanFfi {
     /// Calls the Lean backend and performs type-aware partial evaluation of the partial request,
@@ -93,6 +100,80 @@ impl CedarLeanFfi {
             .is_authorized_partial_timed(policies, request, entities, schema)?
             .take_result())
     }
+
+    /// Calls the Lean backend to validate partial entities against the provided schema
+    pub fn validate_partial_entities(
+        &self,
+        schema: LeanSchema,
+        entities: &[UncheckedPartialEntity],
+    ) -> Result<ValidationResponse, FfiError> {
+        let response = unsafe {
+            call_lean_ffi_takes_obj_and_protobuf(
+                validatePartialEntities,
+                schema.0,
+                &proto::PartialEntityValidationRequest::new(entities),
+            )
+        };
+        match response.as_borrowed().deserialize_into()? {
+            ResultDef::Ok(res) => Ok(TimedResult::from_def(res).take_result()),
+            ResultDef::Error(s) => Err(FfiError::LeanBackendError(s)),
+        }
+    }
+
+    /// Calls the Lean backend to check that `partial_entities` are consistent with `entities`.
+    pub fn check_partial_entity_consistency(
+        &self,
+        entities: &Entities,
+        partial_entities: &PartialEntities,
+    ) -> Result<ValidationResponse, FfiError> {
+        let response = unsafe {
+            call_lean_ffi_takes_protobuf(
+                checkPartialEntityConsistency,
+                &proto::PartialEntityConsistencyRequest::new(entities, partial_entities),
+            )
+        };
+        match response.as_borrowed().deserialize_into()? {
+            ResultDef::Ok(res) => Ok(TimedResult::from_def(res).take_result()),
+            ResultDef::Error(s) => Err(FfiError::LeanBackendError(s)),
+        }
+    }
+
+    /// Calls the Lean backend to validate a partial request against the provided schema.
+    pub fn validate_partial_request(
+        &self,
+        schema: LeanSchema,
+        request: &UncheckedPartialRequest,
+    ) -> Result<ValidationResponse, FfiError> {
+        let response = unsafe {
+            call_lean_ffi_takes_obj_and_protobuf(
+                validatePartialRequest,
+                schema.0,
+                &proto::PartialRequestValidationRequest::new(request),
+            )
+        };
+        match response.as_borrowed().deserialize_into()? {
+            ResultDef::Ok(res) => Ok(TimedResult::from_def(res).take_result()),
+            ResultDef::Error(s) => Err(FfiError::LeanBackendError(s)),
+        }
+    }
+
+    /// Calls the Lean backend to check that `partial_request` is consistent with `request`.
+    pub fn check_partial_request_consistency(
+        &self,
+        request: &Request,
+        partial_request: &PartialRequest,
+    ) -> Result<ValidationResponse, FfiError> {
+        let response = unsafe {
+            call_lean_ffi_takes_protobuf(
+                checkPartialRequestConsistency,
+                &proto::PartialRequestConsistencyRequest::new(request, partial_request),
+            )
+        };
+        match response.as_borrowed().deserialize_into()? {
+            ResultDef::Ok(res) => Ok(TimedResult::from_def(res).take_result()),
+            ResultDef::Error(s) => Err(FfiError::LeanBackendError(s)),
+        }
+    }
 }
 
 #[cfg(test)]
@@ -108,14 +189,18 @@ mod test {
     unsafe extern "C" {}
 
     use cedar_policy::{
-        Context, EntityTypeName, EntityUid, PartialEntities, PartialEntity, PartialEntityUid,
-        PartialRequest, Policy, PolicyId, PolicySet, RestrictedExpression, Schema,
+        Context, Entities, EntityTypeName, EntityUid, PartialEntities, PartialEntity,
+        PartialEntityUid, PartialRequest, Policy, PolicyId, PolicySet, RestrictedExpression,
+        Schema,
     };
+    use cool_asserts::assert_matches;
 
     use std::collections::{BTreeMap, HashMap, HashSet};
     use std::str::FromStr;
 
-    use crate::CedarLeanFfi;
+    use crate::{
+        CedarLeanFfi, UncheckedPartialEntity, UncheckedPartialRequest, ValidationResponse,
+    };
     use cedar_policy_core::ast::{EntityUID, Value, Var};
     use cedar_policy_core::tpe::residual::{Residual, ResidualKind};
     use cedar_policy_core::validator::types::{EntityKind, EntityLUB, Type};
@@ -788,6 +873,154 @@ mod test {
         assert_eq!(lean_resp.decision, None);
         // 4 policies → 4 residuals
         assert_eq!(lean_resp.residuals.len(), 4);
+    }
+
+    #[test]
+    fn test_validate_partial_entities() {
+        let schema = tpe_schema();
+        let user = UncheckedPartialEntity {
+            uid: EntityUid::from_str(r#"User::"alice""#).unwrap(),
+            attrs: Some(BTreeMap::from([
+                (
+                    "name".into(),
+                    RestrictedExpression::new_string("Alice".into()),
+                ),
+                ("age".into(), RestrictedExpression::new_long(30)),
+            ])),
+            ancestors: None,
+            tags: None,
+        };
+
+        let ffi = CedarLeanFfi::new();
+        let lean_schema = ffi.load_lean_schema_object(&schema).unwrap();
+        assert_eq!(
+            ffi.validate_partial_entities(lean_schema.clone(), std::slice::from_ref(&user))
+                .expect("Lean FFI call failed"),
+            ValidationResponse::Ok(())
+        );
+
+        let ill_typed = UncheckedPartialEntity {
+            attrs: Some(BTreeMap::from([
+                (
+                    "name".into(),
+                    RestrictedExpression::new_string("Alice".into()),
+                ),
+                ("age".into(), RestrictedExpression::new_string("30".into())),
+            ])),
+            ..user
+        };
+        assert_matches!(
+            ffi.validate_partial_entities(lean_schema, &[ill_typed])
+                .expect("Lean FFI call failed"),
+            ValidationResponse::Error(_)
+        );
+    }
+
+    #[test]
+    fn test_check_partial_entity_consistency() {
+        let schema = tpe_schema();
+        let concrete = |age| {
+            Entities::from_json_value(
+                serde_json::json!([
+                    {"uid": {"type": "User", "id": "alice"}, "attrs": {"name": "Alice", "age": age}, "parents": []},
+                    {"uid": {"type": "Action", "id": "transfer"}, "attrs": {}, "parents": []},
+                ]),
+                Some(&schema),
+            )
+            .expect("entities should conform to the schema")
+        };
+        let entities = concrete(30);
+        let partial = PartialEntities::from_concrete(entities.clone(), &schema)
+            .expect("from_concrete should succeed on valid entities");
+        let ffi = CedarLeanFfi::new();
+        assert_eq!(
+            ffi.check_partial_entity_consistency(&entities, &partial)
+                .expect("Lean FFI call failed"),
+            ValidationResponse::Ok(())
+        );
+        assert_matches!(
+            ffi.check_partial_entity_consistency(&concrete(31), &partial)
+                .expect("Lean FFI call failed"),
+            ValidationResponse::Error(_)
+        );
+        assert_matches!(
+            ffi.check_partial_entity_consistency(&Entities::empty(), &partial)
+                .expect("Lean FFI call failed"),
+            ValidationResponse::Error(_)
+        );
+    }
+
+    #[test]
+    fn test_validate_partial_request() {
+        let schema = tpe_schema();
+        let ffi = CedarLeanFfi::new();
+        let lean_schema = ffi.load_lean_schema_object(&schema).unwrap();
+        let valid = UncheckedPartialRequest {
+            principal: PartialEntityUid::new(EntityTypeName::from_str("User").unwrap(), None),
+            action: EntityUid::from_str(r#"Action::"transfer""#).unwrap(),
+            resource: PartialEntityUid::new(EntityTypeName::from_str("Account").unwrap(), None),
+            context: None,
+        };
+        assert_eq!(
+            ffi.validate_partial_request(lean_schema.clone(), &valid)
+                .expect("Lean FFI call failed"),
+            ValidationResponse::Ok(())
+        );
+
+        // `transfer` does not apply to a `User` resource
+        let bad_resource = UncheckedPartialRequest {
+            resource: PartialEntityUid::new(EntityTypeName::from_str("User").unwrap(), None),
+            ..valid
+        };
+        assert_matches!(
+            ffi.validate_partial_request(lean_schema, &bad_resource)
+                .expect("Lean FFI call failed"),
+            ValidationResponse::Error(_)
+        );
+    }
+
+    #[test]
+    fn test_check_partial_request_consistency() {
+        let schema = tpe_schema();
+        let ffi = CedarLeanFfi::new();
+        let action = EntityUid::from_str(r#"Action::"transfer""#).unwrap();
+        let request = cedar_policy::Request::new(
+            EntityUid::from_str(r#"User::"alice""#).unwrap(),
+            action.clone(),
+            EntityUid::from_str(r#"Account::"checking""#).unwrap(),
+            Context::from_pairs([
+                ("amount".into(), RestrictedExpression::new_long(1)),
+                (
+                    "memo".into(),
+                    RestrictedExpression::new_string("rent".into()),
+                ),
+            ])
+            .unwrap(),
+            Some(&schema),
+        )
+        .expect("request should conform to the schema");
+        // the principal eid is unknown, so any `User` principal is consistent
+        let partial = |resource: &str| {
+            PartialRequest::new(
+                PartialEntityUid::new(EntityTypeName::from_str("User").unwrap(), None),
+                action.clone(),
+                PartialEntityUid::from_concrete(EntityUid::from_str(resource).unwrap()),
+                None,
+                &schema,
+            )
+            .unwrap()
+        };
+        assert_eq!(
+            ffi.check_partial_request_consistency(&request, &partial(r#"Account::"checking""#))
+                .expect("Lean FFI call failed"),
+            ValidationResponse::Ok(())
+        );
+        // a known resource eid must match
+        assert_matches!(
+            ffi.check_partial_request_consistency(&request, &partial(r#"Account::"savings""#))
+                .expect("Lean FFI call failed"),
+            ValidationResponse::Error(_)
+        );
     }
 
     /// Regression: enum entity type with `principal is a` scope and unknown principal eid.

--- a/cedar-lean-ffi/src/lib.rs
+++ b/cedar-lean-ffi/src/lib.rs
@@ -28,3 +28,4 @@ pub use datatypes::{
 };
 pub use err::FfiError;
 pub use lean_ffi::{CedarLeanFfi, LeanSchema};
+pub use messages::tpe::{UncheckedPartialEntity, UncheckedPartialRequest};

--- a/cedar-lean-ffi/src/messages.rs
+++ b/cedar-lean-ffi/src/messages.rs
@@ -231,7 +231,12 @@ impl proto::RequestValidationRequest {
 }
 
 pub mod tpe {
-    use cedar_policy::{Entities, PartialEntities, PartialRequest, PolicySet, Request, Schema};
+    use cedar_policy::{
+        Entities, EntityUid, PartialEntities, PartialEntityUid, PartialRequest, PolicySet, Request,
+        RestrictedExpression, Schema, proto::models as cedar_proto,
+    };
+    use smol_str::SmolStr;
+    use std::collections::{BTreeMap, HashMap, HashSet};
 
     use super::proto;
 
@@ -485,6 +490,115 @@ pub mod tpe {
                 has_attrs,
                 has_ancestors,
                 has_tags,
+            }
+        }
+    }
+
+    /// A partial entity that has not been validated against any schema.
+    ///
+    /// All constructors of `PartialEntity` (for both the core and public types) enforce validation,
+    /// so they cannot be used to build an invalid entity to send to Lean.
+    #[derive(Debug, Clone)]
+    pub struct UncheckedPartialEntity {
+        pub uid: EntityUid,
+        pub attrs: Option<BTreeMap<SmolStr, RestrictedExpression>>,
+        pub ancestors: Option<HashSet<EntityUid>>,
+        pub tags: Option<BTreeMap<SmolStr, RestrictedExpression>>,
+    }
+
+    /// A partial request that has not been validated against any schema.
+    #[derive(Debug, Clone)]
+    pub struct UncheckedPartialRequest {
+        pub principal: PartialEntityUid,
+        pub action: EntityUid,
+        pub resource: PartialEntityUid,
+        pub context: Option<BTreeMap<SmolStr, RestrictedExpression>>,
+    }
+
+    fn to_proto_exprs(
+        m: &Option<BTreeMap<SmolStr, RestrictedExpression>>,
+    ) -> HashMap<String, cedar_proto::Expr> {
+        m.iter()
+            .flatten()
+            .map(|(k, v)| {
+                let e = cedar_policy_core::ast::Expr::from(v.as_ref().clone());
+                (k.to_string(), cedar_proto::Expr::from(&e))
+            })
+            .collect()
+    }
+
+    impl proto::PartialEntity {
+        fn from_unchecked(entity: &UncheckedPartialEntity) -> Self {
+            Self {
+                uid: Some(cedar_proto::EntityUid::from(entity.uid.as_ref())),
+                has_attrs: entity.attrs.is_some(),
+                attrs: to_proto_exprs(&entity.attrs),
+                has_ancestors: entity.ancestors.is_some(),
+                ancestors: entity
+                    .ancestors
+                    .iter()
+                    .flatten()
+                    .map(|uid| cedar_proto::EntityUid::from(uid.as_ref()))
+                    .collect(),
+                has_tags: entity.tags.is_some(),
+                tags: to_proto_exprs(&entity.tags),
+            }
+        }
+    }
+
+    impl proto::PartialRequest {
+        fn from_unchecked(req: &UncheckedPartialRequest) -> Self {
+            Self {
+                principal: Some(proto::PartialEntityUid::from_inner(req.principal.as_ref())),
+                action: Some(cedar_proto::EntityUid::from(req.action.as_ref())),
+                resource: Some(proto::PartialEntityUid::from_inner(req.resource.as_ref())),
+                has_context: req.context.is_some(),
+                context: to_proto_exprs(&req.context),
+            }
+        }
+    }
+
+    /// Serialize a partial entity validation request
+    impl proto::PartialEntityValidationRequest {
+        pub(crate) fn new(entities: &[UncheckedPartialEntity]) -> Self {
+            Self {
+                entities: Some(proto::PartialEntities {
+                    entities: entities
+                        .iter()
+                        .map(proto::PartialEntity::from_unchecked)
+                        .collect(),
+                }),
+            }
+        }
+    }
+
+    /// Serialize a partial entity consistency request
+    impl proto::PartialEntityConsistencyRequest {
+        pub(crate) fn new(entities: &Entities, partial_entities: &PartialEntities) -> Self {
+            Self {
+                entities: Some(cedar_proto::Entities::from(entities)),
+                partial_entities: Some(proto::PartialEntities::from_inner(
+                    partial_entities.as_ref(),
+                )),
+            }
+        }
+    }
+
+    /// Serialize a partial request validation request
+    impl proto::PartialRequestValidationRequest {
+        pub(crate) fn new(request: &UncheckedPartialRequest) -> Self {
+            Self {
+                request: Some(proto::PartialRequest::from_unchecked(request)),
+            }
+        }
+    }
+
+    /// Serialize a partial request consistency request
+    impl proto::PartialRequestConsistencyRequest {
+        pub(crate) fn new(request: &Request, partial_request: &PartialRequest) -> Self {
+            Self {
+                request: Some(cedar_proto::Request::from(request)),
+                partial_request: Some(proto::PartialRequest::from_inner(partial_request.as_ref())),
             }
         }
     }

--- a/cedar-lean/Cedar/TPE/Input.lean
+++ b/cedar-lean/Cedar/TPE/Input.lean
@@ -91,6 +91,16 @@ def requestIsValid (env : TypeEnv) (req : PartialRequest) : Bool :=
   (partialIsValid req.context λ m =>
     instanceOfType (.record m) (.record env.reqty.context) env)
 
+/--`requestIsValid` using a schema instead of a `TypeEnv`. The request's principal, action, and
+resource must identify a request environment in the schema, and the request must be valid in it.-/
+def validatePartialRequest (schema : Schema) (req : PartialRequest) : RequestValidationResult :=
+  match schema.environment? req.principal.ty req.resource.ty req.action with
+  | .some env =>
+    if requestIsValid env req
+    then .ok ()
+    else .error (.typeError "partial request is inconsistent with the type store")
+  | .none => .error (.typeError "partial request does not match any environment")
+
 def entitiesIsValid (env : TypeEnv) (es : PartialEntities) : Bool :=
   (es.toList.all entityIsValid) && (env.acts.toList.all instanceOfActionSchema)
 where
@@ -126,6 +136,25 @@ where
 def requestAndEntitiesIsValid (env : TypeEnv) (req : PartialRequest) (es : PartialEntities) : Bool :=
   requestIsValid env req && entitiesIsValid env es
 
+/-- Every known component of `req₂` agrees with `req₁`. -/
+def requestIsConsistent (req₁ : Request) (req₂ : PartialRequest) : Bool :=
+  let ⟨p₁, a₁, r₁, c₁⟩ := req₁
+  let ⟨p₂, a₂, r₂, c₂⟩ := req₂
+  partialIsValid p₂.asEntityUID (· = p₁) &&
+  a₁ = a₂ &&
+  partialIsValid r₂.asEntityUID (· = r₁) &&
+  partialIsValid c₂ (· = c₁)
+
+/-- Every entity of `es₂` is in `es₁`, and every known component of it agrees with `es₁`. -/
+def entitiesIsConsistent (es₁ : Entities) (es₂ : PartialEntities) : Bool :=
+  es₂.toList.all λ (a₂, e₂) => match es₁.find? a₂ with
+    | .some e₁ =>
+      let ⟨attrs₁, ancestors₁, tags₁⟩ := e₁
+      partialIsValid e₂.attrs (· = attrs₁) &&
+      partialIsValid e₂.ancestors (· = ancestors₁) &&
+      partialIsValid e₂.tags (· = tags₁)
+    | .none => false
+
 inductive ConcretizationError
   | typeError
   | requestsDoNotMatch
@@ -134,41 +163,28 @@ inductive ConcretizationError
 
 def isValidAndConsistent (schema : Schema) (req₁ : Request) (es₁ : Entities) (req₂ : PartialRequest) (es₂ : PartialEntities) : Except ConcretizationError Unit :=
   match schema.environment? req₂.principal.ty req₂.resource.ty req₂.action with
-  | .some env => do requestIsConsistent env; entitiesIsConsistent env; envIsWellFormed env
+  | .some env => do requestIsValidAndConsistent env; entitiesIsValidAndConsistent env; envIsWellFormed env
   | .none => .error .invalidEnvironment
 where
-  requestIsConsistent env :=
+  requestIsValidAndConsistent env :=
   if !requestIsValid env req₂ || !requestMatchesEnvironment env req₁
   then
     .error .typeError
   else
-    let ⟨p₁, a₁, r₁, c₁⟩ := req₁
-    let ⟨p₂, a₂, r₂, c₂⟩ := req₂
-    if partialIsValid p₂.asEntityUID (· = p₁) &&
-      a₁ = a₂ &&
-      partialIsValid r₂.asEntityUID (· = r₁) &&
-      partialIsValid c₂ (· = c₁)
+    if requestIsConsistent req₁ req₂
     then
       .ok ()
     else
       .error .requestsDoNotMatch
-  entitiesIsConsistent env : Except ConcretizationError Unit :=
+  entitiesIsValidAndConsistent env : Except ConcretizationError Unit :=
     if !entitiesIsValid env es₂ || !(entitiesMatchEnvironment env es₁).isOk
     then
       .error .typeError
     else
-      if entitiesMatch then
+      if entitiesIsConsistent es₁ es₂ then
         .ok ()
       else
         .error .entitiesDoNotMatch
-  entitiesMatch :=
-      es₂.toList.all λ (a₂, e₂) => match es₁.find? a₂ with
-        | .some e₁ =>
-          let ⟨attrs₁, ancestors₁, tags₁⟩ := e₁
-          partialIsValid e₂.attrs (· = attrs₁) &&
-          partialIsValid e₂.ancestors (· = ancestors₁) &&
-          partialIsValid e₂.tags (· = tags₁)
-        | .none => false
   envIsWellFormed env : Except ConcretizationError Unit :=
     if !env.validateWellFormed.isOk
     then

--- a/cedar-lean/Cedar/Thm/TPE/Authorizer.lean
+++ b/cedar-lean/Cedar/Thm/TPE/Authorizer.lean
@@ -60,11 +60,11 @@ theorem isValidAndConsistent_env
   rename_i env heq
   exists env; refine ⟨heq, ?_⟩
   rcases do_eq_ok₂ h_valid with ⟨h₁, h₂⟩
-  simp only [isValidAndConsistent.requestIsConsistent, Bool.or_eq_true, Bool.not_eq_eq_eq_not,
-    Bool.not_true, Bool.and_eq_true, decide_eq_true_eq] at h₁
+  simp only [isValidAndConsistent.requestIsValidAndConsistent, Bool.or_eq_true,
+    Bool.not_eq_eq_eq_not, Bool.not_true] at h₁
   split at h₁ <;> try cases h₁
   rename_i h_guard; simp only [not_or, Bool.not_eq_false] at h_guard
-  simp only [isValidAndConsistent.entitiesIsConsistent, Bool.or_eq_true, Bool.not_eq_eq_eq_not,
+  simp only [isValidAndConsistent.entitiesIsValidAndConsistent, Bool.or_eq_true, Bool.not_eq_eq_eq_not,
     Bool.not_true] at h₂
   split at h₂ <;> try cases h₂
   rename_i heq₄; simp only [not_or, Bool.not_eq_false] at heq₄

--- a/cedar-lean/Cedar/Thm/TPE/Input.lean
+++ b/cedar-lean/Cedar/Thm/TPE/Input.lean
@@ -93,7 +93,8 @@ theorem consistent_checks_ensure_refinement {schema : Schema} {req : Request} {e
   case _ =>
     simp only [RequestRefines]
     simp only [
-      isValidAndConsistent.requestIsConsistent,
+      isValidAndConsistent.requestIsValidAndConsistent,
+      requestIsConsistent,
       Bool.or_eq_true,
       Bool.not_eq_eq_eq_not,
       Bool.not_true,
@@ -132,9 +133,9 @@ theorem consistent_checks_ensure_refinement {schema : Schema} {req : Request} {e
     split at h₂ <;> simp at h₂
     rename_i h₃
     replace h₂ := h₃
-    simp [isValidAndConsistent.entitiesIsConsistent] at h₂
+    simp [isValidAndConsistent.entitiesIsValidAndConsistent] at h₂
     split at h₂ <;> simp at h₂
-    simp [isValidAndConsistent.entitiesMatch] at h₂
+    simp [entitiesIsConsistent] at h₂
     simp [EntitiesRefine]
     intro uid data₂ hᵢ
     replace hᵢ := Data.Map.find?_mem_toList hᵢ

--- a/cedar-lean/CedarFFI/Main.lean
+++ b/cedar-lean/CedarFFI/Main.lean
@@ -879,6 +879,52 @@ def parseResidualReauthorizationRequest (req: ByteArray):
       (TPE.isAuthorized schema policies partialReq partialEnts).mapError
         (s!"TPE error: {repr ·}"))
 
+/--
+  `req`: binary protobuf for a `PartialEntityValidationRequest`
+-/
+@[export validatePartialEntities] unsafe def validatePartialEntitiesFFI (schema : Schema) (req : ByteArray) : String :=
+  runFfiM do
+    let v ← (@Proto.Message.interpret? Proto.PartialEntityValidationRequest) req |>.mapError (s!"failed to parse input: {·}")
+    runAndTime (λ () =>
+      -- entity validity does not depend on the request type
+      (if TPE.entitiesIsValid { ets := schema.ets, acts := schema.acts, reqty := default } v.entities
+       then .ok ()
+       else .error (.typeError "partial entities are inconsistent with the type store")
+       : EntityValidationResult))
+
+/--
+  `req`: binary protobuf for a `PartialEntityConsistencyRequest`
+-/
+@[export checkPartialEntityConsistency] unsafe def checkPartialEntityConsistencyFFI (req : ByteArray) : String :=
+  runFfiM do
+    let v ← (@Proto.Message.interpret? Proto.PartialEntityConsistencyRequest) req |>.mapError (s!"failed to parse input: {·}")
+    runAndTime (λ () =>
+      (if TPE.entitiesIsConsistent v.entities v.partialEntities
+       then .ok ()
+       else .error (.typeError "partial entities are inconsistent with the concrete entities")
+       : EntityValidationResult))
+
+/--
+  `req`: binary protobuf for a `PartialRequestValidationRequest`
+-/
+@[export validatePartialRequest] unsafe def validatePartialRequestFFI (schema : Schema) (req : ByteArray) : String :=
+  runFfiM do
+    let v ← (@Proto.Message.interpret? Proto.PartialRequestValidationRequest) req |>.mapError (s!"failed to parse input: {·}")
+    runAndTime (λ () =>
+      TPE.validatePartialRequest schema v.request)
+
+/--
+  `req`: binary protobuf for a `PartialRequestConsistencyRequest`
+-/
+@[export checkPartialRequestConsistency] unsafe def checkPartialRequestConsistencyFFI (req : ByteArray) : String :=
+  runFfiM do
+    let v ← (@Proto.Message.interpret? Proto.PartialRequestConsistencyRequest) req |>.mapError (s!"failed to parse input: {·}")
+    runAndTime (λ () =>
+      (if TPE.requestIsConsistent v.request v.partialRequest
+       then .ok ()
+       else .error (.typeError "partial request is inconsistent with the concrete request")
+       : RequestValidationResult))
+
 
 
 --------------------------------- FFI Test Utils ---------------------------------

--- a/cedar-lean/CedarProto/TPERequest.lean
+++ b/cedar-lean/CedarProto/TPERequest.lean
@@ -120,5 +120,82 @@ instance : Message ResidualReauthorizationRequest where
   }
 
 end ResidualReauthorizationRequest
+structure PartialEntityValidationRequest where
+  entities: TPE.PartialEntities
+deriving Inhabited
+
+namespace PartialEntityValidationRequest
+
+instance : Message PartialEntityValidationRequest where
+  parseField (t: Proto.Tag) := do
+    match t.fieldNum with
+      | 1 => parseFieldElement t entities (update entities)
+      | _ => let _ <- t.wireType.skip; pure ignore
+
+  merge x y := {
+    entities := Field.merge x.entities y.entities
+  }
+
+end PartialEntityValidationRequest
+
+structure PartialRequestValidationRequest where
+  request: TPE.PartialRequest
+deriving Inhabited
+
+namespace PartialRequestValidationRequest
+
+instance : Message PartialRequestValidationRequest where
+  parseField (t: Proto.Tag) := do
+    match t.fieldNum with
+      | 1 => parseFieldElement t request (update request)
+      | _ => let _ <- t.wireType.skip; pure ignore
+
+  merge x y := {
+    request := Field.merge x.request y.request
+  }
+
+end PartialRequestValidationRequest
+
+structure PartialRequestConsistencyRequest where
+  request: Spec.Request
+  partialRequest: TPE.PartialRequest
+deriving Inhabited
+
+namespace PartialRequestConsistencyRequest
+
+instance : Message PartialRequestConsistencyRequest where
+  parseField (t: Proto.Tag) := do
+    match t.fieldNum with
+      | 1 => parseFieldElement t request (update request)
+      | 2 => parseFieldElement t partialRequest (update partialRequest)
+      | _ => let _ <- t.wireType.skip; pure ignore
+
+  merge x y := {
+    request := Field.merge x.request y.request
+    partialRequest := Field.merge x.partialRequest y.partialRequest
+  }
+
+end PartialRequestConsistencyRequest
+
+structure PartialEntityConsistencyRequest where
+  entities: Spec.Entities
+  partialEntities: TPE.PartialEntities
+deriving Inhabited
+
+namespace PartialEntityConsistencyRequest
+
+instance : Message PartialEntityConsistencyRequest where
+  parseField (t: Proto.Tag) := do
+    match t.fieldNum with
+      | 1 => parseFieldElement t entities (update entities)
+      | 2 => parseFieldElement t partialEntities (update partialEntities)
+      | _ => let _ <- t.wireType.skip; pure ignore
+
+  merge x y := {
+    entities := Field.merge x.entities y.entities
+    partialEntities := Field.merge x.partialEntities y.partialEntities
+  }
+
+end PartialEntityConsistencyRequest
 
 end Cedar.Proto


### PR DESCRIPTION
Adds differential tests covering validation and consistency for partial requests and entities

* partial-entity-validation-drt
* partial-entity-consistency-drt
* partial-request-validation-drt
* partial-request-consistency-drt