### PR TITLE
Split consistency proof into lemmas for requests and entities

### DIFF
--- a/cedar-lean/Cedar/TPE/Evaluator.lean
+++ b/cedar-lean/Cedar/TPE/Evaluator.lean
@@ -244,9 +244,9 @@ def evaluatePolicy (schema : Schema)
   (req : PartialRequest)
   (es : PartialEntities)
   : Except Error Residual :=
-  match schema.environment? req.principal.ty req.resource.ty req.action with
-    | .some env =>
-      if requestAndEntitiesIsValid env req es
+  match validatePartialRequest schema req with
+    | .ok env =>
+      if entitiesIsValid env.schema es
       then
         do
           checkEntities schema p.toExpr|>.mapError .invalidPolicy
@@ -254,6 +254,6 @@ def evaluatePolicy (schema : Schema)
           let (te, _) ← (typeOf expr ∅ env).mapError Error.invalidPolicy
           .ok (evaluate te.liftBoolTypes.toResidual req es)
       else .error .invalidRequestOrEntities
-    | .none => .error .invalidEnvironment
+    | .error _ => .error .invalidEnvironment
 
 end Cedar.TPE

--- a/cedar-lean/Cedar/TPE/Input.lean
+++ b/cedar-lean/Cedar/TPE/Input.lean
@@ -84,47 +84,45 @@ def partialIsValid {α} (o : Option α) (f : α → Bool) : Bool :=
 
 def requestIsValid (env : TypeEnv) (req : PartialRequest) : Bool :=
   (partialIsValid req.principal.asEntityUID λ principal =>
-    instanceOfEntityType principal env.reqty.principal env) &&
+    instanceOfEntityType principal env.reqty.principal env.schema) &&
   req.action == env.reqty.action &&
   (partialIsValid req.resource.asEntityUID λ resource =>
-    instanceOfEntityType resource env.reqty.resource env) &&
+    instanceOfEntityType resource env.reqty.resource env.schema) &&
   (partialIsValid req.context λ m =>
-    instanceOfType (.record m) (.record env.reqty.context) env)
+    instanceOfType (.record m) (.record env.reqty.context) env.schema)
 
-/--`requestIsValid` using a schema instead of a `TypeEnv`. The request's principal, action, and
-resource must identify a request environment in the schema, and the request must be valid in it.-/
-def validatePartialRequest (schema : Schema) (req : PartialRequest) : RequestValidationResult :=
+def validatePartialRequest (schema : Schema) (req : PartialRequest) : Except RequestValidationError TypeEnv :=
   match schema.environment? req.principal.ty req.resource.ty req.action with
   | .some env =>
     if requestIsValid env req
-    then .ok ()
+    then .ok env
     else .error (.typeError "partial request is inconsistent with the type store")
   | .none => .error (.typeError "partial request does not match any environment")
 
-def entitiesIsValid (env : TypeEnv) (es : PartialEntities) : Bool :=
-  (es.toList.all entityIsValid) && (env.acts.toList.all instanceOfActionSchema)
+def entitiesIsValid (schema : Schema) (es : PartialEntities) : Bool :=
+  (es.toList.all entityIsValid) && (schema.acts.toList.all instanceOfActionSchema)
 where
   actionEntityIsValid uid entityData : Bool :=
-    match env.acts.find? uid with
+    match schema.acts.find? uid with
     | .some actionEntry =>
       (partialIsValid entityData.ancestors (actionEntry.ancestors == ·)) &&
-      (partialIsValid entityData.attrs (instanceOfType · (.record Map.empty) env)) &&
+      (partialIsValid entityData.attrs (instanceOfType · (.record Map.empty) schema)) &&
       (partialIsValid entityData.tags (· == Map.empty))
     | .none             => false
   entityIsValid p :=
     let (uid, entityData) := p
     let (attrs, ancestors, tags) := (entityData.attrs, entityData.ancestors, entityData.tags)
-    match env.ets.find? uid.ty with
+    match schema.ets.find? uid.ty with
     | .some entry =>
       entry.isValidEntityEID uid.eid &&
       (partialIsValid ancestors λ ancestors =>
         ancestors.all (λ ancestor =>
         entry.ancestors.contains ancestor.ty &&
-        instanceOfEntityType ancestor ancestor.ty env)) &&
-      (partialIsValid attrs (instanceOfType · (.record entry.attrs) env)) &&
+        instanceOfEntityType ancestor ancestor.ty schema)) &&
+      (partialIsValid attrs (instanceOfType · (.record entry.attrs) schema)) &&
       (partialIsValid tags λ tags =>
         match entry.tags? with
-        | .some tty => tags.values.all (instanceOfType · tty env)
+        | .some tty => tags.values.all (instanceOfType · tty schema)
         | .none     => tags == Map.empty)
     | .none => actionEntityIsValid uid entityData
   instanceOfActionSchema p :=
@@ -132,9 +130,6 @@ where
     match es.find? uid with
     | .some entry₁ => actionEntityIsValid uid entry₁
     | _            => true
-
-def requestAndEntitiesIsValid (env : TypeEnv) (req : PartialRequest) (es : PartialEntities) : Bool :=
-  requestIsValid env req && entitiesIsValid env es
 
 /-- Every known component of `req₂` agrees with `req₁`. -/
 def requestIsConsistent (req₁ : Request) (req₂ : PartialRequest) : Bool :=
@@ -162,12 +157,12 @@ inductive ConcretizationError
   | invalidEnvironment
 
 def isValidAndConsistent (schema : Schema) (req₁ : Request) (es₁ : Entities) (req₂ : PartialRequest) (es₂ : PartialEntities) : Except ConcretizationError Unit :=
-  match schema.environment? req₂.principal.ty req₂.resource.ty req₂.action with
-  | .some env => do requestIsValidAndConsistent env; entitiesIsValidAndConsistent env; envIsWellFormed env
-  | .none => .error .invalidEnvironment
+  match validatePartialRequest schema req₂ with
+  | .ok env => do requestIsValidAndConsistent env; entitiesIsValidAndConsistent env; envIsWellFormed env
+  | .error _ => .error .invalidEnvironment
 where
   requestIsValidAndConsistent env :=
-  if !requestIsValid env req₂ || !requestMatchesEnvironment env req₁
+  if !requestMatchesEnvironment env req₁
   then
     .error .typeError
   else
@@ -177,7 +172,7 @@ where
     else
       .error .requestsDoNotMatch
   entitiesIsValidAndConsistent env : Except ConcretizationError Unit :=
-    if !entitiesIsValid env es₂ || !(entitiesMatchEnvironment env es₁).isOk
+    if !entitiesIsValid env.schema es₂ || !(entitiesMatchEnvironment env es₁).isOk
     then
       .error .typeError
     else

--- a/cedar-lean/Cedar/Thm/BatchedEvaluator/Authorize.lean
+++ b/cedar-lean/Cedar/Thm/BatchedEvaluator/Authorize.lean
@@ -26,7 +26,7 @@ theorem evaluatePolicy_ok_implies_env_some {schema : Schema} {p : Policy}
   ∃ env, schema.environment? preq.principal.ty preq.resource.ty preq.action = .some env
 := by
   intro h
-  simp only [evaluatePolicy] at h
+  simp only [evaluatePolicy, validatePartialRequest] at h
   split at h <;> grind
 
 private theorem requestIsValid_asPartialRequest_eq {env : TypeEnv} {req : Request} :
@@ -42,12 +42,10 @@ theorem evaluatePolicy_ok_implies_requestMatchesEnvironment
   requestMatchesEnvironment env req
 := by
   intro h env h_env
-  simp only [evaluatePolicy, h_env] at h
-  split at h <;> try cases h
-  rename_i h_valid
-  simp only [requestAndEntitiesIsValid, Bool.and_eq_true] at h_valid
-  simp only [requestMatchesEnvironment, ← requestIsValid_asPartialRequest_eq]
-  exact h_valid.1
+  simp only [evaluatePolicy, validatePartialRequest, h_env] at h
+  by_cases h_valid : requestIsValid env req.asPartialRequest <;>
+    simp only [h_valid, Bool.false_eq_true, ↓reduceIte, reduceCtorEq] at h
+  simp only [h_valid, requestMatchesEnvironment, ← requestIsValid_asPartialRequest_eq]
 
 /--
 If `evaluatePolicy` succeeds on a concrete request, and the schema and entities
@@ -159,7 +157,9 @@ theorem evaluatePolicies_equiv_and_well_typed
   simp only [Except.map_ok, Except.ok.injEq] at h
   subst h
   refine ⟨rfl, rfl, (partial_evaluate_policy_is_sound h_ep h_schema_env h_wf h_ref).symm, ?_⟩
-  simp only [evaluatePolicy, h_schema_env, List.empty_eq] at h_ep
+  simp only [evaluatePolicy, validatePartialRequest, h_schema_env, List.empty_eq] at h_ep
+  by_cases h_valid : requestIsValid env preq <;>
+    simp only [h_valid, Bool.false_eq_true, ↓reduceIte, reduceCtorEq] at h_ep
   split at h_ep <;> try cases h_ep
   simp_do_let (Except.mapError Error.invalidPolicy (checkEntities schema p.toExpr)) as hcheck at h_ep
   simp only [do_ok_eq_ok, Prod.exists, exists_and_right] at h_ep

--- a/cedar-lean/Cedar/Thm/TPE/Authorizer.lean
+++ b/cedar-lean/Cedar/Thm/TPE/Authorizer.lean
@@ -58,14 +58,14 @@ theorem isValidAndConsistent_env
   simp only [isValidAndConsistent] at h_valid
   split at h_valid <;> try cases h_valid
   rename_i env heq
-  exists env; refine ⟨heq, ?_⟩
+  exists env; apply And.intro (validatePartialRequest_ok_environment? heq)
   rcases do_eq_ok₂ h_valid with ⟨h₁, h₂⟩
-  simp only [isValidAndConsistent.requestIsValidAndConsistent, Bool.or_eq_true,
+  simp only [isValidAndConsistent.requestIsValidAndConsistent,
     Bool.not_eq_eq_eq_not, Bool.not_true] at h₁
   split at h₁ <;> try cases h₁
-  rename_i h_guard; simp only [not_or, Bool.not_eq_false] at h_guard
-  simp only [isValidAndConsistent.entitiesIsValidAndConsistent, Bool.or_eq_true, Bool.not_eq_eq_eq_not,
-    Bool.not_true] at h₂
+  rename_i h_guard; simp only [Bool.not_eq_false] at h_guard
+  simp only [isValidAndConsistent.entitiesIsValidAndConsistent, Bool.or_eq_true,
+    Bool.not_eq_eq_eq_not, Bool.not_true] at h₂
   split at h₂ <;> try cases h₂
   rename_i heq₄; simp only [not_or, Bool.not_eq_false] at heq₄
   rcases heq₄ with ⟨_, heq₄⟩
@@ -77,7 +77,7 @@ theorem isValidAndConsistent_env
   simp only [ite_eq_right_iff, reduceCtorEq, imp_false, Bool.not_eq_false] at h₂
   simp only [Except.isOk, Except.toBool] at h₂
   split at h₂ <;> cases h₂; rename_i heq₅
-  exact instance_of_well_formed_env heq₅ h_guard.2 heq₄
+  exact instance_of_well_formed_env heq₅ h_guard heq₄
 
 theorem evaluatePolicies_residuals_equiv
   {schema : Schema}

--- a/cedar-lean/Cedar/Thm/TPE/Input.lean
+++ b/cedar-lean/Cedar/Thm/TPE/Input.lean
@@ -49,7 +49,7 @@ theorem PartialIsValid.some_inv {p : α → Prop} {x : α} :  (PartialIsValid p 
     | none heq => simp at heq
   · exact some _ rfl
 
-theorem partial_is_valid_rfl (f : α → Bool) (p : α → Prop) (o : Option α) :
+theorem partial_is_valid_rfl {f : α → Bool} {p : α → Prop} {o : Option α} :
   (∀ x, f x = true → p x) → partialIsValid o f → PartialIsValid p o
 := by
   intro h₁ h₂
@@ -79,78 +79,95 @@ def EntitiesRefine (es : Entities) (pes : PartialEntities) : Prop :=
 def RequestAndEntitiesRefine (req : Request) (es : Entities) (preq : PartialRequest) (pes : PartialEntities) : Prop :=
   RequestRefines req preq ∧ EntitiesRefine es pes
 
-/-- Requests and entities that pass `isValidAndConsistent` satisfy `RequestAndEntitiesRefine`.
--/
+theorem validatePartialRequest_ok_environment? {schema : Schema} {req : PartialRequest} {env : TypeEnv} :
+  validatePartialRequest schema req = .ok env →
+  schema.environment? req.principal.ty req.resource.ty req.action = .some env
+:= by
+  intro h
+  simp only [validatePartialRequest] at h
+  split at h
+  · rename_i env' heq
+    split at h <;> try contradiction
+    simp only [Except.ok.injEq] at h
+    simp [h, heq]
+  · contradiction
+
+theorem entitiesIsConsistent_implies_refines {es : Entities} {pes : PartialEntities} :
+  entitiesIsConsistent es pes → EntitiesRefine es pes
+:= by
+  intro h uid data₂ hᵢ
+  replace hᵢ := Data.Map.find?_mem_toList hᵢ
+  simp only [entitiesIsConsistent, List.all_eq_true, Prod.forall] at h
+  specialize h uid data₂ hᵢ
+  split at h <;> simp only [Bool.false_eq_true, Bool.and_eq_true] at h
+  rcases h with ⟨⟨h₂₁, h₂₂⟩, h₂₃⟩
+  rename_i data₁ heq
+  exists data₁
+  and_intros
+  · exact heq
+  · exact partial_is_valid_rfl decide_eq_implies_eq h₂₁
+  · exact partial_is_valid_rfl decide_eq_implies_eq h₂₂
+  · exact partial_is_valid_rfl decide_eq_implies_eq h₂₃
+
+theorem environment?_reqty {schema : Schema} {p r : EntityType} {a : EntityUID} {env : TypeEnv} :
+  schema.environment? p r a = .some env →
+  env.reqty.principal = p ∧ env.reqty.resource = r
+:= by
+  intro h
+  unfold Schema.environment? at h
+  cases h_find : schema.acts.find? a
+  · simp [h_find] at h
+  · simp only [h_find, Option.bind_some_fun] at h
+    split at h <;> try contradiction
+    simp only [Option.some.injEq] at h
+    simp [←h]
+
+theorem requestIsConsistent_implies_refines {schema : Schema} {env : TypeEnv} {req : Request} {preq : PartialRequest} :
+  schema.environment? preq.principal.ty preq.resource.ty preq.action = .some env →
+  requestMatchesEnvironment env req →
+  requestIsConsistent req preq →
+  RequestRefines req preq
+:= by
+  intro heq h_guard h₁
+  simp only [requestIsConsistent, Bool.and_eq_true, decide_eq_true_eq] at h₁
+  obtain ⟨⟨⟨h₁₁, h₁₂⟩, h₁₃⟩, h₁₄⟩ := h₁
+  have ⟨h_penv, h_renv⟩ := environment?_reqty heq
+  simp only [requestMatchesEnvironment, instanceOfRequestType, instanceOfEntityType,
+    Bool.and_eq_true, beq_iff_eq] at h_guard
+  and_intros
+  · exact partial_is_valid_rfl decide_eq_implies_eq h₁₁
+  · exact h₁₂
+  · exact partial_is_valid_rfl decide_eq_implies_eq h₁₃
+  · exact partial_is_valid_rfl decide_eq_implies_eq h₁₄
+  · simp [← h_penv, h_guard]
+  · simp [← h_renv, h_guard]
+
+/-- Requests and entities that pass `isValidAndConsistent` satisfy `RequestAndEntitiesRefine`.  -/
 theorem consistent_checks_ensure_refinement {schema : Schema} {req : Request} {es : Entities} {preq : PartialRequest} {pes : PartialEntities} :
   isValidAndConsistent schema req es preq pes = .ok () → RequestAndEntitiesRefine req es preq pes
 := by
   intro h
   simp only [isValidAndConsistent] at h
   split at h <;> try cases h
+  rename_i env heq
   rcases do_eq_ok₂ h with ⟨h₁, h₂⟩
-  simp only [RequestAndEntitiesRefine]
   constructor
   case _ =>
-    simp only [RequestRefines]
-    simp only [
-      isValidAndConsistent.requestIsValidAndConsistent,
-      requestIsConsistent,
-      Bool.or_eq_true,
-      Bool.not_eq_eq_eq_not,
-      Bool.not_true,
-      Bool.and_eq_true,
-      decide_eq_true_eq
-    ] at h₁
-    split at h₁ <;> simp at h₁
-    rcases h₁ with ⟨h₁₁, h₁₂, h₁₃, h₁₄⟩
-    -- Extract type equalities from requestMatchesEnvironment and schema.environment?
-    rename_i env heq h_guard
-    simp only [not_or, Bool.not_eq_false] at h_guard
-    have h_rm := h_guard.2
-    simp only [requestMatchesEnvironment, instanceOfRequestType, instanceOfEntityType,
-      Bool.and_eq_true, beq_iff_eq] at h_rm
-    refine ⟨
-      partial_is_valid_rfl _ _ _ decide_eq_implies_eq h₁₁,
-      h₁₂,
-      partial_is_valid_rfl _ _ _ decide_eq_implies_eq h₁₃,
-      partial_is_valid_rfl _ _ _ decide_eq_implies_eq h₁₄,
-      ?_, ?_⟩
-    all_goals {
-      unfold Schema.environment? at heq
-      cases h_find : schema.acts.find? preq.action
-      · simp [h_find] at heq
-      · simp only [h_find, Option.bind_some_fun] at heq
-        split at heq <;> simp at heq
-        rw [← heq] at h_rm
-        simp_all
-    }
-
+    have ⟨h_matches, h_consistent⟩ :
+      requestMatchesEnvironment env req ∧ requestIsConsistent req preq
+    := by
+      simp only [isValidAndConsistent.requestIsValidAndConsistent] at h₁
+      split at h₁ <;> simp_all
+    exact requestIsConsistent_implies_refines
+      (validatePartialRequest_ok_environment? heq) h_matches h_consistent
   case _ =>
-    simp [
-      isValidAndConsistent.envIsWellFormed,
-      bind, Except.bind,
-    ] at h₂
-    split at h₂ <;> simp at h₂
-    rename_i h₃
-    replace h₂ := h₃
-    simp [isValidAndConsistent.entitiesIsValidAndConsistent] at h₂
-    split at h₂ <;> simp at h₂
-    simp [entitiesIsConsistent] at h₂
-    simp [EntitiesRefine]
-    intro uid data₂ hᵢ
-    replace hᵢ := Data.Map.find?_mem_toList hᵢ
-    simp [Data.Map.toList] at hᵢ
-    specialize h₂ uid data₂ hᵢ
-    split at h₂ <;> simp at h₂
-    rcases h₂ with ⟨⟨h₂₁, h₂₂⟩, h₂₃⟩
-    rename_i data₁ heq
-    exists data₁
-    constructor
-    exact heq
-    constructor
-    exact partial_is_valid_rfl (fun x => decide (x = data₁.attrs)) (fun x => x = data₁.attrs) data₂.attrs decide_eq_implies_eq h₂₁
-    constructor
-    exact partial_is_valid_rfl (fun x => decide (x = data₁.ancestors)) (fun x => x = data₁.ancestors) data₂.ancestors decide_eq_implies_eq h₂₂
-    exact partial_is_valid_rfl (fun x => decide (x = data₁.tags)) (fun x => x = data₁.tags) data₂.tags decide_eq_implies_eq h₂₃
+    have h₃ : isValidAndConsistent.entitiesIsValidAndConsistent es pes env = .ok ()
+    := by
+      simp only [isValidAndConsistent.envIsWellFormed, bind, Except.bind] at h₂
+      split at h₂ <;> simp_all
+    have h_consistent : entitiesIsConsistent es pes := by
+      simp only [isValidAndConsistent.entitiesIsValidAndConsistent] at h₃
+      split at h₃ <;> simp_all
+    exact entitiesIsConsistent_implies_refines h_consistent
 
 end Cedar.Thm

--- a/cedar-lean/Cedar/Thm/TPE/Policy.lean
+++ b/cedar-lean/Cedar/Thm/TPE/Policy.lean
@@ -59,7 +59,9 @@ theorem partial_evaluate_policy_is_sound
   (Spec.evaluate policy.toExpr req es).toOption = (Residual.evaluate residual req es).toOption
 := by
   intro h₁ h_schema_env h₄ h₃
-  simp [evaluatePolicy, h_schema_env] at h₁
+  simp only [evaluatePolicy, validatePartialRequest, h_schema_env] at h₁
+  by_cases hv : requestIsValid env preq <;>
+    simp only [hv, Bool.false_eq_true, ↓reduceIte, reduceCtorEq] at h₁
   split at h₁ <;> try cases h₁
   cases hcheck : Except.mapError Error.invalidPolicy (checkEntities schema policy.toExpr) <;>
     simp only [hcheck, Except.bind_err, reduceCtorEq] at h₁

--- a/cedar-lean/Cedar/Thm/Validation/RequestEntityValidation.lean
+++ b/cedar-lean/Cedar/Thm/Validation/RequestEntityValidation.lean
@@ -18,7 +18,7 @@ theorem instance_of_bool_type_refl {b : Bool} {bty : BoolType} :
   cases h₁ : b <;> cases h₂ : bty <;> subst h₁ <;> subst h₂ <;> simp only [Bool.false_eq_true] at *
 
 theorem instance_of_entity_type_refl {e : EntityUID} {ety : EntityType} {env : TypeEnv} :
-  instanceOfEntityType e ety env = true → InstanceOfEntityType e ety env
+  instanceOfEntityType e ety env.schema = true → InstanceOfEntityType e ety env
 := by
   simp only [InstanceOfEntityType, instanceOfEntityType]
   intro h₀
@@ -34,7 +34,7 @@ theorem instance_of_ext_type_refl {ext : Ext} {extty : ExtType} :
   cases h₁ : ext <;> cases h₂ : extty <;> subst h₁ <;> subst h₂ <;> simp only [Bool.false_eq_true] at *
 
 theorem instance_of_type_refl {v : Value} {ty : CedarType} {env : TypeEnv} :
-  instanceOfType v ty env = true → InstanceOfType env v ty
+  instanceOfType v ty env.schema = true → InstanceOfType env v ty
 := by
   intro h₀
   unfold instanceOfType at h₀
@@ -70,7 +70,7 @@ theorem instance_of_type_refl {v : Value} {ty : CedarType} {env : TypeEnv} :
       split at h₀ <;> simp only [reduceCtorEq, imp_self, implies_true, Value.set.injEq,
         CedarType.set.injEq, imp_false, forall_apply_eq_imp_iff, forall_eq'] at *
       subst s sty
-      rw [Set.all₁_eq_all (f := (instanceOfType · _ env))] at h₀
+      rw [Set.all₁_eq_all (f := (instanceOfType · _ env.schema))] at h₀
       simp only [Set.all, List.all_eq_true] at h₀
       intro v hv
       simp only [Set.mem_elts_iff_mem_set] at h₀

--- a/cedar-lean/Cedar/Validation/RequestEntityValidator.lean
+++ b/cedar-lean/Cedar/Validation/RequestEntityValidator.lean
@@ -47,9 +47,9 @@ public def instanceOfBoolType (b : Bool) (bty : BoolType) : Bool :=
   | _, .anyBool => true
   | _, _ => false
 
-public def instanceOfEntityType (e : EntityUID) (ety : EntityType) (env : TypeEnv) : Bool :=
+public def instanceOfEntityType (e : EntityUID) (ety : EntityType) (schema : Schema) : Bool :=
   ety == e.ty &&
-  (env.ets.isValidEntityUID e || env.acts.contains e)
+  (schema.ets.isValidEntityUID e || schema.acts.contains e)
 
 public def instanceOfExtType (ext : Ext) (extty: ExtType) : Bool :=
 match ext, extty with
@@ -64,17 +64,17 @@ match rty.find? k with
     | .some qty => if qty.isRequired then r.contains k else true
     | _ => true
 
-public def instanceOfType (v : Value) (ty : CedarType) (env : TypeEnv) : Bool :=
+public def instanceOfType (v : Value) (ty : CedarType) (schema : Schema) : Bool :=
   match v, ty with
   | .prim (.bool b), .bool bty => instanceOfBoolType b bty
   | .prim (.int _), .int => true
   | .prim (.string _), .string => true
-  | .prim (.entityUID e), .entity ety => instanceOfEntityType e ety env
-  | .set s, .set ty => s.all₁ (λ ⟨v, _⟩ => instanceOfType v ty env)
+  | .prim (.entityUID e), .entity ety => instanceOfEntityType e ety schema
+  | .set s, .set ty => s.all₁ (λ ⟨v, _⟩ => instanceOfType v ty schema)
   | .record r, .record rty =>
     r.toList.all (λ (k, _) => rty.contains k) &&
     (r.toList.attach₂.all (λ ⟨(k, v), _⟩ => (match rty.find? k with
-        | .some qty => instanceOfType v qty.getType env
+        | .some qty => instanceOfType v qty.getType schema
         | _ => true))) &&
     rty.toList.all (λ (k, _) => requiredAttributePresent r rty k)
   | .ext x, .ext xty => instanceOfExtType x xty
@@ -91,10 +91,10 @@ public def instanceOfType (v : Value) (ty : CedarType) (env : TypeEnv) : Bool :=
         omega
 
 public def instanceOfRequestType (request : Request) (env : TypeEnv) : Bool :=
-  instanceOfEntityType request.principal env.reqty.principal env &&
+  instanceOfEntityType request.principal env.reqty.principal env.schema &&
   request.action == env.reqty.action &&
-  instanceOfEntityType request.resource env.reqty.resource env &&
-  instanceOfType request.context (.record env.reqty.context) env
+  instanceOfEntityType request.resource env.reqty.resource env.schema &&
+  instanceOfType request.context (.record env.reqty.context) env.schema
 
 /--
 For every entity in the store,
@@ -115,14 +115,14 @@ public def instanceOfSchema (entities : Entities) (env : TypeEnv) : EntityValida
 where
   instanceOfEntityTags (data : EntityData) (entry : EntitySchemaEntry) : Bool :=
     match entry.tags? with
-    | .some tty => data.tags.values.all (instanceOfType · tty env)
+    | .some tty => data.tags.values.all (instanceOfType · tty env.schema)
     | .none     => data.tags == Map.empty
   instanceOfEntitySchemaEntry uid data entry :=
     if entry.isValidEntityEID uid.eid then
-      if instanceOfType data.attrs (.record entry.attrs) env then
+      if instanceOfType data.attrs (.record entry.attrs) env.schema then
         if data.ancestors.all (λ ancestor =>
           entry.ancestors.contains ancestor.ty &&
-          instanceOfEntityType ancestor ancestor.ty env) then
+          instanceOfEntityType ancestor ancestor.ty env.schema) then
           if instanceOfEntityTags data entry then .ok ()
           else .error (.typeError s!"entity tags inconsistent with type store")
         else .error (.typeError s!"entity ancestors inconsistent with type store")

--- a/cedar-lean/Cedar/Validation/Types.lean
+++ b/cedar-lean/Cedar/Validation/Types.lean
@@ -203,6 +203,8 @@ public structure TypeEnv where
   reqty : RequestType
 deriving Inhabited
 
+public def TypeEnv.schema (env : TypeEnv) : Schema := ⟨env.ets, env.acts⟩
+
 public def ActionSchema.maybeDescendentOf (as : ActionSchema) (ety₁ ety₂ : EntityType) : Bool :=
   as.toList.any λ (act, entry) => act.ty = ety₁ && entry.ancestors.any (EntityUID.ty · == ety₂)
 

--- a/cedar-lean/CedarFFI/Main.lean
+++ b/cedar-lean/CedarFFI/Main.lean
@@ -886,8 +886,7 @@ def parseResidualReauthorizationRequest (req: ByteArray):
   runFfiM do
     let v ← (@Proto.Message.interpret? Proto.PartialEntityValidationRequest) req |>.mapError (s!"failed to parse input: {·}")
     runAndTime (λ () =>
-      -- entity validity does not depend on the request type
-      (if TPE.entitiesIsValid { ets := schema.ets, acts := schema.acts, reqty := default } v.entities
+      (if TPE.entitiesIsValid schema v.entities
        then .ok ()
        else .error (.typeError "partial entities are inconsistent with the type store")
        : EntityValidationResult))
@@ -911,7 +910,7 @@ def parseResidualReauthorizationRequest (req: ByteArray):
   runFfiM do
     let v ← (@Proto.Message.interpret? Proto.PartialRequestValidationRequest) req |>.mapError (s!"failed to parse input: {·}")
     runAndTime (λ () =>
-      TPE.validatePartialRequest schema v.request)
+      ((TPE.validatePartialRequest schema v.request).map (λ _ => ()) : RequestValidationResult))
 
 /--
   `req`: binary protobuf for a `PartialRequestConsistencyRequest`


### PR DESCRIPTION
Change on top of #1012 

* Splits `consistent_checks_ensure_refinement` into lemmas for requests and entities
* Update `entitiesIsValid` to require a schema instead of type env (it needs the entity types and actions, not the request environment). 

