### PR TITLE
Start batched evaluation with action entities from schema

### DIFF
--- a/cedar-lean/Cedar/TPE/BatchedEvaluator.lean
+++ b/cedar-lean/Cedar/TPE/BatchedEvaluator.lean
@@ -59,6 +59,10 @@ def batchedEvaluateLoop
     | .val v _ty => .val v _ty
     | newRes => batchedEvaluateLoop newRes req loader newStore n
 
+def actionEntities (acts : ActionSchema) : PartialEntities :=
+  Map.make (acts.toList.map λ (uid, entry) =>
+    (uid, ⟨.some Map.empty, .some entry.ancestors, .some Map.empty⟩))
+
 /--
 Evaluate a single cedar expression using an EntityLoader
 instead of a full Entities store.
@@ -66,13 +70,14 @@ Performs a maximum of `iter` number of calls to `loader`,
 but may perform fewer when a value is found.
 -/
 def batchedEvaluate
+  (acts : ActionSchema)
   (x : TypedExpr)
   (req : Request)
   (loader : EntityLoader)
   (iters : Nat)
   : Residual :=
-  let residual := Cedar.TPE.evaluate x.toResidual req.asPartialRequest Map.empty
-  batchedEvaluateLoop residual req loader Map.empty iters
+  let residual := Cedar.TPE.evaluate x.toResidual req.asPartialRequest (actionEntities acts)
+  batchedEvaluateLoop residual req loader (actionEntities acts) iters
 
 /--
 The batched authorization loop for authorization over a list of policies.
@@ -109,8 +114,9 @@ def batchedAuthorize
   (iters : Nat)
   : Except Error Response := do
   let residualPolicies ← policies.mapM (λ p => do
-    pure ⟨p.id, p.effect, ← evaluatePolicy schema p req.asPartialRequest Map.empty⟩)
-  pure (batchedAuthorizeLoop residualPolicies req loader Map.empty iters)
+    pure ⟨p.id, p.effect,
+      ← evaluatePolicy schema p req.asPartialRequest (actionEntities schema.acts)⟩)
+  pure (batchedAuthorizeLoop residualPolicies req loader (actionEntities schema.acts) iters)
 
 /--
 Create an entity loader for a given entity store.

--- a/cedar-lean/Cedar/Thm/BatchedEvaluator.lean
+++ b/cedar-lean/Cedar/Thm/BatchedEvaluator.lean
@@ -27,7 +27,7 @@ theorem batched_evaluate_eq_evaluate
   EntityLoader.WellBehaved es loader →
   TypedExpr.WellTyped env x →
   InstanceOfWellFormedEnvironment req es env →
-  (Residual.evaluate (batchedEvaluate x req loader iters) req es).toOption = (evaluate x.toExpr req es).toOption := by
+  (Residual.evaluate (batchedEvaluate env.acts x req loader iters) req es).toOption = (evaluate x.toExpr req es).toOption := by
   simp only [batchedEvaluate]
   intro h₁ h₂ h₃
   have h₄ := (direct_request_and_entities_refine req es)
@@ -39,29 +39,72 @@ theorem batched_evaluate_eq_evaluate
   rw [conversion_preserves_evaluation x req es]
   rw [partial_evaluate_is_sound h₅ h₃ h₄]
 
-  have h₆ : Residual.WellTyped env (TPE.evaluate x.toResidual req.asPartialRequest Map.empty) := by
-    apply partial_eval_preserves_well_typed h₃ _ h₅
-    . constructor
-      . apply as_partial_request_refines
-      . apply any_refines_empty_entities
-  have h₇: RequestAndEntitiesRefine req es req.asPartialRequest Map.empty := by
+  have h₇: RequestAndEntitiesRefine req es req.asPartialRequest (actionEntities env.acts) := by
     constructor
     . apply as_partial_request_refines
-    . apply any_refines_empty_entities
+    . exact actionEntities_refines h₃.1 h₃.2.2
+  have h₆ : Residual.WellTyped env
+      (TPE.evaluate x.toResidual req.asPartialRequest (actionEntities env.acts)) :=
+    partial_eval_preserves_well_typed h₃ h₇ h₅
 
   rw [batched_evaluate_loop_eq_evaluate es h₁ h₆ h₇ h₃]
   rw [←partial_evaluate_is_sound h₅ h₃ h₇]
   rw [←partial_evaluate_is_sound h₅ h₃ h₄]
 
 /--
+A successful batched authorization returns `isAuthorizedFromResiduals` of a list equivalent to the
+policies, so any property of it transfers to the batched path without a second induction.
+-/
+theorem batched_authorize_ok_equiv
+  {schema : Schema} {policies : List Policy} {req : Request}
+  {es : Entities} {response : TPE.Response} :
+  EntityLoader.WellBehaved es loader →
+  schema.validateWellFormed = .ok () →
+  validateEntities schema es = .ok () →
+  batchedAuthorize schema policies req loader iters = .ok response →
+  ∃ rps, response = isAuthorizedFromResiduals rps ∧
+    ResidualPoliciesEquiv policies rps req es
+:= by
+  intro h_loader h_schema_wf h_entities h_batched
+  simp only [batchedAuthorize] at h_batched
+  cases h_mapM : policies.mapM (λ p =>
+    ResidualPolicy.mk p.id p.effect <$>
+      evaluatePolicy schema p req.asPartialRequest (actionEntities schema.acts)) with
+  | error e => simp [h_mapM, bind_pure_comp] at h_batched
+  | ok residualPolicies =>
+    simp only [bind_pure_comp, h_mapM, Except.map_ok, Except.ok.injEq] at h_batched
+    subst h_batched
+    rw [List.mapM_ok_iff_forall₂] at h_mapM
+    match policies, h_mapM with
+    | [], .nil =>
+      -- The empty response already has a decision, so the loop returns at once.
+      have h_dec : (isAuthorizedFromResiduals []).decision.isSome = true := by
+        simp [isAuthorizedFromResiduals, isAuthorizedFromResiduals.satisfiedPolicies,
+          isAuthorizedFromResiduals.residualPolicies]
+      refine ⟨[], ?_, .nil⟩
+      unfold batchedAuthorizeLoop
+      simp only [h_dec, if_true]
+    | p :: _, .cons h_first h_rest =>
+      have ⟨r, h_ep⟩ : ∃ r,
+          evaluatePolicy schema p req.asPartialRequest (actionEntities schema.acts) = .ok r := by
+        cases h_ep : evaluatePolicy schema p req.asPartialRequest (actionEntities schema.acts) <;>
+          simp [h_ep] at ⊢ h_first
+      obtain ⟨env, h_schema_env, h_wf⟩ :=
+        evaluatePolicy_ok_implies_well_formed_env h_ep h_schema_wf h_entities
+      have h_acts : env.acts = schema.acts :=
+        (environment?_schema (by simpa only [Request.asPartialRequest] using h_schema_env)).2
+      have h_ref : RequestAndEntitiesRefine req es req.asPartialRequest
+          (actionEntities schema.acts) :=
+        ⟨as_partial_request_refines, h_acts ▸ actionEntities_refines h_wf.1 h_wf.2.2⟩
+      obtain ⟨rps, heq, hequiv⟩ := batched_authorize_loop_equiv es h_loader
+        (evaluatePolicies_equiv_and_well_typed (.cons h_first h_rest) h_schema_env h_wf h_ref)
+        h_ref h_wf
+      exact ⟨rps, heq, equiv_well_typed_implies_equiv hequiv⟩
+
+/--
 The main correctness theorem for batched authorization:
 If the batched authorizer reaches a definitive decision, that decision
 agrees with the concrete authorizer.
-
-Request and policy well-typedness are checked by `batchedAuthorize`, so we do
-not need those as an explicit precondition. We do need entity to explicitly
-require well-typed entities because `batchedAuthorize` only has access to these
-through the entity loader.
 -/
 theorem batched_authorize_decision_eq_authorize
   {schema : Schema} {policies : List Policy} {req : Request}
@@ -74,29 +117,9 @@ theorem batched_authorize_decision_eq_authorize
   (Spec.isAuthorized req es policies).decision = d
 := by
   intro h_loader h_schema_wf h_entities h_batched h_dec
-  simp only [batchedAuthorize] at h_batched
-  cases h_mapM : policies.mapM (λ p =>
-    ResidualPolicy.mk p.id p.effect <$> evaluatePolicy schema p req.asPartialRequest Map.empty) with
-  | error e => simp [h_mapM, bind_pure_comp] at h_batched
-  | ok residualPolicies =>
-    simp only [bind_pure_comp, h_mapM, Except.map_ok, Except.ok.injEq] at h_batched
-    subst h_batched
-    rw [List.mapM_ok_iff_forall₂] at h_mapM
-    match policies, h_mapM with
-    | [], .nil =>
-      have h_dec' : (isAuthorizedFromResiduals []).decision = some .deny := by
-        simp [isAuthorizedFromResiduals, isAuthorizedFromResiduals.satisfiedPolicies, isAuthorizedFromResiduals.residualPolicies]
-      apply residuals_decision_agrees .nil
-      unfold batchedAuthorizeLoop at h_dec
-      simpa [h_dec'] using h_dec
-    | p :: _, .cons h_first h_rest =>
-      have ⟨r, h_ep⟩ : ∃ r, evaluatePolicy schema p req.asPartialRequest Map.empty = .ok r := by
-        cases h_ep : evaluatePolicy schema p req.asPartialRequest Map.empty <;>
-          simp [h_ep] at ⊢ h_first
-      obtain ⟨env, h_schema_env, h_wf⟩ :=
-        evaluatePolicy_ok_implies_well_formed_env h_ep h_schema_wf h_entities
-      have h_ref : RequestAndEntitiesRefine req es req.asPartialRequest Map.empty :=
-        ⟨as_partial_request_refines, any_refines_empty_entities⟩
-      exact batched_authorize_loop_decision_agrees es h_loader
-        (evaluatePolicies_equiv_and_well_typed (.cons h_first h_rest) h_schema_env h_wf h_ref)
-        h_ref h_wf h_dec
+  obtain ⟨rps, heq, hequiv⟩ :=
+    batched_authorize_ok_equiv h_loader h_schema_wf h_entities h_batched
+  rw [heq] at h_dec
+  exact residuals_decision_agrees hequiv h_dec
+
+end Cedar.Thm

--- a/cedar-lean/Cedar/Thm/BatchedEvaluator/Authorize.lean
+++ b/cedar-lean/Cedar/Thm/BatchedEvaluator/Authorize.lean
@@ -36,8 +36,8 @@ private theorem requestIsValid_asPartialRequest_eq {env : TypeEnv} {req : Reques
     partialIsValid, Option.map_some, Option.getD_some, instanceOfRequestType]
 
 theorem evaluatePolicy_ok_implies_requestMatchesEnvironment
-  {schema : Schema} {p : Policy} {req : Request} {r : Residual} :
-  evaluatePolicy schema p req.asPartialRequest Map.empty = .ok r →
+  {schema : Schema} {p : Policy} {req : Request} {r : Residual} {pes : PartialEntities} :
+  evaluatePolicy schema p req.asPartialRequest pes = .ok r →
   ∀ env, schema.environment? req.asPartialRequest.principal.ty req.asPartialRequest.resource.ty req.asPartialRequest.action = .some env →
   requestMatchesEnvironment env req
 := by
@@ -53,8 +53,9 @@ pass validation, then `InstanceOfWellFormedEnvironment` holds for the
 environment determined by the schema and request.
 -/
 theorem evaluatePolicy_ok_implies_well_formed_env
-  {schema : Schema} {p : Policy} {req : Request} {es : Entities} {r : Residual} :
-  evaluatePolicy schema p req.asPartialRequest Map.empty = .ok r →
+  {schema : Schema} {p : Policy} {req : Request} {es : Entities} {r : Residual}
+  {pes : PartialEntities} :
+  evaluatePolicy schema p req.asPartialRequest pes = .ok r →
   schema.validateWellFormed = .ok () →
   validateEntities schema es = .ok () →
   ∃ env,
@@ -105,6 +106,40 @@ theorem residuals_equiv_preserved
      partial_eval_preserves_well_typed h_wf h_ref h_wt⟩
   ) h_sound
 
+/-- The loop's response is `isAuthorizedFromResiduals` of a list still equivalent to the policies. -/
+theorem batched_authorize_loop_equiv
+  {policies : List Policy} {residuals : List ResidualPolicy} {req : Request}
+  (es : Entities) {current_store : PartialEntities} {env : TypeEnv} :
+  EntityLoader.WellBehaved es loader →
+  ResidualPoliciesEquivAndWellTyped env policies residuals req es →
+  RequestAndEntitiesRefine req es req.asPartialRequest current_store →
+  InstanceOfWellFormedEnvironment req es env →
+  ∃ rps, batchedAuthorizeLoop residuals req loader current_store iters
+      = isAuthorizedFromResiduals rps ∧
+    ResidualPoliciesEquivAndWellTyped env policies rps req es
+:= by
+  intro h₀ h₁ h₂ h₃
+  unfold batchedAuthorizeLoop
+  simp only
+  split
+  case isTrue => exact ⟨residuals, rfl, h₁⟩
+  case isFalse =>
+    cases iters with
+    | zero => exact ⟨residuals, rfl, h₁⟩
+    | succ n =>
+      have h₆ : RequestAndEntitiesRefine req es req.asPartialRequest
+        ((((loader
+          (Set.filter (fun uid => (Map.find? current_store uid).isNone)
+            (List.mapUnion (fun rp => rp.residual.allLiteralUIDs) residuals))).mapOnValues
+            MaybeEntityData.asPartial)) ++ current_store) := by
+        constructor
+        · exact as_partial_request_refines
+        · apply entities_refine_append
+          · exact h₂.right
+          · exact (h₀ _).2
+      exact batched_authorize_loop_equiv es h₀ (residuals_equiv_preserved h₁ h₃ h₆) h₆ h₃
+
+/-- The loop's decision agrees with concrete authorization. -/
 theorem batched_authorize_loop_decision_agrees
   {policies : List Policy} {residuals : List ResidualPolicy} {req : Request}
   (es : Entities) {current_store : PartialEntities} {env : TypeEnv} {d : Decision} :
@@ -116,28 +151,9 @@ theorem batched_authorize_loop_decision_agrees
   (Spec.isAuthorized req es policies).decision = d
 := by
   intro h₀ h₁ h₂ h₃ h_dec
-  unfold batchedAuthorizeLoop at h_dec
-  simp only at h_dec
-  split at h_dec
-  case isTrue =>
-    exact residuals_decision_agrees (equiv_well_typed_implies_equiv h₁) h_dec
-  case isFalse =>
-    cases iters with
-    | zero =>
-      exact residuals_decision_agrees (equiv_well_typed_implies_equiv h₁) h_dec
-    | succ n =>
-      have h₆ : RequestAndEntitiesRefine req es req.asPartialRequest
-        (((loader
-          (Set.filter (fun uid => (Map.find? current_store uid).isNone)
-            (List.mapUnion (fun rp => rp.residual.allLiteralUIDs) residuals))).mapOnValues
-            MaybeEntityData.asPartial) ++ current_store) := by
-        constructor
-        · exact as_partial_request_refines
-        · apply entities_refine_append
-          · exact h₂.right
-          · exact (h₀ _).2
-      exact batched_authorize_loop_decision_agrees es h₀
-        (residuals_equiv_preserved h₁ h₃ h₆) h₆ h₃ h_dec
+  obtain ⟨rps, heq, hequiv⟩ := batched_authorize_loop_equiv es h₀ h₁ h₂ h₃
+  rw [heq] at h_dec
+  exact residuals_decision_agrees (equiv_well_typed_implies_equiv hequiv) h_dec
 
 theorem evaluatePolicies_equiv_and_well_typed
   {schema : Schema} {policies : List Policy} {rps : List ResidualPolicy}

--- a/cedar-lean/Cedar/Thm/BatchedEvaluator/Common.lean
+++ b/cedar-lean/Cedar/Thm/BatchedEvaluator/Common.lean
@@ -12,6 +12,7 @@ namespace Cedar.Thm
 open Cedar.TPE
 open Cedar.Spec
 open Cedar.Data
+open Cedar.Validation
 
 /-- A well behaved entity loader
 1. Loads all the requested entities, returning none for missing entities
@@ -24,6 +25,47 @@ in the code base at the moment.
 abbrev EntityLoader.WellBehaved (store: Entities) (loader: EntityLoader) : Prop :=
   ∀ s, s ⊆ (loader s).keys ∧
        EntitiesRefine store ((loader s).mapOnValues MaybeEntityData.asPartial)
+
+/-- `Schema.environment?` carries the schema's entity and action types through unchanged. -/
+theorem environment?_schema {schema : Schema} {pty rty : EntityType} {act : EntityUID}
+  {env : TypeEnv} (h : schema.environment? pty rty act = .some env) :
+  env.ets = schema.ets ∧ env.acts = schema.acts
+:= by
+  simp only [Schema.environment?] at h
+  cases h_find : schema.acts.find? act <;>
+    simp only [h_find, Option.bind_none_fun, Option.bind_some_fun, reduceCtorEq] at h
+  split at h <;> simp only [reduceCtorEq, Option.some.injEq] at h
+  subst h
+  exact ⟨rfl, rfl⟩
+
+theorem actionEntities_refines {env : TypeEnv} {es : Entities}
+  (hwf : env.WellFormed) (hinst : InstanceOfSchema es env) :
+  EntitiesRefine es (actionEntities env.acts)
+:= by
+  intro uid ped hfind
+  rw [actionEntities] at hfind
+  have hmem := Data.Map.mem_make_mem_list (Data.Map.find?_mem_toList hfind)
+  simp only [List.mem_map, Prod.mk.injEq] at hmem
+  obtain ⟨p, hp, huid, hped⟩ := hmem
+  subst huid
+  subst hped
+  have hact : env.acts.find? p.fst = .some p.snd :=
+    (Data.Map.in_list_iff_find?_some hwf.2.1.1).mp hp
+  obtain ⟨data, hdata⟩ := hinst.2 p.fst p.snd hact
+  rcases hinst.1 p.fst data hdata with hentity | haction
+  · exfalso
+    obtain ⟨entry, hentry, _⟩ := hentity
+    refine hwf.2.1.2.2.1 p.fst ?_ ?_
+    · show (env.acts.find? p.fst).isSome = true
+      simp only [hact, Option.isSome_some]
+    · show (env.ets.find? p.fst.ty).isSome = true
+      simp only [hentry, Option.isSome_some]
+  · obtain ⟨hattrs, htags, entry, hentry, hanc⟩ := haction
+    have hentry' : entry = p.snd := by
+      rw [hact] at hentry
+      simpa only [Option.some.injEq] using hentry.symm
+    subst hentry'
+    exact ⟨data, hdata, .some _ rfl hattrs.symm, .some _ rfl hanc.symm, .some _ rfl htags.symm⟩
 
 theorem as_partial_request_refines {req : Request} :
   RequestRefines req req.asPartialRequest := by

--- a/cedar-lean/Cedar/Thm/BatchedEvaluator/Evaluate.lean
+++ b/cedar-lean/Cedar/Thm/BatchedEvaluator/Evaluate.lean
@@ -52,8 +52,8 @@ theorem batched_evaluate_loop_eq_evaluate
 
     simp only
     split
-    case h_1 h₆ =>
-      rw [← h₆]
+    case h_1 hval =>
+      rw [← hval]
       exact h₇
     case h_2 =>
       have h₈ := (partial_eval_preserves_well_typed h₃ h₆ h₁)

--- a/cedar-lean/UnitTest/BatchedEvaluator.lean
+++ b/cedar-lean/UnitTest/BatchedEvaluator.lean
@@ -59,11 +59,12 @@ def testBatchedEvaluatorEquivalence (name : String) (expr : Expr) (req : Request
     -- Create a minimal TypeEnv for typechecking
     match typeOf expr ∅ type_env with
     | .ok (typedExpr, _) =>
-      let batchedResult := batchedEvaluate typedExpr req loader
-      match (batchedResult, regularResult) with
-      | (.ok br, .ok rr) => checkEq br rr
-      | (.error _, .error _) => (.ok (.ok ()))
-      | _ => checkEq batchedResult regularResult
+      let batchedResult := batchedEvaluate action_schema typedExpr req loader 10
+      match batchedResult.asValue, regularResult with
+      | .some bv, .ok rv => checkEq bv rv
+      | .none, .error _ => .ok (.ok ())
+      | _, _ =>
+        .error s!"batched {repr batchedResult} disagrees with concrete {repr regularResult}"
     | .error e =>
       .error s!"Type error: {repr e}"
   ⟩
@@ -115,7 +116,7 @@ def tests :=
       testEntities
       testLoader,
     testBatchedEvaluatorEquivalence
-     "missing entity - User::\"nonexistent\".name == \"test\""
+      "missing entity - User::\"nonexistent\".name == \"test\""
       (.binaryApp .eq (.getAttr (.lit (.entityUID ⟨UserType, "nonexistent"⟩)) "name") (.lit (.string "test")))
       testRequest
       testEntities
@@ -131,6 +132,5 @@ def tests :=
       testLoader
   ]
 
-#eval do TestSuite.runAll [tests]
 
 end UnitTest.BatchedEvaluator

--- a/cedar-lean/UnitTest/Main.lean
+++ b/cedar-lean/UnitTest/Main.lean
@@ -14,6 +14,7 @@
  limitations under the License.
 -/
 
+import UnitTest.BatchedEvaluator
 import UnitTest.CedarProto
 import UnitTest.Datetime
 import UnitTest.Decimal
@@ -26,6 +27,7 @@ import UnitTest.Levels
 open UnitTest
 
 def tests :=
+  [BatchedEvaluator.tests] ++
   Datetime.tests ++
   Decimal.tests ++
   IPAddr.tests ++


### PR DESCRIPTION
- Start batched evaluation from the schema's action entities. Previously these would be requested by the loader, but we already know them from the schema.
