### PR TITLE
Extend testing to cover partial attributes

### DIFF
--- a/cedar-drt/fuzz/fuzz_targets/tpe-is-authorized-abstract-drt.rs
+++ b/cedar-drt/fuzz/fuzz_targets/tpe-is-authorized-abstract-drt.rs
@@ -149,6 +149,6 @@ fuzz_target!(|input: AbstractAuthorizerInput| {
         &SCHEMA,
         &policyset,
         &REQUEST,
-        &PartialEntities::empty(),
+        &PartialEntities::empty(&SCHEMA).unwrap(),
     );
 });

--- a/cedar-drt/fuzz/src/tpe.rs
+++ b/cedar-drt/fuzz/src/tpe.rs
@@ -23,11 +23,11 @@ use cedar_lean_ffi::{
 };
 use cedar_policy::pst::{Clause, Expr, UnaryOp};
 use cedar_policy::{
-    Context, Entities, Entity, EntityId, EntityUid, PartialEntities, PartialEntity,
-    PartialEntityUid, PartialRequest, PolicyId, PolicySet, Request, RestrictedExpression, Schema,
-    Validator,
+    Context, Entities, Entity, EntityId, EntityUid, PartialAttribute, PartialContext,
+    PartialEntities, PartialEntity, PartialEntityUid, PartialRecord, PartialRequest, PolicyId,
+    PolicySet, Request, RestrictedExpression, Schema, Validator,
 };
-use cedar_policy_core::ast::{self, Value};
+use cedar_policy_core::ast::{self, Value, ValueKind};
 use cedar_policy_core::extensions::Extensions;
 use cedar_policy_core::tpe::residual::Residual;
 use cedar_policy_generators::{
@@ -108,17 +108,112 @@ pub fn schema_and_requests_size_hint(
     ]))
 }
 
-fn to_restricted_exprs<'a>(
+/// Downgrade one concrete attribute value into an arbitrary [`PartialAttribute`].
+///
+/// Never emits [`PartialAttribute::Absent`]: absence of a required attribute is a schema violation,
+/// and the value alone does not say whether the attribute is required. The unchecked builders cover
+/// that case.
+fn arbitrary_partial_attribute(
+    value: &Value,
+    u: &mut Unstructured<'_>,
+) -> arbitrary::Result<PartialAttribute> {
+    if let ValueKind::Record(fields) = value.value_kind() {
+        if u.ratio(1, 2)? {
+            let mut sub = Vec::new();
+            for (k, v) in fields.iter() {
+                // Omission is not `Absent`: a key that is not stated is `Unknown`.
+                if u.ratio(1, 5)? {
+                    continue;
+                }
+                sub.push((k.clone(), arbitrary_partial_attribute(v, u)?));
+            }
+            return Ok(PartialAttribute::record(sub));
+        }
+    }
+    Ok(match u.int_in_range::<u8>(0..=2)? {
+        0 => PartialAttribute::value(RestrictedExpression::from(ast::RestrictedExpr::from(
+            value.clone(),
+        ))),
+        1 => PartialAttribute::Exists,
+        _ => PartialAttribute::Unknown,
+    })
+}
+
+/// Downgrade concrete attributes or tags; every state produced is schema-valid, so the result
+/// passes the validation gate in `PartialEntity::new`/`PartialRequest::new`.
+fn to_partial_attrs<'a>(
     pairs: impl Iterator<Item = (&'a SmolStr, &'a ast::PartialValue)>,
-) -> BTreeMap<SmolStr, RestrictedExpression> {
-    pairs
-        .map(|(k, v)| {
-            (
-                k.clone(),
-                ast::RestrictedExpr::from(Value::try_from(v.clone()).unwrap()).into(),
-            )
-        })
-        .collect()
+    u: &mut Unstructured<'_>,
+) -> arbitrary::Result<BTreeMap<SmolStr, PartialAttribute>> {
+    let mut out = BTreeMap::new();
+    for (k, v) in pairs {
+        if u.ratio(1, 5)? {
+            continue;
+        }
+        let value = Value::try_from(v.clone()).map_err(|_| arbitrary::Error::IncorrectFormat)?;
+        out.insert(k.clone(), arbitrary_partial_attribute(&value, u)?);
+    }
+    Ok(out)
+}
+
+/// As [`to_partial_attrs`], but may emit [`PartialAttribute::Absent`] for a *required* attribute.
+///
+/// That is a schema violation on purpose: the validation and consistency targets check that Rust
+/// and Lean agree on which inputs are rejected.
+fn unchecked_partial_attrs<'a>(
+    pairs: impl Iterator<Item = (&'a SmolStr, &'a ast::PartialValue)>,
+    u: &mut Unstructured<'_>,
+) -> arbitrary::Result<BTreeMap<SmolStr, PartialAttribute>> {
+    let mut out = BTreeMap::new();
+    for (k, v) in pairs {
+        if u.ratio(1, 6)? {
+            continue;
+        }
+        let attr = match u.int_in_range::<u8>(0..=3)? {
+            0 => {
+                let value =
+                    Value::try_from(v.clone()).map_err(|_| arbitrary::Error::IncorrectFormat)?;
+                PartialAttribute::value(RestrictedExpression::from(ast::RestrictedExpr::from(
+                    value,
+                )))
+            }
+            1 => PartialAttribute::Exists,
+            2 => PartialAttribute::Absent,
+            _ => PartialAttribute::Unknown,
+        };
+        out.insert(k.clone(), attr);
+    }
+    Ok(out)
+}
+
+fn concrete_context(context: &ast::Context) -> arbitrary::Result<Context> {
+    let ast::Context::Value(fields) = context else {
+        return Err(arbitrary::Error::IncorrectFormat);
+    };
+    Context::from_pairs(fields.iter().map(|(k, v)| {
+        (
+            k.to_string(),
+            RestrictedExpression::from(ast::RestrictedExpr::from(v.clone())),
+        )
+    }))
+    .map_err(|_| arbitrary::Error::IncorrectFormat)
+}
+
+fn to_partial_context(
+    context: &ast::Context,
+    u: &mut Unstructured<'_>,
+) -> arbitrary::Result<PartialContext> {
+    let ast::Context::Value(fields) = context else {
+        return Err(arbitrary::Error::IncorrectFormat);
+    };
+    let mut record = Vec::new();
+    for (k, v) in fields.iter() {
+        if u.ratio(1, 5)? {
+            continue;
+        }
+        record.push((k.clone(), arbitrary_partial_attribute(v, u)?));
+    }
+    Ok(PartialContext::Partial(PartialRecord::new(record)))
 }
 
 /// Builds a partial entity whose uid and ancestors come from `entity` and whose attributes
@@ -136,7 +231,7 @@ fn entity_to_partial_entity(
         if !is_action && u.ratio(1, 4)? {
             None
         } else {
-            Some(to_restricted_exprs(attrs_from.as_ref().attrs()))
+            Some(to_partial_attrs(attrs_from.as_ref().attrs(), u)?)
         },
         // We can only mark ancestors of leaf nodes to unknown
         if !is_action && leafs.contains(&entity.uid()) && u.ratio(1, 4)? {
@@ -149,7 +244,7 @@ fn entity_to_partial_entity(
         if !is_action && u.ratio(1, 4)? {
             None
         } else {
-            Some(to_restricted_exprs(attrs_from.as_ref().tags()))
+            Some(to_partial_attrs(attrs_from.as_ref().tags(), u)?)
         },
         schema,
     )
@@ -260,12 +355,22 @@ pub fn make_unchecked_partial_request(
         context: if u.ratio(1, 4)? {
             None
         } else {
-            Some(
-                context
-                    .iter()
-                    .map(|(k, v)| (k.clone(), ast::RestrictedExpr::from(v.clone()).into()))
-                    .collect(),
-            )
+            let mut out = BTreeMap::new();
+            for (k, v) in context.iter() {
+                if u.ratio(1, 6)? {
+                    continue;
+                }
+                let attr = match u.int_in_range::<u8>(0..=3)? {
+                    0 => PartialAttribute::value(RestrictedExpression::from(
+                        ast::RestrictedExpr::from(v.clone()),
+                    )),
+                    1 => PartialAttribute::Exists,
+                    2 => PartialAttribute::Absent,
+                    _ => PartialAttribute::Unknown,
+                };
+                out.insert(k.clone(), attr);
+            }
+            Some(out)
         },
     })
 }
@@ -279,7 +384,7 @@ pub fn entity_to_unchecked_partial_entity(
         attrs: if u.ratio(1, 4)? {
             None
         } else {
-            Some(to_restricted_exprs(entity.as_ref().attrs()))
+            Some(unchecked_partial_attrs(entity.as_ref().attrs(), u)?)
         },
         ancestors: if u.ratio(1, 4)? {
             None
@@ -291,22 +396,26 @@ pub fn entity_to_unchecked_partial_entity(
         tags: if u.ratio(1, 4)? {
             None
         } else {
-            Some(to_restricted_exprs(entity.as_ref().tags()))
+            Some(unchecked_partial_attrs(entity.as_ref().tags(), u)?)
         },
     })
 }
 
-/// Construct a partial request from a concrete request, randomly dropping eids.
 pub fn make_partial_request(
     req: &ABACRequest,
     u: &mut Unstructured<'_>,
     schema: &Schema,
 ) -> arbitrary::Result<PartialRequest> {
+    let context: PartialContext = match u.int_in_range::<u8>(0..=2)? {
+        0 => PartialContext::Unknown,
+        1 => concrete_context(&req.context)?.into(),
+        _ => to_partial_context(&req.context, u)?,
+    };
     PartialRequest::new(
         maybe_eid(&req.principal, u)?,
         req.action.clone().into(),
         maybe_eid(&req.resource, u)?,
-        None,
+        context,
         schema,
     )
     .map_err(|_| arbitrary::Error::IncorrectFormat)
@@ -656,10 +765,10 @@ pub fn test_partial_request_validation_equiv(
     lean_schema: LeanSchema,
     request: &UncheckedPartialRequest,
 ) {
-    let context = request.context.clone().map(|c| {
-        Context::from_pairs(c.into_iter().map(|(k, v)| (k.to_string(), v)))
-            .expect("context built from a concrete context should be valid")
-    });
+    let context: PartialContext = match request.context.clone() {
+        Some(fields) => PartialContext::Partial(PartialRecord::new(fields)),
+        None => PartialContext::Unknown,
+    };
     let rust_res = PartialRequest::new(
         request.principal.clone(),
         request.action.clone(),

--- a/cedar-lean-ffi/protobuf_schema/Messages.proto
+++ b/cedar-lean-ffi/protobuf_schema/Messages.proto
@@ -303,22 +303,45 @@ message PartialEntityUID {
     optional string id = 2;
 }
 
+message AttrState {
+    AttrStateKind kind = 1;
+    cedar_policy_core.Expr value = 2;
+    repeated AttrStateEntry record = 3;
+}
+
+enum AttrStateKind {
+    ATTR_STATE_UNKNOWN = 0;
+    ATTR_STATE_VALUE = 1;
+    ATTR_STATE_PRESENT = 2;
+    ATTR_STATE_ABSENT = 3;
+    ATTR_STATE_PARTIAL_RECORD = 4;
+}
+
+message AttrStateEntry {
+    string key = 1;
+    AttrState state = 2;
+}
+
+message PartialRecord {
+    repeated AttrStateEntry entries = 1;
+}
+
+message EntityUidSet {
+    repeated cedar_policy_core.EntityUid uids = 1;
+}
+
 message PartialRequest {
     PartialEntityUID principal = 1;
     cedar_policy_core.EntityUid action = 2;
     PartialEntityUID resource = 3;
-    map<string, cedar_policy_core.Expr> context = 4;
-    bool has_context = 5;
+    PartialRecord context = 4;
 }
 
 message PartialEntity {
     cedar_policy_core.EntityUid uid = 1;
-    map<string, cedar_policy_core.Expr> attrs = 2;
-    repeated cedar_policy_core.EntityUid ancestors = 3;
-    map<string, cedar_policy_core.Expr> tags = 4;
-    bool has_attrs = 5;
-    bool has_ancestors = 6;
-    bool has_tags = 7;
+    PartialRecord attrs = 2;
+    EntityUidSet ancestors = 3;
+    PartialRecord tags = 4;
 }
 
 message PartialEntities {

--- a/cedar-lean-ffi/src/lean_ffi/tpe.rs
+++ b/cedar-lean-ffi/src/lean_ffi/tpe.rs
@@ -892,9 +892,12 @@ mod test {
             attrs: Some(BTreeMap::from([
                 (
                     "name".into(),
-                    RestrictedExpression::new_string("Alice".into()),
+                    PartialAttribute::value(RestrictedExpression::new_string("Alice".into())),
                 ),
-                ("age".into(), RestrictedExpression::new_long(30)),
+                (
+                    "age".into(),
+                    PartialAttribute::value(RestrictedExpression::new_long(30)),
+                ),
             ])),
             ancestors: None,
             tags: None,
@@ -912,9 +915,12 @@ mod test {
             attrs: Some(BTreeMap::from([
                 (
                     "name".into(),
-                    RestrictedExpression::new_string("Alice".into()),
+                    PartialAttribute::value(RestrictedExpression::new_string("Alice".into())),
                 ),
-                ("age".into(), RestrictedExpression::new_string("30".into())),
+                (
+                    "age".into(),
+                    PartialAttribute::value(RestrictedExpression::new_string("30".into())),
+                ),
             ])),
             ..user
         };

--- a/cedar-lean-ffi/src/messages.rs
+++ b/cedar-lean-ffi/src/messages.rs
@@ -232,16 +232,15 @@ impl proto::RequestValidationRequest {
 
 pub mod tpe {
     use cedar_policy::{
-        Entities, EntityUid, PartialEntities, PartialEntityUid, PartialRequest, PolicySet, Request,
-        RestrictedExpression, Schema, proto::models as cedar_proto,
+        Entities, EntityUid, PartialAttribute, PartialEntities, PartialEntityUid, PartialRequest,
+        PartialValue, PolicySet, Request, Schema, proto::models as cedar_proto,
     };
-    use cedar_policy_core::ast::{Expr, Value, ValueKind};
+    use cedar_policy_core::ast::{Expr, Value};
     use cedar_policy_core::tpe::value::{
-        PartialAttribute as CorePartialAttribute, PartialRecord as CorePartialRecord,
-        PartialValue as CorePartialValue,
+        AttrState as CoreAttrState, PartialRecord as CorePartialRecord,
     };
     use smol_str::SmolStr;
-    use std::collections::{BTreeMap, HashMap, HashSet};
+    use std::collections::{BTreeMap, HashSet};
 
     use super::proto;
 
@@ -409,61 +408,96 @@ pub mod tpe {
         }
     }
 
-    fn expr_from_partial_value(value: &CorePartialValue) -> Option<Expr> {
-        match value {
-            CorePartialValue::Lit(lit) => Some(Expr::from(Value::new(lit.clone(), None))),
-            CorePartialValue::Set(set) => {
-                Some(Expr::from(Value::new(ValueKind::Set(set.clone()), None)))
+    fn expr_from_value(value: &Value) -> cedar_proto::Expr {
+        cedar_proto::Expr::from(&Expr::from(value.clone()))
+    }
+
+    impl proto::AttrState {
+        fn from_inner(attr: &CoreAttrState) -> Self {
+            let mut state = Self::default();
+            match attr {
+                CoreAttrState::PartialRecord(record) => {
+                    state.set_kind(proto::AttrStateKind::AttrStatePartialRecord);
+                    state.record = record
+                        .attrs()
+                        .map(proto::AttrStateEntry::from_inner)
+                        .collect();
+                }
+                CoreAttrState::Value(value) => {
+                    state.set_kind(proto::AttrStateKind::AttrStateValue);
+                    state.value = Some(expr_from_value(value));
+                }
+                CoreAttrState::Present => state.set_kind(proto::AttrStateKind::AttrStatePresent),
+                CoreAttrState::Absent => state.set_kind(proto::AttrStateKind::AttrStateAbsent),
+                CoreAttrState::Unknown => state.set_kind(proto::AttrStateKind::AttrStateUnknown),
             }
-            CorePartialValue::ExtensionValue(ext) => Some(Expr::from(Value::new(
-                ValueKind::ExtensionValue(ext.clone()),
-                None,
-            ))),
-            CorePartialValue::Record(record) => {
-                let fields = partial_record_exprs(record)?;
-                Expr::record(fields).ok()
+            state
+        }
+
+        fn from_unchecked(attr: &PartialAttribute) -> Self {
+            let mut state = Self::default();
+            match attr {
+                // The public `PartialRecord` exposes no field accessor, so the unchecked path
+                // cannot introspect a nested record; nesting is covered by the checked generator.
+                PartialAttribute::Value(PartialValue::Record(_)) => {
+                    state.set_kind(proto::AttrStateKind::AttrStatePresent)
+                }
+                PartialAttribute::Value(PartialValue::Concrete(value)) => {
+                    let expr = Expr::from(value.as_ref().clone());
+                    state.value = Some(cedar_proto::Expr::from(&expr));
+                    state.set_kind(proto::AttrStateKind::AttrStateValue);
+                }
+                PartialAttribute::Exists => state.set_kind(proto::AttrStateKind::AttrStatePresent),
+                PartialAttribute::Absent => state.set_kind(proto::AttrStateKind::AttrStateAbsent),
+                PartialAttribute::Unknown => state.set_kind(proto::AttrStateKind::AttrStateUnknown),
+            }
+            state
+        }
+    }
+
+    impl proto::AttrStateEntry {
+        fn from_inner((key, state): (&SmolStr, &CoreAttrState)) -> Self {
+            Self {
+                key: key.to_string(),
+                state: Some(proto::AttrState::from_inner(state)),
+            }
+        }
+
+        fn from_unchecked((key, attr): (&SmolStr, &PartialAttribute)) -> Self {
+            Self {
+                key: key.to_string(),
+                state: Some(proto::AttrState::from_unchecked(attr)),
             }
         }
     }
 
-    /// Encode only records representable by the legacy concrete-value wire format.
-    /// Returning `None` makes the entire component unknown, which is conservative.
-    fn partial_record_exprs(record: &CorePartialRecord) -> Option<BTreeMap<SmolStr, Expr>> {
-        record
-            .attrs()
-            .filter_map(|(key, state)| match state {
-                CorePartialAttribute::Value(value) => {
-                    Some(expr_from_partial_value(value).map(|expr| (key.clone(), expr)))
-                }
-                CorePartialAttribute::Absent => None,
-                CorePartialAttribute::Exists | CorePartialAttribute::Unknown => Some(None),
-            })
-            .collect()
-    }
+    impl proto::PartialRecord {
+        fn from_inner(record: &CorePartialRecord) -> Self {
+            Self {
+                entries: record
+                    .attrs()
+                    .map(proto::AttrStateEntry::from_inner)
+                    .collect(),
+            }
+        }
 
-    fn partial_record_to_proto(
-        record: &CorePartialRecord,
-    ) -> Option<HashMap<String, cedar_proto::Expr>> {
-        Some(
-            partial_record_exprs(record)?
-                .into_iter()
-                .map(|(key, expr)| (key.to_string(), cedar_proto::Expr::from(&expr)))
-                .collect(),
-        )
+        fn from_unchecked(record: &BTreeMap<SmolStr, PartialAttribute>) -> Self {
+            Self {
+                entries: record
+                    .iter()
+                    .map(proto::AttrStateEntry::from_unchecked)
+                    .collect(),
+            }
+        }
     }
 
     impl proto::PartialRequest {
         fn from_inner(req: &cedar_policy_core::tpe::request::PartialRequest) -> Self {
-            let (context, has_context) = req
-                .context()
-                .and_then(partial_record_to_proto)
-                .map_or_else(|| (Default::default(), false), |context| (context, true));
             Self {
                 principal: Some(proto::PartialEntityUid::from_inner(req.principal())),
                 action: Some(cedar_proto::EntityUid::from(req.action())),
                 resource: Some(proto::PartialEntityUid::from_inner(req.resource())),
-                context,
-                has_context,
+                context: req.context().map(proto::PartialRecord::from_inner),
             }
         }
     }
@@ -481,31 +515,13 @@ pub mod tpe {
 
     impl proto::PartialEntity {
         fn from_inner(entity: &cedar_policy_core::tpe::entities::PartialEntity) -> Self {
-            let (attrs, has_attrs) = entity
-                .attrs()
-                .and_then(partial_record_to_proto)
-                .map_or_else(|| (Default::default(), false), |attrs| (attrs, true));
-            let (ancestors, has_ancestors) = entity.ancestors().map_or_else(
-                || (Default::default(), false),
-                |ancestors| {
-                    (
-                        ancestors.iter().map(cedar_proto::EntityUid::from).collect(),
-                        true,
-                    )
-                },
-            );
-            let (tags, has_tags) = entity
-                .tags()
-                .and_then(partial_record_to_proto)
-                .map_or_else(|| (Default::default(), false), |tags| (tags, true));
             Self {
                 uid: Some(cedar_proto::EntityUid::from(entity.uid())),
-                attrs,
-                ancestors,
-                tags,
-                has_attrs,
-                has_ancestors,
-                has_tags,
+                attrs: entity.attrs().map(proto::PartialRecord::from_inner),
+                ancestors: entity.ancestors().map(|ancestors| proto::EntityUidSet {
+                    uids: ancestors.iter().map(cedar_proto::EntityUid::from).collect(),
+                }),
+                tags: entity.tags().map(proto::PartialRecord::from_inner),
             }
         }
     }
@@ -517,9 +533,9 @@ pub mod tpe {
     #[derive(Debug, Clone)]
     pub struct UncheckedPartialEntity {
         pub uid: EntityUid,
-        pub attrs: Option<BTreeMap<SmolStr, RestrictedExpression>>,
+        pub attrs: Option<BTreeMap<SmolStr, PartialAttribute>>,
         pub ancestors: Option<HashSet<EntityUid>>,
-        pub tags: Option<BTreeMap<SmolStr, RestrictedExpression>>,
+        pub tags: Option<BTreeMap<SmolStr, PartialAttribute>>,
     }
 
     /// A partial request that has not been validated against any schema.
@@ -528,36 +544,30 @@ pub mod tpe {
         pub principal: PartialEntityUid,
         pub action: EntityUid,
         pub resource: PartialEntityUid,
-        pub context: Option<BTreeMap<SmolStr, RestrictedExpression>>,
-    }
-
-    fn to_proto_exprs(
-        m: &Option<BTreeMap<SmolStr, RestrictedExpression>>,
-    ) -> HashMap<String, cedar_proto::Expr> {
-        m.iter()
-            .flatten()
-            .map(|(k, v)| {
-                let e = cedar_policy_core::ast::Expr::from(v.as_ref().clone());
-                (k.to_string(), cedar_proto::Expr::from(&e))
-            })
-            .collect()
+        pub context: Option<BTreeMap<SmolStr, PartialAttribute>>,
     }
 
     impl proto::PartialEntity {
         fn from_unchecked(entity: &UncheckedPartialEntity) -> Self {
             Self {
                 uid: Some(cedar_proto::EntityUid::from(entity.uid.as_ref())),
-                has_attrs: entity.attrs.is_some(),
-                attrs: to_proto_exprs(&entity.attrs),
-                has_ancestors: entity.ancestors.is_some(),
+                attrs: entity
+                    .attrs
+                    .as_ref()
+                    .map(proto::PartialRecord::from_unchecked),
                 ancestors: entity
                     .ancestors
-                    .iter()
-                    .flatten()
-                    .map(|uid| cedar_proto::EntityUid::from(uid.as_ref()))
-                    .collect(),
-                has_tags: entity.tags.is_some(),
-                tags: to_proto_exprs(&entity.tags),
+                    .as_ref()
+                    .map(|ancestors| proto::EntityUidSet {
+                        uids: ancestors
+                            .iter()
+                            .map(|uid| cedar_proto::EntityUid::from(uid.as_ref()))
+                            .collect(),
+                    }),
+                tags: entity
+                    .tags
+                    .as_ref()
+                    .map(proto::PartialRecord::from_unchecked),
             }
         }
     }
@@ -568,8 +578,10 @@ pub mod tpe {
                 principal: Some(proto::PartialEntityUid::from_inner(req.principal.as_ref())),
                 action: Some(cedar_proto::EntityUid::from(req.action.as_ref())),
                 resource: Some(proto::PartialEntityUid::from_inner(req.resource.as_ref())),
-                has_context: req.context.is_some(),
-                context: to_proto_exprs(&req.context),
+                context: req
+                    .context
+                    .as_ref()
+                    .map(proto::PartialRecord::from_unchecked),
             }
         }
     }

--- a/cedar-lean/CedarProto/PartialInput.lean
+++ b/cedar-lean/CedarProto/PartialInput.lean
@@ -24,14 +24,162 @@ import CedarProto.EntityUID
 import CedarProto.Expr
 import CedarProto.Value
 
-
-
 open Proto
 
 namespace Cedar.TPE.Proto
 
 open Cedar.Data
 open Cedar.Spec
+
+/-! ### Explicit recursive partial records -/
+
+inductive AttrStateKind where
+  | unknown
+  | value
+  | present
+  | absent
+  | partialRecord
+deriving Inhabited, Repr, DecidableEq
+
+namespace AttrStateKind
+@[inline]
+def fromInt (n : Int) : Except String AttrStateKind :=
+  match n with
+  | 0 => .ok .unknown
+  | 1 => .ok .value
+  | 2 => .ok .present
+  | 3 => .ok .absent
+  | 4 => .ok .partialRecord
+  | n => .error s!"Field {n} does not exist in enum AttrStateKind"
+
+instance : ProtoEnum AttrStateKind := { fromInt := fromInt }
+end AttrStateKind
+
+mutual
+
+/-- The wire form of one attribute's state. -/
+inductive AttrState where
+  | mk (kind : AttrStateKind) (value : Option Expr) (record : List AttrStateEntry)
+
+/-- The wire form of one entry in a partial record. -/
+inductive AttrStateEntry where
+  | mk (key : String) (state : Option AttrState)
+
+end
+
+instance : Inhabited AttrState where
+  default := .mk .unknown .none []
+
+instance : Inhabited AttrStateEntry where
+  default := .mk "" .none
+
+namespace AttrState
+def kind : AttrState → AttrStateKind | .mk k _ _ => k
+def value : AttrState → Option Expr | .mk _ v _ => v
+def record : AttrState → List AttrStateEntry | .mk _ _ r => r
+
+def mergeKind (s : AttrState) (k : AttrStateKind) : AttrState := .mk k s.value s.record
+def mergeValue (s : AttrState) (v : Expr) : AttrState := .mk s.kind (.some v) s.record
+def mergeRecord (s : AttrState) (r : Array AttrStateEntry) : AttrState :=
+  .mk s.kind s.value (s.record ++ r.toList)
+
+def merge (x y : AttrState) : AttrState :=
+  .mk (if y.kind == .unknown then x.kind else y.kind)
+      (y.value <|> x.value)
+      (x.record ++ y.record)
+end AttrState
+
+namespace AttrStateEntry
+def key : AttrStateEntry → String | .mk k _ => k
+def state : AttrStateEntry → Option AttrState | .mk _ s => s
+
+def mergeKey (e : AttrStateEntry) (k : String) : AttrStateEntry := .mk k e.state
+def mergeState (e : AttrStateEntry) (s : AttrState) : AttrStateEntry := .mk e.key (.some s)
+
+def merge (x y : AttrStateEntry) : AttrStateEntry :=
+  .mk (if y.key == "" then x.key else y.key) (y.state <|> x.state)
+end AttrStateEntry
+
+mutual
+
+partial def AttrState.parseField (t : Proto.Tag) : BParsec (MergeFn AttrState) := do
+  have : Message AttrStateEntry :=
+    { parseField := AttrStateEntry.parseField, merge := AttrStateEntry.merge }
+  match t.fieldNum with
+  | 1 =>
+    let x : AttrStateKind ← Field.guardedParse t
+    pureMergeFn (AttrState.mergeKind · x)
+  | 2 =>
+    let x : Expr ← Field.guardedParse t
+    pureMergeFn (AttrState.mergeValue · x)
+  | 3 =>
+    let x : Repeated AttrStateEntry ← Field.guardedParse t
+    pureMergeFn (AttrState.mergeRecord · x)
+  | _ =>
+    t.wireType.skip
+    pure ignore
+
+partial def AttrStateEntry.parseField (t : Proto.Tag) : BParsec (MergeFn AttrStateEntry) := do
+  have : Message AttrState := { parseField := AttrState.parseField, merge := AttrState.merge }
+  match t.fieldNum with
+  | 1 =>
+    let x : String ← Field.guardedParse t
+    pureMergeFn (AttrStateEntry.mergeKey · x)
+  | 2 =>
+    let x : AttrState ← Field.guardedParse t
+    pureMergeFn (AttrStateEntry.mergeState · x)
+  | _ =>
+    t.wireType.skip
+    pure ignore
+
+end
+
+instance : Message AttrState :=
+  { parseField := AttrState.parseField, merge := AttrState.merge }
+instance : Message AttrStateEntry :=
+  { parseField := AttrStateEntry.parseField, merge := AttrStateEntry.merge }
+
+partial def AttrState.toAttrState : AttrState → Except String TPE.AttrState
+  | .mk kind value record =>
+    match kind with
+    | .unknown => .ok .unknown
+    | .present => .ok .present
+    | .absent  => .ok .absent
+    | .value =>
+      match value with
+      | .some e => do .ok (TPE.AttrState.value (← Spec.Value.exprToValue e))
+      | .none   => .error "AttrState of kind VALUE carries no value"
+    | .partialRecord => do
+      let pairs ← record.mapM λ e =>
+        match e with
+        | .mk k (.some st) => do .ok (k, ← AttrState.toAttrState st)
+        | .mk k .none      => .error s!"AttrState record entry {k} carries no state"
+      .ok (TPE.AttrState.partialRecord (Data.Map.make pairs))
+
+/-! ### PartialRecord -/
+
+structure PartialRecord where
+  entries : Repeated AttrStateEntry
+deriving Inhabited
+
+namespace PartialRecord
+
+instance : Message PartialRecord where
+  parseField (t : Proto.Tag) := do
+    match t.fieldNum with
+    | 1 => parseFieldElement t entries (update entries)
+    | _ => let _ ← t.wireType.skip ; pure ignore
+
+  merge x y := { entries := Field.merge x.entries y.entries }
+
+def toPartialRecord (r : PartialRecord) : Except String TPE.PartialRecord := do
+  let pairs ← r.entries.toList.mapM λ e =>
+    match e with
+    | .mk k (.some st) => do .ok (k, ← AttrState.toAttrState st)
+    | .mk k .none      => .error s!"PartialRecord entry {k} carries no state"
+  .ok (Data.Map.make pairs)
+
+end PartialRecord
 
 /-! ### PartialEntityUID -/
 
@@ -65,8 +213,7 @@ structure PartialRequest where
   principal : PartialEntityUID
   action : EntityUID
   resource : PartialEntityUID
-  context : Proto.Map String Expr := default
-  hasContext : Bool := false
+  context : Option PartialRecord := none
 deriving Inhabited
 
 namespace PartialRequest
@@ -78,42 +225,49 @@ instance : Message PartialRequest where
     | 2 => parseFieldElement t action (update action)
     | 3 => parseFieldElement t resource (update resource)
     | 4 => parseFieldElement t context (update context)
-    | 5 => parseFieldElement t hasContext (update hasContext)
     | _ => let _ ← t.wireType.skip ; pure ignore
 
   merge x y := {
-    principal  := Field.merge x.principal  y.principal
-    action     := Field.merge x.action     y.action
-    resource   := Field.merge x.resource   y.resource
-    context    := Field.merge x.context    y.context
-    hasContext  := Field.merge x.hasContext  y.hasContext
+    principal := Field.merge x.principal y.principal
+    action := Field.merge x.action y.action
+    resource := Field.merge x.resource y.resource
+    context := Field.merge x.context y.context
   }
 
 def toPartialRequest (p : PartialRequest) : Except String TPE.PartialRequest := do
-  let context ← if p.hasContext then do
-      let pairs ← p.context.mapM fun (k, v) =>
-        do .ok (k, TPE.AttrState.value (← Spec.Value.exprToValue v))
-      .ok (some (Data.Map.make pairs.toList))
-    else .ok none
+  let context ← p.context.mapM PartialRecord.toPartialRecord
   .ok {
     principal := p.principal.toPartialEntityUID
-    action    := p.action
-    resource  := p.resource.toPartialEntityUID
-    context   := context
+    action := p.action
+    resource := p.resource.toPartialEntityUID
+    context
   }
 
 end PartialRequest
 
-/-! ### PartialEntityData -/
+/-! ### PartialEntity -/
+
+structure EntityUidSet where
+  uids : Repeated EntityUID
+deriving Inhabited
+
+namespace EntityUidSet
+
+instance : Message EntityUidSet where
+  parseField (t : Proto.Tag) := do
+    match t.fieldNum with
+    | 1 => parseFieldElement t uids (update uids)
+    | _ => let _ ← t.wireType.skip ; pure ignore
+
+  merge x y := { uids := Field.merge x.uids y.uids }
+
+end EntityUidSet
 
 structure PartialEntity where
   uid : EntityUID
-  attrs : Proto.Map String Expr := default
-  ancestors : Repeated EntityUID := default
-  tags : Proto.Map String Expr := default
-  hasAttrs : Bool := false
-  hasAncestors : Bool := false
-  hasTags : Bool := false
+  attrs : Option PartialRecord := none
+  ancestors : Option EntityUidSet := none
+  tags : Option PartialRecord := none
 deriving Inhabited
 
 namespace PartialEntity
@@ -125,20 +279,20 @@ instance : Message PartialEntity where
     | 2 => parseFieldElement t attrs (update attrs)
     | 3 => parseFieldElement t ancestors (update ancestors)
     | 4 => parseFieldElement t tags (update tags)
-    | 5 => parseFieldElement t hasAttrs (update hasAttrs)
-    | 6 => parseFieldElement t hasAncestors (update hasAncestors)
-    | 7 => parseFieldElement t hasTags (update hasTags)
     | _ => let _ ← t.wireType.skip ; pure ignore
 
   merge x y := {
-    uid          := Field.merge x.uid          y.uid
-    attrs        := Field.merge x.attrs        y.attrs
-    ancestors    := Field.merge x.ancestors    y.ancestors
-    tags         := Field.merge x.tags         y.tags
-    hasAttrs     := Field.merge x.hasAttrs     y.hasAttrs
-    hasAncestors := Field.merge x.hasAncestors y.hasAncestors
-    hasTags      := Field.merge x.hasTags      y.hasTags
+    uid := Field.merge x.uid y.uid
+    attrs := Field.merge x.attrs y.attrs
+    ancestors := Field.merge x.ancestors y.ancestors
+    tags := Field.merge x.tags y.tags
   }
+
+def toPartialEntity (p : PartialEntity) : Except String (EntityUID × TPE.PartialEntityData) := do
+  let attrs ← p.attrs.mapM PartialRecord.toPartialRecord
+  let tags ← p.tags.mapM PartialRecord.toPartialRecord
+  let ancestors := p.ancestors.map (Data.Set.make ·.uids.toList)
+  .ok (p.uid, TPE.PartialEntityData.mk attrs ancestors tags)
 
 end PartialEntity
 
@@ -161,49 +315,10 @@ instance : Message PartialEntities where
 
   merge := (· ++ ·)
 
-private def convertMap (has : Bool) (m : Proto.Map String Expr) :
-  Except String (Option TPE.PartialRecord) :=
-  if has then do
-    let pairs ← m.mapM fun (k, v) =>
-      do .ok (k, TPE.AttrState.value (← Spec.Value.exprToValue v))
-    .ok (some (Data.Map.make pairs.toList))
-  else .ok none
-
 def toPartialEntities (e : PartialEntities) : Except String TPE.PartialEntities := do
-  let pairs ← e.entities.toList.mapM fun pe => do
-    let attrs ← convertMap pe.hasAttrs pe.attrs
-    let ancestors := if pe.hasAncestors then some (Data.Set.make pe.ancestors.toList) else none
-    let tags ← convertMap pe.hasTags pe.tags
-    .ok (pe.uid, TPE.PartialEntityData.mk attrs ancestors tags)
+  let pairs ← e.entities.toList.mapM PartialEntity.toPartialEntity
   .ok (Data.Map.make pairs)
 
 end PartialEntities
 
 end Cedar.TPE.Proto
-
-/-! ### Field instances -/
-
-namespace Cedar.TPE
-
-open Cedar.Data
-
-def PartialRequest.merge (x y : PartialRequest) : PartialRequest := {
-  principal := { ty := Proto.Field.merge x.principal.ty y.principal.ty, id := y.principal.id <|> x.principal.id }
-  action    := Proto.Field.merge x.action y.action
-  resource  := { ty := Proto.Field.merge x.resource.ty y.resource.ty, id := y.resource.id <|> x.resource.id }
-  context   := y.context <|> x.context
-}
-
-instance : Proto.Field PartialRequest :=
-  Proto.Field.fromInterFieldFallible Proto.PartialRequest.toPartialRequest PartialRequest.merge
-
-def PartialEntities.merge (x y : PartialEntities) : PartialEntities :=
-  match x.toList, y.toList with
-  | [], _ => y
-  | _, [] => x
-  | _, _  => Data.Map.make (x.toList ++ y.toList)
-
-instance : Proto.Field PartialEntities :=
-  Proto.Field.fromInterFieldFallible Proto.PartialEntities.toPartialEntities PartialEntities.merge
-
-end Cedar.TPE


### PR DESCRIPTION
Extends TPE targets to test partial attributes in entities and context. Adds these to protobuf layer to support testing.

*Issue #, if available:*

*Description of changes:*


